### PR TITLE
CASMTRIAGE-6523: Update FAS documentation for additional targets

### DIFF
--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -19,7 +19,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
 The following procedures are included in this section:
 
-1. [Update Liquid-Cooled Compute Node BMC, FPGA, and BIOS](#liquid-cooled-nodes-update-procedures)
+1. [Update Liquid-Cooled Compute Node BMC, FPGA, Management Ethernet, `AccVBIOS` and BIOS](#liquid-cooled-nodes-update-procedures)
 1. [Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM](#update-air-cooled-compute-node-bmc-bios-ilo-5-and-system-rom)
 1. [Update Chassis Management Module (CMM) Firmware](#update-chassis-management-module-firmware)
 1. [Update NCN BIOS and BMC Firmware with FAS](#update-non-compute-node-ncn-bios-and-bmc-firmware)
@@ -153,7 +153,7 @@ If the nodes are not off when the update command is issued, the update will get 
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
     "timeLimit": 1000,
-    "description": "Dryrun upgrade of Node Management Ethernet"
+    "description": "Dryrun upgrade of Node AccVBIOS"
   }
 }
 ```

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -113,6 +113,8 @@ After identifying which hardware is in the system, start with the top item on th
       1. [BMC](FAS_Use_Cases.md#manufacturer-cray--device-type-nodebmc--target-bmc)
       1. [`NodeBIOS`](FAS_Use_Cases.md#manufacturer-cray--device-type--nodebmc--target--nodebios)
       1. [Redstone FPGA](FAS_Use_Cases.md#manufacturer-cray--device-type-nodebmc--target-redstone-fpga)
+      1. [Management Ethernet](FAS_Use_Cases.md#manufacturer-cray--device-type-nodebmc--target-management-ethernet)
+      1. [`AccVBIOS`](FAS_Use_Cases.md#manufacturer-cray--device-type-nodebmc--target-accvbios)
 1. [Gigabyte](FAS_Use_Cases.md#gigabyte)
    1. [BMC](FAS_Use_Cases.md#manufacturer-gigabyte--device-type-nodebmc--target-bmc)
    1. [BIOS](FAS_Use_Cases.md#manufacturer-gigabyte--device-type--nodebmc--target--bios)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Added additional targets to FAS lists.  Some minor changes.

- CASMTRIAGE-6523

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
