### PR TITLE
CASMTRIAGE-6571 1.5

### DIFF
--- a/operations/power_management/Save_Management_Network_Switch_Configurations.md
+++ b/operations/power_management/Save_Management_Network_Switch_Configurations.md
@@ -17,8 +17,8 @@ For each switch:
     for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
     ```
 
-2. Execute the `write memory` command
-3. Exit the switch shell
+1. Execute the `write memory` command
+1. Exit the switch shell
 
 ### Dell and Mellanox Switch and Gigabyte/Intel Server Systems
 
@@ -30,9 +30,9 @@ On Dell and Mellanox based systems, all spine and any leaf switches will be Mell
     for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
     ```
 
-2. Enter `enable` mode (Mellanox only)
-3. Execute the `write memory` command
-4. Exit the switch shell
+1. Enter `enable` mode (Mellanox only)
+1. Execute the `write memory` command
+1. Exit the switch shell
 
 ### Edge Routers and Storage Switches
 

--- a/operations/power_management/Save_Management_Network_Switch_Configurations.md
+++ b/operations/power_management/Save_Management_Network_Switch_Configurations.md
@@ -12,29 +12,27 @@ On Aruba-based systems all management network switches will be Aruba and the fol
 For each switch:
 
 1. Run the command below
-1. Execute the `write memory` command
-1. Exit the switch shell
 
-Example:
+    ```bash
+    for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
+    ```
 
- ```bash
-for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
- ```
+2. Execute the `write memory` command
+3. Exit the switch shell
 
 ### Dell and Mellanox Switch and Gigabyte/Intel Server Systems
 
 On Dell and Mellanox based systems, all spine and any leaf switches will be Mellanox. Any leaf-bmc and cdu switches will be Dell. The overall procedure is the same but the specifics of execution are slightly different.
 
 1. Run the command below
+
+    ```bash
+    for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
+    ```
+
 2. Enter `enable` mode (Mellanox only)
 3. Execute the `write memory` command
 4. Exit the switch shell
-
-Example:
-
- ```bash
-for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
- ```
 
 ### Edge Routers and Storage Switches
 

--- a/operations/power_management/Save_Management_Network_Switch_Configurations.md
+++ b/operations/power_management/Save_Management_Network_Switch_Configurations.md
@@ -4,23 +4,6 @@ Switches must be powered on and operating. This procedure is optional if switch 
 
 **Optional Task:** Save management network switch configurations before removing power from cabinets or the CDU. Management switch names are listed in the `/etc/hosts` file.
 
-## Obtain the list of switches
-
-From the command line on any NCN run:
-
-```bash
-grep 'sw-' /etc/hosts
-```
-
-Example output:
-
-```bash
-10.254.0.2 sw-spine-001
-10.254.0.3 sw-spine-002
-10.254.0.4 sw-leaf-001
-ncn-m001:~ #
-```
-
 ## Save switch configs
 
 ### Aruba Switch and HPE Server Systems
@@ -28,45 +11,29 @@ ncn-m001:~ #
 On Aruba-based systems all management network switches will be Aruba and the following procedure.
 For each switch:
 
-1. `ssh` to the switch
+1. Run the command below
 1. Execute the `write memory` command
 1. Exit the switch shell
 
 Example:
 
  ```bash
- ssh admin@sw-spine-001.hmn
- admin@sw-spine-001 password:
- write memory
- exit
+for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
  ```
 
 ### Dell and Mellanox Switch and Gigabyte/Intel Server Systems
 
 On Dell and Mellanox based systems, all spine and any leaf switches will be Mellanox. Any leaf-bmc and cdu switches will be Dell. The overall procedure is the same but the specifics of execution are slightly different.
 
-1. `ssh` to the switch
-1. Enter `enable` mode (Mellanox only)
-1. Execute the `write memory` command
-1. Exit the switch shell
+1. Run the command below
+2. Enter `enable` mode (Mellanox only)
+3. Execute the `write memory` command
+4. Exit the switch shell
 
-Mellanox Example:
-
- ```bash
- ssh admin@sw-spine-001.hmn
- admin@sw-spine-001 password:
- enable
- write memory
- exit
- ```
-
-Dell Example:
+Example:
 
  ```bash
- ssh admin@sw-leaf-bmc-001
- admin@sw-leaf-bmc-001s password:
- write memory
- exit
+for switch in $(awk '{print $2}' /etc/hosts | grep 'sw-'); do echo  "switch ${switch}:" ; ssh admin@$switch; done
  ```
 
 ### Edge Routers and Storage Switches


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Update the procedure to save switch configs per CASMTRIAGE-6571
Tested on Surtur and Drax
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
