### PR TITLE
CASMTRIAGE-6543: auth requirement in API docs (#4648)

### DIFF
--- a/api/bos.md
+++ b/api/bos.md
@@ -87,7 +87,9 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/bos">https://api-gw-service-nmn.local/apis/bos</a>
 
-* <a href="https://cray-bos">https://cray-bos</a>
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="boot-orchestration-service-version">version</h1>
 
@@ -105,14 +107,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/', headers = headers)
@@ -133,6 +137,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -192,8 +197,9 @@ Status Code **200**
 |»» href|string|false|none|none|
 |»» rel|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get
@@ -212,14 +218,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1', headers = headers)
@@ -240,6 +248,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -288,8 +297,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get_version
@@ -308,14 +318,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/version', headers = headers)
@@ -336,6 +348,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -384,8 +397,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-healthz">healthz</h1>
@@ -406,14 +420,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/healthz', headers = headers)
@@ -434,6 +450,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -472,8 +489,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-sessiontemplate">sessiontemplate</h1>
@@ -496,7 +514,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -504,7 +523,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -526,6 +546,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -634,8 +655,9 @@ Create a new session template.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Session Template name|[V1SessionTemplateName](#schemav1sessiontemplatename)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplates
@@ -654,14 +676,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -682,6 +706,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -786,8 +811,9 @@ uniquely identified by the name.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template details array|[SessionTemplateArray](#schemasessiontemplatearray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplate
@@ -806,14 +832,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -834,6 +862,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -958,8 +987,9 @@ targeted to start being enforced in an upcoming BOS version.
 
 <h3 id="get_v1_sessiontemplate-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_sessiontemplate
@@ -978,14 +1008,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -1006,6 +1038,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1064,8 +1097,9 @@ targeted to start being enforced in an upcoming BOS version.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplatetemplate
@@ -1084,14 +1118,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate', headers = headers)
@@ -1112,6 +1148,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1215,8 +1252,9 @@ session templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template details|[V1SessionTemplate](#schemav1sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-session">session</h1>
@@ -1239,7 +1277,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1247,7 +1286,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1269,6 +1309,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1337,8 +1378,9 @@ on the boot set(s) defined in the session template.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessions
@@ -1357,14 +1399,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1385,6 +1429,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1428,8 +1473,9 @@ Status Code **200**
 |---|---|---|---|---|
 |*anonymous*|[[V1SessionId](#schemav1sessionid)]|false|none|[Unique BOS v1 session identifier.]|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session
@@ -1448,14 +1494,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1476,6 +1524,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1528,8 +1577,9 @@ Get session details by session ID.
 
 <h3 id="get_v1_session-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session
@@ -1548,14 +1598,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1576,6 +1628,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1622,8 +1675,9 @@ Delete session by session ID.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status
@@ -1642,14 +1696,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1670,6 +1726,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1728,8 +1785,9 @@ A list of the statuses for the different boot sets.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of Boot Set Statuses and metadata|[V1SessionStatus](#schemav1sessionstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_session_status
@@ -1750,7 +1808,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1758,7 +1817,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/s
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1780,6 +1840,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1864,8 +1925,9 @@ Creates the initial session status.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status
@@ -1886,7 +1948,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1894,7 +1957,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1916,6 +1980,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1987,8 +2052,9 @@ Update the session status. You can update the start or stop times.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of Boot Set Statuses and metadata|[V1SessionStatus](#schemav1sessionstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session_status
@@ -2007,14 +2073,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -2035,6 +2103,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2082,8 +2151,9 @@ Deletes an existing Session status
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset
@@ -2102,14 +2172,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2130,6 +2202,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2218,8 +2291,9 @@ Get the status for a boot set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Metadata and a list of the Phase Statuses for the Boot Set|[V1BootSetStatus](#schemav1bootsetstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_boot_set_status
@@ -2240,7 +2314,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2248,7 +2323,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/s
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2270,6 +2346,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2412,8 +2489,9 @@ Create a status for a Boot Set
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|The created Boot Set status|[V1BootSetStatus](#schemav1bootsetstatus)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status_by_bootset
@@ -2434,7 +2512,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2442,7 +2521,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2464,6 +2544,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2574,8 +2655,9 @@ the boot set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of Boot Set Statuses and metadata|[V1BootSetStatus](#schemav1bootsetstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_boot_set_status
@@ -2594,14 +2676,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2622,6 +2706,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2669,8 +2754,9 @@ Deletes an existing Boot Set status
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase
@@ -2689,14 +2775,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}', headers = headers)
@@ -2717,6 +2805,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2787,8 +2876,9 @@ Get the status for a specific boot set and phase.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of the nodes in the Phase and Category|[V1PhaseStatus](#schemav1phasestatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase_and_category
@@ -2807,14 +2897,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name}', headers = headers)
@@ -2835,6 +2927,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2884,8 +2977,9 @@ Get the status for a specific boot set, phase, and category.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of the nodes in the Phase and Category|[V1PhaseCategoryStatus](#schemav1phasecategorystatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-v2">v2</h1>
@@ -2906,14 +3000,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2', headers = headers)
@@ -2934,6 +3030,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2982,8 +3079,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_healthz
@@ -3002,14 +3100,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/healthz', headers = headers)
@@ -3030,6 +3130,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3068,8 +3169,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplates
@@ -3088,14 +3190,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates', headers = headers)
@@ -3116,6 +3220,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3220,8 +3325,9 @@ uniquely identified by the name.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template details array|[SessionTemplateArray](#schemasessiontemplatearray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## validate_v2_sessiontemplate
@@ -3240,14 +3346,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id}', headers = headers)
@@ -3268,6 +3376,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3322,8 +3431,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template validity details|[V2SessionTemplateValidation](#schemav2sessiontemplatevalidation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplate
@@ -3342,14 +3452,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3370,6 +3482,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3494,8 +3607,9 @@ targeted to start being enforced in an upcoming BOS version.
 
 <h3 id="get_v2_sessiontemplate-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_sessiontemplate
@@ -3516,7 +3630,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3524,7 +3639,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{sessi
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3546,6 +3662,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3720,8 +3837,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_sessiontemplate
@@ -3742,7 +3860,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3750,7 +3869,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{ses
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3772,6 +3892,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3947,8 +4068,9 @@ targeted to start being enforced in an upcoming BOS version.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessiontemplate
@@ -3967,14 +4089,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3995,6 +4119,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4053,8 +4178,9 @@ targeted to start being enforced in an upcoming BOS version.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplatetemplate
@@ -4073,14 +4199,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate', headers = headers)
@@ -4101,6 +4229,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4197,8 +4326,9 @@ session templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_session
@@ -4219,7 +4349,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4227,7 +4358,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4249,6 +4381,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4318,8 +4451,9 @@ on the boot set(s) defined in the session template.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Session details|[V2Session](#schemav2session)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessions
@@ -4338,14 +4472,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4366,6 +4502,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4431,8 +4568,9 @@ List all sessions, including those in progress and those complete.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details array|[V2SessionArray](#schemav2sessionarray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessions
@@ -4451,14 +4589,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4479,6 +4619,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4536,8 +4677,9 @@ all filters will be deleted.  By default only completed sessions will be deleted
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session
@@ -4556,14 +4698,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4584,6 +4728,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4648,8 +4793,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_session
@@ -4670,7 +4816,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4678,7 +4825,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4700,6 +4848,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4786,8 +4935,9 @@ targeted to start being enforced in an upcoming BOS version.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_session
@@ -4806,14 +4956,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4834,6 +4986,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4890,8 +5043,9 @@ targeted to start being enforced in an upcoming BOS version.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session_status
@@ -4910,14 +5064,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -4938,6 +5094,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5006,8 +5163,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session status details|[V2SessionExtendedStatus](#schemav2sessionextendedstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## save_v2_session_status
@@ -5026,14 +5184,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -5054,6 +5214,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5118,8 +5279,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_components
@@ -5138,14 +5300,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5166,6 +5330,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5263,8 +5428,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_components
@@ -5285,7 +5451,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5293,7 +5460,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5315,6 +5483,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5460,8 +5629,9 @@ Update the state for a collection of components in the BOS database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_components
@@ -5482,7 +5652,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5490,7 +5661,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5512,6 +5684,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5662,8 +5835,9 @@ Update the state for a collection of components in the BOS database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_component
@@ -5682,14 +5856,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -5710,6 +5886,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5810,8 +5987,9 @@ targeted to start being enforced in an upcoming BOS version.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_component
@@ -5832,7 +6010,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5840,7 +6019,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -5862,6 +6042,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6013,8 +6194,9 @@ targeted to start being enforced in an upcoming BOS version.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V2Component](#schemav2component)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_component
@@ -6035,7 +6217,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6043,7 +6226,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6065,6 +6249,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6218,8 +6403,9 @@ targeted to start being enforced in an upcoming BOS version.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The update was not allowed due to a conflict.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_component
@@ -6238,14 +6424,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6266,6 +6454,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6321,8 +6510,9 @@ targeted to start being enforced in an upcoming BOS version.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_apply_staged
@@ -6343,7 +6533,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/applystaged \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6351,7 +6542,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/applystaged \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/applystaged', headers = headers)
@@ -6373,6 +6565,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6436,8 +6629,9 @@ be returned in the response.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of xnames that should have their staged session applied.|[V2ApplyStagedStatus](#schemav2applystagedstatus)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_options
@@ -6458,7 +6652,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6466,7 +6661,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -6488,6 +6684,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6558,8 +6755,9 @@ Update one or more of the BOS service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_version_v2
@@ -6578,14 +6776,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/version', headers = headers)
@@ -6606,6 +6806,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6654,8 +6855,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-options">options</h1>
@@ -6676,14 +6878,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -6704,6 +6908,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6749,8 +6954,9 @@ Retrieve the list of BOS service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -7533,7 +7739,7 @@ Operation -- An operation to perform on nodes in this session.
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|*anonymous*|string|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
+|*anonymous*|string|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
 
 <h2 id="tocS_V1TemplateName">V1TemplateName</h2>
 <!-- backwards compatibility -->
@@ -7679,7 +7885,7 @@ Details about a Session.
 |error_count|[V1ErrorCountMetadata](#schemav1errorcountmetadata)|false|none|How many errors were encountered|
 |in_progress|[V1InProgressMetadata](#schemav1inprogressmetadata)|false|none|Is the object still doing something|
 |job|[V1BoaKubernetesJob](#schemav1boakubernetesjob)|false|none|The identity of the Kubernetes job that is created to handle the session.|
-|operation|[V1Operation](#schemav1operation)|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
+|operation|[V1Operation](#schemav1operation)|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
 |start_time|[V1StartTimeMetadata](#schemav1starttimemetadata)|false|none|The start time|
 |status_link|[V1SessionStatusUri](#schemav1sessionstatusuri)|false|none|URI to the status for this session|
 |stop_time|[V1StopTimeMetadata](#schemav1stoptimemetadata)|false|none|The stop time|
@@ -7718,7 +7924,7 @@ DEPRECATED -- these will only exist from sessions created before templateUuid wa
 |error_count|[V1ErrorCountMetadata](#schemav1errorcountmetadata)|false|none|How many errors were encountered|
 |in_progress|[V1InProgressMetadata](#schemav1inprogressmetadata)|false|none|Is the object still doing something|
 |job|[V1BoaKubernetesJob](#schemav1boakubernetesjob)|false|none|The identity of the Kubernetes job that is created to handle the session.|
-|operation|[V1Operation](#schemav1operation)|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
+|operation|[V1Operation](#schemav1operation)|false|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
 |start_time|[V1StartTimeMetadata](#schemav1starttimemetadata)|false|none|The start time|
 |status_link|[V1SessionStatusUri](#schemav1sessionstatusuri)|false|none|URI to the status for this session|
 |stop_time|[V1StopTimeMetadata](#schemav1stoptimemetadata)|false|none|The stop time|
@@ -7760,7 +7966,7 @@ A Session object specified by templateName
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|operation|[V1Operation](#schemav1operation)|true|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
+|operation|[V1Operation](#schemav1operation)|true|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
 |templateUuid|[V1TemplateUuid](#schemav1templateuuid)|false|none|DEPRECATED - use templateName. This field is ignored if templateName is also set.<br><br>It is recommended to use names which meet the following restrictions:<br>* Length of 1-127 characters.<br>* Use only letters, digits, periods (.), dashes (-), and underscores (_).<br>* Begin and end with a letter or digit.<br><br>These restrictions are not enforced in this version of BOS, but will be<br>enforced in a future version.|
 |templateName|[V1TemplateName](#schemav1templatename)|true|none|The name of the Session Template<br><br>It is recommended to use names which meet the following restrictions:<br>* Maximum length of 127 characters.<br>* Use only letters, digits, periods (.), dashes (-), and underscores (_).<br>* Begin and end with a letter or digit.<br><br>These restrictions are not enforced in this version of BOS, but will be<br>enforced in a future version.|
 |job|[V1BoaKubernetesJob](#schemav1boakubernetesjob)|false|none|The identity of the Kubernetes job that is created to handle the session.|
@@ -7802,7 +8008,7 @@ A Session object specified by templateUuid (DEPRECATED -- use templateName)
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|operation|[V1Operation](#schemav1operation)|true|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
+|operation|[V1Operation](#schemav1operation)|true|none|A Session represents an operation on a SessionTemplate. The creation of a session effectively results in the creation of a Kubernetes Boot Orchestration Agent (BOA) job to perform the duties required to complete the operation.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br><br>    Boot         Boot nodes that are off.<br><br>    Configure    Reconfigure the nodes using the Configuration Framework<br>                 Service (CFS).<br><br>    Reboot       Gracefully power down nodes that are on and then power<br>                 them back up.<br><br>    Shutdown     Gracefully power down nodes that are on.|
 |templateUuid|[V1TemplateUuid](#schemav1templateuuid)|true|none|DEPRECATED - use templateName. This field is ignored if templateName is also set.<br><br>It is recommended to use names which meet the following restrictions:<br>* Length of 1-127 characters.<br>* Use only letters, digits, periods (.), dashes (-), and underscores (_).<br>* Begin and end with a letter or digit.<br><br>These restrictions are not enforced in this version of BOS, but will be<br>enforced in a future version.|
 |job|[V1BoaKubernetesJob](#schemav1boakubernetesjob)|false|none|The identity of the Kubernetes job that is created to handle the session.|
 |limit|string|false|none|A comma-separated of nodes, groups, or roles to which the session will be limited. Components are treated as OR operations unless preceded by "&" for AND or "!" for NOT.<br>It is recommended that this should be 1-65535 characters in length.<br>This restriction is not enforced in this version of BOS, but it is targeted to start being enforced in an upcoming BOS version.|
@@ -8197,7 +8403,7 @@ A Session Creation object
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |name|string|false|none|Name of the session. A UUID name is generated if a name is not provided.|
-|operation|string|true|none|A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.<br>Operation -- An operation to perform on nodes in this session.<br><br>    Boot                 Applies the template to the components and boots/reboots if necessary.<br>    Reboot               Applies the template to the components guarantees a reboot.<br>    Shutdown             Power down nodes that are on.|
+|operation|string|true|none|A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br>    Boot                 Applies the template to the components and boots/reboots if necessary.<br>    Reboot               Applies the template to the components guarantees a reboot.<br>    Shutdown             Power down nodes that are on.|
 |template_name|[V2TemplateName](#schemav2templatename)|true|none|The name of the Session Template<br><br>It is recommended to use names which meet the following restrictions:<br>* Maximum length of 127 characters.<br>* Use only letters, digits, periods (.), dashes (-), and underscores (_).<br>* Begin and end with a letter or digit.<br><br>These restrictions are not enforced in this version of BOS, but will be<br>enforced in a future version.|
 |limit|string|false|none|A comma-separated of nodes, groups, or roles to which the session will be limited. Components are treated as OR operations unless preceded by "&" for AND or "!" for NOT.<br>It is recommended that this should be 1-65535 characters in length.<br>This restriction is not enforced in this version of BOS, but it is targeted to start being enforced in an upcoming BOS version.|
 |stage|boolean|false|none|Set to stage a session which will not immediately change the state of any components. The "applystaged" endpoint can be called at a later time to trigger the start of this session.|
@@ -8339,7 +8545,7 @@ A Session object
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |name|string|false|none|Name of the session.|
-|operation|string|false|none|A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.<br>Operation -- An operation to perform on nodes in this session.<br><br>    Boot                 Applies the template to the components and boots/reboots if necessary.<br>    Reboot               Applies the template to the components guarantees a reboot.<br>    Shutdown             Power down nodes that are on.|
+|operation|string|false|none|A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.<br>Operation -- An operation to perform on nodes in this session.<br><br><br><br><br>    Boot                 Applies the template to the components and boots/reboots if necessary.<br>    Reboot               Applies the template to the components guarantees a reboot.<br>    Shutdown             Power down nodes that are on.|
 |template_name|[V2TemplateName](#schemav2templatename)|false|none|The name of the Session Template<br><br>It is recommended to use names which meet the following restrictions:<br>* Maximum length of 127 characters.<br>* Use only letters, digits, periods (.), dashes (-), and underscores (_).<br>* Begin and end with a letter or digit.<br><br>These restrictions are not enforced in this version of BOS, but will be<br>enforced in a future version.|
 |limit|string|false|none|A comma-separated of nodes, groups, or roles to which the session will be limited. Components are treated as OR operations unless preceded by "&" for AND or "!" for NOT.|
 |stage|boolean|false|none|Set to stage a session which will not immediately change the state of any components. The "applystaged" endpoint can be called at a later time to trigger the start of this session.|

--- a/api/bss.md
+++ b/api/bss.md
@@ -35,7 +35,11 @@ Verify the boot parameters for the specific host.
 
 Base URLs:
 
-* <a href="http://bootscriptserver:27778/apis/bss">http://bootscriptserver:27778/apis/bss</a>
+* <a href="https://api-gw-service-nmn.local/apis/bss">https://api-gw-service-nmn.local/apis/bss</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="boot-script-service-cli_ignore">cli_ignore</h1>
 
@@ -46,26 +50,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/meta-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/meta-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/meta-data \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/meta-data \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/meta-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/meta-data', headers = headers)
 
 print(r.json())
 
@@ -83,10 +89,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/meta-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/meta-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -125,8 +132,9 @@ func main() {
 
 <h3 id="meta_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## user_data_get
@@ -136,26 +144,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/user-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/user-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/yaml
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/user-data \
-  -H 'Accept: text/yaml'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/user-data \
+  -H 'Accept: text/yaml' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/yaml'
+  'Accept': 'text/yaml',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/user-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/user-data', headers = headers)
 
 print(r.json())
 
@@ -173,10 +183,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/yaml"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/user-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/user-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -205,8 +216,9 @@ func main() {
 
 <h3 id="user_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## phone_home_post
@@ -216,8 +228,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/phone-home HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/phone-home HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -225,9 +237,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/phone-home \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -235,10 +248,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/phone-home', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/phone-home', headers = headers)
 
 print(r.json())
 
@@ -257,10 +271,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/phone-home", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/phone-home", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -338,8 +353,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC or nid are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootscript">bootscript</h1>
@@ -351,26 +367,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/plain
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript \
-  -H 'Accept: text/plain'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/plain'
+  'Accept': 'text/plain',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootscript', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript', headers = headers)
 
 print(r.json())
 
@@ -388,10 +406,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/plain"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootscript", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -435,8 +454,9 @@ Retrieve iPXE boot script for the host specified by the MAC parameter. Alternati
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC or nid are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootparameters">bootparameters</h1>
@@ -446,8 +466,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -455,9 +475,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -465,10 +486,11 @@ curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -487,10 +509,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -620,8 +643,9 @@ Status Code **200**
 |»»» hostname|string|false|none|none|
 |»»» fqdn|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_bootparameters
@@ -629,8 +653,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -638,9 +662,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -648,10 +673,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -670,10 +696,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -762,8 +789,9 @@ Special entries for HSM roles like 'Compute', 'Storage' and 'Application' can al
 |---|---|---|---|---|
 |201|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__boot_v1_bootparameters
@@ -771,8 +799,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -780,9 +808,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -790,10 +819,11 @@ curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -812,10 +842,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -904,8 +935,9 @@ Along with the hosts, there must be a kernel image reference in order for the bo
 |---|---|---|---|---|
 |200|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__boot_v1_bootparameters
@@ -913,8 +945,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -922,9 +954,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -932,10 +965,11 @@ curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -954,10 +988,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1035,8 +1070,9 @@ Update an existing entry with new boot parameters while retaining existing setti
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find entry for specified host, mac, or nid|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__boot_v1_bootparameters
@@ -1044,8 +1080,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1053,9 +1089,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1063,10 +1100,11 @@ curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -1085,10 +1123,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1166,8 +1205,9 @@ Remove an existing boot parameter settings for one or more hosts, as specified b
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find specified host, mac, or nid|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-hosts">hosts</h1>
@@ -1177,26 +1217,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1214,10 +1256,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1278,8 +1321,9 @@ Retrieve list of known hosts obtained from HSM. This list can be filtered by spe
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Return list of hosts and associated attributes known to BSS|[HostInfo](#schemahostinfo)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_hosts
@@ -1287,26 +1331,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1324,10 +1370,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1365,8 +1412,9 @@ Retrieve the latest host information from HSM.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-dumpstate">dumpstate</h1>
@@ -1376,26 +1424,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate', headers = headers)
 
 print(r.json())
 
@@ -1413,10 +1463,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1507,8 +1558,9 @@ Dump internal state of boot script service for debugging purposes. Return known 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-endpoint-history">endpoint-history</h1>
@@ -1518,26 +1570,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history', headers = headers)
 
 print(r.json())
 
@@ -1555,10 +1609,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1626,8 +1681,9 @@ Status Code **200**
 |endpoint|bootscript|
 |endpoint|user-data|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-service-status">service-status</h1>
@@ -1637,26 +1693,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -1674,10 +1732,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1726,8 +1785,9 @@ Status Code **200**
 |---|---|
 |bss-status|running|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_etcd
@@ -1735,26 +1795,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd', headers = headers)
 
 print(r.json())
 
@@ -1772,10 +1834,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,8 +1902,9 @@ Status Code **500**
 |---|---|
 |bss-status-etcd|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_hsm
@@ -1848,26 +1912,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm', headers = headers)
 
 print(r.json())
 
@@ -1885,10 +1951,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1950,8 +2017,9 @@ Status Code **500**
 |---|---|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_version
@@ -1959,26 +2027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -1996,10 +2066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2052,8 +2123,9 @@ Status Code **500**
 |---|---|
 |bss-version|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_status_all
@@ -2061,26 +2133,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all', headers = headers)
 
 print(r.json())
 
@@ -2098,10 +2172,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2178,8 +2253,9 @@ Status Code **500**
 |bss-status-hsm|connected|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/capmc.md
+++ b/api/capmc.md
@@ -63,7 +63,11 @@ This implementation of CAPMC uses Redfish APIs to communicate directly with the 
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/capmc/capmc/v1">http://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/capmc/capmc/v1">https://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--component-control">component control</h1>
 
@@ -72,7 +76,7 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -81,9 +85,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -91,10 +96,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_statu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
 
 print(r.json())
 
@@ -113,10 +119,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -218,8 +225,9 @@ Status Code **200**
 |» ready|[string]|false|none|Optional, list of booted components by xname. Operating system is fully booted and sending heartbeats.|
 |» standby|[string]|false|none|Optional, list of components in standby by xname. Components that were previously booted and but are no longer sending heartbeat.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_reinit
@@ -227,7 +235,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -236,9 +244,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -246,10 +255,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
 
 print(r.json())
 
@@ -268,10 +278,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -362,8 +373,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power restart attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_on
@@ -371,7 +383,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -380,9 +392,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -390,10 +403,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
 
 print(r.json())
 
@@ -412,10 +426,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -510,8 +525,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power up attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__xname_off
@@ -519,7 +535,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -528,9 +544,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -538,10 +555,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
 
 print(r.json())
 
@@ -560,10 +578,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,8 +677,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Non-zero status code for failed request.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--power-capping">power capping</h1>
@@ -669,7 +689,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -678,9 +698,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -688,10 +709,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
 
 print(r.json())
 
@@ -710,10 +732,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -816,8 +839,9 @@ Status Code **200**
 |»»» name|string|true|none|Unique control or status object identifier.|
 |»»» val|integer(int32)|true|none|Control object setting, or zero to indicate control is unconstrained, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__get_power_cap_capabilities
@@ -825,7 +849,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -834,9 +858,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -844,10 +869,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_c
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
 
 print(r.json())
 
@@ -866,10 +892,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -996,8 +1023,9 @@ Status Code **200**
 |»»» min|integer(int32)|true|none|Minimum value which may be assigned to the control object, units are dependent upon control type.|
 |»»» max|integer(int32)|true|none|Maximum value which may be assigned to the control object, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__set_power_cap
@@ -1005,7 +1033,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1014,9 +1042,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1024,10 +1053,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
 
 print(r.json())
 
@@ -1046,10 +1076,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1156,8 +1187,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Error status, non-zero indicates operation failed on this node.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--utilities">utilities</h1>
@@ -1167,7 +1199,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1175,18 +1207,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
 
 print(r.json())
 
@@ -1204,10 +1238,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1259,8 +1294,9 @@ Status Code **200**
 |» vault|string|true|none|Description of the connection to the credentials vault.  If there is an error returned when attempting to access the vault that will be included here.|
 |» hsm|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included in this description.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1268,7 +1304,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1276,18 +1312,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1305,10 +1343,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1344,8 +1383,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1353,7 +1393,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1361,18 +1401,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1390,10 +1432,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1429,8 +1472,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/cfs.md
+++ b/api/cfs.md
@@ -74,6 +74,10 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/cfs">https://api-gw-service-nmn.local/apis/cfs</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="configuration-framework-service-version">version</h1>
 
 ## get_version
@@ -92,14 +96,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/', headers = headers)
@@ -120,6 +126,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -157,8 +164,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions
@@ -177,14 +185,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/versions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/versions', headers = headers)
@@ -205,6 +215,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -242,8 +253,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions_v2
@@ -262,14 +274,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2', headers = headers)
@@ -290,6 +304,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -327,8 +342,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-healthz">healthz</h1>
@@ -349,14 +365,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/healthz', headers = headers)
@@ -377,6 +395,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -414,8 +433,9 @@ Get cfs-api health details.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Status information for the service|[Healthz](#schemahealthz)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Status information for the service|[Healthz](#schemahealthz)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-options">options</h1>
@@ -436,14 +456,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -464,6 +486,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -511,8 +534,9 @@ Retrieve the list of configuration service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_options
@@ -533,7 +557,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -541,7 +566,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -563,6 +589,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -637,8 +664,9 @@ Update one or more of the configuration service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-sessions">sessions</h1>
@@ -659,14 +687,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -687,6 +717,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -852,8 +883,9 @@ Status Code **200**
 |succeeded|false|
 |succeeded|unknown|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_session
@@ -874,7 +906,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -882,7 +915,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -904,6 +938,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1033,8 +1068,9 @@ Create a new configuration session. A configuration session stages Ansible inven
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A session with the same name already exists.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_sessions
@@ -1053,14 +1089,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1081,6 +1119,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1145,8 +1184,9 @@ Delete multiple configuration sessions.  If filters are provided, only sessions 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_session
@@ -1165,14 +1205,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1193,6 +1235,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1284,8 +1327,9 @@ View details about a specific configuration session. This allows you to track th
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration session|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_session
@@ -1304,14 +1348,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1332,6 +1378,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1424,8 +1471,9 @@ Update the status of an existing configuration framework session
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_session
@@ -1444,14 +1492,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1472,6 +1522,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1518,8 +1569,9 @@ Deleting a configuration session deletes the Kubernetes objects associated with 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-components">components</h1>
@@ -1540,14 +1592,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -1568,6 +1622,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1660,8 +1715,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_components
@@ -1682,7 +1738,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1690,7 +1747,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -1712,6 +1770,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1829,8 +1888,9 @@ Update the state for a collection of components in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_components
@@ -1851,7 +1911,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1859,7 +1920,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -1881,6 +1943,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1999,8 +2062,9 @@ Update the state for a collection of components in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_component
@@ -2019,14 +2083,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -2047,6 +2113,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2125,8 +2192,9 @@ Retrieve the configuration and current state of a single component
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_component
@@ -2147,7 +2215,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2155,7 +2224,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -2177,6 +2247,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2284,8 +2355,9 @@ Update the state for a given component in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V2ComponentState](#schemav2componentstate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_component
@@ -2306,7 +2378,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2314,7 +2387,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -2336,6 +2410,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2444,8 +2519,9 @@ Update the state for a given component in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_component
@@ -2464,14 +2540,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -2492,6 +2570,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2538,8 +2617,9 @@ Delete the given component
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-configurations">configurations</h1>
@@ -2560,14 +2640,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations', headers = headers)
@@ -2588,6 +2670,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2649,8 +2732,9 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configurations|[ConfigurationArray](#schemaconfigurationarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configuration
@@ -2669,14 +2753,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -2697,6 +2783,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2756,8 +2843,9 @@ Retrieve the given configuration
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[Configuration](#schemaconfiguration)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_configuration
@@ -2778,7 +2866,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2786,7 +2875,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -2808,6 +2898,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2891,8 +2982,9 @@ Add a configuration to CFS or replace an existing configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[Configuration](#schemaconfiguration)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_configuration
@@ -2911,14 +3003,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -2939,6 +3033,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2998,8 +3093,9 @@ Updates the commits for all layers that specify a branch
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[Configuration](#schemaconfiguration)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_configuration
@@ -3018,14 +3114,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -3046,6 +3144,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3093,8 +3192,9 @@ Delete the given configuration. This will fail in any components are using the s
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/crus.md
+++ b/api/crus.md
@@ -76,7 +76,9 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/crus">https://api-gw-service-nmn.local/apis/crus</a>
 
-* <a href="https://cray-crus/">https://cray-crus/</a>
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="compute-rolling-upgrade-service-default">Default</h1>
 
@@ -96,7 +98,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/crus/session \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -104,7 +107,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/crus/session \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/crus/session', headers = headers)
@@ -126,6 +130,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -197,8 +202,9 @@ specified in the starting group.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|None|
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Unprocessable Entity|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__session
@@ -215,14 +221,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/crus/session \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/crus/session', headers = headers)
@@ -243,6 +251,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -324,8 +333,9 @@ Status Code **200**
 |state|UPDATING|
 |workload_manager_type|slurm|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__session_{upgrade_id}
@@ -342,14 +352,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/crus/session/{upgrade_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/crus/session/{upgrade_id}', headers = headers)
@@ -370,6 +382,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -425,8 +438,9 @@ Retrieve session details by upgrade_id.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The status of the CRUS session.|[SessionStatus](#schemasessionstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__session_{upgrade_id}
@@ -443,14 +457,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/crus/session/{upgrade_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/crus/session/{upgrade_id}', headers = headers)
@@ -471,6 +487,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -526,8 +543,9 @@ Delete session by upgrade_id.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The status of the CRUS session.|[SessionStatus](#schemasessionstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/firmware-action.md
+++ b/api/firmware-action.md
@@ -64,11 +64,11 @@ FAS receives information from the Hardware State Manager (HSM) for each xname.
 
 Base URLs:
 
-* <a href="https://rocket-ncn-w001.us.cray.com/apis/fas/v1">https://rocket-ncn-w001.us.cray.com/apis/fas/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/fas/v1">https://api-gw-service-nmn.local/apis/fas/v1</a>
 
-* <a href="http://localhost:28800/v1">http://localhost:28800/v1</a>
+# Authentication
 
-* <a href="http://localhost:28800">http://localhost:28800</a>
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="firmware-action-service-actions">actions</h1>
 
@@ -77,26 +77,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -114,10 +116,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -181,8 +184,9 @@ end time for completed and in-progress actions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummarys](#schemaactionsummarys)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__actions
@@ -190,8 +194,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -199,9 +203,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/actions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -209,10 +214,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -231,10 +237,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -368,8 +375,9 @@ commands:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[ActionID](#schemaactionid)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}
@@ -377,26 +385,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -414,10 +424,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -633,8 +644,9 @@ Retrieve detailed information for a firmware action set specified by actionID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Action](#schemaaction)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}
@@ -642,26 +654,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -679,10 +693,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -716,8 +731,9 @@ Delete all information about a completed firmware action set.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|cannot delete a running action|[Problem7807](#schemaproblem7807)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}_instance
@@ -725,26 +741,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance', headers = headers)
 
 print(r.json())
 
@@ -762,10 +780,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -809,8 +828,9 @@ Abort a running firmware action set. Stops all actions in progress (will not rol
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Aborting action|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_status
@@ -818,26 +838,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status', headers = headers)
 
 print(r.json())
 
@@ -855,10 +877,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -926,8 +949,9 @@ Retrieve summary information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummary](#schemaactionsummary)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations
@@ -935,26 +959,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations', headers = headers)
 
 print(r.json())
 
@@ -972,10 +998,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1371,8 +1398,9 @@ Retrieve detailed information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionDetail](#schemaactiondetail)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations_{operationID}
@@ -1380,26 +1408,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1417,10 +1447,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1482,8 +1513,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__operations_{operationID}
@@ -1491,26 +1523,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1528,10 +1562,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1592,8 +1627,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|operation not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-images">images</h1>
@@ -1603,8 +1639,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1612,9 +1648,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1622,10 +1659,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1644,10 +1682,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1726,8 +1765,9 @@ Create a new image record
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[Problem7807](#schemaproblem7807)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Imaage Record Already Exists|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images
@@ -1735,26 +1775,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1772,10 +1814,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,8 +1882,9 @@ Retrieve a list of images that are known to the system.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageList](#schemaimagelist)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__images_{imageID}
@@ -1848,8 +1892,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/error
 
@@ -1857,9 +1901,10 @@ Accept: application/error
 
 ```shell
 # You can also use wget
-curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
+curl -X PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1867,10 +1912,11 @@ curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -1889,10 +1935,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1964,8 +2011,9 @@ Modify or update an existing image record.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images_{imageID}
@@ -1973,26 +2021,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2010,10 +2060,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2082,8 +2133,9 @@ Retrieve the image record that is associated with the imageID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageGet](#schemaimageget)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__images_{imageID}
@@ -2091,26 +2143,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2128,10 +2182,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2164,8 +2219,9 @@ Deletes an image record from the FAS datastore. Does not delete the actual image
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-service">service</h1>
@@ -2175,26 +2231,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -2212,10 +2270,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2250,8 +2309,9 @@ Retrieve the status of the Firmware Action Service.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatus](#schemaservicestatus)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_status_details
@@ -2259,26 +2319,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status/details', headers = headers)
 
 print(r.json())
 
@@ -2296,10 +2358,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status/details", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2337,8 +2400,9 @@ Retrieve the status of the Firmware Action Service. HSM, ETCD, Service Status an
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatusDetails](#schemaservicestatusdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_version
@@ -2346,26 +2410,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -2383,10 +2449,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2421,8 +2488,9 @@ Retrieve the internal version of FAS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceVersion](#schemaserviceversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-snapshots">snapshots</h1>
@@ -2432,26 +2500,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2469,10 +2539,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2523,8 +2594,9 @@ Return summary of all stored snapshots
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[SnapshotAll](#schemasnapshotall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots
@@ -2532,8 +2604,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2541,9 +2613,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2551,10 +2624,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2573,10 +2647,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2658,8 +2733,9 @@ Records a snapshot of the firmware versions for every target for every device th
 |---|---|---|---|---|
 |201|Location|string||location of snapshot|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__snapshots_{snapshotName}
@@ -2667,26 +2743,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2704,10 +2782,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2806,8 +2885,9 @@ Retrieve a snapshot of the system
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Snapshot](#schemasnapshot)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__snapshots_{snapshotName}
@@ -2815,26 +2895,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2852,10 +2934,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2888,8 +2971,9 @@ Delete a snapshot of the system. Does not delete any firmware images from S3.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots_{snapshotName}_restore
@@ -2897,26 +2981,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore', params={
   'confirm': 'yes'
 }, headers = headers)
 
@@ -2936,10 +3022,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2991,8 +3078,9 @@ Restore a snapshot by replacing each component (device + target) with the stored
 |---|---|---|---|---|
 |202|Location|string|uuid|actionID of the created firmware action set|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-loader">loader</h1>
@@ -3002,8 +3090,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/octet-stream
 Accept: application/json
 
@@ -3011,9 +3099,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader \
   -H 'Content-Type: application/octet-stream' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3021,10 +3110,11 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
 import requests
 headers = {
   'Content-Type': 'application/octet-stream',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3043,10 +3133,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/octet-stream"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3097,8 +3188,9 @@ string
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Inernal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader
@@ -3106,26 +3198,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3143,10 +3237,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3181,8 +3276,9 @@ Return the loader status and list loader runs
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderStatus](#schemaloaderstatus)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader_{loaderRunID}
@@ -3190,26 +3286,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3227,10 +3325,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3273,8 +3372,9 @@ Return the results of a loader run
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunOutput](#schemaloaderrunoutput)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__loader_{loaderRunID}
@@ -3282,26 +3382,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/error'
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3319,10 +3421,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3355,8 +3458,9 @@ Delete a loader run
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loader_nexus
@@ -3364,26 +3468,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus', headers = headers)
 
 print(r.json())
 
@@ -3401,10 +3507,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3439,8 +3546,9 @@ Have the loader read the firmware library from Nexus and add to S3 and create FA
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunID](#schemaloaderrunid)|
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -3568,7 +3676,7 @@ This operation does not require authentication
 |overrideDryrun|boolean|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |operationCounts|[OperationCounts](#schemaoperationcounts)|false|none|none|
 |description|string|false|none|none|
 |blockedBy|[string]|false|none|none|
@@ -3834,7 +3942,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationSummary](#schemaoperationsummary)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4231,7 +4339,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationDetail](#schemaoperationdetail)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4752,7 +4860,7 @@ This operation does not require authentication
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the operation -<br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerifed* - operation was sent update command, waiting for finish to verify<br>  *verifing* - opertion verifing operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - opeartion completed successfully<br>  *failed* - operation failed|
+|state|string|false|none|The state of the operation -<br><br><br><br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerifed* - operation was sent update command, waiting for finish to verify<br>  *verifing* - opertion verifing operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - opeartion completed successfully<br>  *failed* - operation failed|
 |error|string|false|none|none|
 |xname|string|false|none|none|
 |deviceType|string|false|none|none|
@@ -5394,7 +5502,7 @@ RFC 7807 compliant error payload.  All fields are optional except the 'type' fie
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 
 #### Enumerated Values
 

--- a/api/hbtd.md
+++ b/api/hbtd.md
@@ -39,9 +39,11 @@ To change a parameter, perform a PATCH operation with a JSON-formatted payload c
 
 Base URLs:
 
-* <a href="http://cray-hbtd/hmi/v1">http://cray-hbtd/hmi/v1</a>
-
 * <a href="https://api-gw-service-nmn.local/apis/hbtd/hmi/v1">https://api-gw-service-nmn.local/apis/hbtd/hmi/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="heartbeat-tracker-service-heartbeat">heartbeat</h1>
 
@@ -52,8 +54,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -61,9 +63,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -71,10 +74,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
 
 print(r.json())
 
@@ -93,10 +97,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -143,8 +148,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## TrackHeartbeat
@@ -154,8 +160,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -163,9 +169,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -173,10 +180,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat', headers = headers)
 
 print(r.json())
 
@@ -195,10 +203,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -247,8 +256,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-hbstates">hbstates</h1>
@@ -260,8 +270,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/hbstates HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -269,9 +279,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/hbstates \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -279,10 +290,11 @@ curl -X POST http://cray-hbtd/hmi/v1/hbstates \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/hbstates', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates', headers = headers)
 
 print(r.json())
 
@@ -301,10 +313,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/hbstates", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -364,8 +377,9 @@ Sends a list of components to the service in a JSON formatted payload. The servi
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstates, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hbstate_{xname}
@@ -373,26 +387,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/hbstate/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/hbstate/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}', headers = headers)
 
 print(r.json())
 
@@ -410,10 +426,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/hbstate/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +473,9 @@ Query the service for the heartbeat status of a single component.  The service w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found. Endpoint not available. Check IP routing between managed and management plane. Check that any SMS node services are running on management plane. Check that SMS node API gateway service is running on management plane. Check that SMS node HMI service is running on management plane.|[Error](#schemaerror)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstate/{xname}, only GET operations are allowed.|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-params">params</h1>
@@ -467,26 +485,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: */*
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/params \
-  -H 'Accept: */*'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -504,10 +524,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -551,8 +572,9 @@ Fetch current heartbeat tracker configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__params
@@ -560,8 +582,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -569,9 +591,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X PATCH http://cray-hbtd/hmi/v1/params \
+curl -X PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -579,10 +602,11 @@ curl -X PATCH http://cray-hbtd/hmi/v1/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -601,10 +625,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -672,8 +697,9 @@ Set one or more configurable parameters for the heartbeat tracker service and ha
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-health">health</h1>
@@ -683,26 +709,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/health HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health', headers = headers)
 
 print(r.json())
 
@@ -720,10 +748,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -774,8 +803,9 @@ Status Code **200**
 |» MsgBus|string|true|none|Status of the connection with the message bus.|
 |» HsmStatus|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included here.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -783,26 +813,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/liveness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -820,10 +852,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -862,8 +895,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -871,26 +905,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/readiness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -908,10 +944,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -950,8 +987,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/hmnfd.md
+++ b/api/hmnfd.md
@@ -53,7 +53,9 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2">https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2</a>
 
-* <a href="http://cray-hmnfd/hmi/v2">http://cray-hmnfd/hmi/v2</a>
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="hms-notification-fanout-daemon-subscriptions">subscriptions</h1>
 
@@ -75,14 +77,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions', headers = headers)
@@ -103,6 +107,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -163,8 +168,9 @@ Retrieve all information on currently held State Change Notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSubscriptionInfoXName
@@ -183,14 +189,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}', headers = headers)
@@ -211,6 +219,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -277,8 +286,9 @@ Retrieve currently held State Change Notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXName
@@ -297,14 +307,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents', headers = headers)
@@ -325,6 +337,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -375,8 +388,9 @@ Delete all state change notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPOSTV2
@@ -397,7 +411,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -405,7 +420,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{x
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -427,6 +443,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -501,8 +518,9 @@ Subscribe to state change notifications for a set of components. Once this is do
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPATCHV2
@@ -523,7 +541,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -531,7 +550,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -553,6 +573,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -627,8 +648,9 @@ Modify an existing subscription to state change notifications for a  component a
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXNameAgentV2
@@ -647,14 +669,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -675,6 +699,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -726,8 +751,9 @@ Delete a specific state change notification subscription associated  with a targ
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-scn">scn</h1>
@@ -752,7 +778,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -760,7 +787,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn', headers = headers)
@@ -782,6 +810,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -847,8 +876,9 @@ Send a state change notification for fanout to subscribers. This is the API endp
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-params">params</h1>
@@ -869,14 +899,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -897,6 +929,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -947,8 +980,9 @@ Retrieve a JSON-formatted list of current configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doParamsPatch
@@ -969,7 +1003,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -977,7 +1012,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -999,6 +1035,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1068,8 +1105,9 @@ Change the value of one or more configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-health">health</h1>
@@ -1088,14 +1126,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health', headers = headers)
@@ -1116,6 +1156,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1174,8 +1215,9 @@ Status Code **200**
 |» PruneMap|string|true|none|Status of the list of subscriptions to be pruned.|
 |» WorkerPool|string|true|none|Status of the worker pool servicing the notifications.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1192,14 +1234,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness', headers = headers)
@@ -1220,6 +1264,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1262,8 +1307,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1280,14 +1326,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness', headers = headers)
@@ -1308,6 +1356,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1350,8 +1399,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/ims.md
+++ b/api/ims.md
@@ -109,9 +109,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/ims">https://api-gw-service-nmn.local/apis/ims</a>
 
-* <a href="cray-ims.services.svc.cluster.local">cray-ims.services.svc.cluster.local</a>
-
 License: <a href="http://www.hpe.com/">Hewlett Packard Enterprise Development LP</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="image-management-service-images">images</h1>
 
@@ -133,14 +135,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -161,6 +165,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -221,8 +226,9 @@ Status Code **200**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_image
@@ -243,7 +249,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -251,7 +258,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -273,6 +281,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -354,8 +363,9 @@ Status Code **201**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_images
@@ -374,14 +384,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -402,6 +414,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -443,8 +456,9 @@ Delete all ImageRecords. Deleted images are soft deleted and added to the /delet
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_image
@@ -463,14 +477,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -491,6 +507,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -541,8 +558,9 @@ Retrieve an image by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_image
@@ -563,7 +581,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -571,7 +590,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -593,6 +613,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -659,8 +680,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_image
@@ -679,14 +701,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -707,6 +731,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -755,8 +780,9 @@ Delete an ImageRecord by Id. Deleted images are soft deleted and added to the /d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_images
@@ -775,14 +801,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -803,6 +831,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -865,8 +894,9 @@ Status Code **200**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_images
@@ -885,14 +915,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -913,6 +945,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -954,8 +987,9 @@ Permanently delete all DeletedImageRecords. Associated artifacts are permanently
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_images
@@ -976,7 +1010,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -984,7 +1019,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -1006,6 +1042,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1065,8 +1102,9 @@ Restore all DeletedImageRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_image
@@ -1085,14 +1123,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1113,6 +1153,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1181,8 +1222,9 @@ Status Code **200**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_image
@@ -1201,14 +1243,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1229,6 +1273,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1277,8 +1322,9 @@ Permanently delete image record associated with deleted_image_id. Associated art
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_image
@@ -1299,7 +1345,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1307,7 +1354,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{delet
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1329,6 +1377,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1389,8 +1438,9 @@ Restore a DeletedImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_images
@@ -1409,14 +1459,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1437,6 +1489,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1497,8 +1550,9 @@ Status Code **200**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_image
@@ -1519,7 +1573,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1527,7 +1582,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1549,6 +1605,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1631,8 +1688,9 @@ Status Code **201**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_images
@@ -1651,14 +1709,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1679,6 +1739,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1726,8 +1787,9 @@ Delete all ImageRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_image
@@ -1746,14 +1808,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1774,6 +1838,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1840,8 +1905,9 @@ Status Code **200**
 |»» etag|string|false|none|Opaque identifier used to uniquely identify the artifact in the artifact repository|
 |»» type|string|true|none|Identifier specifying the artifact repository where the artifact is located|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_image
@@ -1862,7 +1928,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1870,7 +1937,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1892,6 +1960,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1958,8 +2027,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_image
@@ -1978,14 +2048,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -2006,6 +2078,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2055,8 +2128,9 @@ Delete an ImageRecord by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-healthz">healthz</h1>
@@ -2079,14 +2153,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/ready \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/ready', headers = headers)
@@ -2107,6 +2183,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2137,8 +2214,9 @@ Readiness probe for IMS. This is used by Kubernetes to determine if IMS is ready
 
 <h3 id="get_healthz_ready-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_healthz_live
@@ -2157,14 +2235,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/live \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/live', headers = headers)
@@ -2185,6 +2265,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2215,8 +2296,9 @@ Liveness probe for IMS. This is used by Kubernetes to determine if IMS is respon
 
 <h3 id="get_healthz_live-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-jobs">jobs</h1>
@@ -2239,14 +2321,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2267,6 +2351,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2386,8 +2471,9 @@ Status Code **200**
 |status|error|
 |status|success|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_job
@@ -2408,7 +2494,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2416,7 +2503,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2438,6 +2526,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2575,8 +2664,9 @@ depending on request body parameter, job_type.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_jobs
@@ -2595,14 +2685,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2623,6 +2715,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2687,8 +2780,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_job
@@ -2707,14 +2801,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2735,6 +2831,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2810,8 +2907,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_job
@@ -2832,7 +2930,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2840,7 +2939,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2862,6 +2962,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2950,8 +3051,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_job
@@ -2970,14 +3072,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2998,6 +3102,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3046,8 +3151,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_jobs
@@ -3066,14 +3172,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3094,6 +3202,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3213,8 +3322,9 @@ Status Code **200**
 |status|error|
 |status|success|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_job
@@ -3235,7 +3345,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3243,7 +3354,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3265,6 +3377,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3451,8 +3564,9 @@ Status Code **201**
 |status|error|
 |status|success|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_jobs
@@ -3471,14 +3585,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3499,6 +3615,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3563,8 +3680,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_job
@@ -3583,14 +3701,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3611,6 +3731,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3686,8 +3807,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_job
@@ -3708,7 +3830,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3716,7 +3839,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3738,6 +3862,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3826,8 +3951,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_job
@@ -3846,14 +3972,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3874,6 +4002,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3922,8 +4051,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-recipes">recipes</h1>
@@ -3946,14 +4076,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -3974,6 +4106,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4057,8 +4190,9 @@ Status Code **200**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipes
@@ -4079,7 +4213,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4087,7 +4222,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4109,6 +4245,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4222,8 +4359,9 @@ Status Code **201**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_recipes
@@ -4242,14 +4380,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4270,6 +4410,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4311,8 +4452,9 @@ Delete all RecipeRecords. Deleted recipes are soft deleted and added to the /del
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_recipe
@@ -4331,14 +4473,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4359,6 +4503,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4416,8 +4561,9 @@ Retrieve a RecipeRecord by id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_recipe
@@ -4438,7 +4584,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4446,7 +4593,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4468,6 +4616,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4542,8 +4691,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_recipe
@@ -4562,14 +4712,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4590,6 +4742,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4638,8 +4791,9 @@ Delete a RecipeRecord by id. The deleted recipes are soft deleted and added to t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_recipes
@@ -4658,14 +4812,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4686,6 +4842,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4762,8 +4919,9 @@ Status Code **200**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_recipes
@@ -4782,14 +4940,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4810,6 +4970,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4851,8 +5012,9 @@ Permanently delete all DeletedRecipeRecords. Associated artifacts are permanentl
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_recipes
@@ -4873,7 +5035,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4881,7 +5044,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4903,6 +5067,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4962,8 +5127,9 @@ Restore all DeletedRecipeRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_recipe
@@ -4982,14 +5148,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5010,6 +5178,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5062,8 +5231,9 @@ Retrieve a DeletedRecipeRecord by id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A deleted recipe record|[DeletedRecipeRecord](#schemadeletedreciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_recipe
@@ -5082,14 +5252,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5110,6 +5282,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5158,8 +5331,9 @@ Permanently delete a DeletedRecipeRecord by id. Associated artifacts are permane
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_recipe
@@ -5180,7 +5354,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5188,7 +5363,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{reci
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5210,6 +5386,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5270,8 +5447,9 @@ Restore a DeletedRecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_recipes
@@ -5290,14 +5468,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5318,6 +5498,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5401,8 +5582,9 @@ Status Code **200**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipe
@@ -5423,7 +5605,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5431,7 +5614,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5453,6 +5637,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5565,8 +5750,9 @@ Status Code **201**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_recipes
@@ -5585,14 +5771,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5613,6 +5801,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5660,8 +5849,9 @@ Delete all RecipeRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_recipe
@@ -5680,14 +5870,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5708,6 +5900,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5765,8 +5958,9 @@ Retrieve a RecipeRecord by id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_recipe
@@ -5787,7 +5981,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5795,7 +5990,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5817,6 +6013,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5891,8 +6088,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_recipe
@@ -5911,14 +6109,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5939,6 +6139,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5988,8 +6189,9 @@ Delete a recipe by id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-public-keys">public keys</h1>
@@ -6012,14 +6214,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6040,6 +6244,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6093,8 +6298,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_public_key
@@ -6115,7 +6321,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6123,7 +6330,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6145,6 +6353,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6216,8 +6425,9 @@ Status Code **201**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_public_keys
@@ -6236,14 +6446,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6264,6 +6476,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6305,8 +6518,9 @@ Delete all public key-records. Deleted public-keys are soft deleted and added to
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_public_key
@@ -6325,14 +6539,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6353,6 +6569,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6412,8 +6629,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_public_key
@@ -6432,14 +6650,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6460,6 +6680,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6508,8 +6729,9 @@ Delete a PublicKeyRecord by Id. Deleted public-keys are soft deleted and added t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_public_keys
@@ -6528,14 +6750,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6556,6 +6780,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6611,8 +6836,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_public_keys
@@ -6631,14 +6857,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6659,6 +6887,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6700,8 +6929,9 @@ Permanently delete all public key-records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|PublicKey records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_public_keys
@@ -6722,7 +6952,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6730,7 +6961,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6752,6 +6984,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6811,8 +7044,9 @@ Restore all DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_public_key
@@ -6831,14 +7065,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6859,6 +7095,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6920,8 +7157,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_public_key
@@ -6940,14 +7178,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6968,6 +7208,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7016,8 +7257,9 @@ Permanently delete a DeletedPublicKeyRecord by Id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_public_key
@@ -7038,7 +7280,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7046,7 +7289,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -7068,6 +7312,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7128,8 +7373,9 @@ Restore a DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_public_keys
@@ -7148,14 +7394,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7176,6 +7424,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7229,8 +7478,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_public_key
@@ -7251,7 +7501,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7259,7 +7510,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7281,6 +7533,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7353,8 +7606,9 @@ Status Code **201**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_public_keys
@@ -7373,14 +7627,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7401,6 +7657,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7442,8 +7699,9 @@ Delete all public key records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_public_key
@@ -7462,14 +7720,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7490,6 +7750,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7549,8 +7810,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_public_key
@@ -7569,14 +7831,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7597,6 +7861,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7645,8 +7910,9 @@ Delete a public key by public_key_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-version">version</h1>
@@ -7669,14 +7935,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/version', headers = headers)
@@ -7697,6 +7965,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7731,8 +8000,9 @@ Retrieve the version of the IMS Service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|IMS Version|string|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/nls.md
+++ b/api/nls.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="/apis">/apis</a>
+* <a href="https://api-gw-service-nmn.local/apis">https://api-gw-service-nmn.local/apis</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="ncn-lifecycle-service-ncn-lifecycle-events">NCN Lifecycle Events</h1>
 
@@ -15,8 +19,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/reboot HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -24,9 +28,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/reboot \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -34,10 +39,11 @@ curl -X POST /apis/nls/v1/ncns/reboot \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/reboot', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot', headers = headers)
 
 print(r.json())
 
@@ -56,10 +62,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/reboot", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -114,8 +121,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__nls_v1_ncns_rebuild
@@ -123,8 +131,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/rebuild HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -132,9 +140,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/rebuild \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -142,10 +151,11 @@ curl -X POST /apis/nls/v1/ncns/rebuild \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/rebuild', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild', headers = headers)
 
 print(r.json())
 
@@ -164,10 +174,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/rebuild", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -229,8 +240,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="ncn-lifecycle-service-workflow-management">Workflow Management</h1>
@@ -240,26 +252,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/nls/v1/workflows HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/nls/v1/workflows HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/nls/v1/workflows \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/nls/v1/workflows \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/nls/v1/workflows', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/nls/v1/workflows', headers = headers)
 
 print(r.json())
 
@@ -277,10 +291,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/nls/v1/workflows", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/nls/v1/workflows", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -334,8 +349,9 @@ Status Code **200**
 |» name|string|false|none|none|
 |» status|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__nls_v1_workflows_{name}
@@ -343,26 +359,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/nls/v1/workflows/{name} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/nls/v1/workflows/{name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/nls/v1/workflows/{name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}', headers = headers)
 
 print(r.json())
 
@@ -380,10 +398,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/nls/v1/workflows/{name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -422,8 +441,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_rerun
@@ -431,26 +451,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/rerun HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/rerun \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/rerun', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun', headers = headers)
 
 print(r.json())
 
@@ -468,10 +490,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/rerun", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -510,8 +533,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_retry
@@ -519,8 +543,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/retry HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -528,9 +552,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/retry \
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -538,10 +563,11 @@ curl -X PUT /apis/nls/v1/workflows/{name}/retry \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/retry', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry', headers = headers)
 
 print(r.json())
 
@@ -560,10 +586,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/retry", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -612,8 +639,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/power-control.md
+++ b/api/power-control.md
@@ -38,13 +38,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/power-control/v1">https://api-gw-service-nmn.local/apis/power-control/v1</a>
 
-* <a href="http://cray-power-control/v1">http://cray-power-control/v1</a>
-
-* <a href="https://loki-ncn-m001.us.cray.com/apis/power-control/v1">https://loki-ncn-m001.us.cray.com/apis/power-control/v1</a>
-
-* <a href="http://localhost:26970">http://localhost:26970</a>
-
  License: MIT
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="power-control-service-pcs--transitions">transitions</h1>
 
@@ -66,7 +64,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -74,7 +73,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions 
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -96,6 +96,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -157,8 +158,9 @@ Request to perform power transitions.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented starting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions
@@ -175,14 +177,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -203,6 +207,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -259,8 +264,9 @@ are automatically deleted.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[transitions_getAll](#schematransitions_getall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transitions|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions_{transitionID}
@@ -277,14 +283,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -305,6 +313,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -371,8 +380,9 @@ transitionID.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__transitions_{transitionID}
@@ -389,14 +399,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -417,6 +429,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -463,8 +476,9 @@ Attempt to abort an in-progress transition by transitionID
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TransitionID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented abort signaling|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-status">power-status</h1>
@@ -485,14 +499,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-status', headers = headers)
@@ -513,6 +529,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -581,8 +598,9 @@ Retrieve the power state of the component specified by xname.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-cap">power-cap</h1>
@@ -605,7 +623,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -613,7 +632,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/sn
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot', headers = headers)
@@ -635,6 +655,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -690,8 +711,9 @@ Get power cap snapshot for a set of targets.  This operation returns a taskID to
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__power-cap
@@ -710,7 +732,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -718,7 +741,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -740,6 +764,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -803,8 +828,9 @@ Set power cap parameters for a list of targets.  The PATCH payload contains the 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap
@@ -821,14 +847,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -849,6 +877,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -901,8 +930,9 @@ func main() {
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. The data was successfully retrieved|[power_cap_task_list](#schemapower_cap_task_list)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap_{taskID}
@@ -919,14 +949,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID}', headers = headers)
@@ -947,6 +979,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1023,8 +1056,9 @@ Queries the current status for the specified taskID. Use the taskID returned fro
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TaskID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--cli_ignore">cli_ignore</h1>
@@ -1041,14 +1075,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1063,6 +1101,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/liveness", data)
@@ -1088,8 +1130,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1104,14 +1147,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1126,6 +1173,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/readiness", data)
@@ -1151,8 +1202,9 @@ Get readiness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1169,14 +1221,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/health', headers = headers)
@@ -1197,6 +1251,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1245,8 +1300,9 @@ This is primarily intended as a diagnostic tool to investigate the functioning o
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) Network API call success|[health_rsp](#schemahealth_rsp)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted. For /health, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/scsd.md
+++ b/api/scsd.md
@@ -71,11 +71,13 @@ Set TPM State in the BIOS settings.
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/scsd/v1">http://api-gw-service-nmn.local/apis/scsd/v1</a>
-
-* <a href="http://cray-scsd/v1">http://cray-scsd/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/scsd/v1">https://api-gw-service-nmn.local/apis/scsd/v1</a>
 
  License: Cray Proprietary
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="system-configuration-service-nwp">nwp</h1>
 
@@ -86,7 +88,7 @@ Endpoints that set or get Redfish Network Protocol information
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -95,9 +97,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -105,10 +108,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
 
 print(r.json())
 
@@ -127,10 +131,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -203,8 +208,9 @@ Get the Redfish Network Protocol data (NTP server, syslog server, SSH key) for a
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_loadcfg
@@ -212,7 +218,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -221,9 +227,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -231,10 +238,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
 
 print(r.json())
 
@@ -253,10 +261,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -329,8 +338,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_cfg_{xname}
@@ -338,7 +348,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -346,18 +356,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -375,10 +387,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -433,8 +446,9 @@ Retrieve selected Redfish network protocol data for a single target. You can sel
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_cfg_{xname}
@@ -442,7 +456,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -451,9 +465,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -461,10 +476,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -483,10 +499,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -552,8 +569,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-creds">creds</h1>
@@ -565,7 +583,7 @@ Endpoints that set Redfish access credentials
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -574,9 +592,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -584,10 +603,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
 
 print(r.json())
 
@@ -606,10 +626,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -674,8 +695,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_creds_{xname}
@@ -683,7 +705,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -692,9 +714,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -702,10 +725,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
 
 print(r.json())
 
@@ -724,10 +748,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -782,8 +807,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_creds
@@ -791,7 +817,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -799,18 +825,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
 
 print(r.json())
 
@@ -828,10 +856,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -878,8 +907,9 @@ Fetch controller login credentials for a specified targets.  Targets are specifi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET, POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_globalcreds
@@ -887,7 +917,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -896,9 +926,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -906,10 +937,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
 
 print(r.json())
 
@@ -928,10 +960,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -992,8 +1025,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-bios">bios</h1>
@@ -1005,7 +1039,7 @@ Endpoints that set or get BIOS information
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1013,18 +1047,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1042,10 +1078,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1094,8 +1131,9 @@ Fetch the current BIOS setting for the TPM State.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__bmc_bios_{xname}_{bios_field}
@@ -1103,7 +1141,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1112,9 +1150,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1122,10 +1161,11 @@ curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bio
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1144,10 +1184,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1208,8 +1249,9 @@ Set the TPM State in the BIOS settings.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-version">version</h1>
@@ -1221,7 +1263,7 @@ Endpoints that perform health and version checks
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1229,18 +1271,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
 
 print(r.json())
 
@@ -1258,10 +1302,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1295,8 +1340,9 @@ Retrieve service version information.  Version is returned in vmaj.min.bld forma
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-certs">certs</h1>
@@ -1308,7 +1354,7 @@ Endpoints that create, delete, fetch, and apply TLS certs
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1317,9 +1363,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1327,10 +1374,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
 
 print(r.json())
 
@@ -1349,10 +1397,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1409,8 +1458,9 @@ Create TLS cert/key pairs for a set of BMC targets.  A TLS cert/key is created p
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_deletecerts
@@ -1418,7 +1468,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1427,9 +1477,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1437,10 +1488,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
 
 print(r.json())
 
@@ -1459,10 +1511,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1519,8 +1572,9 @@ Delete TLS cert/key information for domain-level TLS certs based on the given ta
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_fetchcerts
@@ -1528,7 +1582,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1537,9 +1591,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1547,10 +1602,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
 
 print(r.json())
 
@@ -1569,10 +1625,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1633,8 +1690,9 @@ Fetches BMC TLS certs previously created using the /bmc/createcerts endpoint and
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcerts
@@ -1642,7 +1700,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1651,9 +1709,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1661,10 +1720,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
 
 print(r.json())
 
@@ -1683,10 +1743,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1744,8 +1805,9 @@ Apply TLS cert/key pairs, previously generated using the /bmc/createcerts endpoi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcert_{xname}
@@ -1753,21 +1815,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}')
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1783,8 +1849,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1816,8 +1886,9 @@ Apply a TLS cert/key pairs previously generated using the /bmc/createcerts endpo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-cli_ignore">cli_ignore</h1>
@@ -1827,21 +1898,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/liveness')
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1857,8 +1932,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1881,8 +1960,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1890,21 +1970,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/readiness')
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1920,8 +2004,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1944,8 +2032,9 @@ Get readiness status of the service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1953,7 +2042,7 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1961,18 +2050,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
 
 print(r.json())
 
@@ -1990,10 +2081,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2029,8 +2121,9 @@ Get readiness status of the service
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|The service encountered an error when gathering health information|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/sls.md
+++ b/api/sls.md
@@ -121,9 +121,11 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/sls/v1">https://api-gw-service-nmn.local/apis/sls/v1</a>
 
-* <a href="http://cray-sls">http://cray-sls</a>
-
  License: Cray Proprietary
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="system-layout-service-hardware">hardware</h1>
 
@@ -143,14 +145,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -171,6 +175,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -345,8 +350,9 @@ Status Code **200**
 |NodeType|Storage|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__hardware
@@ -365,7 +371,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -373,7 +380,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -395,6 +403,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -467,8 +476,9 @@ Create a new hardware object.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hardware_{xname}
@@ -485,14 +495,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -513,6 +525,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -568,8 +581,9 @@ Retrieve information about the requested xname. All properties are returned as a
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[hardware](#schemahardware)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__hardware_{xname}
@@ -588,7 +602,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -596,7 +611,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -618,6 +634,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -690,8 +707,9 @@ Update a hardware object.  Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__hardware_{xname}
@@ -706,14 +724,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -728,6 +750,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}", data)
@@ -760,8 +786,9 @@ Delete the requested xname from SLS. Note that if you delete a parent object, th
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname not found|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The xname probably still had children.|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-search">search</h1>
@@ -782,14 +809,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/hardware', headers = headers)
@@ -810,6 +839,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1009,8 +1039,9 @@ Status Code **200**
 |NodeType|Storage|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__search_networks
@@ -1027,14 +1058,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/networks', headers = headers)
@@ -1055,6 +1088,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1172,8 +1206,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-dumpstate">dumpstate</h1>
@@ -1194,14 +1229,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/dumpstate', headers = headers)
@@ -1222,6 +1259,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1375,8 +1413,9 @@ Get a dump of current service state. The format of this is implementation-specif
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|State dumped successfully|[slsState](#schemaslsstate)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred in state dumping.  See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loadstate
@@ -1393,14 +1432,16 @@ Content-Type: multipart/form-data
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-  -H 'Content-Type: multipart/form-data'
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'multipart/form-data'
+  'Content-Type': 'multipart/form-data',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/loadstate', headers = headers)
@@ -1421,6 +1462,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1613,8 +1655,9 @@ sls_dump:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|State loaded successfully|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Loading state failed.  See body for error|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-misc">misc</h1>
@@ -1635,14 +1678,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/health', headers = headers)
@@ -1663,6 +1708,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1714,8 +1760,9 @@ Status Code **200**
 |» Vault|string|true|none|Status of the Vault.|
 |» DBConnection|string|true|none|Status of the connection with the database.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1732,14 +1779,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/liveness', headers = headers)
@@ -1760,6 +1809,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1802,8 +1852,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1820,14 +1871,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/readiness', headers = headers)
@@ -1848,6 +1901,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1890,8 +1944,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__version
@@ -1908,14 +1963,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/version', headers = headers)
@@ -1936,6 +1993,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1977,8 +2035,9 @@ Retrieve the current version of the SLS mapping. Information returned is a JSON 
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Information retrieved successfully|[versionResponse](#schemaversionresponse)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred, see text of response for more information|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-network">network</h1>
@@ -1997,14 +2056,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2025,6 +2086,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2133,8 +2195,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__networks
@@ -2151,14 +2214,16 @@ Content-Type: application/json
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Content-Type: application/json'
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'application/json'
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2179,6 +2244,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2255,8 +2321,9 @@ Create a new network. Must include all fields at the time of upload.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Network with that name already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__networks_{network}
@@ -2273,14 +2340,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2301,6 +2370,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2380,8 +2450,9 @@ Retrieve the specific network.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[network](#schemanetwork)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No network item found with requested name|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__networks_{network}
@@ -2400,7 +2471,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2408,7 +2480,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2430,6 +2503,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2554,8 +2628,9 @@ Update a network object. Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__networks_{network}
@@ -2570,14 +2645,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
 
 print(r.json())
 
@@ -2592,6 +2671,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}", data)
@@ -2623,8 +2706,9 @@ Delete the specific network from SLS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. Network removed|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Network not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/smd.md
+++ b/api/smd.md
@@ -107,7 +107,11 @@ Generally, nodes transition 'Off' -> 'On' -> 'Ready' when going from 'Off' to bo
 
 Base URLs:
 
-* <a href="https://sms/apis/smd/hsm/v2">https://sms/apis/smd/hsm/v2</a>
+* <a href="https://api-gw-service-nmn.local/apis/smd/hsm/v2">https://api-gw-service-nmn.local/apis/smd/hsm/v2</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="hardware-state-manager-api-service-info">Service Info</h1>
 
@@ -120,26 +124,28 @@ Service information APIs for getting information on the HSM service such as read
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/ready HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/ready \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/ready', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready', headers = headers)
 
 print(r.json())
 
@@ -157,10 +163,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/ready", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -197,8 +204,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is unhealthy and not ready|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doLivenessGet
@@ -208,26 +216,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/liveness HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness', headers = headers)
 
 print(r.json())
 
@@ -245,10 +255,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -288,8 +299,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doValuesGet
@@ -299,26 +311,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values', headers = headers)
 
 print(r.json())
 
@@ -336,10 +350,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -370,8 +385,9 @@ null
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of parameters and their valid values.|[Values.1.0.0_Values](#schemavalues.1.0.0_values)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doArchValuesGet
@@ -381,26 +397,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/arch HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/arch \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/arch', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch', headers = headers)
 
 print(r.json())
 
@@ -418,10 +436,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/arch", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +475,9 @@ Retrieve all valid values for use with the 'arch' (component architecture) param
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'arch' parameter.|[Values.1.0.0_ArchArray](#schemavalues.1.0.0_archarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doClassValuesGet
@@ -467,26 +487,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/class HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/class \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/class', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class', headers = headers)
 
 print(r.json())
 
@@ -504,10 +526,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/class", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -542,8 +565,9 @@ Retrieve all valid values for use with the 'class' (hardware class) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'class' parameter.|[Values.1.0.0_ClassArray](#schemavalues.1.0.0_classarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doFlagValuesGet
@@ -553,26 +577,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/flag HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/flag \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/flag', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag', headers = headers)
 
 print(r.json())
 
@@ -590,10 +616,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/flag", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -628,8 +655,9 @@ Retrieve all valid values for use with the 'flag' (component flag) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'flag' parameter.|[Values.1.0.0_FlagArray](#schemavalues.1.0.0_flagarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNetTypeValuesGet
@@ -639,26 +667,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/nettype \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/nettype', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype', headers = headers)
 
 print(r.json())
 
@@ -676,10 +706,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/nettype", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -714,8 +745,9 @@ Retrieve all valid values for use with the 'nettype' (component network type) pa
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'nettype' parameter.|[Values.1.0.0_NetTypeArray](#schemavalues.1.0.0_nettypearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRoleValuesGet
@@ -725,26 +757,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/role HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/role \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/role', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role', headers = headers)
 
 print(r.json())
 
@@ -762,10 +796,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/role", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -800,8 +835,9 @@ Retrieve all valid values for use with the 'role' (component role) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'role' parameter.|[Values.1.0.0_RoleArray](#schemavalues.1.0.0_rolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubRoleValuesGet
@@ -811,26 +847,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/subrole \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/subrole', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole', headers = headers)
 
 print(r.json())
 
@@ -848,10 +886,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/subrole", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -886,8 +925,9 @@ Retrieve all valid values for use with the 'subrole' (component subrole) paramet
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'subrole' parameter.|[Values.1.0.0_SubRoleArray](#schemavalues.1.0.0_subrolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doStateValuesGet
@@ -897,26 +937,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/state HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/state \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/state', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state', headers = headers)
 
 print(r.json())
 
@@ -934,10 +976,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/state", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -972,8 +1015,9 @@ Retrieve all valid values for use with the 'state' (component state) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'state' parameter.|[Values.1.0.0_StateArray](#schemavalues.1.0.0_statearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doTypeValuesGet
@@ -983,26 +1027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/type HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/type \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/type', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type', headers = headers)
 
 print(r.json())
 
@@ -1020,10 +1066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/type", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1058,8 +1105,9 @@ Retrieve all valid values for use with the 'type' (component HMSType) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'type' parameter.|[Values.1.0.0_TypeArray](#schemavalues.1.0.0_typearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-component">Component</h1>
@@ -1073,26 +1121,28 @@ High-level component information by xname: state, flag, NID, role, etc.
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1110,10 +1160,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1265,8 +1316,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for filter|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsPost
@@ -1276,8 +1328,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1285,9 +1337,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1295,10 +1348,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1317,10 +1371,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1388,8 +1443,9 @@ Create/Update a collection of state/components. If the component already exists 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsDeleteAll
@@ -1399,26 +1455,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1436,10 +1494,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1475,8 +1534,9 @@ Delete all entries in the components collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentGet
@@ -1486,26 +1546,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1523,10 +1585,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1581,8 +1644,9 @@ Retrieve state or components by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentPut
@@ -1592,8 +1656,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1601,9 +1665,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1611,10 +1676,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1633,10 +1699,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1703,8 +1770,9 @@ Create/Update a state/component. If the component already exists it will not be 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentDelete
@@ -1714,26 +1782,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1751,10 +1821,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1796,8 +1867,9 @@ Delete a component by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDGet
@@ -1807,26 +1879,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
 
 print(r.json())
 
@@ -1844,10 +1918,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1902,8 +1977,9 @@ Retrieve a component by NID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkStateDataPatch
@@ -1913,8 +1989,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1922,9 +1998,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1932,10 +2009,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
 
 print(r.json())
 
@@ -1954,10 +2032,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkStateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2020,8 +2099,9 @@ Specify a list of xnames to update the State and Flag fields. If the Flag field 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompStatePatch
@@ -2031,8 +2111,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2040,9 +2120,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2050,10 +2131,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
 
 print(r.json())
 
@@ -2072,10 +2154,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2136,8 +2219,9 @@ Update the component's state and flag fields only. If Flag field is omitted, the
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkFlagOnlyPatch
@@ -2147,8 +2231,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2156,9 +2240,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2166,10 +2251,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2188,10 +2274,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2252,8 +2339,9 @@ Specify a list of xnames to update the Flag field and specify the value. The lis
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompFlagOnlyPatch
@@ -2263,8 +2351,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2272,9 +2360,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2282,10 +2371,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2304,10 +2394,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2366,8 +2457,9 @@ The State is not modified. Only the Flag is updated.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkEnabledPatch
@@ -2377,8 +2469,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2386,9 +2478,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2396,10 +2489,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
 
 print(r.json())
 
@@ -2418,10 +2512,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2482,8 +2577,9 @@ Update the Enabled field for a list of xnames. Specify a single value for Enable
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEnabledPatch
@@ -2493,8 +2589,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2502,9 +2598,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2512,10 +2609,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
 
 print(r.json())
 
@@ -2534,10 +2632,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2596,8 +2695,9 @@ Update the component's Enabled field only. The State and other fields are not mo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkSwStatusPatch
@@ -2607,8 +2707,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2616,9 +2716,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2626,10 +2727,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2648,10 +2750,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2712,8 +2815,9 @@ Update the SoftwareStatus field for a list of xnames. Specify a single new value
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompSwStatusPatch
@@ -2723,8 +2827,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2732,9 +2836,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2742,10 +2847,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2764,10 +2870,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2826,8 +2933,9 @@ Update the component's SoftwareStatus field only. The State and other fields are
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkRolePatch
@@ -2837,8 +2945,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2846,9 +2954,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2856,10 +2965,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
 
 print(r.json())
 
@@ -2878,10 +2988,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkRole", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2943,8 +3054,9 @@ Update the Role and SubRole field for a list of xnames. Specify the Role and Sub
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompRolePatch
@@ -2954,8 +3066,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2963,9 +3075,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2973,10 +3086,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
 
 print(r.json())
 
@@ -2995,10 +3109,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3058,8 +3173,9 @@ Update the component's Role and SubRole fields only. Valid only for nodes. The S
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompArrayNIDPatch
@@ -3069,8 +3185,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3078,9 +3194,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3088,10 +3205,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
 
 print(r.json())
 
@@ -3110,10 +3228,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkNID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3176,8 +3295,9 @@ Modify the submitted ComponentArray and update the corresponding NID value for e
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompNIDPatch
@@ -3187,8 +3307,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3196,9 +3316,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3206,10 +3327,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
 
 print(r.json())
 
@@ -3228,10 +3350,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3290,8 +3413,9 @@ Update the component's NID field only. Valid only for nodes. State and other fie
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsQueryPost
@@ -3301,8 +3425,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3310,9 +3434,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3320,10 +3445,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query', headers = headers)
 
 print(r.json())
 
@@ -3342,10 +3468,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3459,8 +3586,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDQueryPost
@@ -3470,8 +3598,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3479,9 +3607,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3489,10 +3618,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
 
 print(r.json())
 
@@ -3511,10 +3641,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3588,8 +3719,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentQueryGet
@@ -3599,26 +3731,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -3636,10 +3770,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3792,8 +3927,9 @@ Additional valid values may be added via configuration file. See the results of 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-nodemap">NodeMap</h1>
@@ -3807,26 +3943,28 @@ Given a node xname ID, provide defaults for NID, Role, etc. to be used when the 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3844,10 +3982,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3888,8 +4027,9 @@ Retrieve all Node map entries as a named array, or an empty array if the collect
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPost
@@ -3899,8 +4039,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3908,9 +4048,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3918,10 +4059,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3940,10 +4082,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4012,8 +4155,9 @@ Note the following points:
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapsDeleteAll
@@ -4023,26 +4167,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -4060,10 +4206,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4099,8 +4246,9 @@ Delete all entries in the NodeMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapGet
@@ -4110,26 +4258,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4147,10 +4297,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4194,8 +4345,9 @@ Retrieve NodeMap, i.e. defaults NID/Role/etc. for node located at physical locat
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapDelete
@@ -4205,26 +4357,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4242,10 +4396,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4287,8 +4442,9 @@ Delete NodeMap entry for a specific node {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPut
@@ -4298,8 +4454,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -4307,9 +4463,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4317,10 +4474,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4339,10 +4497,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4400,8 +4559,9 @@ Update or create an entry for an individual node xname using PUT. Note the follo
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventory">HWInventory</h1>
@@ -4415,26 +4575,28 @@ HWInventoryByLocation collection containing all components matching the query th
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4452,10 +4614,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5071,8 +5234,9 @@ Default is NestNodesOnly.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybylocation">HWInventoryByLocation</h1>
@@ -5086,26 +5250,28 @@ Hardware inventory information for the given system location/xname
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5123,10 +5289,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5339,8 +5506,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationPost
@@ -5350,8 +5518,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -5359,9 +5527,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5369,10 +5538,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5391,10 +5561,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5583,8 +5754,9 @@ Create/Update hardware inventory entries
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDeleteAll
@@ -5594,26 +5766,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5631,10 +5805,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5670,8 +5845,9 @@ Delete all entries in the HWInventoryByLocation collection. Note that this does 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationGet
@@ -5681,26 +5857,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -5718,10 +5896,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5990,8 +6169,9 @@ null
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDelete
@@ -6001,26 +6181,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6038,10 +6220,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6083,8 +6266,9 @@ Delete HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybyfru">HWInventoryByFRU</h1>
@@ -6098,26 +6282,28 @@ This represents a physical piece of hardware with properties specific to a uniqu
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6135,10 +6321,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6306,8 +6493,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDeleteAll
@@ -6317,26 +6505,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6354,10 +6544,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6393,8 +6584,9 @@ Delete all entries in the HWInventoryByFRU collection. Note that this does not d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUGet
@@ -6404,26 +6596,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6441,10 +6635,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6499,8 +6694,9 @@ Retrieve HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDelete
@@ -6510,26 +6706,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6547,10 +6745,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6592,8 +6791,9 @@ Delete an entry in the HWInventoryByFRU collection. Note that this does not dele
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventoryhistory">HWInventoryHistory</h1>
@@ -6607,26 +6807,28 @@ Hardware inventory historical information for the given system location/xname/FR
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6644,10 +6846,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6703,8 +6906,9 @@ Retrieve the history entries for all HWInventoryByLocation entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDeleteAll
@@ -6714,26 +6918,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6751,10 +6957,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6790,8 +6997,9 @@ Delete all HWInventory history entries. Note that this also deletes history for 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationGet
@@ -6801,26 +7009,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6838,10 +7048,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6893,8 +7104,9 @@ Retrieve the history entries for a HWInventoryByLocation entry with a specific x
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDelete
@@ -6904,26 +7116,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6941,10 +7155,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6986,8 +7201,9 @@ Delete history for the HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUsGet
@@ -6997,26 +7213,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
 
 print(r.json())
 
@@ -7034,10 +7252,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7093,8 +7312,9 @@ Retrieve the history entries for all HWInventoryByFRU entries. Sorted by FRU.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUGet
@@ -7104,26 +7324,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7141,10 +7363,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7196,8 +7419,9 @@ Retrieve the history entries for the HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUDelete
@@ -7207,26 +7431,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7244,10 +7470,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7289,8 +7516,9 @@ Delete history for an entry in the HWInventoryByFRU collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-redfishendpoint">RedfishEndpoint</h1>
@@ -7304,26 +7532,28 @@ This is a BMC or other Redfish controller that has a Redfish entry point and Red
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7341,10 +7571,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7453,8 +7684,9 @@ Retrieve all Redfish endpoint entries as a named array, optionally filtering it.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsPost
@@ -7464,8 +7696,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7473,9 +7705,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7483,10 +7716,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7505,10 +7739,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7594,8 +7829,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsDeleteAll
@@ -7605,26 +7841,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7642,10 +7880,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7681,8 +7920,9 @@ Delete all entries in the RedfishEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointGet
@@ -7692,26 +7932,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7729,10 +7971,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7793,8 +8036,9 @@ Retrieve RedfishEndpoint, located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointDelete
@@ -7804,26 +8048,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7841,10 +8087,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7886,8 +8133,9 @@ Delete RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPut
@@ -7897,8 +8145,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7906,9 +8154,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7916,10 +8165,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7938,10 +8188,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8024,8 +8275,9 @@ Create or update RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPatch
@@ -8035,8 +8287,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -8044,9 +8296,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -8054,10 +8307,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8076,10 +8330,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8162,8 +8417,9 @@ Update (PATCH) RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointQueryGet
@@ -8173,26 +8429,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8210,10 +8468,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8278,8 +8537,9 @@ Given xname and modifiers in query string, retrieve zero or more RedfishEndpoint
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matches|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentendpoint">ComponentEndpoint</h1>
@@ -8293,26 +8553,28 @@ The Redfish-discovered properties for a component discovered through, and manage
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8330,10 +8592,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8485,8 +8748,9 @@ Retrieve the full collection of ComponentEndpoints in the form of a ComponentEnd
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointsDeleteAll
@@ -8496,26 +8760,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8533,10 +8799,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8572,8 +8839,9 @@ Delete all entries in the ComponentEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointGet
@@ -8583,26 +8851,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8620,10 +8890,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8727,8 +8998,9 @@ Retrieve ComponentEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointDelete
@@ -8738,26 +9010,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8775,10 +9049,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8820,8 +9095,9 @@ Delete ComponentEndpoint for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-serviceendpoint">ServiceEndpoint</h1>
@@ -8835,26 +9111,28 @@ The Redfish-discovered properties for a service discovered through, and managed 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8872,10 +9150,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8965,8 +9244,9 @@ Retrieve the full collection of ServiceEndpoints in the form of a ServiceEndpoin
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsDeleteAll
@@ -8976,26 +9256,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -9013,10 +9295,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9052,8 +9335,9 @@ Delete all entries in the ServiceEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsGet
@@ -9063,26 +9347,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
 
 print(r.json())
 
@@ -9100,10 +9386,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9194,8 +9481,9 @@ Retrieve all ServiceEndpoint records for the Redfish service.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Service does not exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointGet
@@ -9205,26 +9493,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9242,10 +9532,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9330,8 +9621,9 @@ Retrieve the ServiceEndpoint for a Redfish service that is managed by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointDelete
@@ -9341,26 +9633,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9378,10 +9672,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9424,8 +9719,9 @@ Delete the {service} ServiceEndpoint managed by {xname}
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matching ServiceEndpoint to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentethernetinterfaces">ComponentEthernetInterfaces</h1>
@@ -9439,26 +9735,28 @@ The MAC address to IP address relation for components in the system. If the comp
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9476,10 +9774,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9593,8 +9892,9 @@ Status Code **200**
 |Type|HSNConnector|
 |Type|INVALID|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePostV2
@@ -9604,8 +9904,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -9613,9 +9913,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -9623,10 +9924,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9645,10 +9947,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9713,8 +10016,9 @@ Create a new component ethernet interface.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate component ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteAllV2
@@ -9724,26 +10028,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9761,10 +10067,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9800,8 +10107,9 @@ Delete all component ethernet interface entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceGetV2
@@ -9811,26 +10119,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -9848,10 +10158,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9903,8 +10214,9 @@ Retrieve the component ethernet interface which was created with the given {ethI
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteV2
@@ -9914,26 +10226,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -9951,10 +10265,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9996,8 +10311,9 @@ Delete the given component ethernet interface with {ethInterfaceID}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No component ethernet interface with ethInterfaceID.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePatchV2
@@ -10007,8 +10323,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10016,9 +10332,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10026,10 +10343,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -10048,10 +10366,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10112,8 +10431,9 @@ To update the IP address, CompID, and/or description of a component ethernet int
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The component ethernet interface with this ethInterfaceID does not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesGetV2
@@ -10123,26 +10443,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10160,10 +10482,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10217,8 +10540,9 @@ Status Code **200**
 |» IPAddress|string|true|none|The IP address associated with the MAC address for this component ethernet interface on for this particular network.|
 |» Network|string|false|none|The network that this IP Addresses is associated with.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesPostV2
@@ -10228,8 +10552,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10237,9 +10561,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10247,10 +10572,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterf
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10269,10 +10595,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10323,8 +10650,9 @@ Create a new IP address mapping in a component ethernet interface {ethInterfaceI
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate IP address in component ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressPatchV2
@@ -10334,8 +10662,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10343,9 +10671,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10353,10 +10682,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10375,10 +10705,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10433,8 +10764,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component ethernet interface.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressDeleteV2
@@ -10444,26 +10776,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10481,10 +10815,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10527,8 +10862,9 @@ Delete the given IP Address mapping with {ipAddress} from a component ethernet i
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component ethernet interface|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-group">Group</h1>
@@ -10542,26 +10878,28 @@ A group is an informal, possibly overlapping division of the system that groups 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10579,10 +10917,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10653,8 +10992,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupsPost
@@ -10664,8 +11004,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10673,9 +11013,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10683,10 +11024,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10705,10 +11047,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10794,8 +11137,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupGet
@@ -10805,26 +11149,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -10842,10 +11188,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10901,8 +11248,9 @@ Retrieve the group which was created with the given {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupDelete
@@ -10912,26 +11260,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -10949,10 +11299,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10994,8 +11345,9 @@ Delete the given group with {group_label}. Any members previously in the group w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No group matches label.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupPatch
@@ -11005,8 +11357,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11014,9 +11366,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11024,10 +11377,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -11046,10 +11400,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11107,8 +11462,9 @@ To update the tags array and/or description, a PATCH operation can be used.  Omi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The group with this label did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupLabelsGet
@@ -11118,26 +11474,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/labels HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/labels \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/labels', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels', headers = headers)
 
 print(r.json())
 
@@ -11155,10 +11513,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/labels", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11205,8 +11564,9 @@ Retrieve a string array of all group labels (i.e. group names) that currently ex
 
 <h3 id="dogrouplabelsget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersGet
@@ -11216,26 +11576,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11253,10 +11615,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11303,8 +11666,9 @@ Retrieve members of an existing group {group_label}, optionally filtering the se
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such group {group_label}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersPost
@@ -11314,8 +11678,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11323,9 +11687,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11333,10 +11698,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11355,10 +11721,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11430,8 +11797,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMemberDelete
@@ -11441,26 +11809,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -11478,10 +11848,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11524,8 +11895,9 @@ Delete component {xname_id} from the members of group {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or group.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-partition">Partition</h1>
@@ -11539,26 +11911,28 @@ A partition is a formal, non-overlapping division of the system that forms an ad
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11576,10 +11950,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11648,8 +12023,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionsPost
@@ -11659,8 +12035,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11668,9 +12044,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11678,10 +12055,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11700,10 +12078,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11786,8 +12165,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionGet
@@ -11797,26 +12177,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -11834,10 +12216,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11891,8 +12274,9 @@ Retrieve the partition which was created with the given {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionDelete
@@ -11902,26 +12286,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -11939,10 +12325,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11984,8 +12371,9 @@ Delete partition {partition_name}. Any members previously in the partition will 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No partition matches partition_name.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionPatch
@@ -11995,8 +12383,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12004,9 +12392,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12014,10 +12403,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -12036,10 +12426,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12097,8 +12488,9 @@ Update the tags array and/or description by using PATCH. Omitted fields are not 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The partition with this partition_name did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionNamesGet
@@ -12108,26 +12500,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/names HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/names \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/names', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names', headers = headers)
 
 print(r.json())
 
@@ -12145,10 +12539,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/names", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12193,8 +12588,9 @@ Retrieve a string array of all partition names that currently exist in HSM. Thes
 
 <h3 id="dopartitionnamesget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersGet
@@ -12204,26 +12600,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12241,10 +12639,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12290,8 +12689,9 @@ Retrieve all members of existing partition {partition_name}, optionally filterin
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such partition {partition_name}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersPost
@@ -12301,8 +12701,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12310,9 +12710,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12320,10 +12721,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12342,10 +12744,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12417,8 +12820,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMemberDelete
@@ -12428,26 +12832,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -12465,10 +12871,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12511,8 +12918,9 @@ Delete component {xname_id} from the members of partition {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or partition.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-membership">Membership</h1>
@@ -12526,26 +12934,28 @@ A membership is a mapping of a component xname to its set of group labels and pa
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships', headers = headers)
 
 print(r.json())
 
@@ -12563,10 +12973,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12715,8 +13126,9 @@ Status Code **200**
 |» partitionName|string|false|none|The name is a human-readable identifier for the partition and uniquely identifies it.|
 |» groupLabels|[string]|false|none|An array with all group labels the component is associated with The label is the human-readable identifier for a group and uniquely identifies it.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doMembershipGet
@@ -12726,26 +13138,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
 
 print(r.json())
 
@@ -12763,10 +13177,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12813,8 +13228,9 @@ Display group labels and partition names for a given component xname id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found - no such xname.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discoverystatus">DiscoveryStatus</h1>
@@ -12828,26 +13244,28 @@ Contains status information about the discovery operation for clients to query. 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
 
 print(r.json())
 
@@ -12865,10 +13283,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12927,8 +13346,9 @@ Status Code **200**
 |Status|InProgress|
 |Status|Complete|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDiscoveryStatusGet
@@ -12938,26 +13358,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
 
 print(r.json())
 
@@ -12975,10 +13397,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13022,8 +13445,9 @@ Retrieve DiscoveryStatus entry with the specific id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found (no such ID)|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discover">Discover</h1>
@@ -13037,8 +13461,8 @@ Trigger a discovery of system component data by interrogating all, or a subset, 
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13046,9 +13470,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13056,10 +13481,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
 
 print(r.json())
 
@@ -13078,10 +13504,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Discover", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13155,8 +13582,9 @@ Status Code **200**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-scn">SCN</h1>
@@ -13170,8 +13598,8 @@ Manage subscriptions to state change notifications (SCNs) from HSM.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13179,9 +13607,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13189,10 +13618,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13211,10 +13641,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13293,8 +13724,9 @@ Request a subscription for state change notifications for a set of component sta
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscriptionsAll
@@ -13304,26 +13736,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13341,10 +13775,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13382,8 +13817,9 @@ Delete all subscriptions.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscriptionsAll
@@ -13393,26 +13829,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13430,10 +13868,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13486,8 +13925,9 @@ Retrieve all information on currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPutSCNSubscription
@@ -13497,8 +13937,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13506,9 +13946,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13516,10 +13957,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13538,10 +13980,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13610,8 +14053,9 @@ Update an existing state change notification subscription in whole. This will ov
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPatchSCNSubscription
@@ -13621,8 +14065,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13630,9 +14074,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13640,10 +14085,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13662,10 +14108,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13733,8 +14180,9 @@ Update a subscription for state change notifications to add or remove triggers.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error. Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscription
@@ -13744,26 +14192,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13781,10 +14231,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13829,8 +14280,9 @@ Delete a state change notification subscription.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscription
@@ -13840,26 +14292,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13877,10 +14331,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13934,8 +14389,9 @@ Return the information on a currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-locking">Locking</h1>
@@ -13947,8 +14403,8 @@ Manage locks and reservations on components.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13956,9 +14412,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13966,10 +14423,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
 
 print(r.json())
 
@@ -13988,10 +14446,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/remove", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14096,8 +14555,9 @@ Given a list of components, forcibly deletes any existing reservation. Does not 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations_release
@@ -14105,8 +14565,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14114,9 +14574,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14124,10 +14585,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14146,10 +14608,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14218,8 +14681,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations
@@ -14227,8 +14691,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14236,9 +14700,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14246,10 +14711,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations', headers = headers)
 
 print(r.json())
 
@@ -14268,10 +14734,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14373,8 +14840,9 @@ Creates reservations on a set of xnames of infinite duration.  Component must be
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_release
@@ -14382,8 +14850,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14391,9 +14859,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14401,10 +14870,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14423,10 +14893,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14495,8 +14966,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations
@@ -14504,8 +14976,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14513,9 +14985,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14523,10 +14996,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
 
 print(r.json())
 
@@ -14545,10 +15019,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14652,8 +15127,9 @@ Creates reservations on a set of xnames of finite duration.  Component must be u
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_renew
@@ -14661,8 +15137,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14670,9 +15146,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14680,10 +15157,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
 
 print(r.json())
 
@@ -14702,10 +15180,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/renew", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14775,8 +15254,9 @@ Given a list of {xname & reservation key}, renews the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_check
@@ -14784,8 +15264,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14793,9 +15273,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14803,10 +15284,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
 
 print(r.json())
 
@@ -14825,10 +15307,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/check", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14893,8 +15376,9 @@ Using xname + reservation key check on the validity of reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not check reservations.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_status
@@ -14902,8 +15386,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14911,9 +15395,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14921,10 +15406,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -14943,10 +15429,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15008,8 +15495,9 @@ Using component ID retrieve the status of any lock and/or reservation.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__locks_status
@@ -15017,26 +15505,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/locks/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -15054,10 +15544,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15178,8 +15669,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_lock
@@ -15187,8 +15679,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/lock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15196,9 +15688,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15206,10 +15699,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/lock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock', headers = headers)
 
 print(r.json())
 
@@ -15228,10 +15722,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/lock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15336,8 +15831,9 @@ Using a component create a lock.  Cannot be locked if already locked, or if ther
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not lock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_unlock
@@ -15345,8 +15841,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/unlock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15354,9 +15850,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15364,10 +15861,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/unlock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock', headers = headers)
 
 print(r.json())
 
@@ -15386,10 +15884,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/unlock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15494,8 +15993,9 @@ Using a component unlock a lock.  Cannot be unlocked if already unlocked.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not unlock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_repair
@@ -15503,8 +16003,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/repair HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15512,9 +16012,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15522,10 +16023,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/repair', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair', headers = headers)
 
 print(r.json())
 
@@ -15544,10 +16046,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/repair", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15652,8 +16155,9 @@ Repairs the disabled status of an xname allowing new reservations to be created.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not repair lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_disable
@@ -15661,8 +16165,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/disable HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15670,9 +16174,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15680,10 +16185,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/disable', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable', headers = headers)
 
 print(r.json())
 
@@ -15702,10 +16208,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/disable", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15810,8 +16317,9 @@ Disables the ability to create a reservation on components, deletes any existing
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not disable lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-powermap">PowerMap</h1>
@@ -15825,26 +16333,28 @@ Power mapping of components to the components supplying them power. This may con
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -15862,10 +16372,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15905,8 +16416,9 @@ Retrieve all power map entries as a named array, or an empty array if the collec
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsPost
@@ -15916,8 +16428,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15925,9 +16437,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15935,10 +16448,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -15957,10 +16471,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16015,8 +16530,9 @@ Create or update the given set of PowerMaps whose ID fields are each a valid xna
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsDeleteAll
@@ -16026,26 +16542,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -16063,10 +16581,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16102,8 +16621,9 @@ Delete all entries in the PowerMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapGet
@@ -16113,26 +16633,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16150,10 +16672,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16198,8 +16721,9 @@ Retrieve PowerMap for a component located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapDelete
@@ -16209,26 +16733,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16246,10 +16772,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16291,8 +16818,9 @@ Delete PowerMap entry for a specific component {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapPut
@@ -16302,8 +16830,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -16311,9 +16839,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -16321,10 +16850,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16343,10 +16873,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16400,8 +16931,9 @@ Update or create an entry for an individual component xname using PUT. If the PU
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -18627,7 +19159,7 @@ Either way, the 'Target' field is the parent component, partition or system that
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |XName|[XName.1.0.0](#schemaxname.1.0.0)|false|none|Uniquely identifies the component by its physical location (xname). There are formatting rules depending on the matching HMSType.|
-|Format|string|false|none|How results are displayed<br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
+|Format|string|false|none|How results are displayed<br><br><br><br><br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
 |Cabinets|[[HWInvByLocCabinet](#schemahwinvbyloccabinet)]|false|read-only|All components with HMS type 'Cabinet' appropriate given Target component/partition and query type.|
 |Chassis|[[HWInvByLocChassis](#schemahwinvbylocchassis)]|false|read-only|All appropriate components with HMS type 'Chassis' given Target component/partition and query type.|
 |ComputeModules|[[HWInvByLocComputeModule](#schemahwinvbyloccomputemodule)]|false|read-only|All appropriate components with HMS type 'ComputeModule' given Target component/partition and query type.|

--- a/api/sts.md
+++ b/api/sts.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="http://localhost:9090/">http://localhost:9090/</a>
+* <a href="https://api-gw-service-nmn.local/apis/sts">https://api-gw-service-nmn.local/apis/sts</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-sts-token-generator-default">Default</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-PUT http://localhost:9090/token HTTP/1.1
-Host: localhost:9090
+PUT https://api-gw-service-nmn.local/apis/sts/token HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT http://localhost:9090/token \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/sts/token \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://localhost:9090/token', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/sts/token', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://localhost:9090/token", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/sts/token", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -95,8 +102,9 @@ Generates a STS Token.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|A generated STS Token|[Token](#schematoken)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-sts-token-generator-cli_ignore">cli_ignore</h1>
@@ -108,26 +116,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://localhost:9090/healthz HTTP/1.1
-Host: localhost:9090
+GET https://api-gw-service-nmn.local/apis/sts/healthz HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://localhost:9090/healthz \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/sts/healthz \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://localhost:9090/healthz', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/sts/healthz', headers = headers)
 
 print(r.json())
 
@@ -145,10 +155,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://localhost:9090/healthz", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/sts/healthz", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -188,8 +199,9 @@ Status Code **200**
 |---|---|---|---|---|
 |» Status|string|false|read-only|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/tapms-operator.md
+++ b/api/tapms-operator.md
@@ -8,7 +8,11 @@ Read-Only APIs to Retrieve Tenant Status
 
 Base URLs:
 
-* <a href="/">/</a>
+* <a href="https://api-gw-service-nmn.local/apis/tapms-operator">https://api-gw-service-nmn.local/apis/tapms-operator</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="tapms-tenant-status-api-tenant-and-partition-management-system">Tenant and Partition Management System</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET /apis/tapms/v1/tenant/{id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenant/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/tapms/v1/tenant/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenant/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/tapms/v1/tenant/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenant/{id}', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/tapms/v1/tenant/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenant/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -132,8 +139,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__apis_tapms_v1_tenants
@@ -141,26 +149,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/tapms/v1/tenants HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenants HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/tapms/v1/tenants \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenants \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/tapms/v1/tenants', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenants', headers = headers)
 
 print(r.json())
 
@@ -178,10 +188,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/tapms/v1/tenants", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms-operator/apis/tapms/v1/tenants", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -274,8 +285,9 @@ Status Code **200**
 |»» tenantresources|[[TenantResource](#schematenantresource)]|false|none|The desired resources for the Tenant|
 |»» uuid|string(uuid)|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/uas-mgr.md
+++ b/api/uas-mgr.md
@@ -288,7 +288,11 @@ list of available choices.
 
 Base URLs:
 
-* <a href="/apis/uas-mgr/v1">/apis/uas-mgr/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/uas-mgr/v1">https://api-gw-service-nmn.local/apis/uas-mgr/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="user-access-service-versions">versions</h1>
 
@@ -299,20 +303,25 @@ Base URLs:
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/ HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('/apis/uas-mgr/v1/')
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/', headers = headers)
 
 print(r.json())
 
@@ -328,8 +337,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -351,8 +364,9 @@ Return supported UAS API versions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version response|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uas">uas</h1>
@@ -364,26 +378,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uas HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uas \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -401,10 +417,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -472,8 +489,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai
@@ -483,8 +501,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/uas HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: multipart/form-data
 Accept: application/json
 
@@ -492,9 +510,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/uas \
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
   -H 'Content-Type: multipart/form-data' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -502,10 +521,11 @@ curl -X POST /apis/uas-mgr/v1/uas \
 import requests
 headers = {
   'Content-Type': 'multipart/form-data',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -524,10 +544,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -582,8 +603,9 @@ to ports 80, 443, and 8888.
 
 <h3 id="create_uai-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uai_by_name
@@ -593,25 +615,30 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uas', params={
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', params={
   'uai_list': [
   "uai-asdfgh098",
   "uai-qwerty123"
 ]
-})
+}, headers = headers)
 
 print(r.json())
 
@@ -627,8 +654,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,8 +689,9 @@ associated UAI(s).
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAIs deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete UAI with {uai_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-images">images</h1>
@@ -671,26 +703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/images', headers = headers)
 
 print(r.json())
 
@@ -708,10 +742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -747,8 +782,9 @@ List all available UAS images.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image List|[Image_list](#schemaimage_list)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Images not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uas_image_admin
@@ -758,26 +794,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/images', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', params={
   'imagename': 'docker.local/cray/cray-uas-sles15sp1:latest'
 }, headers = headers)
 
@@ -797,10 +835,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -843,8 +882,9 @@ upload container image.  Optionally, set default.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image added|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Image not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_images_admin
@@ -854,26 +894,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', headers = headers)
 
 print(r.json())
 
@@ -891,10 +933,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -942,8 +985,9 @@ Status Code **200**
 |» imagename|string|false|none|none|
 |» default|boolean|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_image_admin
@@ -953,26 +997,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -990,10 +1036,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1039,8 +1086,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Image {image_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_image_admin
@@ -1050,26 +1098,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1087,10 +1137,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1141,8 +1192,9 @@ instance.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image updated|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Image](#schemaimage)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_image_admin
@@ -1152,26 +1204,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1189,10 +1243,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1238,8 +1293,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Image removed|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete image {image_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-mgr-info">mgr-info</h1>
@@ -1251,26 +1307,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/mgr-info HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/mgr-info \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/mgr-info', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info', headers = headers)
 
 print(r.json())
 
@@ -1288,10 +1346,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/mgr-info", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1327,8 +1386,9 @@ Return User Access Service information.
 
 <h3 id="get_uas_mgr_info-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uais">uais</h1>
@@ -1340,26 +1400,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1377,10 +1439,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1422,8 +1485,9 @@ list UAIs that implements a superset of this functionality under the
 
 <h3 id="get_all_uais-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_uais
@@ -1433,20 +1497,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uais HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uais
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uais')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1462,8 +1531,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1495,8 +1568,9 @@ of the functionality found here.  This path is deprecated in favor of
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|All UAIs Deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No UAIs found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-admin">admin</h1>
@@ -1508,26 +1582,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1545,10 +1621,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1634,8 +1711,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai_admin
@@ -1645,26 +1723,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1682,10 +1762,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1780,8 +1861,9 @@ character.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI Created|[UAI](#schemauai)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uais_admin
@@ -1791,26 +1873,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1828,10 +1912,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1925,8 +2010,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uai_admin
@@ -1936,26 +2022,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais/{uai_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
 
 print(r.json())
 
@@ -1973,10 +2061,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2030,8 +2119,9 @@ Retrieve information on the specified UAI.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI Description|[UAI](#schemauai)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-config">config</h1>
@@ -2043,20 +2133,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config', headers = headers)
 
 print(r.json())
 
@@ -2072,8 +2167,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2100,8 +2199,9 @@ with this request.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Local configuration reset to defaults|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-volumes">volumes</h1>
@@ -2113,26 +2213,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/volumes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', params={
   'volumename': 'my-mount',  'mount_path': '/mnt/test',  'volume_description': '{ "config_map": { "name": "my-configmap" } }'
 }, headers = headers)
 
@@ -2152,10 +2254,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2235,8 +2338,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Volume not added|string|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volumes_admin
@@ -2246,26 +2350,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
 
 print(r.json())
 
@@ -2283,10 +2389,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2338,8 +2445,9 @@ Status Code **200**
 |» mount_path|string|false|none|none|
 |» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volume_admin
@@ -2349,26 +2457,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2386,10 +2496,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2436,8 +2547,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Volume|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Volume {volumename} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_volume_admin
@@ -2447,26 +2559,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2484,10 +2598,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2576,8 +2691,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Volume](#schemavolume)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not updated|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_volume_admin
@@ -2587,26 +2703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2624,10 +2742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2676,8 +2795,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Volume removed from list|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete volume {volume_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-resources">resources</h1>
@@ -2689,26 +2809,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2726,10 +2848,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2795,8 +2918,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource configuration added|[Resource](#schemaresource)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid limit or request specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resources_admin
@@ -2806,26 +2930,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2843,10 +2969,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2896,8 +3023,9 @@ Status Code **200**
 |» limit|string|false|none|none|
 |» request|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resource_admin
@@ -2907,26 +3035,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -2944,10 +3074,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2995,8 +3126,9 @@ config to be retrieved from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource Limit / Request Configuration Item|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource Configuration {resource_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_resource_admin
@@ -3006,26 +3138,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3043,10 +3177,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3114,8 +3249,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource updated|[Resource](#schemaresource)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Resource](#schemaresource)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_resource_admin
@@ -3125,26 +3261,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3162,10 +3300,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3213,8 +3352,9 @@ configuration to be removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-classes">classes</h1>
@@ -3226,26 +3366,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/classes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', params={
   'image_id': 'af4e59ab-6275-47f9-8f4a-90911eba3f9c'
 }, headers = headers)
 
@@ -3265,10 +3407,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3478,8 +3621,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class added|[UAIClass](#schemauaiclass)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid UAI / Broker Class specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_classes_admin
@@ -3489,26 +3633,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', headers = headers)
 
 print(r.json())
 
@@ -3526,10 +3672,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3633,8 +3780,9 @@ Status Code **200**
 |»»» mount_path|string|false|none|none|
 |»»» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_class_admin
@@ -3644,26 +3792,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3681,10 +3831,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3762,8 +3913,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI / Broker Class|[UAIClass](#schemauaiclass)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI / Broker Class {class_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_class_admin
@@ -3773,26 +3925,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3810,10 +3964,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4021,8 +4176,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class updated|[UAIClass](#schemauaiclass)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[UAIClass](#schemauaiclass)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_class_admin
@@ -4032,26 +4188,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -4069,10 +4227,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4119,8 +4278,9 @@ removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -25,20 +25,20 @@
 
 set -e -o pipefail
 function usage() {
-    echo "Generate API docs from swagger file URLs provided in csm manifests."
-    echo ""
-    echo "Usage: $0 <manifest-dir> <dest-dir>"
-    echo ""
-    exit 1
+  echo "Generate API docs from swagger file URLs provided in csm manifests."
+  echo ""
+  echo "Usage: $0 <manifest-dir> <dest-dir>"
+  echo ""
+  exit 1
 }
 
 function error() {
-    echo "${1}"
-    exit 1
+  echo "${1}"
+  exit 1
 }
 
 if [ $# -ne 2 ]; then
-    usage
+  usage
 fi
 
 manifest_dir=$(realpath "${1}")
@@ -47,42 +47,60 @@ tmp_dir=$(mktemp -d)
 mkdir -p "${dest_dir}" "${tmp_dir}"
 
 echo "Preparing yq container ..."
-docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 >/dev/null
+docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 > /dev/null
 yq="docker exec yq-swagger yq"
 
 echo "Preparing widdershins container ..."
-docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 >/dev/null
+docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 > /dev/null
 docker exec widdershins npm install -g widdershins
 
 trap 'echo "Cleaning up ..."; docker rm -f widdershins >/dev/null; docker rm -f yq-swagger >/dev/null; rm -Rf "${tmp_dir}"' EXIT
 
 find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
-    echo "Parsing ${manifest_file} ..."
-    while read -r swagger_def; do
-        IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
-        echo ""
-        echo "Downloading from ${endpoint_url} ..."
-        curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
-        if [ -n "${endpoint_title}" ]; then
-            ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        if [ -n "${endpoint_version}" ]; then
-            ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
-        docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
-    done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
+  echo "Parsing ${manifest_file} ..."
+  while read -r swagger_def; do
+    IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
+    echo ""
+    echo "Downloading from ${endpoint_url} ..."
+    curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+    openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
+    if [ -n "${endpoint_title}" ]; then
+      ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    if [ -n "${endpoint_version}" ]; then
+      ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    if [[ ${openapi_version} == 3.* ]]; then
+      ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      # Many services have both external (through API Gateway, requires auth) and internal (does not require auth) sample URLs.
+      # Auth requirement can not be scoped to URL, we remove all sample URLs and set one mandatory external URL instead.
+      base_url=$(${yq} e '.servers[] | select(.url == "*/apis/*") | .url | sub(".+/apis/", "/apis/")' "/swagger/${endpoint_name}.yaml" | sort -u | head -1)
+      if [ -z "${base_url}" ]; then
+        base_url="/apis/${endpoint_name}"
+        echo "WARNING: unable to identify sample URL for ${endpoint_name}, guessed as ${base_url}."
+      fi
+      ${yq} e -i ".servers=[{\"url\": \"https://api-gw-service-nmn.local${base_url}\"}]" "/swagger/${endpoint_name}.yaml"
+    elif [[ ${openapi_version} == 2.* ]]; then
+      ${yq} e -i '.securityDefinitions.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.host="api-gw-service-nmn.local"' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.schemes=["https"]' "/swagger/${endpoint_name}.yaml"
+    fi
+    echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
+    docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
+  done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
 done
 
 cd "${dest_dir}"
 echo "# REST API Documentation" > README.md
 for file in *.md; do
-    if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
-        title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
-        if [ -z "${title}" ]; then
-            error "ERROR: Could not determine title for service named ${file%.md}"
-        fi
-        echo " * [${title}](./${file})" >> README.md
+  if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
+    title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
+    if [ -z "${title}" ]; then
+      error "ERROR: Could not determine title for service named ${file%.md}"
     fi
+    echo " * [${title}](./${file})" >> README.md
+  fi
 done
 ln -sf ./README.md ./index.md


### PR DESCRIPTION
Backport of #4648 into `release/1.4`. Content of `/api` folder was regenerated from latest state of CSM manifests (tagged as `v1.4.3`). 