### PR TITLE
1.5 Backport MTL-2348 `.editorconfig` and `assign-ncn-images.sh`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,4 +21,4 @@ indent_size = 2
 
 [*.{adoc,md}]
 trim_trailing_whitespace = false
-indent_size = 2
+indent_size = 4

--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -56,11 +56,11 @@ MD006: true
 # MD007/ul-indent - Unordered list indentation
 MD007:
   # Spaces for indent
-  indent: 2
+  indent: 4
   # Whether to indent the first level of the list
   start_indented: false
   # Spaces for first level indent (when start_indented is set)
-  start_indent: 2
+  start_indent: 4
 
 # MD009/no-trailing-spaces - Trailing spaces
 MD009:

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -2,14 +2,14 @@
 
 This page describes the procedure to customize a management node image using the
 [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) and
-the [Image Management Service (IMS)](../../glossary.md#image-management-service-ims). The procedure
-has options for configuring Kubernetes master or worker nodes or Ceph storage nodes.
+the [Image Management Service (IMS)](../../glossary.md#image-management-service-ims). The procedure has options for
+configuring Kubernetes master or worker nodes or Ceph storage nodes.
 
-When performing an upgrade of CSM and/or additional HPE Cray EX software products, this procedure is
-not followed end-to-end, but certain portions of the procedure are referenced. When performing an
-install or upgrade, be sure to follow the appropriate procedures in
-[Cray System Management Install](../../install/README.md) or [Upgrade CSM](../../upgrade/README.md).
-This procedure is referenced from operational procedures that occur after CSM install or upgrade.
+When performing an upgrade of CSM and/or additional HPE Cray EX software products, this procedure is not followed
+end-to-end, but certain portions of the procedure are referenced. When performing an install or upgrade, be sure to
+follow the appropriate procedures in
+[Cray System Management Install](../../install/README.md) or [Upgrade CSM](../../upgrade/README.md). This procedure is
+referenced from operational procedures that occur after CSM install or upgrade.
 
 * [Prerequisites](#prerequisites)
 * [Procedure](#procedure)
@@ -22,16 +22,17 @@ This procedure is referenced from operational procedures that occur after CSM in
 ## Prerequisites
 
 * The Cray CLI must be configured and authenticated.
-  * See [Configure the Cray CLI](../configure_cray_cli.md).
+    * See [Configure the Cray CLI](../configure_cray_cli.md).
 * SAT must be configured and authenticated.
-  * See [SAT documentation](../sat/sat_in_csm.md#sat-documentation).
+    * See [SAT documentation](../sat/sat_in_csm.md#sat-documentation).
 
 ## Procedure
 
 ### 1. Determine management node image ID
 
-Determine the ID of the management node boot image in the [Image Management Service (IMS)](../../glossary.md#image-management-service-ims).
-There are several alternatives to find the management node image ID to use.
+Determine the ID of the management node boot image in
+the [Image Management Service (IMS)](../../glossary.md#image-management-service-ims). There are several alternatives to
+find the management node image ID to use.
 
 * [Option 1: Get IMS image ID for a management node from BSS](#option-1-get-ims-image-id-for-a-management-node-from-bss)
 * [Option 2: Get IMS image ID for a booted management node](#option-2-get-ims-image-id-for-a-booted-management-node)
@@ -39,40 +40,41 @@ There are several alternatives to find the management node image ID to use.
 
 #### Option 1: Get IMS image ID for a management node from BSS
 
-Use this option to find the IMS image ID of the image which is configured to boot on a management
-node the next time it boots. This may not necessarily match what the management node is currently
-booted with. This procedure can be used whether the management node is booted or not.
+Use this option to find the IMS image ID of the image which is configured to boot on a management node the next time it
+boots. This may not necessarily match what the management node is currently booted with. This procedure can be used
+whether the management node is booted or not.
 
 This image is identified by examining the management node's boot parameters in the
-[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) as described in the
-procedure below.
+[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) as described in the procedure below.
 
-1. (`ncn-mw#`) Set `NODE_XNAME` to the [component name (xname)](../../glossary.md#xname) of the management node whose boot image is to be used.
+1. (`ncn-mw#`) Set `NODE_XNAME` to the [component name (xname)](../../glossary.md#xname) of the management node whose
+   boot image is to be used.
 
-   * If customizing a Kubernetes master node image, get the xname of `ncn-m001`.
+    * If customizing a Kubernetes master node image, get the xname of `ncn-m001`.
 
-     ```bash
-     NODE_XNAME=$(ssh ncn-m001 cat /etc/cray/xname)
-     echo "${NODE_XNAME}"
-     ```
+      ```bash
+      NODE_XNAME=$(ssh ncn-m001 cat /etc/cray/xname)
+      echo "${NODE_XNAME}"
+      ```
 
-   * If customizing a Kubernetes worker node image, get the xname of `ncn-w001`.
+    * If customizing a Kubernetes worker node image, get the xname of `ncn-w001`.
 
-     ```bash
-     NODE_XNAME=$(ssh ncn-w001 cat /etc/cray/xname)
-     echo "${NODE_XNAME}"
-     ```
+      ```bash
+      NODE_XNAME=$(ssh ncn-w001 cat /etc/cray/xname)
+      echo "${NODE_XNAME}"
+      ```
 
-   * If customizing a Ceph storage node image, get the xname of `ncn-s001`:
+    * If customizing a Ceph storage node image, get the xname of `ncn-s001`:
 
-     For example:
+      For example:
 
-     ```bash
-     NODE_XNAME=$(ssh ncn-s001 cat /etc/cray/xname)
-     echo "${NODE_XNAME}"
-     ```
+      ```bash
+      NODE_XNAME=$(ssh ncn-s001 cat /etc/cray/xname)
+      echo "${NODE_XNAME}"
+      ```
 
-1. (`ncn-mw#`) Extract the S3 path prefix for the image that will be used on the next boot of the chosen management node.
+1. (`ncn-mw#`) Extract the S3 path prefix for the image that will be used on the next boot of the chosen management
+   node.
 
    This prefix corresponds to the IMS image ID of the boot image.
 
@@ -85,25 +87,26 @@ procedure below.
 
    The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
 
-   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter for the
-   > NCN in BSS. For more information on that parameter, see [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
+   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter
+   for the
+   > NCN in BSS. For more information on that parameter,
+   see [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
 
 #### Option 2: Get IMS image ID for a booted management node
 
-Use this option to find the IMS image ID of the image which is currently booted on a management
-node. In this case, the image is identified by examining the kernel command-line parameters on
-the booted node.
+Use this option to find the IMS image ID of the image which is currently booted on a management node. In this case, the
+image is identified by examining the kernel command-line parameters on the booted node.
 
 **NOTE:** Do not use this option if either of the following are true:
 
-* The management nodes are currently booted from the PIT node. This will be the case after an initial
-  install of CSM before additional HPE Cray EX products have been installed. In this case, the boot
-  parameters will be pointing at the PIT node rather than to an IMS image artifact in S3.
-* The management node has been booted from disk instead of over the network. Network boots are the
-  default behavior, but disk boots may be necessary in special cases.
+* The management nodes are currently booted from the PIT node. This will be the case after an initial install of CSM
+  before additional HPE Cray EX products have been installed. In this case, the boot parameters will be pointing at the
+  PIT node rather than to an IMS image artifact in S3.
+* The management node has been booted from disk instead of over the network. Network boots are the default behavior, but
+  disk boots may be necessary in special cases.
 
-1. (`ncn-mw#`) Set the `BOOTED_NODE` variable to the hostname of the management node that is booted
-   using the image to be modified.
+1. (`ncn-mw#`) Set the `BOOTED_NODE` variable to the hostname of the management node that is booted using the image to
+   be modified.
 
    > For example, `ncn-w001` or `ncn-s002`.
 
@@ -124,16 +127,16 @@ the booted node.
 
    The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
 
-   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter in
+   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter
+   in
    > the `/proc/cmdline` file on the booted NCN. For more information on that parameter, see
    > [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
 
 #### Option 3: Get IMS image ID of a base image provided by CSM
 
-Use this option to find the IMS image ID of a base image provided by the CSM product. The CSM
-product provides two images for management nodes. One image is for Kubernetes master and worker
-nodes. The other image is for Ceph storage nodes. Starting with CSM 1.4.0, the CSM product adds
-these image IDs to the `cray-product-catalog` Kubernetes ConfigMap.
+Use this option to find the IMS image ID of a base image provided by the CSM product. The CSM product provides two
+images for management nodes. One image is for Kubernetes master and worker nodes. The other image is for Ceph storage
+nodes. Starting with CSM 1.4.0, the CSM product adds these image IDs to the `cray-product-catalog` Kubernetes ConfigMap.
 
 These images can be used as a base for configuration if the administrator does not need to preserve any additional
 customizations on the images which are currently booted or assigned to be booted on management nodes.
@@ -179,14 +182,14 @@ customizations on the images which are currently booted or assigned to be booted
 
 ### 2. Find or create a CFS configuration
 
-If the CFS configuration to be used for management node image customization has already been
-identified, skip this step and and proceed to [Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
+If the CFS configuration to be used for management node image customization has already been identified, skip this step
+and and proceed to [Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
 
-A CFS configuration that applies to management nodes and works for both image customization and
-post-boot personalization is created as part of the CSM install and upgrade procedures. Generally,
-this is the configuration that should be used to perform management node image customization. The
-first option below shows how to find the name of that CFS configuration. The second option describes
-how to manually create a new CFS configuration that contains just the minimum CSM layers.
+A CFS configuration that applies to management nodes and works for both image customization and post-boot
+personalization is created as part of the CSM install and upgrade procedures. Generally, this is the configuration that
+should be used to perform management node image customization. The first option below shows how to find the name of that
+CFS configuration. The second option describes how to manually create a new CFS configuration that contains just the
+minimum CSM layers.
 
 * [Option 1: Find the current CFS configuration for management nodes](#option-1-find-the-current-cfs-configuration-for-management-nodes)
 * [Option 2: Create a new CFS configuration for management nodes](#option-2-create-a-new-cfs-configuration-for-management-nodes)
@@ -203,8 +206,8 @@ The following procedure describes how to find the CFS configuration applied to t
    sat status --filter role=Management --fields xname,role,subrole,desiredconfig
    ```
 
-   The output will be a table showing xname, role, subrole, and desired configuration set in CFS
-   for all the management nodes on the system. For example:
+   The output will be a table showing xname, role, subrole, and desired configuration set in CFS for all the management
+   nodes on the system. For example:
 
    ```text
    +----------------+------------+---------+-------------------+
@@ -225,10 +228,11 @@ The following procedure describes how to find the CFS configuration applied to t
    +----------------+------------+---------+-------------------+
    ```
 
-   The value of the `Desired Config` column is the name of the CFS configuration currently applied
-   to the nodes. There will typically be only one CFS configuration applied to all management nodes.
+   The value of the `Desired Config` column is the name of the CFS configuration currently applied to the nodes. There
+   will typically be only one CFS configuration applied to all management nodes.
 
-   Kindly ensure the selected "desired config" from above has the `ncn-initrd.yml` within the layers by using command as below:
+   Kindly ensure the selected "desired config" from above has the `ncn-initrd.yml` within the layers by using command as
+   below:
 
    ```bash
    cray cfs configurations describe "<config name>"
@@ -244,7 +248,8 @@ The following procedure describes how to find the CFS configuration applied to t
    
    ```
 
-   In case the "desired config" from above does not have `ncn-initrd.yml` within the layers, create a configuration as follows:
+   In case the "desired config" from above does not have `ncn-initrd.yml` within the layers, create a configuration as
+   follows:
 
    ```bash
    cat <filename>.json
@@ -304,8 +309,7 @@ The following procedure describes how to find the CFS configuration applied to t
 
 Use this option to create a new CFS configuration for management nodes.
 
-The following procedure describes how to create a CFS configuration that contains the minimal
-layers provided by CSM.
+The following procedure describes how to create a CFS configuration that contains the minimal layers provided by CSM.
 
 1. (`ncn-mw#`) Clone the `csm-config-management` repository.
 
@@ -315,8 +319,9 @@ layers provided by CSM.
     git clone "https://${VCS_USER}:${VCS_PASS}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
     ```
 
-    A Git commit hash from this repository is needed in the following step. After cloning repo, verify that the "yaml" files used in image customization are present.
-    If not, check the other branches in cloned repo and switch to correct branch which has the required "yaml" files.
+   A Git commit hash from this repository is needed in the following step. After cloning repo, verify that the "yaml"
+   files used in image customization are present. If not, check the other branches in cloned repo and switch to correct
+   branch which has the required "yaml" files.
 
    ```bash
     git branch -a
@@ -334,9 +339,9 @@ layers provided by CSM.
 
 1. (`ncn-mw#`) Create the CFS configuration to use for image customization.
 
-    For more information on creating CFS configurations, see [CFS Configurations](CFS_Configurations.md).
+   For more information on creating CFS configurations, see [CFS Configurations](CFS_Configurations.md).
 
-    The first layer in the CFS configuration should be similar to this:
+   The first layer in the CFS configuration should be similar to this:
 
     ```json
     {
@@ -347,7 +352,7 @@ layers provided by CSM.
     }
     ```
 
-    The last layer in the CFS configuration should be similar to this:
+   The last layer in the CFS configuration should be similar to this:
 
     ```json
     {
@@ -362,8 +367,8 @@ layers provided by CSM.
 
 1. (`ncn-mw#`) Record the name of the CFS configuration to use for image customization.
 
-    Set the `CFS_CONFIG_NAME` variable to the name of the CFS configuration identified or created
-    in the previous section, [2. Find or create a CFS configuration](#2-find-or-create-a-cfs-configuration).
+   Set the `CFS_CONFIG_NAME` variable to the name of the CFS configuration identified or created in the previous
+   section, [2. Find or create a CFS configuration](#2-find-or-create-a-cfs-configuration).
 
     ```bash
     CFS_CONFIG_NAME=management-23.4.0
@@ -371,8 +376,8 @@ layers provided by CSM.
 
 1. (`ncn-mw#`) Ensure that the environment variable `IMS_IMAGE_ID` is set.
 
-    This variable should have been set in the earlier step,
-    [1. Determine management node image ID](#1-determine-management-node-image-id)
+   This variable should have been set in the earlier step,
+   [1. Determine management node image ID](#1-determine-management-node-image-id)
 
     ```bash
     echo "${IMS_IMAGE_ID}"
@@ -380,7 +385,8 @@ layers provided by CSM.
 
 1. (`ncn-mw#`) Create an image customization CFS session.
 
-    See [Create an Image Customization CFS Session](Create_an_Image_Customization_CFS_Session.md) for additional information.
+   See [Create an Image Customization CFS Session](Create_an_Image_Customization_CFS_Session.md) for additional
+   information.
 
     1. Set a name for the session.
 
@@ -389,21 +395,22 @@ layers provided by CSM.
         echo "${CFS_SESSION_NAME}"
         ```
 
-    1. Set the `TARGET_GROUP` environment variable based on the type of management node for which the image is being customized (master, worker, or storage).
+    1. Set the `TARGET_GROUP` environment variable based on the type of management node for which the image is being
+       customized (master, worker, or storage).
 
-       * For worker nodes:
+        * For worker nodes:
 
-         ```bash
-         TARGET_GROUP=Management_Worker
-         ```
+          ```bash
+          TARGET_GROUP=Management_Worker
+          ```
 
-       * For master nodes:
+        * For master nodes:
 
         ```bash
         TARGET_GROUP=Management_Master
         ```
 
-       * For storage nodes:
+        * For storage nodes:
 
         ```bash
         TARGET_GROUP=Management_Storage
@@ -421,7 +428,7 @@ layers provided by CSM.
 
     1. Monitor the CFS session until it completes successfully.
 
-        See [Track the Status of a Session](Track_the_Status_of_a_Session.md).
+       See [Track the Status of a Session](Track_the_Status_of_a_Session.md).
 
     1. Obtain the IMS resultant image ID.
 
@@ -431,7 +438,7 @@ layers provided by CSM.
         echo "${IMS_RESULTANT_IMAGE_ID}"
         ```
 
-        Example output:
+       Example output:
 
         ```text
         a44ff301-6232-46b4-9ba6-88ee1d19e2c2
@@ -439,57 +446,57 @@ layers provided by CSM.
 
 ### 4. Update management node boot parameters
 
-This step describes how to update each management node to boot from a new customized image. This is
-accomplished by updating the management nodes' boot parameters in BSS to use the artifacts from the
-new customized image.
+This step describes how to update each management node to boot from a new customized image. This is accomplished by
+updating the management nodes' boot parameters in BSS to use the artifacts from the new customized image.
 
 1. (`ncn-mw#`) Set an environment variable for the IMS image ID.
 
-   * If executing this step in the context of
-     [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-     of the CSM upgrade procedure, use the appropriate IMS image ID environment variable set in that procedure.
+    * If executing this step in the context of
+      [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+      of the CSM upgrade procedure, use the appropriate IMS image ID environment variable set in that procedure.
 
-     > ***NOTE*** To target both master and worker nodes at the same time, use the following:
-     >
-     > ```bash
-     > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-     >     -mw \
-     >     -p "$MASTER_IMAGE_ID"
-     > ```
+      > ***NOTE*** To target both master and worker nodes at the same time, use the following:
+      >
+      > ```bash
+   > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+   >     -mw \
+   >     -p "$MASTER_IMAGE_ID"
+   > ```
 
-     1. Update master management nodes:
+        1. Update master management nodes:
 
-       ```bash
-       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-           -m \
-           -p "$MASTER_IMAGE_ID"
-       ```
+        ```bash
+        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+            -m \
+            -p "$MASTER_IMAGE_ID"
+        ```
 
-     1. Update storage management nodes:
+        1. Update storage management nodes:
 
-       ```bash
-       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-           -s \
-           -p "$STORAGE_IMAGE_ID"
-       ```
+        ```bash
+        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+            -s \
+            -p "$STORAGE_IMAGE_ID"
+        ```
 
-     1. Update worker management nodes:
+        1. Update worker management nodes:
 
-       ```bash
-       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-           -w \
-           -p "$WORKER_IMAGE_ID"
-       ```
+        ```bash
+        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+            -w \
+            -p "$WORKER_IMAGE_ID"
+        ```
 
-     1. Return to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+        1. Return
+           to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
 
-   * If executing this step in the context of the entire procedure on this page, then use the
-     `IMS_RESULTANT_IMAGE_ID` set in the previous step,
-     [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
+    * If executing this step in the context of the entire procedure on this page, then use the
+      `IMS_RESULTANT_IMAGE_ID` set in the previous step,
+      [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
 
-     ```bash
-     NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
-     ```
+      ```bash
+      NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
+      ```
 
 1. (`ncn-mw#`) Determine the component names (xnames) for the management nodes which will boot from the new image.
 
@@ -513,33 +520,33 @@ new customized image.
 
     1. Create updated boot parameters that point to the new artifacts.
 
-       1. Set the path to the artifacts in S3.
+        1. Set the path to the artifacts in S3.
 
-          ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
+           ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
 
-          ```bash
-          S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"
-          echo "${S3_ARTIFACT_PATH}"
-          ```
+            ```bash
+            S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"
+            echo "${S3_ARTIFACT_PATH}"
+            ```
 
-       1. Set the new `metal.server` value.
+        1. Set the new `metal.server` value.
 
-          ```bash
-          NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
-          echo "${NEW_METAL_SERVER}"
-          ```
+           ```bash
+           NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+           echo "${NEW_METAL_SERVER}"
+           ```
 
-       1. Determine the modified boot parameters for the node.
+        1. Determine the modified boot parameters for the node.
 
-          ```bash
-          PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-              sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-              tr -d \")
-          echo "${PARAMS}"
-          ```
+           ```bash
+           PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
+               sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+               tr -d \")
+           echo "${PARAMS}"
+           ```
 
-          In the output of the `echo` command, verify that the value of `metal.server` is
-          correctly set to the value of `${NEW_METAL_SERVER}`.
+           In the output of the `echo` command, verify that the value of `metal.server` is correctly set to the value
+           of `${NEW_METAL_SERVER}`.
 
     1. Update BSS with the new boot parameters.
 
@@ -555,6 +562,6 @@ new customized image.
 If a particular step of this procedure is being performed as part of a CSM upgrade, then return
 to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image).
 
-If this procedure is being performed as an operational task outside the context of an install or upgrade,
-then proceed to [Rebuild NCNs](../node_management/Rebuild_NCNs/Rebuild_NCNs.md)
+If this procedure is being performed as an operational task outside the context of an install or upgrade, then proceed
+to [Rebuild NCNs](../node_management/Rebuild_NCNs/Rebuild_NCNs.md)
 when ready to reboot the management nodes to their new images.

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -458,7 +458,7 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
       > ***NOTE*** To target both master and worker nodes at the same time, use the following:
       >
       >```bash
-      > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh 
+      > /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh 
       >     -mw \
       >     -p "$MASTER_IMAGE_ID"
       > ```
@@ -466,7 +466,7 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
         1. Update master management nodes:
 
             ```bash
-            /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+            /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
                 -m \
                 -p "$MASTER_IMAGE_ID"
             ```
@@ -474,7 +474,7 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
         1. Update storage management nodes:
 
             ```bash
-            /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+            /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
                 -s \
                 -p "$STORAGE_IMAGE_ID"
             ```
@@ -482,7 +482,7 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
         1. Update worker management nodes:
 
            ```bash
-           /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+           /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
                -w \
                -p "$WORKER_IMAGE_ID"
            ```

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -319,9 +319,9 @@ The following procedure describes how to create a CFS configuration that contain
     git clone "https://${VCS_USER}:${VCS_PASS}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
     ```
 
-   A Git commit hash from this repository is needed in the following step. After cloning repo, verify that the "yaml"
+   A Git commit hash from this repository is needed in the following step. After cloning repo, verify that the YAML
    files used in image customization are present. If not, check the other branches in cloned repo and switch to correct
-   branch which has the required "yaml" files.
+   branch which has the required YAML files.
 
    ```bash
     git branch -a

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -445,121 +445,110 @@ new customized image.
 
 1. (`ncn-mw#`) Set an environment variable for the IMS image ID.
 
-    * If executing this step in the context of
-      [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-      of the CSM upgrade procedure, use the appropriate IMS image ID environment variable set in that procedure.
+   * If executing this step in the context of
+     [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+     of the CSM upgrade procedure, use the appropriate IMS image ID environment variable set in that procedure.
 
-      * For worker management nodes:
+     > ***NOTE*** To target both master and worker nodes at the same time, use the following:
+     >
+     > ```bash
+     > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+     >     -mw \
+     >     -p "$MASTER_IMAGE_ID"
+     > ```
 
-        ```bash
-        NEW_IMS_IMAGE_ID="${WORKER_IMAGE_ID}"
-        ```
+     1. Update master management nodes:
 
-      * For master management nodes:
+       ```bash
+       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+           -m \
+           -p "$MASTER_IMAGE_ID"
+       ```
 
-        ```bash
-        NEW_IMS_IMAGE_ID="${MASTER_IMAGE_ID}"
-        ```
+     1. Update storage management nodes:
 
-      * For storage management nodes:
+       ```bash
+       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+           -s \
+           -p "$STORAGE_IMAGE_ID"
+       ```
 
-        ```bash
-        NEW_IMS_IMAGE_ID="${STORAGE_IMAGE_ID}"
-        ```
+     1. Update worker management nodes:
 
-    * If executing this step in the context of the entire procedure on this page, then use the
-      `IMS_RESULTANT_IMAGE_ID` set in the previous step,
-      [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
+       ```bash
+       /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+           -w \
+           -p "$WORKER_IMAGE_ID"
+       ```
 
-      ```bash
-      NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
-      ```
+     1. Return to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+
+   * If executing this step in the context of the entire procedure on this page, then use the
+     `IMS_RESULTANT_IMAGE_ID` set in the previous step,
+     [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
+
+     ```bash
+     NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
+     ```
 
 1. (`ncn-mw#`) Determine the component names (xnames) for the management nodes which will boot from the new image.
 
-    Options to determine node xnames:
+   > In this example, the xname for `ncn-w001` is being found.
 
-    * Get a comma-separated list of all worker NCN xnames:
-
-        ```bash
-        cray hsm state components list --role Management --subrole Worker --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")'
-        ```
-
-    * Get a comma-separated list of all master NCN xnames:
-
-        ```bash
-        cray hsm state components list --role Management --subrole Master --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")'
-        ```
-
-    * Get a comma-separated list of all storage NCN xnames:
-
-        ```bash
-        cray hsm state components list --role Management --subrole Storage --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")'
-        ```
-
-    * Get the xname for a specific NCN:
-
-        > In this example, the xname for `ncn-w001` is being found.
-
-        ```bash
-        ssh ncn-w001 cat /etc/cray/xname
-        ```
+   ```bash
+   ssh ncn-w001 cat /etc/cray/xname
+   ```
 
 1. (`ncn-mw#`) Update boot parameters for a management node.
 
-    Perform the following procedure **for each xname** identified in the previous step.
-
     1. Get the existing `metal.server` setting for the component name (xname) of the node of interest.
 
-        ```bash
-        XNAME=<node-xname>
-        METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
-            | awk -F 'metal.server=' '{print $2}' \
-            | awk -F ' ' '{print $1}')
-        echo "${METAL_SERVER}"
-        ```
+       ```bash
+       XNAME=<node-xname>
+       METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
+           | awk -F 'metal.server=' '{print $2}' \
+           | awk -F ' ' '{print $1}')
+       echo "${METAL_SERVER}"
+       ```
 
     1. Create updated boot parameters that point to the new artifacts.
 
-        1. Set the path to the artifacts in S3.
+       1. Set the path to the artifacts in S3.
 
-            **NOTE:** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
+          ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
 
-            ```bash
-            S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"
-            echo "${S3_ARTIFACT_PATH}"
-            ```
+          ```bash
+          S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"
+          echo "${S3_ARTIFACT_PATH}"
+          ```
 
-        1. Set the new `metal.server` value.
+       1. Set the new `metal.server` value.
 
-            ```bash
-            NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
-            echo "${NEW_METAL_SERVER}"
-            ```
+          ```bash
+          NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+          echo "${NEW_METAL_SERVER}"
+          ```
 
-        1. Determine the modified boot parameters for the node.
+       1. Determine the modified boot parameters for the node.
 
-            ```bash
-            PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-                sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-                tr -d \")
-            echo "${PARAMS}"
-            ```
+          ```bash
+          PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
+              sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+              tr -d \")
+          echo "${PARAMS}"
+          ```
 
-            In the output of the `echo` command, verify that the value of `metal.server` is
-            correctly set to the value of `${NEW_METAL_SERVER}`.
+          In the output of the `echo` command, verify that the value of `metal.server` is
+          correctly set to the value of `${NEW_METAL_SERVER}`.
 
     1. Update BSS with the new boot parameters.
 
-        ```bash
-        cray bss bootparameters update --hosts "${XNAME}" \
-            --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
-            --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
-            --params "${PARAMS}"
-        ```
+       ```bash
+       cray bss bootparameters update --hosts "${XNAME}" \
+           --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
+           --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
+           --params "${PARAMS}" && echo SUCCESS || echo ERROR
+       ```
 
 ## Next steps
 

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -457,38 +457,38 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
 
       > ***NOTE*** To target both master and worker nodes at the same time, use the following:
       >
-      > ```bash
-   > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-   >     -mw \
-   >     -p "$MASTER_IMAGE_ID"
-   > ```
+      >```bash
+      > /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh 
+      >     -mw \
+      >     -p "$MASTER_IMAGE_ID"
+      > ```
 
         1. Update master management nodes:
 
-        ```bash
-        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-            -m \
-            -p "$MASTER_IMAGE_ID"
-        ```
+            ```bash
+            /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+                -m \
+                -p "$MASTER_IMAGE_ID"
+            ```
 
         1. Update storage management nodes:
 
-        ```bash
-        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-            -s \
-            -p "$STORAGE_IMAGE_ID"
-        ```
+            ```bash
+            /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+                -s \
+                -p "$STORAGE_IMAGE_ID"
+            ```
 
         1. Update worker management nodes:
 
-        ```bash
-        /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
-            -w \
-            -p "$WORKER_IMAGE_ID"
-        ```
+           ```bash
+           /usr/share/doc/csm/scripts/operations/configuration/node_management/assign-ncn-images.sh \
+               -w \
+               -p "$WORKER_IMAGE_ID"
+           ```
 
         1. Return
-           to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+           to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image).
 
     * If executing this step in the context of the entire procedure on this page, then use the
       `IMS_RESULTANT_IMAGE_ID` set in the previous step,
@@ -522,7 +522,7 @@ updating the management nodes' boot parameters in BSS to use the artifacts from 
 
         1. Set the path to the artifacts in S3.
 
-           ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
+           > ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
 
             ```bash
             S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"

--- a/scripts/operations/node_management/assign-ncn-images.sh
+++ b/scripts/operations/node_management/assign-ncn-images.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+function usage {
+
+  cat << EOF
+usage:
+
+Updates boot parameters for a comma delimited list of hosts.
+
+NOTE: This script requires that the rootfs, initrd, and kernel for the given host all reside at the same S3 path.
+
+./$(basename "$0") [-k kernel_name] [-i initrd_name] [-r rootfs_name]
+                   [-p S3_path] [-b bucket] [-msw]
+                   xname1[,xnameN,...]
+
+Positional:
+
+<xnames>  A comma delimited list of XNAME(s)
+
+Options:
+
+-i [string]        Name of initrd file (default: initrd)
+-k [string]        Name of kernel file (default: kernel)
+-r [string]        Name of the rootfs (default: rootfs)
+-p [string]        S3 Path, not including the bucket or filename (e.g. "foo" if the file exists at my-images/foo/kernel)
+-b [string]        Bucket name (default: boot-images)
+-m                 Auto-resolve all NCN master XNAME(s).
+-s                 Auto-resolve all NCN storage XNAME(s).
+-w                 Auto-resolve all NCN worker XNAME(s).
+
+Examples:
+
+# All masters and workers.
+./$(basename "$0") -p 69bc17cb-da1d-412c-a43d-ab8cacf5ab2b -mw
+
+# Two specific XNAMES.
+./$(basename "$0") -p 69bc17cb-da1d-412c-a43d-ab8cacf5ab2b x3000c0s4b0n0,x3000c0s30b0n0
+
+# All NCN masters, including two specific XNAMES.
+./$(basename "$0") -p 69bc17cb-da1d-412c-a43d-ab8cacf5ab2b -m x3000c0s4b0n0,x3000c0s30b0n0
+
+EOF
+}
+
+bucket="boot-images"
+s3path=""
+kernel="kernel"
+initrd="initrd"
+rootfs="rootfs"
+masters=0
+workers=0
+storage=0
+while getopts ":k:i:b:p:r:msw" o; do
+  case "${o}" in
+    p)
+      s3path="${OPTARG}"
+      ;;
+    b)
+      bucket="${OPTARG}"
+      ;;
+    i)
+      initrd="${OPTARG}"
+      ;;
+    k)
+      kernel="${OPTARG}"
+      ;;
+    r)
+      rootfs="${OPTARG}"
+      ;;
+    m)
+      masters=1
+      ;;
+    s)
+      storage=1
+      ;;
+    w)
+      workers=1
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+if [ $OPTIND -eq 1 ]; then usage; fi
+shift $((OPTIND - 1))
+
+xnames=("$@")
+subroles=()
+if [ "$masters" -ne 0 ]; then
+  subroles+=('Master')
+fi
+if [ "$workers" -ne 0 ]; then
+  subroles+=('Worker')
+fi
+if [ "$storage" -ne 0 ]; then
+  subroles+=('Storage')
+fi
+for subrole in "${subroles[@]}"; do
+  if IFS=$'\n' read -rd '' -a found; then
+    :
+  fi <<< "$(cray hsm state components list --role Management --subrole "${subrole}" --type Node --format json | jq -r '.Components | map(.ID) | join("\n")')"
+  xnames+=("${found[@]}")
+done
+
+if [ "${#xnames[@]}" -eq 0 ]; then
+  echo >&2 'Provide an array of xnames, or use the auto-switches -m, -w, or -s.'
+  exit 1
+fi
+
+echo "Updating [${#xnames[@]}] hosts with"
+artifact_base="${bucket//\//}/${s3path//\//}"
+rootfs_url="s3://${artifact_base}/${rootfs}"
+initrd_url="s3://$artifact_base/${initrd}"
+kernel_url="s3://$artifact_base/${kernel}"
+printf "rootfs URL: % -30s\n" "$rootfs_url"
+printf "initrd URL: % -30s\n" "$initrd_url"
+printf "kernel URL: % -30s\n" "$kernel_url"
+
+for xname in "${xnames[@]}"; do
+  current_rootfs_url=""
+  params=""
+  error=0
+  printf "% -15s: " "$xname"
+  current_rootfs_url="$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' \
+    | awk -F 'metal.server=' '{print $2}' \
+    | awk -F ' ' '{print $1}')"
+  if [ -z "$current_rootfs_url" ]; then
+    echo "ERROR - Missing metal.server for $xname! Skipping ... "
+    error=1
+    continue
+  fi
+  params=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' \
+    | sed "/metal.server/ s|${current_rootfs_url}|${rootfs_url}|" \
+    | tr -d \")
+  if [ -z "$params" ]; then
+    echo "ERROR - Failed to create new boot parameters for $xname! Skipping ... "
+    error=1
+    continue
+  fi
+  if ! cray bss bootparameters update --hosts "${xname}" \
+    --kernel "$kernel_url" \
+    --initrd "$initrd_url" \
+    --params "${params}" > /dev/null 2>&1; then
+    echo "ERROR - Failed to update boot parameters for $xname! Skipping ..."
+    error=1
+    continue
+  fi
+  echo 'OK'
+done
+if [ "$error" -ne 0 ]; then
+  echo >&2 "Errors were detected, please inspect the scripts output."
+else
+  echo "Successfully updated boot parameters for [${#xnames[@]}] xname(s):"
+  printf "\t%s\n" "${xnames[@]}"
+fi


### PR DESCRIPTION
Backports the extra parts from #4647 to 1.5.