### PR TITLE
CASMTRIAGE-6543: auth requirement in API docs (#4648)

### DIFF
--- a/api/bos.md
+++ b/api/bos.md
@@ -98,7 +98,9 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/bos">https://api-gw-service-nmn.local/apis/bos</a>
 
-* <a href="https://cray-bos">https://cray-bos</a>
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="boot-orchestration-service-version">version</h1>
 
@@ -116,14 +118,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/', headers = headers)
@@ -144,6 +148,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -203,8 +208,9 @@ Status Code **200**
 |»» href|string|false|none|none|
 |»» rel|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get
@@ -223,14 +229,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1', headers = headers)
@@ -251,6 +259,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -299,8 +308,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get_version
@@ -319,14 +329,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/version', headers = headers)
@@ -347,6 +359,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -395,8 +408,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-healthz">healthz</h1>
@@ -417,14 +431,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/healthz', headers = headers)
@@ -445,6 +461,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -483,8 +500,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-sessiontemplate">sessiontemplate</h1>
@@ -509,7 +527,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -518,7 +537,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -541,6 +561,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -658,8 +679,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplates
@@ -680,7 +702,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -688,7 +711,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -710,6 +734,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -821,8 +846,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details array|[V2SessionTemplateArray](#schemav2sessiontemplatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplate
@@ -843,7 +869,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -851,7 +878,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{sessio
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -873,6 +901,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -986,8 +1015,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_sessiontemplate
@@ -1008,7 +1038,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1016,7 +1047,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{ses
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -1038,6 +1070,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1091,8 +1124,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplatetemplate
@@ -1111,14 +1145,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate', headers = headers)
@@ -1139,6 +1175,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1238,8 +1275,9 @@ Session Templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-session">session</h1>
@@ -1264,7 +1302,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1273,7 +1312,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1296,6 +1336,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1370,8 +1411,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessions
@@ -1392,7 +1434,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1400,7 +1443,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1422,6 +1466,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1477,8 +1522,9 @@ Status Code **200**
 |---|---|---|---|---|
 |*anonymous*|[[V1SessionId](#schemav1sessionid)]|false|none|[Unique BOS v1 Session identifier.]|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session
@@ -1499,7 +1545,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1507,7 +1554,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1529,6 +1577,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1588,8 +1637,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 
 <h3 id="get_v1_session-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session
@@ -1610,7 +1660,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1618,7 +1669,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1640,6 +1692,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1693,8 +1746,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status
@@ -1715,7 +1769,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1723,7 +1778,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1745,6 +1801,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1810,8 +1867,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_session_status
@@ -1834,7 +1892,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1843,7 +1902,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1866,6 +1926,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1957,8 +2018,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status
@@ -1981,7 +2043,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1990,7 +2053,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -2013,6 +2077,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2091,8 +2156,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session_status
@@ -2113,7 +2179,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2121,7 +2188,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -2143,6 +2211,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2197,8 +2266,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset
@@ -2219,7 +2289,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2227,7 +2298,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2249,6 +2321,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2344,8 +2417,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_boot_set_status
@@ -2368,7 +2442,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2377,7 +2452,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2400,6 +2476,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2549,8 +2626,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status_by_bootset
@@ -2573,7 +2651,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2582,7 +2661,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2605,6 +2685,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2722,8 +2803,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_boot_set_status
@@ -2744,7 +2826,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2752,7 +2835,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2774,6 +2858,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2828,8 +2913,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase
@@ -2850,7 +2936,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2858,7 +2945,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}', headers = headers)
@@ -2880,6 +2968,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2957,8 +3046,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase_and_category
@@ -2979,7 +3069,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2987,7 +3078,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name}', headers = headers)
@@ -3009,6 +3101,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3065,8 +3158,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-v2">v2</h1>
@@ -3087,14 +3181,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2', headers = headers)
@@ -3115,6 +3211,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3163,8 +3260,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_healthz
@@ -3183,14 +3281,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/healthz', headers = headers)
@@ -3211,6 +3311,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3249,8 +3350,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplates
@@ -3271,7 +3373,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3279,7 +3382,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates', headers = headers)
@@ -3301,6 +3405,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3414,8 +3519,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details array|[V2SessionTemplateArray](#schemav2sessiontemplatearray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## validate_v2_sessiontemplate
@@ -3436,7 +3542,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3444,7 +3551,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id}', headers = headers)
@@ -3466,6 +3574,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3517,8 +3626,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template validity details|[V2SessionTemplateValidation](#schemav2sessiontemplatevalidation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplate
@@ -3539,7 +3649,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3547,7 +3658,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{sessi
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3569,6 +3681,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3684,8 +3797,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_sessiontemplate
@@ -3708,7 +3822,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3717,7 +3832,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3740,6 +3856,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3916,8 +4033,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_sessiontemplate
@@ -3940,7 +4058,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3949,7 +4068,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3972,6 +4092,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4149,8 +4270,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessiontemplate
@@ -4171,7 +4293,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4179,7 +4302,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{se
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -4201,6 +4325,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4256,8 +4381,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplatetemplate
@@ -4276,14 +4402,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate', headers = headers)
@@ -4304,6 +4432,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4403,8 +4532,9 @@ Session Templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_session
@@ -4427,7 +4557,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4436,7 +4567,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4459,6 +4591,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4538,8 +4671,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Session details|[V2Session](#schemav2session)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessions
@@ -4560,7 +4694,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4568,7 +4703,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4590,6 +4726,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4665,8 +4802,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details array|[V2SessionArray](#schemav2sessionarray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessions
@@ -4687,7 +4825,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4695,7 +4834,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions \
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4717,6 +4857,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4783,8 +4924,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session
@@ -4805,7 +4947,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4813,7 +4956,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4835,6 +4979,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4899,8 +5044,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_session
@@ -4923,7 +5069,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4932,7 +5079,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4955,6 +5103,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5041,8 +5190,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_session
@@ -5063,7 +5213,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5071,7 +5222,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -5093,6 +5245,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5148,8 +5301,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session_status
@@ -5170,7 +5324,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5178,7 +5333,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/s
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -5200,6 +5356,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5267,8 +5424,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session status details|[V2SessionExtendedStatus](#schemav2sessionextendedstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## save_v2_session_status
@@ -5289,7 +5447,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5297,7 +5456,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -5319,6 +5479,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5383,8 +5544,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_components
@@ -5405,7 +5567,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5413,7 +5576,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5435,6 +5599,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5550,8 +5715,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of Component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_components
@@ -5574,7 +5740,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5583,7 +5750,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5606,6 +5774,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5760,8 +5929,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of Component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_components
@@ -5784,7 +5954,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5793,7 +5964,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5816,6 +5988,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5975,8 +6148,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_component
@@ -5997,7 +6171,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6005,7 +6180,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components/{component_i
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6027,6 +6203,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6127,8 +6304,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_component
@@ -6151,7 +6329,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6160,7 +6339,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6183,6 +6363,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6334,8 +6515,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single Component state|[V2Component](#schemav2component)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_component
@@ -6358,7 +6540,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6367,7 +6550,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6390,6 +6574,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6543,8 +6728,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The update was not allowed due to a conflict.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_component
@@ -6565,7 +6751,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6573,7 +6760,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/components/{componen
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6595,6 +6783,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6650,8 +6839,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_apply_staged
@@ -6674,7 +6864,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/applystaged \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6683,7 +6874,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/applystaged', headers = headers)
@@ -6706,6 +6898,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6778,8 +6971,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of xnames that should have their staged Session applied.|[V2ApplyStagedStatus](#schemav2applystagedstatus)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_options
@@ -6800,7 +6994,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6808,7 +7003,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -6830,6 +7026,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6900,8 +7097,9 @@ Update one or more of the BOS service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_version_v2
@@ -6920,14 +7118,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/version', headers = headers)
@@ -6948,6 +7148,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6996,8 +7197,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-options">options</h1>
@@ -7018,14 +7220,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -7046,6 +7250,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7091,8 +7296,9 @@ Retrieve the list of BOS service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/bss.md
+++ b/api/bss.md
@@ -35,7 +35,11 @@ Verify the boot parameters for the specific host.
 
 Base URLs:
 
-* <a href="http://bootscriptserver:27778/apis/bss">http://bootscriptserver:27778/apis/bss</a>
+* <a href="https://api-gw-service-nmn.local/apis/bss">https://api-gw-service-nmn.local/apis/bss</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="boot-script-service-cli_ignore">cli_ignore</h1>
 
@@ -46,26 +50,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/meta-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/meta-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/meta-data \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/meta-data \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/meta-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/meta-data', headers = headers)
 
 print(r.json())
 
@@ -83,10 +89,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/meta-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/meta-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -125,8 +132,9 @@ func main() {
 
 <h3 id="meta_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## user_data_get
@@ -136,26 +144,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/user-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/user-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/yaml
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/user-data \
-  -H 'Accept: text/yaml'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/user-data \
+  -H 'Accept: text/yaml' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/yaml'
+  'Accept': 'text/yaml',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/user-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/user-data', headers = headers)
 
 print(r.json())
 
@@ -173,10 +183,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/yaml"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/user-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/user-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -205,8 +216,9 @@ func main() {
 
 <h3 id="user_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## phone_home_post
@@ -216,8 +228,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/phone-home HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/phone-home HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -225,9 +237,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/phone-home \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -235,10 +248,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/phone-home', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/phone-home', headers = headers)
 
 print(r.json())
 
@@ -257,10 +271,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/phone-home", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/phone-home", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -338,8 +353,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC or NID are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootscript">bootscript</h1>
@@ -351,26 +367,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/plain
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript \
-  -H 'Accept: text/plain'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/plain'
+  'Accept': 'text/plain',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootscript', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript', headers = headers)
 
 print(r.json())
 
@@ -388,10 +406,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/plain"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootscript", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -435,8 +454,9 @@ Retrieve iPXE boot script for the host specified by the MAC parameter. Alternati
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC, or NID are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootparameters">bootparameters</h1>
@@ -446,8 +466,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -455,9 +475,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -465,10 +486,11 @@ curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -487,10 +509,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -620,8 +643,9 @@ Status Code **200**
 |»»» hostname|string|false|none|none|
 |»»» fqdn|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_bootparameters
@@ -629,8 +653,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -638,9 +662,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -648,10 +673,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -670,10 +696,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -762,8 +789,9 @@ Special entries for HSM roles like 'Compute', 'Storage' and 'Application' can al
 |---|---|---|---|---|
 |201|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__boot_v1_bootparameters
@@ -771,8 +799,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -780,9 +808,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -790,10 +819,11 @@ curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -812,10 +842,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -904,8 +935,9 @@ Along with the hosts, there must be a kernel image reference in order for the bo
 |---|---|---|---|---|
 |200|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__boot_v1_bootparameters
@@ -913,8 +945,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -922,9 +954,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -932,10 +965,11 @@ curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -954,10 +988,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1035,8 +1070,9 @@ Update an existing entry with new boot parameters while retaining existing setti
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find entry for specified host, MAC, or NID|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__boot_v1_bootparameters
@@ -1044,8 +1080,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1053,9 +1089,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1063,10 +1100,11 @@ curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -1085,10 +1123,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1166,8 +1205,9 @@ Remove an existing boot parameter settings for one or more hosts, as specified b
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find specified host, MAC, or NID|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-hosts">hosts</h1>
@@ -1177,26 +1217,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1214,10 +1256,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1278,8 +1321,9 @@ Retrieve list of known hosts obtained from HSM. This list can be filtered by spe
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Return list of hosts and associated attributes known to BSS|[HostInfo](#schemahostinfo)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_hosts
@@ -1287,26 +1331,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1324,10 +1370,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1365,8 +1412,9 @@ Retrieve the latest host information from HSM.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-dumpstate">dumpstate</h1>
@@ -1376,26 +1424,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate', headers = headers)
 
 print(r.json())
 
@@ -1413,10 +1463,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1507,8 +1558,9 @@ Dump internal state of boot script service for debugging purposes. Return known 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-endpoint-history">endpoint-history</h1>
@@ -1518,26 +1570,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history', headers = headers)
 
 print(r.json())
 
@@ -1555,10 +1609,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1626,8 +1681,9 @@ Status Code **200**
 |endpoint|bootscript|
 |endpoint|user-data|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-service-status">service-status</h1>
@@ -1637,26 +1693,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -1674,10 +1732,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1726,8 +1785,9 @@ Status Code **200**
 |---|---|
 |bss-status|running|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_etcd
@@ -1735,26 +1795,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd', headers = headers)
 
 print(r.json())
 
@@ -1772,10 +1834,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,8 +1902,9 @@ Status Code **500**
 |---|---|
 |bss-status-etcd|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_hsm
@@ -1848,26 +1912,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm', headers = headers)
 
 print(r.json())
 
@@ -1885,10 +1951,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1950,8 +2017,9 @@ Status Code **500**
 |---|---|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_version
@@ -1959,26 +2027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -1996,10 +2066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2052,8 +2123,9 @@ Status Code **500**
 |---|---|
 |bss-version|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_status_all
@@ -2061,26 +2133,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all', headers = headers)
 
 print(r.json())
 
@@ -2098,10 +2172,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2178,8 +2253,9 @@ Status Code **500**
 |bss-status-hsm|connected|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/capmc.md
+++ b/api/capmc.md
@@ -63,7 +63,11 @@ This implementation of CAPMC uses Redfish APIs to communicate directly with the 
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/capmc/capmc/v1">http://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/capmc/capmc/v1">https://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--component-control">component control</h1>
 
@@ -72,7 +76,7 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -81,9 +85,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -91,10 +96,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_statu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
 
 print(r.json())
 
@@ -113,10 +119,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -218,8 +225,9 @@ Status Code **200**
 |» ready|[string]|false|none|Optional, list of booted components by xname. Operating system is fully booted and sending heartbeats.|
 |» standby|[string]|false|none|Optional, list of components in standby by xname. Components that were previously booted and but are no longer sending heartbeat.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_reinit
@@ -227,7 +235,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -236,9 +244,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -246,10 +255,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
 
 print(r.json())
 
@@ -268,10 +278,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -362,8 +373,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power restart attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_on
@@ -371,7 +383,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -380,9 +392,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -390,10 +403,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
 
 print(r.json())
 
@@ -412,10 +426,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -510,8 +525,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power up attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_off
@@ -519,7 +535,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -528,9 +544,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -538,10 +555,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
 
 print(r.json())
 
@@ -560,10 +578,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,8 +677,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Non-zero status code for failed request.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--power-capping">power capping</h1>
@@ -669,7 +689,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -678,9 +698,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -688,10 +709,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
 
 print(r.json())
 
@@ -710,10 +732,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -816,8 +839,9 @@ Status Code **200**
 |»»» name|string|true|none|Unique control or status object identifier.|
 |»»» val|integer(int32)|true|none|Control object setting, or zero to indicate control is unconstrained, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__get_power_cap_capabilities
@@ -825,7 +849,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -834,9 +858,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -844,10 +869,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_c
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
 
 print(r.json())
 
@@ -866,10 +892,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -996,8 +1023,9 @@ Status Code **200**
 |»»» min|integer(int32)|true|none|Minimum value which may be assigned to the control object, units are dependent upon control type.|
 |»»» max|integer(int32)|true|none|Maximum value which may be assigned to the control object, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__set_power_cap
@@ -1005,7 +1033,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1014,9 +1042,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1024,10 +1053,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
 
 print(r.json())
 
@@ -1046,10 +1076,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1156,8 +1187,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Error status, non-zero indicates operation failed on this node.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--utilities">utilities</h1>
@@ -1167,7 +1199,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1175,18 +1207,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
 
 print(r.json())
 
@@ -1204,10 +1238,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1259,8 +1294,9 @@ Status Code **200**
 |» vault|string|true|none|Description of the connection to the credentials vault.  If there is an error returned when attempting to access the vault that will be included here.|
 |» hsm|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included in this description.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1268,7 +1304,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1276,18 +1312,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1305,10 +1343,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1344,8 +1383,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1353,7 +1393,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1361,18 +1401,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1390,10 +1432,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1429,8 +1472,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/cfs.md
+++ b/api/cfs.md
@@ -76,6 +76,10 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/cfs">https://api-gw-service-nmn.local/apis/cfs</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="configuration-framework-service-version">version</h1>
 
 ## get_version
@@ -94,14 +98,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/', headers = headers)
@@ -122,6 +128,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -159,8 +166,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions
@@ -179,14 +187,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/versions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/versions', headers = headers)
@@ -207,6 +217,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -244,8 +255,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions_v2
@@ -264,14 +276,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2', headers = headers)
@@ -292,6 +306,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -329,8 +344,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions_v3
@@ -349,14 +365,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3', headers = headers)
@@ -377,6 +395,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -414,8 +433,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-healthz">healthz</h1>
@@ -436,14 +456,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/healthz', headers = headers)
@@ -464,6 +486,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -501,8 +524,9 @@ Get cfs-api health details.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Status information for the service|[Healthz](#schemahealthz)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Status information for the service|[Healthz](#schemahealthz)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-options">options</h1>
@@ -523,14 +547,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -551,6 +577,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -598,8 +625,9 @@ Retrieve the list of configuration service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_options_v2
@@ -620,7 +648,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -628,7 +657,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -650,6 +680,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -724,8 +755,9 @@ Update one or more of the configuration service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_options_v3
@@ -744,14 +776,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/options', headers = headers)
@@ -772,6 +806,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -823,8 +858,9 @@ Retrieve the list of configuration service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V3Options](#schemav3options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_options_v3
@@ -845,7 +881,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -853,7 +890,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/options', headers = headers)
@@ -875,6 +913,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -956,8 +995,9 @@ Update one or more of the configuration service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V3Options](#schemav3options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-sessions">sessions</h1>
@@ -978,14 +1018,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1006,6 +1048,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1117,8 +1160,9 @@ Retrieve all the configuration framework sessions on the system.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V2SessionArray](#schemav2sessionarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_session_v2
@@ -1139,7 +1183,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1147,7 +1192,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1169,6 +1215,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1298,8 +1345,9 @@ Create a new configuration session. A configuration session stages Ansible inven
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A session with the same name already exists.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_sessions_v2
@@ -1318,14 +1366,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1346,6 +1396,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1410,8 +1461,9 @@ Delete multiple configuration sessions.  If filters are provided, only sessions 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_session_v2
@@ -1430,14 +1482,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1458,6 +1512,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1549,8 +1604,9 @@ View details about a specific configuration session. This allows you to track th
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration session|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_session_v2
@@ -1569,14 +1625,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1597,6 +1655,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1689,8 +1748,9 @@ Update the status of an existing configuration framework session
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_session_v2
@@ -1709,14 +1769,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1737,6 +1799,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1783,8 +1846,9 @@ Deleting a configuration session deletes the Kubernetes objects associated with 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_sessions_v3
@@ -1803,14 +1867,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -1831,6 +1897,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1954,8 +2021,9 @@ Retrieve all the configuration framework sessions on the system.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V3SessionDataCollection](#schemav3sessiondatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_session_v3
@@ -1976,7 +2044,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1984,7 +2053,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -2006,6 +2076,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2139,8 +2210,9 @@ Create a new configuration session. A configuration session stages Ansible inven
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A session with the same name already exists.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_sessions_v3
@@ -2159,14 +2231,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -2187,6 +2261,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2304,8 +2379,9 @@ Delete multiple configuration sessions.  If filters are provided, only sessions 
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V3SessionIdCollection](#schemav3sessionidcollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_session_v3
@@ -2324,14 +2400,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2352,6 +2430,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2446,8 +2525,9 @@ View details about a specific configuration session. This allows you to track th
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration session|[V3SessionData](#schemav3sessiondata)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_session_v3
@@ -2466,14 +2546,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2494,6 +2576,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2589,8 +2672,9 @@ Update the status of an existing configuration framework session
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_session_v3
@@ -2609,14 +2693,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2637,6 +2723,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2683,8 +2770,9 @@ Deleting a configuration session deletes the Kubernetes objects associated with 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-components">components</h1>
@@ -2705,14 +2793,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -2733,6 +2823,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2825,8 +2916,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_components_v2
@@ -2847,7 +2939,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2855,7 +2948,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -2877,6 +2971,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2994,8 +3089,9 @@ Update the state for a collection of components in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_components_v2
@@ -3016,7 +3112,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3024,7 +3121,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -3046,6 +3144,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3164,8 +3263,9 @@ Update the state for a collection of components in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_component_v2
@@ -3184,14 +3284,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3212,6 +3314,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3290,8 +3393,9 @@ Retrieve the configuration and current state of a single component
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_component_v2
@@ -3312,7 +3416,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3320,7 +3425,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3342,6 +3448,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3449,8 +3556,9 @@ Update the state for a given component in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V2ComponentState](#schemav2componentstate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_component_v2
@@ -3471,7 +3579,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3479,7 +3588,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3501,6 +3611,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3609,8 +3720,9 @@ Update the state for a given component in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_component_v2
@@ -3629,14 +3741,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3657,6 +3771,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3703,8 +3818,9 @@ Delete the given component
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_components_v3
@@ -3723,14 +3839,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -3751,6 +3869,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3857,8 +3976,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V3ComponentDataCollection](#schemav3componentdatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_components_v3
@@ -3879,7 +3999,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3887,7 +4008,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -3909,6 +4031,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3994,8 +4117,9 @@ Update the state for a collection of components in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component ids|[V3ComponentIdCollection](#schemav3componentidcollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_components_v3
@@ -4016,7 +4140,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4024,7 +4149,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -4046,6 +4172,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4132,8 +4259,9 @@ Update the state for a collection of components in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_component_v3
@@ -4152,14 +4280,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4180,6 +4310,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4263,8 +4394,9 @@ Retrieve the configuration and current state of a single component
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_component_v3
@@ -4285,7 +4417,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4293,7 +4426,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4315,6 +4449,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4428,8 +4563,9 @@ Update the state for a given component in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V3ComponentData](#schemav3componentdata)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_component_v3
@@ -4450,7 +4586,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4458,7 +4595,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4480,6 +4618,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4594,8 +4733,9 @@ Update the state for a given component in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_component_v3
@@ -4614,14 +4754,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4642,6 +4784,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4688,8 +4831,9 @@ Delete the given component
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-configurations">configurations</h1>
@@ -4710,14 +4854,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations', headers = headers)
@@ -4738,6 +4884,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4802,8 +4949,9 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configurations|[V2ConfigurationArray](#schemav2configurationarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configuration_v2
@@ -4822,14 +4970,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -4850,6 +5000,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4912,8 +5063,9 @@ Retrieve the given configuration
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V2Configuration](#schemav2configuration)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_configuration_v2
@@ -4934,7 +5086,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4942,7 +5095,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -4964,6 +5118,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5053,8 +5208,9 @@ Add a configuration to CFS or replace an existing configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V2Configuration](#schemav2configuration)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_configuration_v2
@@ -5073,14 +5229,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -5101,6 +5259,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5164,8 +5323,9 @@ Updates the commits for all layers that specify a branch
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_configuration_v2
@@ -5184,14 +5344,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -5212,6 +5374,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5259,8 +5422,9 @@ Delete the given configuration. This will fail in any components are using the s
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configurations_v3
@@ -5279,14 +5443,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/configurations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/configurations', headers = headers)
@@ -5307,6 +5473,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5378,8 +5545,9 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configurations|[V3ConfigurationDataCollection](#schemav3configurationdatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configuration_v3
@@ -5398,14 +5566,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5426,6 +5596,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5487,8 +5658,9 @@ Retrieve the given configuration
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V3ConfigurationData](#schemav3configurationdata)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_configuration_v3
@@ -5509,7 +5681,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5517,7 +5690,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5539,6 +5713,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5627,8 +5802,9 @@ Add a configuration to CFS or replace an existing configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V3ConfigurationData](#schemav3configurationdata)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_configuration_v3
@@ -5647,14 +5823,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5675,6 +5853,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5737,8 +5916,9 @@ Updates the commits for all layers that specify a branch
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_configuration_v3
@@ -5757,14 +5937,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5785,6 +5967,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5832,8 +6015,9 @@ Delete the given configuration. This will fail in any components are using the s
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-sources">sources</h1>
@@ -5854,14 +6038,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sources \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sources', headers = headers)
@@ -5882,6 +6068,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5945,8 +6132,9 @@ Retrieve the full collection of sources in the form of a SourceArray.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of sources|[V3SourceDataCollection](#schemav3sourcedatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_source_v3
@@ -5967,7 +6155,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sources \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5975,7 +6164,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sources \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v3/sources', headers = headers)
@@ -5997,6 +6187,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6070,8 +6261,9 @@ Add a source to CFS
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A source with the same name already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_source_v3
@@ -6090,14 +6282,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
@@ -6118,6 +6312,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6171,8 +6366,9 @@ Retrieve the given source
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single source|[V3SourceData](#schemav3sourcedata)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_source_v3
@@ -6193,7 +6389,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6201,7 +6398,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
@@ -6223,6 +6421,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6296,8 +6495,9 @@ Updates a CFS source
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_source_v3
@@ -6316,14 +6516,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
@@ -6344,6 +6546,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6391,8 +6594,9 @@ Delete the given source. This will fail in any components are using the specifie
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/firmware-action.md
+++ b/api/firmware-action.md
@@ -64,11 +64,11 @@ FAS receives information from the Hardware State Manager (HSM) for each xname.
 
 Base URLs:
 
-* <a href="https://rocket-ncn-w001.us.cray.com/apis/fas/v1">https://rocket-ncn-w001.us.cray.com/apis/fas/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/fas/v1">https://api-gw-service-nmn.local/apis/fas/v1</a>
 
-* <a href="http://localhost:28800/v1">http://localhost:28800/v1</a>
+# Authentication
 
-* <a href="http://localhost:28800">http://localhost:28800</a>
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="firmware-action-service-actions">actions</h1>
 
@@ -77,26 +77,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -114,10 +116,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -181,8 +184,9 @@ end time for completed and in-progress actions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummarys](#schemaactionsummarys)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__actions
@@ -190,8 +194,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -199,9 +203,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/actions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -209,10 +214,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -231,10 +237,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -368,8 +375,9 @@ commands:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[ActionID](#schemaactionid)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}
@@ -377,26 +385,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -414,10 +424,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -633,8 +644,9 @@ Retrieve detailed information for a firmware action set specified by actionID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Action](#schemaaction)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}
@@ -642,26 +654,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -679,10 +693,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -716,8 +731,9 @@ Delete all information about a completed firmware action set.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|cannot delete a running action|[Problem7807](#schemaproblem7807)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}_instance
@@ -725,26 +741,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance', headers = headers)
 
 print(r.json())
 
@@ -762,10 +780,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -809,8 +828,9 @@ Abort a running firmware action set. Stops all actions in progress (will not rol
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Aborting action|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_status
@@ -818,26 +838,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status', headers = headers)
 
 print(r.json())
 
@@ -855,10 +877,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -926,8 +949,9 @@ Retrieve summary information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummary](#schemaactionsummary)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations
@@ -935,26 +959,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations', headers = headers)
 
 print(r.json())
 
@@ -972,10 +998,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1371,8 +1398,9 @@ Retrieve detailed information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionDetail](#schemaactiondetail)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations_{operationID}
@@ -1380,26 +1408,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1417,10 +1447,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1482,8 +1513,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__operations_{operationID}
@@ -1491,26 +1523,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1528,10 +1562,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1592,8 +1627,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|operation not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-images">images</h1>
@@ -1603,8 +1639,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1612,9 +1648,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1622,10 +1659,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1644,10 +1682,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1726,8 +1765,9 @@ Create a new image record
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[Problem7807](#schemaproblem7807)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Image Record Already Exists|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images
@@ -1735,26 +1775,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1772,10 +1814,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,8 +1882,9 @@ Retrieve a list of images that are known to the system.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageList](#schemaimagelist)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__images_{imageID}
@@ -1848,8 +1892,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/error
 
@@ -1857,9 +1901,10 @@ Accept: application/error
 
 ```shell
 # You can also use wget
-curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
+curl -X PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1867,10 +1912,11 @@ curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -1889,10 +1935,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1964,8 +2011,9 @@ Modify or update an existing image record.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images_{imageID}
@@ -1973,26 +2021,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2010,10 +2060,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2082,8 +2133,9 @@ Retrieve the image record that is associated with the imageID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageGet](#schemaimageget)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__images_{imageID}
@@ -2091,26 +2143,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2128,10 +2182,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2164,8 +2219,9 @@ Deletes an image record from the FAS datastore. Does not delete the actual image
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-service">service</h1>
@@ -2175,26 +2231,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -2212,10 +2270,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2250,8 +2309,9 @@ Retrieve the status of the Firmware Action Service.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatus](#schemaservicestatus)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_status_details
@@ -2259,26 +2319,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status/details', headers = headers)
 
 print(r.json())
 
@@ -2296,10 +2358,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status/details", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2337,8 +2400,9 @@ Retrieve the status of the Firmware Action Service. HSM, ETCD, Service Status an
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatusDetails](#schemaservicestatusdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_version
@@ -2346,26 +2410,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -2383,10 +2449,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2421,8 +2488,9 @@ Retrieve the internal version of FAS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceVersion](#schemaserviceversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-snapshots">snapshots</h1>
@@ -2432,26 +2500,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2469,10 +2539,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2523,8 +2594,9 @@ Return summary of all stored snapshots
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[SnapshotAll](#schemasnapshotall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots
@@ -2532,8 +2604,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2541,9 +2613,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2551,10 +2624,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2573,10 +2647,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2658,8 +2733,9 @@ Records a snapshot of the firmware versions for every target for every device th
 |---|---|---|---|---|
 |201|Location|string||location of snapshot|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__snapshots_{snapshotName}
@@ -2667,26 +2743,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2704,10 +2782,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2806,8 +2885,9 @@ Retrieve a snapshot of the system
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Snapshot](#schemasnapshot)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__snapshots_{snapshotName}
@@ -2815,26 +2895,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2852,10 +2934,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2888,8 +2971,9 @@ Delete a snapshot of the system. Does not delete any firmware images from S3.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots_{snapshotName}_restore
@@ -2897,26 +2981,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore', params={
   'confirm': 'yes'
 }, headers = headers)
 
@@ -2936,10 +3022,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2991,8 +3078,9 @@ Restore a snapshot by replacing each component (device + target) with the stored
 |---|---|---|---|---|
 |202|Location|string|uuid|actionID of the created firmware action set|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-loader">loader</h1>
@@ -3002,8 +3090,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/octet-stream
 Accept: application/json
 
@@ -3011,9 +3099,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader \
   -H 'Content-Type: application/octet-stream' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3021,10 +3110,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
 import requests
 headers = {
   'Content-Type': 'application/octet-stream',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3043,10 +3133,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/octet-stream"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3097,8 +3188,9 @@ string
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader
@@ -3106,26 +3198,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3143,10 +3237,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3181,8 +3276,9 @@ Return the loader status and list loader runs
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderStatus](#schemaloaderstatus)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader_{loaderRunID}
@@ -3190,26 +3286,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3227,10 +3325,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3273,8 +3372,9 @@ Return the results of a loader run
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunOutput](#schemaloaderrunoutput)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__loader_{loaderRunID}
@@ -3282,26 +3382,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3319,10 +3421,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3355,8 +3458,9 @@ Delete a loader run
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loader_nexus
@@ -3364,26 +3468,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus', headers = headers)
 
 print(r.json())
 
@@ -3401,10 +3507,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3439,8 +3546,9 @@ Have the loader read the firmware library from Nexus and add to S3 and create FA
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunID](#schemaloaderrunid)|
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -3568,7 +3676,7 @@ This operation does not require authentication
 |overrideDryrun|boolean|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |operationCounts|[OperationCounts](#schemaoperationcounts)|false|none|none|
 |description|string|false|none|none|
 |blockedBy|[string]|false|none|none|
@@ -3834,7 +3942,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationSummary](#schemaoperationsummary)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4231,7 +4339,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationDetail](#schemaoperationdetail)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4752,7 +4860,7 @@ This operation does not require authentication
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the operation -<br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
+|state|string|false|none|The state of the operation -<br><br><br><br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
 |error|string|false|none|none|
 |xname|string|false|none|none|
 |deviceType|string|false|none|none|
@@ -5394,7 +5502,7 @@ RFC 7807 compliant error payload.  All fields are optional except the 'type' fie
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 
 #### Enumerated Values
 

--- a/api/hbtd.md
+++ b/api/hbtd.md
@@ -39,9 +39,11 @@ To change a parameter, perform a PATCH operation with a JSON-formatted payload c
 
 Base URLs:
 
-* <a href="http://cray-hbtd/hmi/v1">http://cray-hbtd/hmi/v1</a>
-
 * <a href="https://api-gw-service-nmn.local/apis/hbtd/hmi/v1">https://api-gw-service-nmn.local/apis/hbtd/hmi/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="heartbeat-tracker-service-heartbeat">heartbeat</h1>
 
@@ -52,8 +54,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -61,9 +63,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -71,10 +74,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
 
 print(r.json())
 
@@ -93,10 +97,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -143,8 +148,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## TrackHeartbeat
@@ -154,8 +160,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -163,9 +169,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -173,10 +180,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat', headers = headers)
 
 print(r.json())
 
@@ -195,10 +203,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -247,8 +256,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-hbstates">hbstates</h1>
@@ -260,8 +270,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/hbstates HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -269,9 +279,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/hbstates \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -279,10 +290,11 @@ curl -X POST http://cray-hbtd/hmi/v1/hbstates \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/hbstates', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates', headers = headers)
 
 print(r.json())
 
@@ -301,10 +313,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/hbstates", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -364,8 +377,9 @@ Sends a list of components to the service in a JSON formatted payload. The servi
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstates, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hbstate_{xname}
@@ -373,26 +387,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/hbstate/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/hbstate/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}', headers = headers)
 
 print(r.json())
 
@@ -410,10 +426,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/hbstate/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +473,9 @@ Query the service for the heartbeat status of a single component.  The service w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found. Endpoint not available. Check IP routing between managed and management plane. Check that any SMS node services are running on management plane. Check that SMS node API gateway service is running on management plane. Check that SMS node HMI service is running on management plane.|[Error](#schemaerror)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstate/{xname}, only GET operations are allowed.|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-params">params</h1>
@@ -467,26 +485,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: */*
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/params \
-  -H 'Accept: */*'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -504,10 +524,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -551,8 +572,9 @@ Fetch current heartbeat tracker configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__params
@@ -560,8 +582,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -569,9 +591,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X PATCH http://cray-hbtd/hmi/v1/params \
+curl -X PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -579,10 +602,11 @@ curl -X PATCH http://cray-hbtd/hmi/v1/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -601,10 +625,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -672,8 +697,9 @@ Set one or more configurable parameters for the heartbeat tracker service and ha
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-health">health</h1>
@@ -683,26 +709,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/health HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health', headers = headers)
 
 print(r.json())
 
@@ -720,10 +748,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -774,8 +803,9 @@ Status Code **200**
 |» MsgBus|string|true|none|Status of the connection with the message bus.|
 |» HsmStatus|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included here.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -783,26 +813,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/liveness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -820,10 +852,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -862,8 +895,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -871,26 +905,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/readiness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -908,10 +944,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -950,8 +987,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/hmnfd.md
+++ b/api/hmnfd.md
@@ -53,7 +53,9 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2">https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2</a>
 
-* <a href="http://cray-hmnfd/hmi/v2">http://cray-hmnfd/hmi/v2</a>
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="hms-notification-fanout-daemon-subscriptions">subscriptions</h1>
 
@@ -75,14 +77,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions', headers = headers)
@@ -103,6 +107,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -163,8 +168,9 @@ Retrieve all information on currently held State Change Notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSubscriptionInfoXName
@@ -183,14 +189,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}', headers = headers)
@@ -211,6 +219,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -278,8 +287,9 @@ Retrieve currently held State Change Notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXName
@@ -298,14 +308,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents', headers = headers)
@@ -326,6 +338,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -377,8 +390,9 @@ Delete all state change notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPOSTV2
@@ -399,7 +413,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -407,7 +422,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{x
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -429,6 +445,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -503,8 +520,9 @@ Subscribe to state change notifications for a set of components. Once this is do
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPATCHV2
@@ -525,7 +543,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -533,7 +552,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -555,6 +575,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -629,8 +650,9 @@ Modify an existing subscription to state change notifications for a  component a
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXNameAgentV2
@@ -649,14 +671,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -677,6 +701,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -729,8 +754,9 @@ Delete a specific state change notification subscription associated  with a targ
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-scn">scn</h1>
@@ -755,7 +781,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -763,7 +790,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn', headers = headers)
@@ -785,6 +813,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -850,8 +879,9 @@ Send a state change notification for fanout to subscribers. This is the API endp
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-params">params</h1>
@@ -872,14 +902,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -900,6 +932,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -950,8 +983,9 @@ Retrieve a JSON-formatted list of current configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doParamsPatch
@@ -972,7 +1006,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -980,7 +1015,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -1002,6 +1038,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1071,8 +1108,9 @@ Change the value of one or more configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-health">health</h1>
@@ -1091,14 +1129,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health', headers = headers)
@@ -1119,6 +1159,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1177,8 +1218,9 @@ Status Code **200**
 |» PruneMap|string|true|none|Status of the list of subscriptions to be pruned.|
 |» WorkerPool|string|true|none|Status of the worker pool servicing the notifications.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1195,14 +1237,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness', headers = headers)
@@ -1223,6 +1267,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1265,8 +1310,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1283,14 +1329,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness', headers = headers)
@@ -1311,6 +1359,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1353,8 +1402,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/ims.md
+++ b/api/ims.md
@@ -106,9 +106,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/ims">https://api-gw-service-nmn.local/apis/ims</a>
 
-* <a href="cray-ims.services.svc.cluster.local">cray-ims.services.svc.cluster.local</a>
-
 License: <a href="http://www.hpe.com/">Hewlett Packard Enterprise Development LP</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="image-management-service-images">images</h1>
 
@@ -130,14 +132,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -158,6 +162,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -227,8 +232,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_image
@@ -249,7 +255,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -257,7 +264,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -279,6 +287,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -345,8 +354,9 @@ Create a new ImageRecord and register the new image with IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_images
@@ -365,14 +375,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -393,6 +405,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -434,8 +447,9 @@ Delete all ImageRecords. Deleted images are soft deleted and added to the /delet
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_image
@@ -454,14 +468,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -482,6 +498,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -533,8 +550,9 @@ Retrieve an image by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_image
@@ -555,7 +573,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -563,7 +582,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -585,6 +605,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -653,8 +674,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_image
@@ -673,14 +695,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -701,6 +725,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -749,8 +774,9 @@ Delete an ImageRecord by ID. Deleted images are soft deleted and added to the /d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_images
@@ -769,14 +795,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -797,6 +825,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -868,8 +897,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_images
@@ -888,14 +918,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -916,6 +948,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -957,8 +990,9 @@ Permanently delete all DeletedImageRecords. Associated artifacts are permanently
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_images
@@ -979,7 +1013,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -987,7 +1022,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -1009,6 +1045,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1068,8 +1105,9 @@ Restore all DeletedImageRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_image
@@ -1088,14 +1126,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1116,6 +1156,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1168,8 +1209,9 @@ Retrieve deleted image details by using deleted_image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_image
@@ -1188,14 +1230,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1216,6 +1260,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1264,8 +1309,9 @@ Permanently delete image record associated with deleted_image_id. Associated art
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_image
@@ -1286,7 +1332,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1294,7 +1341,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{delet
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1316,6 +1364,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1376,8 +1425,9 @@ Restore a DeletedImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_images
@@ -1396,14 +1446,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1424,6 +1476,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1493,8 +1546,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_image
@@ -1515,7 +1569,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1523,7 +1578,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1545,6 +1601,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1612,8 +1669,9 @@ Create a new ImageRecord and register the new image with IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_images
@@ -1632,14 +1690,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1660,6 +1720,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1707,8 +1768,9 @@ Delete all ImageRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_image
@@ -1727,14 +1789,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1755,6 +1819,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1806,8 +1871,9 @@ Retrieve an image by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_image
@@ -1828,7 +1894,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1836,7 +1903,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1858,6 +1926,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1926,8 +1995,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_image
@@ -1946,14 +2016,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1974,6 +2046,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2023,8 +2096,9 @@ Delete an ImageRecord by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-healthz">healthz</h1>
@@ -2047,14 +2121,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/ready \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/ready', headers = headers)
@@ -2075,6 +2151,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2105,8 +2182,9 @@ Readiness probe for IMS. This is used by Kubernetes to determine if IMS is ready
 
 <h3 id="get_healthz_ready-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_healthz_live
@@ -2125,14 +2203,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/live \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/live', headers = headers)
@@ -2153,6 +2233,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2183,8 +2264,9 @@ Liveness probe for IMS. This is used by Kubernetes to determine if IMS is respon
 
 <h3 id="get_healthz_live-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-jobs">jobs</h1>
@@ -2207,14 +2289,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2235,6 +2319,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2360,8 +2445,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_job
@@ -2382,7 +2468,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2390,7 +2477,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2412,6 +2500,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2552,8 +2641,9 @@ depending on request body parameter, job_type.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_jobs
@@ -2572,14 +2662,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2600,6 +2692,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2664,8 +2757,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_job
@@ -2684,14 +2778,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2712,6 +2808,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2789,8 +2886,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_job
@@ -2811,7 +2909,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2819,7 +2918,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2841,6 +2941,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2931,8 +3032,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_job
@@ -2951,14 +3053,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2979,6 +3083,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3027,8 +3132,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_jobs
@@ -3047,14 +3153,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3075,6 +3183,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3200,8 +3309,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_job
@@ -3222,7 +3332,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3230,7 +3341,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3252,6 +3364,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3392,8 +3505,9 @@ depending on request body parameter, job_type.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_jobs
@@ -3412,14 +3526,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3440,6 +3556,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3504,8 +3621,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_job
@@ -3524,14 +3642,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3552,6 +3672,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3629,8 +3750,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_job
@@ -3651,7 +3773,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3659,7 +3782,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3681,6 +3805,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3771,8 +3896,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_job
@@ -3791,14 +3917,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3819,6 +3947,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3867,8 +3996,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-recipes">recipes</h1>
@@ -3891,14 +4021,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -3919,6 +4051,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4008,8 +4141,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipes
@@ -4030,7 +4164,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4038,7 +4173,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4060,6 +4196,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4145,8 +4282,9 @@ A compressed Kiwi-NG image description is actually stored in the artifact reposi
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_recipes
@@ -4165,14 +4303,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4193,6 +4333,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4234,8 +4375,9 @@ Delete all RecipeRecords. Deleted recipes are soft deleted and added to the /del
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_recipe
@@ -4254,14 +4396,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4282,6 +4426,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4341,8 +4486,9 @@ Retrieve a RecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_recipe
@@ -4363,7 +4509,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4371,7 +4518,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4393,6 +4541,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4477,8 +4626,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_recipe
@@ -4497,14 +4647,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4525,6 +4677,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4573,8 +4726,9 @@ Delete a RecipeRecord by ID. The deleted recipes are soft deleted and added to t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_recipes
@@ -4593,14 +4747,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4621,6 +4777,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4703,8 +4860,9 @@ Status Code **200**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_recipes
@@ -4723,14 +4881,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4751,6 +4911,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4792,8 +4953,9 @@ Permanently delete all DeletedRecipeRecords. Associated artifacts are permanentl
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_recipes
@@ -4814,7 +4976,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4822,7 +4985,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4844,6 +5008,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4903,8 +5068,9 @@ Restore all DeletedRecipeRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_recipe
@@ -4923,14 +5089,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -4951,6 +5119,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5005,8 +5174,9 @@ Retrieve a DeletedRecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A deleted recipe record|[DeletedRecipeRecord](#schemadeletedreciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_recipe
@@ -5025,14 +5195,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5053,6 +5225,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5101,8 +5274,9 @@ Permanently delete a DeletedRecipeRecord by ID. Associated artifacts are permane
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_recipe
@@ -5123,7 +5297,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5131,7 +5306,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{reci
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5153,6 +5329,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5213,8 +5390,9 @@ Restore a DeletedRecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_recipes
@@ -5233,14 +5411,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5261,6 +5441,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5350,8 +5531,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipe
@@ -5372,7 +5554,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5380,7 +5563,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5402,6 +5586,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5487,8 +5672,9 @@ A compressed Kiwi-NG image description is actually stored in the artifact reposi
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_recipes
@@ -5507,14 +5693,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5535,6 +5723,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5582,8 +5771,9 @@ Delete all RecipeRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_recipe
@@ -5602,14 +5792,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5630,6 +5822,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5689,8 +5882,9 @@ Retrieve a RecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_recipe
@@ -5711,7 +5905,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5719,7 +5914,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5741,6 +5937,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5825,8 +6022,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_recipe
@@ -5845,14 +6043,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5873,6 +6073,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5922,8 +6123,9 @@ Delete a recipe by ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-public-keys">public keys</h1>
@@ -5946,14 +6148,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -5974,6 +6178,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6027,8 +6232,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_public_key
@@ -6049,7 +6255,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6057,7 +6264,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6079,6 +6287,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6135,8 +6344,9 @@ Create a new public SSH key record. Uploaded by administrator to allow them to a
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_public_keys
@@ -6155,14 +6365,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6183,6 +6395,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6224,8 +6437,9 @@ Delete all public key-records. Deleted public-keys are soft deleted and added to
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_public_key
@@ -6244,14 +6458,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6272,6 +6488,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6318,8 +6535,9 @@ Retrieve a public key by public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_public_key
@@ -6338,14 +6556,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6366,6 +6586,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6414,8 +6635,9 @@ Delete a PublicKeyRecord by ID. Deleted public-keys are soft deleted and added t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_public_keys
@@ -6434,14 +6656,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6462,6 +6686,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6517,8 +6742,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_public_keys
@@ -6537,14 +6763,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6565,6 +6793,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6606,8 +6835,9 @@ Permanently delete all public key-records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|PublicKey records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_public_keys
@@ -6628,7 +6858,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6636,7 +6867,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6658,6 +6890,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6717,8 +6950,9 @@ Restore all DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_public_key
@@ -6737,14 +6971,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6765,6 +7001,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6812,8 +7049,9 @@ Retrieve a deleted public key by deleted_public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_public_key
@@ -6832,14 +7070,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6860,6 +7100,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6908,8 +7149,9 @@ Permanently delete a DeletedPublicKeyRecord by ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_public_key
@@ -6930,7 +7172,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6938,7 +7181,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6960,6 +7204,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7020,8 +7265,9 @@ Restore a DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_public_keys
@@ -7040,14 +7286,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7068,6 +7316,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7121,8 +7370,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_public_key
@@ -7143,7 +7393,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7151,7 +7402,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7173,6 +7425,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7229,8 +7482,9 @@ Create a new public SSH key record. Uploaded by administrator to allow them to a
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_public_keys
@@ -7249,14 +7503,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7277,6 +7533,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7318,8 +7575,9 @@ Delete all public key records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_public_key
@@ -7338,14 +7596,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7366,6 +7626,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7412,8 +7673,9 @@ Retrieve a public key by public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_public_key
@@ -7432,14 +7694,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7460,6 +7724,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7508,8 +7773,9 @@ Delete a public key by public_key_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-version">version</h1>
@@ -7532,14 +7798,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/version', headers = headers)
@@ -7560,6 +7828,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7594,8 +7863,9 @@ Retrieve the version of the IMS Service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|IMS Version|string|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/nls.md
+++ b/api/nls.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="/apis">/apis</a>
+* <a href="https://api-gw-service-nmn.local/apis">https://api-gw-service-nmn.local/apis</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="ncn-lifecycle-service-ncn-lifecycle-events">NCN Lifecycle Events</h1>
 
@@ -15,8 +19,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/reboot HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -24,9 +28,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/reboot \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -34,10 +39,11 @@ curl -X POST /apis/nls/v1/ncns/reboot \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/reboot', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot', headers = headers)
 
 print(r.json())
 
@@ -56,10 +62,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/reboot", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -114,8 +121,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__nls_v1_ncns_rebuild
@@ -123,8 +131,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/rebuild HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -132,9 +140,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/rebuild \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -142,10 +151,11 @@ curl -X POST /apis/nls/v1/ncns/rebuild \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/rebuild', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild', headers = headers)
 
 print(r.json())
 
@@ -164,10 +174,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/rebuild", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -229,8 +240,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="ncn-lifecycle-service-workflow-management">Workflow Management</h1>
@@ -240,26 +252,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/nls/v1/workflows HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/nls/v1/workflows HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/nls/v1/workflows \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/nls/v1/workflows \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/nls/v1/workflows', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/nls/v1/workflows', headers = headers)
 
 print(r.json())
 
@@ -277,10 +291,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/nls/v1/workflows", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/nls/v1/workflows", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -334,8 +349,9 @@ Status Code **200**
 |» name|string|false|none|none|
 |» status|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__nls_v1_workflows_{name}
@@ -343,26 +359,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/nls/v1/workflows/{name} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/nls/v1/workflows/{name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/nls/v1/workflows/{name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}', headers = headers)
 
 print(r.json())
 
@@ -380,10 +398,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/nls/v1/workflows/{name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -422,8 +441,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_rerun
@@ -431,26 +451,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/rerun HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/rerun \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/rerun', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun', headers = headers)
 
 print(r.json())
 
@@ -468,10 +490,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/rerun", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -510,8 +533,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_retry
@@ -519,8 +543,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/retry HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -528,9 +552,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/retry \
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -538,10 +563,11 @@ curl -X PUT /apis/nls/v1/workflows/{name}/retry \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/retry', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry', headers = headers)
 
 print(r.json())
 
@@ -560,10 +586,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/retry", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -612,8 +639,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/power-control.md
+++ b/api/power-control.md
@@ -38,13 +38,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/power-control/v1">https://api-gw-service-nmn.local/apis/power-control/v1</a>
 
-* <a href="http://cray-power-control/v1">http://cray-power-control/v1</a>
-
-* <a href="https://loki-ncn-m001.us.cray.com/apis/power-control/v1">https://loki-ncn-m001.us.cray.com/apis/power-control/v1</a>
-
-* <a href="http://localhost:26970">http://localhost:26970</a>
-
  License: MIT
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="power-control-service-pcs--transitions">transitions</h1>
 
@@ -66,7 +64,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -74,7 +73,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions 
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -96,6 +96,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -157,8 +158,9 @@ Request to perform power transitions.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented starting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions
@@ -175,14 +177,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -203,6 +207,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -259,8 +264,9 @@ are automatically deleted.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[transitions_getAll](#schematransitions_getall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transitions|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions_{transitionID}
@@ -277,14 +283,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -305,6 +313,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -371,8 +380,9 @@ transitionID.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__transitions_{transitionID}
@@ -389,14 +399,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -417,6 +429,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -463,8 +476,9 @@ Attempt to abort an in-progress transition by transitionID
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TransitionID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented abort signaling|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-status">power-status</h1>
@@ -485,14 +499,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-status', headers = headers)
@@ -513,6 +529,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -581,8 +598,9 @@ Retrieve the power state of the component specified by xname.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-cap">power-cap</h1>
@@ -605,7 +623,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -613,7 +632,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/sn
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot', headers = headers)
@@ -635,6 +655,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -690,8 +711,9 @@ Get power cap snapshot for a set of targets.  This operation returns a taskID to
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__power-cap
@@ -710,7 +732,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -718,7 +741,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -740,6 +764,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -803,8 +828,9 @@ Set power cap parameters for a list of targets.  The PATCH payload contains the 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap
@@ -821,14 +847,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -849,6 +877,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -901,8 +930,9 @@ func main() {
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. The data was successfully retrieved|[power_cap_task_list](#schemapower_cap_task_list)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap_{taskID}
@@ -919,14 +949,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID}', headers = headers)
@@ -947,6 +979,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1023,8 +1056,9 @@ Queries the current status for the specified taskID. Use the taskID returned fro
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TaskID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--cli_ignore">cli_ignore</h1>
@@ -1041,14 +1075,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1063,6 +1101,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/liveness", data)
@@ -1088,8 +1130,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1104,14 +1147,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1126,6 +1173,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/readiness", data)
@@ -1151,8 +1202,9 @@ Get readiness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1169,14 +1221,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/health', headers = headers)
@@ -1197,6 +1251,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1245,8 +1300,9 @@ This is primarily intended as a diagnostic tool to investigate the functioning o
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) Network API call success|[health_rsp](#schemahealth_rsp)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted. For /health, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/scsd.md
+++ b/api/scsd.md
@@ -71,11 +71,13 @@ Set TPM State in the BIOS settings.
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/scsd/v1">http://api-gw-service-nmn.local/apis/scsd/v1</a>
-
-* <a href="http://cray-scsd/v1">http://cray-scsd/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/scsd/v1">https://api-gw-service-nmn.local/apis/scsd/v1</a>
 
  License: Cray Proprietary
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="system-configuration-service-nwp">nwp</h1>
 
@@ -86,7 +88,7 @@ Endpoints that set or get Redfish Network Protocol information
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -95,9 +97,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -105,10 +108,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
 
 print(r.json())
 
@@ -127,10 +131,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -203,8 +208,9 @@ Get the Redfish Network Protocol data (NTP server, syslog server, SSH key) for a
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_loadcfg
@@ -212,7 +218,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -221,9 +227,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -231,10 +238,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
 
 print(r.json())
 
@@ -253,10 +261,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -329,8 +338,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_cfg_{xname}
@@ -338,7 +348,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -346,18 +356,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -375,10 +387,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -433,8 +446,9 @@ Retrieve selected Redfish network protocol data for a single target. You can sel
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_cfg_{xname}
@@ -442,7 +456,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -451,9 +465,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -461,10 +476,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -483,10 +499,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -552,8 +569,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-creds">creds</h1>
@@ -565,7 +583,7 @@ Endpoints that set Redfish access credentials
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -574,9 +592,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -584,10 +603,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
 
 print(r.json())
 
@@ -606,10 +626,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -674,8 +695,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_creds_{xname}
@@ -683,7 +705,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -692,9 +714,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -702,10 +725,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
 
 print(r.json())
 
@@ -724,10 +748,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -782,8 +807,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_creds
@@ -791,7 +817,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -799,18 +825,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
 
 print(r.json())
 
@@ -828,10 +856,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -878,8 +907,9 @@ Fetch controller login credentials for a specified targets.  Targets are specifi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET, POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_globalcreds
@@ -887,7 +917,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -896,9 +926,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -906,10 +937,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
 
 print(r.json())
 
@@ -928,10 +960,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -992,8 +1025,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-bios">bios</h1>
@@ -1005,7 +1039,7 @@ Endpoints that set or get BIOS information
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1013,18 +1047,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1042,10 +1078,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1094,8 +1131,9 @@ Fetch the current BIOS setting for the TPM State.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__bmc_bios_{xname}_{bios_field}
@@ -1103,7 +1141,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1112,9 +1150,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1122,10 +1161,11 @@ curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bio
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1144,10 +1184,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1208,8 +1249,9 @@ Set the TPM State in the BIOS settings.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-version">version</h1>
@@ -1221,7 +1263,7 @@ Endpoints that perform health and version checks
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1229,18 +1271,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
 
 print(r.json())
 
@@ -1258,10 +1302,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1295,8 +1340,9 @@ Retrieve service version information.  Version is returned in vmaj.min.bld forma
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-certs">certs</h1>
@@ -1308,7 +1354,7 @@ Endpoints that create, delete, fetch, and apply TLS certs
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1317,9 +1363,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1327,10 +1374,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
 
 print(r.json())
 
@@ -1349,10 +1397,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1409,8 +1458,9 @@ Create TLS cert/key pairs for a set of BMC targets.  A TLS cert/key is created p
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_deletecerts
@@ -1418,7 +1468,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1427,9 +1477,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1437,10 +1488,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
 
 print(r.json())
 
@@ -1459,10 +1511,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1519,8 +1572,9 @@ Delete TLS cert/key information for domain-level TLS certs based on the given ta
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_fetchcerts
@@ -1528,7 +1582,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1537,9 +1591,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1547,10 +1602,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
 
 print(r.json())
 
@@ -1569,10 +1625,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1633,8 +1690,9 @@ Fetches BMC TLS certs previously created using the /bmc/createcerts endpoint and
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcerts
@@ -1642,7 +1700,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1651,9 +1709,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1661,10 +1720,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
 
 print(r.json())
 
@@ -1683,10 +1743,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1744,8 +1805,9 @@ Apply TLS cert/key pairs, previously generated using the /bmc/createcerts endpoi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcert_{xname}
@@ -1753,21 +1815,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}')
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1783,8 +1849,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1816,8 +1886,9 @@ Apply a TLS cert/key pairs previously generated using the /bmc/createcerts endpo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-cli_ignore">cli_ignore</h1>
@@ -1827,21 +1898,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/liveness')
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1857,8 +1932,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1881,8 +1960,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1890,21 +1970,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/readiness')
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1920,8 +2004,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1944,8 +2032,9 @@ Get readiness status of the service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1953,7 +2042,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1961,18 +2050,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
 
 print(r.json())
 
@@ -1990,10 +2081,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2029,8 +2121,9 @@ Get readiness status of the service
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|The service encountered an error when gathering health information|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/sls.md
+++ b/api/sls.md
@@ -121,9 +121,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/sls/v1">https://api-gw-service-nmn.local/apis/sls/v1</a>
 
-* <a href="http://cray-sls">http://cray-sls</a>
-
  License: Cray Proprietary
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="system-layout-service-hardware">hardware</h1>
 
@@ -143,14 +145,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -171,6 +175,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -345,8 +350,9 @@ Status Code **200**
 |NodeType|Storage|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__hardware
@@ -365,7 +371,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -373,7 +380,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -395,6 +403,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -467,8 +476,9 @@ Create a new hardware object.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hardware_{xname}
@@ -485,14 +495,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -513,6 +525,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -568,8 +581,9 @@ Retrieve information about the requested xname. All properties are returned as a
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[hardware](#schemahardware)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__hardware_{xname}
@@ -588,7 +602,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -596,7 +611,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -618,6 +634,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -690,8 +707,9 @@ Update a hardware object.  Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__hardware_{xname}
@@ -706,14 +724,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -728,6 +750,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}", data)
@@ -760,8 +786,9 @@ Delete the requested xname from SLS. Note that if you delete a parent object, th
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname not found|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The xname probably still had children.|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-search">search</h1>
@@ -782,14 +809,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/hardware', headers = headers)
@@ -810,6 +839,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1009,8 +1039,9 @@ Status Code **200**
 |NodeType|Storage|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__search_networks
@@ -1027,14 +1058,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/networks', headers = headers)
@@ -1055,6 +1088,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1172,8 +1206,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-dumpstate">dumpstate</h1>
@@ -1194,14 +1229,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/dumpstate', headers = headers)
@@ -1222,6 +1259,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1375,8 +1413,9 @@ Get a dump of current service state. The format of this is implementation-specif
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|State dumped successfully|[slsState](#schemaslsstate)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred in state dumping.  See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loadstate
@@ -1393,14 +1432,16 @@ Content-Type: multipart/form-data
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-  -H 'Content-Type: multipart/form-data'
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'multipart/form-data'
+  'Content-Type': 'multipart/form-data',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/loadstate', headers = headers)
@@ -1421,6 +1462,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1613,8 +1655,9 @@ sls_dump:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|State loaded successfully|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Loading state failed.  See body for error|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-misc">misc</h1>
@@ -1635,14 +1678,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/health', headers = headers)
@@ -1663,6 +1708,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1714,8 +1760,9 @@ Status Code **200**
 |» Vault|string|true|none|Status of the Vault.|
 |» DBConnection|string|true|none|Status of the connection with the database.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1732,14 +1779,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/liveness', headers = headers)
@@ -1760,6 +1809,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1802,8 +1852,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1820,14 +1871,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/readiness', headers = headers)
@@ -1848,6 +1901,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1890,8 +1944,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__version
@@ -1908,14 +1963,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/version', headers = headers)
@@ -1936,6 +1993,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1977,8 +2035,9 @@ Retrieve the current version of the SLS mapping. Information returned is a JSON 
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Information retrieved successfully|[versionResponse](#schemaversionresponse)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred, see text of response for more information|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-network">network</h1>
@@ -1997,14 +2056,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2025,6 +2086,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2133,8 +2195,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__networks
@@ -2151,14 +2214,16 @@ Content-Type: application/json
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Content-Type: application/json'
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'application/json'
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2179,6 +2244,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2255,8 +2321,9 @@ Create a new network. Must include all fields at the time of upload.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Network with that name already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__networks_{network}
@@ -2273,14 +2340,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2301,6 +2370,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2380,8 +2450,9 @@ Retrieve the specific network.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[network](#schemanetwork)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No network item found with requested name|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__networks_{network}
@@ -2400,7 +2471,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2408,7 +2480,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2430,6 +2503,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2554,8 +2628,9 @@ Update a network object. Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__networks_{network}
@@ -2570,14 +2645,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
 
 print(r.json())
 
@@ -2592,6 +2671,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}", data)
@@ -2623,8 +2706,9 @@ Delete the specific network from SLS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. Network removed|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Network not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/smd.md
+++ b/api/smd.md
@@ -107,7 +107,11 @@ Generally, nodes transition 'Off' -> 'On' -> 'Ready' when going from 'Off' to bo
 
 Base URLs:
 
-* <a href="https://sms/apis/smd/hsm/v2">https://sms/apis/smd/hsm/v2</a>
+* <a href="https://api-gw-service-nmn.local/apis/smd/hsm/v2">https://api-gw-service-nmn.local/apis/smd/hsm/v2</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="hardware-state-manager-api-service-info">Service Info</h1>
 
@@ -120,26 +124,28 @@ Service information APIs for getting information on the HSM service such as read
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/ready HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/ready \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/ready', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready', headers = headers)
 
 print(r.json())
 
@@ -157,10 +163,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/ready", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -197,8 +204,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is unhealthy and not ready|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doLivenessGet
@@ -208,26 +216,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/liveness HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness', headers = headers)
 
 print(r.json())
 
@@ -245,10 +255,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -288,8 +299,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doValuesGet
@@ -299,26 +311,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values', headers = headers)
 
 print(r.json())
 
@@ -336,10 +350,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -370,8 +385,9 @@ null
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of parameters and their valid values.|[Values.1.0.0_Values](#schemavalues.1.0.0_values)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doArchValuesGet
@@ -381,26 +397,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/arch HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/arch \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/arch', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch', headers = headers)
 
 print(r.json())
 
@@ -418,10 +436,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/arch", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +475,9 @@ Retrieve all valid values for use with the 'arch' (component architecture) param
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'arch' parameter.|[Values.1.0.0_ArchArray](#schemavalues.1.0.0_archarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doClassValuesGet
@@ -467,26 +487,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/class HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/class \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/class', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class', headers = headers)
 
 print(r.json())
 
@@ -504,10 +526,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/class", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -542,8 +565,9 @@ Retrieve all valid values for use with the 'class' (hardware class) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'class' parameter.|[Values.1.0.0_ClassArray](#schemavalues.1.0.0_classarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doFlagValuesGet
@@ -553,26 +577,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/flag HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/flag \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/flag', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag', headers = headers)
 
 print(r.json())
 
@@ -590,10 +616,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/flag", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -628,8 +655,9 @@ Retrieve all valid values for use with the 'flag' (component flag) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'flag' parameter.|[Values.1.0.0_FlagArray](#schemavalues.1.0.0_flagarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNetTypeValuesGet
@@ -639,26 +667,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/nettype \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/nettype', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype', headers = headers)
 
 print(r.json())
 
@@ -676,10 +706,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/nettype", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -714,8 +745,9 @@ Retrieve all valid values for use with the 'nettype' (component network type) pa
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'nettype' parameter.|[Values.1.0.0_NetTypeArray](#schemavalues.1.0.0_nettypearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRoleValuesGet
@@ -725,26 +757,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/role HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/role \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/role', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role', headers = headers)
 
 print(r.json())
 
@@ -762,10 +796,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/role", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -800,8 +835,9 @@ Retrieve all valid values for use with the 'role' (component role) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'role' parameter.|[Values.1.0.0_RoleArray](#schemavalues.1.0.0_rolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubRoleValuesGet
@@ -811,26 +847,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/subrole \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/subrole', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole', headers = headers)
 
 print(r.json())
 
@@ -848,10 +886,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/subrole", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -886,8 +925,9 @@ Retrieve all valid values for use with the 'subrole' (component subrole) paramet
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'subrole' parameter.|[Values.1.0.0_SubRoleArray](#schemavalues.1.0.0_subrolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doStateValuesGet
@@ -897,26 +937,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/state HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/state \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/state', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state', headers = headers)
 
 print(r.json())
 
@@ -934,10 +976,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/state", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -972,8 +1015,9 @@ Retrieve all valid values for use with the 'state' (component state) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'state' parameter.|[Values.1.0.0_StateArray](#schemavalues.1.0.0_statearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doTypeValuesGet
@@ -983,26 +1027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/type HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/type \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/type', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type', headers = headers)
 
 print(r.json())
 
@@ -1020,10 +1066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/type", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1058,8 +1105,9 @@ Retrieve all valid values for use with the 'type' (component HMSType) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'type' parameter.|[Values.1.0.0_TypeArray](#schemavalues.1.0.0_typearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-component">Component</h1>
@@ -1073,26 +1121,28 @@ High-level component information by xname: state, flag, NID, role, etc.
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1110,10 +1160,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1268,8 +1319,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for filter|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsPost
@@ -1279,8 +1331,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1288,9 +1340,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1298,10 +1351,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1320,10 +1374,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1391,8 +1446,9 @@ Create/Update a collection of state/components. If the component already exists 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsDeleteAll
@@ -1402,26 +1458,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1439,10 +1497,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1478,8 +1537,9 @@ Delete all entries in the components collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentGet
@@ -1489,26 +1549,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1526,10 +1588,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1584,8 +1647,9 @@ Retrieve state or components by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentPut
@@ -1595,8 +1659,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1604,9 +1668,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1614,10 +1679,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1636,10 +1702,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1706,8 +1773,9 @@ Create/Update a state/component. If the component already exists it will not be 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentDelete
@@ -1717,26 +1785,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1754,10 +1824,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1799,8 +1870,9 @@ Delete a component by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDGet
@@ -1810,26 +1882,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
 
 print(r.json())
 
@@ -1847,10 +1921,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1905,8 +1980,9 @@ Retrieve a component by NID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkStateDataPatch
@@ -1916,8 +1992,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1925,9 +2001,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1935,10 +2012,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
 
 print(r.json())
 
@@ -1957,10 +2035,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkStateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2023,8 +2102,9 @@ Specify a list of xnames to update the State and Flag fields. If the Flag field 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompStatePatch
@@ -2034,8 +2114,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2043,9 +2123,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2053,10 +2134,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
 
 print(r.json())
 
@@ -2075,10 +2157,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2139,8 +2222,9 @@ Update the component's state and flag fields only. If Flag field is omitted, the
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkFlagOnlyPatch
@@ -2150,8 +2234,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2159,9 +2243,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2169,10 +2254,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2191,10 +2277,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2255,8 +2342,9 @@ Specify a list of xnames to update the Flag field and specify the value. The lis
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompFlagOnlyPatch
@@ -2266,8 +2354,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2275,9 +2363,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2285,10 +2374,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2307,10 +2397,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2369,8 +2460,9 @@ The State is not modified. Only the Flag is updated.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkEnabledPatch
@@ -2380,8 +2472,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2389,9 +2481,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2399,10 +2492,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
 
 print(r.json())
 
@@ -2421,10 +2515,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2485,8 +2580,9 @@ Update the Enabled field for a list of xnames. Specify a single value for Enable
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEnabledPatch
@@ -2496,8 +2592,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2505,9 +2601,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2515,10 +2612,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
 
 print(r.json())
 
@@ -2537,10 +2635,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2599,8 +2698,9 @@ Update the component's Enabled field only. The State and other fields are not mo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkSwStatusPatch
@@ -2610,8 +2710,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2619,9 +2719,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2629,10 +2730,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2651,10 +2753,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2715,8 +2818,9 @@ Update the SoftwareStatus field for a list of xnames. Specify a single new value
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompSwStatusPatch
@@ -2726,8 +2830,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2735,9 +2839,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2745,10 +2850,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2767,10 +2873,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2829,8 +2936,9 @@ Update the component's SoftwareStatus field only. The State and other fields are
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkRolePatch
@@ -2840,8 +2948,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2849,9 +2957,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2859,10 +2968,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
 
 print(r.json())
 
@@ -2881,10 +2991,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkRole", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2946,8 +3057,9 @@ Update the Role and SubRole field for a list of xnames. Specify the Role and Sub
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompRolePatch
@@ -2957,8 +3069,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2966,9 +3078,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2976,10 +3089,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
 
 print(r.json())
 
@@ -2998,10 +3112,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3061,8 +3176,9 @@ Update the component's Role and SubRole fields only. Valid only for nodes. The S
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompArrayNIDPatch
@@ -3072,8 +3188,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3081,9 +3197,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3091,10 +3208,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
 
 print(r.json())
 
@@ -3113,10 +3231,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkNID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3179,8 +3298,9 @@ Modify the submitted ComponentArray and update the corresponding NID value for e
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompNIDPatch
@@ -3190,8 +3310,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3199,9 +3319,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3209,10 +3330,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
 
 print(r.json())
 
@@ -3231,10 +3353,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3293,8 +3416,9 @@ Update the component's NID field only. Valid only for nodes. State and other fie
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsQueryPost
@@ -3304,8 +3428,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3313,9 +3437,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3323,10 +3448,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query', headers = headers)
 
 print(r.json())
 
@@ -3345,10 +3471,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3462,8 +3589,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDQueryPost
@@ -3473,8 +3601,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3482,9 +3610,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3492,10 +3621,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
 
 print(r.json())
 
@@ -3514,10 +3644,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3591,8 +3722,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentQueryGet
@@ -3602,26 +3734,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -3639,10 +3773,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3798,8 +3933,9 @@ Additional valid values may be added via configuration file. See the results of 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-nodemap">NodeMap</h1>
@@ -3813,26 +3949,28 @@ Given a node xname ID, provide defaults for NID, Role, etc. to be used when the 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3850,10 +3988,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3894,8 +4033,9 @@ Retrieve all Node map entries as a named array, or an empty array if the collect
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPost
@@ -3905,8 +4045,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3914,9 +4054,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3924,10 +4065,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3946,10 +4088,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4018,8 +4161,9 @@ Note the following points:
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapsDeleteAll
@@ -4029,26 +4173,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -4066,10 +4212,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4105,8 +4252,9 @@ Delete all entries in the NodeMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapGet
@@ -4116,26 +4264,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4153,10 +4303,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4200,8 +4351,9 @@ Retrieve NodeMap, i.e. defaults NID/Role/etc. for node located at physical locat
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapDelete
@@ -4211,26 +4363,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4248,10 +4402,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4293,8 +4448,9 @@ Delete NodeMap entry for a specific node {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPut
@@ -4304,8 +4460,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -4313,9 +4469,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4323,10 +4480,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4345,10 +4503,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4406,8 +4565,9 @@ Update or create an entry for an individual node xname using PUT. Note the follo
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventory">HWInventory</h1>
@@ -4421,26 +4581,28 @@ HWInventoryByLocation collection containing all components matching the query th
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4458,10 +4620,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5110,8 +5273,9 @@ Default is NestNodesOnly.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybylocation">HWInventoryByLocation</h1>
@@ -5125,26 +5289,28 @@ Hardware inventory information for the given system location/xname
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5162,10 +5328,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5393,8 +5560,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationPost
@@ -5404,8 +5572,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -5413,9 +5581,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5423,10 +5592,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5445,10 +5615,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5649,8 +5820,9 @@ Create/Update hardware inventory entries
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDeleteAll
@@ -5660,26 +5832,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5697,10 +5871,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5736,8 +5911,9 @@ Delete all entries in the HWInventoryByLocation collection. Note that this does 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationGet
@@ -5747,26 +5923,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -5784,10 +5962,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6056,8 +6235,9 @@ null
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDelete
@@ -6067,26 +6247,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6104,10 +6286,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6149,8 +6332,9 @@ Delete HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybyfru">HWInventoryByFRU</h1>
@@ -6164,26 +6348,28 @@ This represents a physical piece of hardware with properties specific to a uniqu
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6201,10 +6387,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6381,8 +6568,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDeleteAll
@@ -6392,26 +6580,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6429,10 +6619,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6468,8 +6659,9 @@ Delete all entries in the HWInventoryByFRU collection. Note that this does not d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUGet
@@ -6479,26 +6671,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6516,10 +6710,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6574,8 +6769,9 @@ Retrieve HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDelete
@@ -6585,26 +6781,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6622,10 +6820,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6667,8 +6866,9 @@ Delete an entry in the HWInventoryByFRU collection. Note that this does not dele
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventoryhistory">HWInventoryHistory</h1>
@@ -6682,26 +6882,28 @@ Hardware inventory historical information for the given system location/xname/FR
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6719,10 +6921,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6778,8 +6981,9 @@ Retrieve the history entries for all HWInventoryByLocation entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDeleteAll
@@ -6789,26 +6993,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6826,10 +7032,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6865,8 +7072,9 @@ Delete all HWInventory history entries. Note that this also deletes history for 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationGet
@@ -6876,26 +7084,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6913,10 +7123,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6968,8 +7179,9 @@ Retrieve the history entries for a HWInventoryByLocation entry with a specific x
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDelete
@@ -6979,26 +7191,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7016,10 +7230,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7061,8 +7276,9 @@ Delete history for the HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUsGet
@@ -7072,26 +7288,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
 
 print(r.json())
 
@@ -7109,10 +7327,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7168,8 +7387,9 @@ Retrieve the history entries for all HWInventoryByFRU entries. Sorted by FRU.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUGet
@@ -7179,26 +7399,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7216,10 +7438,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7271,8 +7494,9 @@ Retrieve the history entries for the HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUDelete
@@ -7282,26 +7506,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7319,10 +7545,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7364,8 +7591,9 @@ Delete history for an entry in the HWInventoryByFRU collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-redfishendpoint">RedfishEndpoint</h1>
@@ -7379,26 +7607,28 @@ This is a BMC or other Redfish controller that has a Redfish entry point and Red
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7416,10 +7646,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7531,8 +7762,9 @@ Retrieve all Redfish endpoint entries as a named array, optionally filtering it.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsPost
@@ -7542,8 +7774,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7551,9 +7783,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7561,10 +7794,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7583,10 +7817,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7672,8 +7907,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsDeleteAll
@@ -7683,26 +7919,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7720,10 +7958,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7759,8 +7998,9 @@ Delete all entries in the RedfishEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointGet
@@ -7770,26 +8010,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7807,10 +8049,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7871,8 +8114,9 @@ Retrieve RedfishEndpoint, located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointDelete
@@ -7882,26 +8126,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7919,10 +8165,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7964,8 +8211,9 @@ Delete RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPut
@@ -7975,8 +8223,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7984,9 +8232,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7994,10 +8243,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8016,10 +8266,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8102,8 +8353,9 @@ Create or update RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPatch
@@ -8113,8 +8365,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -8122,9 +8374,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -8132,10 +8385,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8154,10 +8408,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8240,8 +8495,9 @@ Update (PATCH) RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointQueryGet
@@ -8251,26 +8507,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8288,10 +8546,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8356,8 +8615,9 @@ Given xname and modifiers in query string, retrieve zero or more RedfishEndpoint
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matches|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentendpoint">ComponentEndpoint</h1>
@@ -8371,26 +8631,28 @@ The Redfish-discovered properties for a component discovered through, and manage
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8408,10 +8670,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8566,8 +8829,9 @@ Retrieve the full collection of ComponentEndpoints in the form of a ComponentEnd
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointsDeleteAll
@@ -8577,26 +8841,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8614,10 +8880,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8653,8 +8920,9 @@ Delete all entries in the ComponentEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointGet
@@ -8664,26 +8932,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8701,10 +8971,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8808,8 +9079,9 @@ Retrieve ComponentEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointDelete
@@ -8819,26 +9091,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8856,10 +9130,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8901,8 +9176,9 @@ Delete ComponentEndpoint for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-serviceendpoint">ServiceEndpoint</h1>
@@ -8916,26 +9192,28 @@ The Redfish-discovered properties for a service discovered through, and managed 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8953,10 +9231,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9046,8 +9325,9 @@ Retrieve the full collection of ServiceEndpoints in the form of a ServiceEndpoin
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsDeleteAll
@@ -9057,26 +9337,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -9094,10 +9376,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9133,8 +9416,9 @@ Delete all entries in the ServiceEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsGet
@@ -9144,26 +9428,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
 
 print(r.json())
 
@@ -9181,10 +9467,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9275,8 +9562,9 @@ Retrieve all ServiceEndpoint records for the Redfish service.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Service does not exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointGet
@@ -9286,26 +9574,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9323,10 +9613,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9411,8 +9702,9 @@ Retrieve the ServiceEndpoint for a Redfish service that is managed by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointDelete
@@ -9422,26 +9714,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9459,10 +9753,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9505,8 +9800,9 @@ Delete the {service} ServiceEndpoint managed by {xname}
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matching ServiceEndpoint to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentethernetinterfaces">ComponentEthernetInterfaces</h1>
@@ -9520,26 +9816,28 @@ The MAC address to IP address relation for components in the system. If the comp
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9557,10 +9855,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9677,8 +9976,9 @@ Status Code **200**
 |Type|HSNConnector|
 |Type|INVALID|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePostV2
@@ -9688,8 +9988,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -9697,9 +9997,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -9707,10 +10008,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9729,10 +10031,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9797,8 +10100,9 @@ Create a new component Ethernet interface.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate component Ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteAllV2
@@ -9808,26 +10112,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9845,10 +10151,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9884,8 +10191,9 @@ Delete all component Ethernet interface entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceGetV2
@@ -9895,26 +10203,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -9932,10 +10242,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9987,8 +10298,9 @@ Retrieve the component Ethernet interface which was created with the given {ethI
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteV2
@@ -9998,26 +10310,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -10035,10 +10349,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10080,8 +10395,9 @@ Delete the given component Ethernet interface with {ethInterfaceID}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No component Ethernet interface with ethInterfaceID.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePatchV2
@@ -10091,8 +10407,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10100,9 +10416,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10110,10 +10427,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -10132,10 +10450,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10196,8 +10515,9 @@ To update the IP address, CompID, and/or description of a component Ethernet int
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The component Ethernet interface with this ethInterfaceID does not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesGetV2
@@ -10207,26 +10527,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10244,10 +10566,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10301,8 +10624,9 @@ Status Code **200**
 |» IPAddress|string|true|none|The IP address associated with the MAC address for this component Ethernet interface on for this particular network.|
 |» Network|string|false|none|The network that this IP addresses is associated with.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesPostV2
@@ -10312,8 +10636,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10321,9 +10645,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10331,10 +10656,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterf
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10353,10 +10679,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10407,8 +10734,9 @@ Create a new IP address mapping in a component Ethernet interface {ethInterfaceI
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate IP address in component Ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressPatchV2
@@ -10418,8 +10746,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10427,9 +10755,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10437,10 +10766,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10459,10 +10789,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10517,8 +10848,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component Ethernet interface.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressDeleteV2
@@ -10528,26 +10860,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10565,10 +10899,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10611,8 +10946,9 @@ Delete the given IP address mapping with {ipAddress} from a component Ethernet i
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component Ethernet interface|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-group">Group</h1>
@@ -10626,26 +10962,28 @@ A group is an informal, possibly overlapping division of the system that groups 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10663,10 +11001,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10737,8 +11076,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupsPost
@@ -10748,8 +11088,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10757,9 +11097,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10767,10 +11108,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10789,10 +11131,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10878,8 +11221,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupGet
@@ -10889,26 +11233,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -10926,10 +11272,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10985,8 +11332,9 @@ Retrieve the group which was created with the given {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupDelete
@@ -10996,26 +11344,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -11033,10 +11383,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11078,8 +11429,9 @@ Delete the given group with {group_label}. Any members previously in the group w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No group matches label.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupPatch
@@ -11089,8 +11441,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11098,9 +11450,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11108,10 +11461,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -11130,10 +11484,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11191,8 +11546,9 @@ To update the tags array and/or description, a PATCH operation can be used.  Omi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The group with this label did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupLabelsGet
@@ -11202,26 +11558,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/labels HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/labels \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/labels', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels', headers = headers)
 
 print(r.json())
 
@@ -11239,10 +11597,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/labels", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11289,8 +11648,9 @@ Retrieve a string array of all group labels (i.e. group names) that currently ex
 
 <h3 id="dogrouplabelsget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersGet
@@ -11300,26 +11660,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11337,10 +11699,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11387,8 +11750,9 @@ Retrieve members of an existing group {group_label}, optionally filtering the se
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such group {group_label}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersPost
@@ -11398,8 +11762,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11407,9 +11771,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11417,10 +11782,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11439,10 +11805,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11514,8 +11881,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMemberDelete
@@ -11525,26 +11893,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -11562,10 +11932,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11608,8 +11979,9 @@ Delete component {xname_id} from the members of group {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or group.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-partition">Partition</h1>
@@ -11623,26 +11995,28 @@ A partition is a formal, non-overlapping division of the system that forms an ad
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11660,10 +12034,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11732,8 +12107,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionsPost
@@ -11743,8 +12119,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11752,9 +12128,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11762,10 +12139,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11784,10 +12162,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11870,8 +12249,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionGet
@@ -11881,26 +12261,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -11918,10 +12300,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11975,8 +12358,9 @@ Retrieve the partition which was created with the given {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionDelete
@@ -11986,26 +12370,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -12023,10 +12409,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12068,8 +12455,9 @@ Delete partition {partition_name}. Any members previously in the partition will 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No partition matches partition_name.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionPatch
@@ -12079,8 +12467,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12088,9 +12476,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12098,10 +12487,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -12120,10 +12510,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12181,8 +12572,9 @@ Update the tags array and/or description by using PATCH. Omitted fields are not 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The partition with this partition_name did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionNamesGet
@@ -12192,26 +12584,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/names HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/names \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/names', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names', headers = headers)
 
 print(r.json())
 
@@ -12229,10 +12623,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/names", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12277,8 +12672,9 @@ Retrieve a string array of all partition names that currently exist in HSM. Thes
 
 <h3 id="dopartitionnamesget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersGet
@@ -12288,26 +12684,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12325,10 +12723,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12374,8 +12773,9 @@ Retrieve all members of existing partition {partition_name}, optionally filterin
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such partition {partition_name}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersPost
@@ -12385,8 +12785,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12394,9 +12794,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12404,10 +12805,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12426,10 +12828,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12501,8 +12904,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMemberDelete
@@ -12512,26 +12916,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -12549,10 +12955,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12595,8 +13002,9 @@ Delete component {xname_id} from the members of partition {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or partition.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-membership">Membership</h1>
@@ -12610,26 +13018,28 @@ A membership is a mapping of a component xname to its set of group labels and pa
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships', headers = headers)
 
 print(r.json())
 
@@ -12647,10 +13057,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12802,8 +13213,9 @@ Status Code **200**
 |» partitionName|string|false|none|The name is a human-readable identifier for the partition and uniquely identifies it.|
 |» groupLabels|[string]|false|none|An array with all group labels the component is associated with The label is the human-readable identifier for a group and uniquely identifies it.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doMembershipGet
@@ -12813,26 +13225,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
 
 print(r.json())
 
@@ -12850,10 +13264,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12900,8 +13315,9 @@ Display group labels and partition names for a given component xname ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found - no such xname.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discoverystatus">DiscoveryStatus</h1>
@@ -12915,26 +13331,28 @@ Contains status information about the discovery operation for clients to query. 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
 
 print(r.json())
 
@@ -12952,10 +13370,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13014,8 +13433,9 @@ Status Code **200**
 |Status|InProgress|
 |Status|Complete|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDiscoveryStatusGet
@@ -13025,26 +13445,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
 
 print(r.json())
 
@@ -13062,10 +13484,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13109,8 +13532,9 @@ Retrieve DiscoveryStatus entry with the specific ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found (no such ID)|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discover">Discover</h1>
@@ -13124,8 +13548,8 @@ Trigger a discovery of system component data by interrogating all, or a subset, 
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13133,9 +13557,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13143,10 +13568,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
 
 print(r.json())
 
@@ -13165,10 +13591,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Discover", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13242,8 +13669,9 @@ Status Code **200**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-scn">SCN</h1>
@@ -13257,8 +13685,8 @@ Manage subscriptions to state change notifications (SCNs) from HSM.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13266,9 +13694,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13276,10 +13705,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13298,10 +13728,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13380,8 +13811,9 @@ Request a subscription for state change notifications for a set of component sta
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscriptionsAll
@@ -13391,26 +13823,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13428,10 +13862,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13469,8 +13904,9 @@ Delete all subscriptions.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscriptionsAll
@@ -13480,26 +13916,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13517,10 +13955,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13573,8 +14012,9 @@ Retrieve all information on currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPutSCNSubscription
@@ -13584,8 +14024,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13593,9 +14033,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13603,10 +14044,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13625,10 +14067,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13697,8 +14140,9 @@ Update an existing state change notification subscription in whole. This will ov
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPatchSCNSubscription
@@ -13708,8 +14152,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13717,9 +14161,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13727,10 +14172,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13749,10 +14195,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13820,8 +14267,9 @@ Update a subscription for state change notifications to add or remove triggers.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error. Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscription
@@ -13831,26 +14279,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13868,10 +14318,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13916,8 +14367,9 @@ Delete a state change notification subscription.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscription
@@ -13927,26 +14379,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13964,10 +14418,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14021,8 +14476,9 @@ Return the information on a currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-locking">Locking</h1>
@@ -14034,8 +14490,8 @@ Manage locks and reservations on components.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14043,9 +14499,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14053,10 +14510,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
 
 print(r.json())
 
@@ -14075,10 +14533,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/remove", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14183,8 +14642,9 @@ Given a list of components, forcibly deletes any existing reservation. Does not 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations_release
@@ -14192,8 +14652,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14201,9 +14661,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14211,10 +14672,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14233,10 +14695,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14305,8 +14768,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations
@@ -14314,8 +14778,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14323,9 +14787,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14333,10 +14798,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations', headers = headers)
 
 print(r.json())
 
@@ -14355,10 +14821,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14460,8 +14927,9 @@ Creates reservations on a set of xnames of infinite duration.  Component must be
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_release
@@ -14469,8 +14937,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14478,9 +14946,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14488,10 +14957,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14510,10 +14980,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14582,8 +15053,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations
@@ -14591,8 +15063,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14600,9 +15072,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14610,10 +15083,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
 
 print(r.json())
 
@@ -14632,10 +15106,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14739,8 +15214,9 @@ Creates reservations on a set of xnames of finite duration.  Component must be u
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_renew
@@ -14748,8 +15224,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14757,9 +15233,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14767,10 +15244,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
 
 print(r.json())
 
@@ -14789,10 +15267,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/renew", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14862,8 +15341,9 @@ Given a list of {xname & reservation key}, renews the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_check
@@ -14871,8 +15351,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14880,9 +15360,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14890,10 +15371,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
 
 print(r.json())
 
@@ -14912,10 +15394,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/check", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14980,8 +15463,9 @@ Using xname + reservation key check on the validity of reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not check reservations.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_status
@@ -14989,8 +15473,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14998,9 +15482,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15008,10 +15493,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -15030,10 +15516,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15095,8 +15582,9 @@ Using component ID retrieve the status of any lock and/or reservation.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__locks_status
@@ -15104,26 +15592,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/locks/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -15141,10 +15631,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15268,8 +15759,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_lock
@@ -15277,8 +15769,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/lock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15286,9 +15778,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15296,10 +15789,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/lock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock', headers = headers)
 
 print(r.json())
 
@@ -15318,10 +15812,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/lock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15426,8 +15921,9 @@ Using a component create a lock.  Cannot be locked if already locked, or if ther
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not lock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_unlock
@@ -15435,8 +15931,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/unlock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15444,9 +15940,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15454,10 +15951,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/unlock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock', headers = headers)
 
 print(r.json())
 
@@ -15476,10 +15974,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/unlock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15584,8 +16083,9 @@ Using a component unlock a lock.  Cannot be unlocked if already unlocked.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not unlock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_repair
@@ -15593,8 +16093,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/repair HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15602,9 +16102,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15612,10 +16113,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/repair', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair', headers = headers)
 
 print(r.json())
 
@@ -15634,10 +16136,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/repair", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15742,8 +16245,9 @@ Repairs the disabled status of an xname allowing new reservations to be created.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not repair lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_disable
@@ -15751,8 +16255,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/disable HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15760,9 +16264,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15770,10 +16275,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/disable', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable', headers = headers)
 
 print(r.json())
 
@@ -15792,10 +16298,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/disable", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15900,8 +16407,9 @@ Disables the ability to create a reservation on components, deletes any existing
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not disable lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-powermap">PowerMap</h1>
@@ -15915,26 +16423,28 @@ Power mapping of components to the components supplying them power. This may con
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -15952,10 +16462,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15995,8 +16506,9 @@ Retrieve all power map entries as a named array, or an empty array if the collec
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsPost
@@ -16006,8 +16518,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -16015,9 +16527,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -16025,10 +16538,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -16047,10 +16561,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16105,8 +16620,9 @@ Create or update the given set of PowerMaps whose ID fields are each a valid xna
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsDeleteAll
@@ -16116,26 +16632,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -16153,10 +16671,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16192,8 +16711,9 @@ Delete all entries in the PowerMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapGet
@@ -16203,26 +16723,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16240,10 +16762,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16288,8 +16811,9 @@ Retrieve PowerMap for a component located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapDelete
@@ -16299,26 +16823,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16336,10 +16862,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16381,8 +16908,9 @@ Delete PowerMap entry for a specific component {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapPut
@@ -16392,8 +16920,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -16401,9 +16929,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -16411,10 +16940,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16433,10 +16963,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16490,8 +17021,9 @@ Update or create an entry for an individual component xname using PUT. If the PU
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -18747,7 +19279,7 @@ Either way, the 'Target' field is the parent component, partition or system that
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |XName|[XName.1.0.0](#schemaxname.1.0.0)|false|none|Uniquely identifies the component by its physical location (xname). There are formatting rules depending on the matching HMSType.|
-|Format|string|false|none|How results are displayed<br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
+|Format|string|false|none|How results are displayed<br><br><br><br><br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
 |Cabinets|[[HWInvByLocCabinet](#schemahwinvbyloccabinet)]|false|read-only|All components with HMS type 'Cabinet' appropriate given Target component/partition and query type.|
 |Chassis|[[HWInvByLocChassis](#schemahwinvbylocchassis)]|false|read-only|All appropriate components with HMS type 'Chassis' given Target component/partition and query type.|
 |ComputeModules|[[HWInvByLocComputeModule](#schemahwinvbyloccomputemodule)]|false|read-only|All appropriate components with HMS type 'ComputeModule' given Target component/partition and query type.|

--- a/api/sts.md
+++ b/api/sts.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="http://localhost:9090/">http://localhost:9090/</a>
+* <a href="https://api-gw-service-nmn.local/apis/sts">https://api-gw-service-nmn.local/apis/sts</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-sts-token-generator-default">Default</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-PUT http://localhost:9090/token HTTP/1.1
-Host: localhost:9090
+PUT https://api-gw-service-nmn.local/apis/sts/token HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT http://localhost:9090/token \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/sts/token \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://localhost:9090/token', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/sts/token', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://localhost:9090/token", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/sts/token", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -95,8 +102,9 @@ Generates a STS Token.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|A generated STS Token|[Token](#schematoken)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-sts-token-generator-cli_ignore">cli_ignore</h1>
@@ -108,26 +116,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://localhost:9090/healthz HTTP/1.1
-Host: localhost:9090
+GET https://api-gw-service-nmn.local/apis/sts/healthz HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://localhost:9090/healthz \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/sts/healthz \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://localhost:9090/healthz', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/sts/healthz', headers = headers)
 
 print(r.json())
 
@@ -145,10 +155,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://localhost:9090/healthz", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/sts/healthz", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -188,8 +199,9 @@ Status Code **200**
 |---|---|---|---|---|
 |» Status|string|false|read-only|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/tapms-operator.md
+++ b/api/tapms-operator.md
@@ -8,7 +8,11 @@ Read-Only APIs to Retrieve Tenant Status
 
 Base URLs:
 
-* <a href="//cray-tapms/apis/tapms/">//cray-tapms/apis/tapms/</a>
+* <a href="https://api-gw-service-nmn.local/apis/tapms/">https://api-gw-service-nmn.local/apis/tapms/</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="tapms-tenant-status-api-tenant-and-partition-management-system">Tenant and Partition Management System</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET /cray-tapms/apis/tapms/v1alpha2/tenants HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /cray-tapms/apis/tapms/v1alpha2/tenants \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/cray-tapms/apis/tapms/v1alpha2/tenants', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/cray-tapms/apis/tapms/v1alpha2/tenants", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -153,8 +160,9 @@ Status Code **200**
 |»» tenantresources|[[TenantResource](#schematenantresource)]|false|none|The desired resources for the Tenant|
 |»» uuid|string(uuid)|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__v1alpha2_tenants_{id}
@@ -162,26 +170,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /cray-tapms/apis/tapms/v1alpha2/tenants/{id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /cray-tapms/apis/tapms/v1alpha2/tenants/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/cray-tapms/apis/tapms/v1alpha2/tenants/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants/{id}', headers = headers)
 
 print(r.json())
 
@@ -199,10 +209,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/cray-tapms/apis/tapms/v1alpha2/tenants/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms/v1alpha2/tenants/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -279,8 +290,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/uas-mgr.md
+++ b/api/uas-mgr.md
@@ -288,7 +288,11 @@ list of available choices.
 
 Base URLs:
 
-* <a href="/apis/uas-mgr/v1">/apis/uas-mgr/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/uas-mgr/v1">https://api-gw-service-nmn.local/apis/uas-mgr/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="user-access-service-versions">versions</h1>
 
@@ -299,20 +303,25 @@ Base URLs:
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/ HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('/apis/uas-mgr/v1/')
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/', headers = headers)
 
 print(r.json())
 
@@ -328,8 +337,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -351,8 +364,9 @@ Return supported UAS API versions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version response|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uas">uas</h1>
@@ -364,26 +378,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uas HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uas \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -401,10 +417,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -472,8 +489,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai
@@ -483,8 +501,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/uas HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: multipart/form-data
 Accept: application/json
 
@@ -492,9 +510,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/uas \
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
   -H 'Content-Type: multipart/form-data' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -502,10 +521,11 @@ curl -X POST /apis/uas-mgr/v1/uas \
 import requests
 headers = {
   'Content-Type': 'multipart/form-data',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -524,10 +544,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -582,8 +603,9 @@ to ports 80, 443, and 8888.
 
 <h3 id="create_uai-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uai_by_name
@@ -593,25 +615,30 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uas', params={
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', params={
   'uai_list': [
   "uai-asdfgh098",
   "uai-qwerty123"
 ]
-})
+}, headers = headers)
 
 print(r.json())
 
@@ -627,8 +654,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,8 +689,9 @@ associated UAI(s).
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAIs deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete UAI with {uai_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-images">images</h1>
@@ -671,26 +703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/images', headers = headers)
 
 print(r.json())
 
@@ -708,10 +742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -747,8 +782,9 @@ List all available UAS images.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image List|[Image_list](#schemaimage_list)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Images not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uas_image_admin
@@ -758,26 +794,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/images', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', params={
   'imagename': 'docker.local/cray/cray-uas-sles15sp1:latest'
 }, headers = headers)
 
@@ -797,10 +835,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -843,8 +882,9 @@ upload container image.  Optionally, set default.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image added|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Image not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_images_admin
@@ -854,26 +894,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', headers = headers)
 
 print(r.json())
 
@@ -891,10 +933,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -942,8 +985,9 @@ Status Code **200**
 |» imagename|string|false|none|none|
 |» default|boolean|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_image_admin
@@ -953,26 +997,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -990,10 +1036,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1039,8 +1086,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Image {image_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_image_admin
@@ -1050,26 +1098,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1087,10 +1137,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1141,8 +1192,9 @@ instance.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image updated|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Image](#schemaimage)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_image_admin
@@ -1152,26 +1204,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1189,10 +1243,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1238,8 +1293,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Image removed|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete image {image_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-mgr-info">mgr-info</h1>
@@ -1251,26 +1307,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/mgr-info HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/mgr-info \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/mgr-info', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info', headers = headers)
 
 print(r.json())
 
@@ -1288,10 +1346,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/mgr-info", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1327,8 +1386,9 @@ Return User Access Service information.
 
 <h3 id="get_uas_mgr_info-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uais">uais</h1>
@@ -1340,26 +1400,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1377,10 +1439,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1422,8 +1485,9 @@ list UAIs that implements a superset of this functionality under the
 
 <h3 id="get_all_uais-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_uais
@@ -1433,20 +1497,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uais HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uais
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uais')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1462,8 +1531,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1495,8 +1568,9 @@ of the functionality found here.  This path is deprecated in favor of
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|All UAIs Deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No UAIs found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-admin">admin</h1>
@@ -1508,26 +1582,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1545,10 +1621,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1634,8 +1711,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai_admin
@@ -1645,26 +1723,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1682,10 +1762,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1780,8 +1861,9 @@ character.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI Created|[UAI](#schemauai)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uais_admin
@@ -1791,26 +1873,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1828,10 +1912,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1925,8 +2010,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uai_admin
@@ -1936,26 +2022,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais/{uai_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
 
 print(r.json())
 
@@ -1973,10 +2061,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2030,8 +2119,9 @@ Retrieve information on the specified UAI.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI Description|[UAI](#schemauai)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-config">config</h1>
@@ -2043,20 +2133,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config', headers = headers)
 
 print(r.json())
 
@@ -2072,8 +2167,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2100,8 +2199,9 @@ with this request.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Local configuration reset to defaults|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-volumes">volumes</h1>
@@ -2113,26 +2213,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/volumes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', params={
   'volumename': 'my-mount',  'mount_path': '/mnt/test',  'volume_description': '{ "config_map": { "name": "my-configmap" } }'
 }, headers = headers)
 
@@ -2152,10 +2254,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2235,8 +2338,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Volume not added|string|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volumes_admin
@@ -2246,26 +2350,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
 
 print(r.json())
 
@@ -2283,10 +2389,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2338,8 +2445,9 @@ Status Code **200**
 |» mount_path|string|false|none|none|
 |» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volume_admin
@@ -2349,26 +2457,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2386,10 +2496,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2436,8 +2547,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Volume|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Volume {volumename} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_volume_admin
@@ -2447,26 +2559,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2484,10 +2598,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2576,8 +2691,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Volume](#schemavolume)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not updated|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_volume_admin
@@ -2587,26 +2703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2624,10 +2742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2676,8 +2795,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Volume removed from list|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete volume {volume_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-resources">resources</h1>
@@ -2689,26 +2809,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2726,10 +2848,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2795,8 +2918,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource configuration added|[Resource](#schemaresource)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid limit or request specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resources_admin
@@ -2806,26 +2930,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2843,10 +2969,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2896,8 +3023,9 @@ Status Code **200**
 |» limit|string|false|none|none|
 |» request|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resource_admin
@@ -2907,26 +3035,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -2944,10 +3074,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2995,8 +3126,9 @@ config to be retrieved from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource Limit / Request Configuration Item|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource Configuration {resource_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_resource_admin
@@ -3006,26 +3138,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3043,10 +3177,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3114,8 +3249,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource updated|[Resource](#schemaresource)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Resource](#schemaresource)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_resource_admin
@@ -3125,26 +3261,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3162,10 +3300,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3213,8 +3352,9 @@ configuration to be removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-classes">classes</h1>
@@ -3226,26 +3366,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/classes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', params={
   'image_id': 'af4e59ab-6275-47f9-8f4a-90911eba3f9c'
 }, headers = headers)
 
@@ -3265,10 +3407,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3478,8 +3621,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class added|[UAIClass](#schemauaiclass)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid UAI / Broker Class specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_classes_admin
@@ -3489,26 +3633,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', headers = headers)
 
 print(r.json())
 
@@ -3526,10 +3672,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3633,8 +3780,9 @@ Status Code **200**
 |»»» mount_path|string|false|none|none|
 |»»» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_class_admin
@@ -3644,26 +3792,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3681,10 +3831,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3762,8 +3913,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI / Broker Class|[UAIClass](#schemauaiclass)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI / Broker Class {class_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_class_admin
@@ -3773,26 +3925,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3810,10 +3964,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4021,8 +4176,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class updated|[UAIClass](#schemauaiclass)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[UAIClass](#schemauaiclass)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_class_admin
@@ -4032,26 +4188,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -4069,10 +4227,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4119,8 +4278,9 @@ removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -25,20 +25,20 @@
 
 set -e -o pipefail
 function usage() {
-    echo "Generate API docs from swagger file URLs provided in csm manifests."
-    echo ""
-    echo "Usage: $0 <manifest-dir> <dest-dir>"
-    echo ""
-    exit 1
+  echo "Generate API docs from swagger file URLs provided in csm manifests."
+  echo ""
+  echo "Usage: $0 <manifest-dir> <dest-dir>"
+  echo ""
+  exit 1
 }
 
 function error() {
-    echo "${1}"
-    exit 1
+  echo "${1}"
+  exit 1
 }
 
 if [ $# -ne 2 ]; then
-    usage
+  usage
 fi
 
 manifest_dir=$(realpath "${1}")
@@ -47,42 +47,60 @@ tmp_dir=$(mktemp -d)
 mkdir -p "${dest_dir}" "${tmp_dir}"
 
 echo "Preparing yq container ..."
-docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 >/dev/null
+docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 > /dev/null
 yq="docker exec yq-swagger yq"
 
 echo "Preparing widdershins container ..."
-docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 >/dev/null
+docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 > /dev/null
 docker exec widdershins npm install -g widdershins
 
 trap 'echo "Cleaning up ..."; docker rm -f widdershins >/dev/null; docker rm -f yq-swagger >/dev/null; rm -Rf "${tmp_dir}"' EXIT
 
 find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
-    echo "Parsing ${manifest_file} ..."
-    while read -r swagger_def; do
-        IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
-        echo ""
-        echo "Downloading from ${endpoint_url} ..."
-        curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
-        if [ -n "${endpoint_title}" ]; then
-            ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        if [ -n "${endpoint_version}" ]; then
-            ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
-        docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
-    done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
+  echo "Parsing ${manifest_file} ..."
+  while read -r swagger_def; do
+    IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
+    echo ""
+    echo "Downloading from ${endpoint_url} ..."
+    curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+    openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
+    if [ -n "${endpoint_title}" ]; then
+      ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    if [ -n "${endpoint_version}" ]; then
+      ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    if [[ ${openapi_version} == 3.* ]]; then
+      ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      # Many services have both external (through API Gateway, requires auth) and internal (does not require auth) sample URLs.
+      # Auth requirement can not be scoped to URL, we remove all sample URLs and set one mandatory external URL instead.
+      base_url=$(${yq} e '.servers[] | select(.url == "*/apis/*") | .url | sub(".+/apis/", "/apis/")' "/swagger/${endpoint_name}.yaml" | sort -u | head -1)
+      if [ -z "${base_url}" ]; then
+        base_url="/apis/${endpoint_name}"
+        echo "WARNING: unable to identify sample URL for ${endpoint_name}, guessed as ${base_url}."
+      fi
+      ${yq} e -i ".servers=[{\"url\": \"https://api-gw-service-nmn.local${base_url}\"}]" "/swagger/${endpoint_name}.yaml"
+    elif [[ ${openapi_version} == 2.* ]]; then
+      ${yq} e -i '.securityDefinitions.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.host="api-gw-service-nmn.local"' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.schemes=["https"]' "/swagger/${endpoint_name}.yaml"
+    fi
+    echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
+    docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
+  done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
 done
 
 cd "${dest_dir}"
 echo "# REST API Documentation" > README.md
 for file in *.md; do
-    if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
-        title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
-        if [ -z "${title}" ]; then
-            error "ERROR: Could not determine title for service named ${file%.md}"
-        fi
-        echo " * [${title}](./${file})" >> README.md
+  if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
+    title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
+    if [ -z "${title}" ]; then
+      error "ERROR: Could not determine title for service named ${file%.md}"
     fi
+    echo " * [${title}](./${file})" >> README.md
+  fi
 done
 ln -sf ./README.md ./index.md


### PR DESCRIPTION
Backport of #4648 into `release/1.5`. Content of `/api` folder was regenerated from latest state of CSM manifests (tagged as `v1.5.0-rc.3`). 