### PR TITLE
CASMTRIAGE-6464 Changed to check for missing creds in SCSD response

### DIFF
--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -148,8 +148,17 @@ spec:
                   TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                     jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                   TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
-                  export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
-                  export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")
+
+                  export SCSD_CREDS=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds")
+
+                  export IPMI_USERNAME=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
+                  export IPMI_PASSWORD=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")
+
+                  export SCSD_STATUS_CODE=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .StatusCode")
+                  if [[ "${SCSD_STATUS_CODE}" != "200" ]]; then
+                      echo "BMC credentials are not currently available for ${TARGET_MGMT_XNAME} in SCSD. SCSD returned the username ${IPMI_USERNAME} and the status code ${SCSD_STATUS_CODE}"
+                      exit 1
+                  fi
                                     
                   # Set ncn to pxe boot
                   ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis bootdev pxe options=efiboot
@@ -184,8 +193,17 @@ spec:
                   TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                   TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
-                  export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
-                  export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")
+
+                  export SCSD_CREDS=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds")
+
+                  export IPMI_USERNAME=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
+                  export IPMI_PASSWORD=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")
+
+                  export SCSD_STATUS_CODE=$(echo "${SCSD_CREDS}" | jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .StatusCode")
+                  if [[ "${SCSD_STATUS_CODE}" != "200" ]]; then
+                      echo "BMC credentials are not currently available for ${TARGET_MGMT_XNAME} in SCSD. SCSD returned the username ${IPMI_USERNAME} and the status code ${SCSD_STATUS_CODE}"
+                      exit 1
+                  fi
 
                   bootscript_last_epoch="{{tasks.get-bootscript-last-access-timestamp.outputs.result}}"
                   # wait for boot


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This makes use of the SCSD change in CASMHMS-6125, but does not require these changes to still work as well as it was working before.

CASMTRIAGE-6464

SCSD changed to return a status code of 404 when the vault data is missing for a node.

Before this change the output looked like:
```
{
  "Targets": [
    {
      "Xname": "x9000c1s7b1",
      "Username": "root",
      "Password": "PGYppWdQBe",
      "StatusCode": 200,
      "StatusMsg": "OK"
    },
    {
      "Xname": "x9000c1s2b1",
      "Username": "<empty>",
      "Password": "<empty>",
      "StatusCode": 200,
      "StatusMsg": "OK"
    }
  ]
}
```

After this change the output looks like:
```
{
  "Targets": [
    {
      "Xname": "x9000c1s7b1",
      "Username": "root",
      "Password": "PGYppWdQBe",
      "StatusCode": 200,
      "StatusMsg": "OK"
    },
    {
      "Xname": "x9000c1s2b1",
      "Username": "<empty>",
      "Password": "<empty>",
      "StatusCode": 404,
      "StatusMsg": "Not Found"
    }
  ]
}
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
