### PR TITLE
CASMTRIAGE-6646 Deterministic SNMP Settings

### DIFF
--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -45,7 +45,7 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
 
 > ***NOTE*** All variables used within this page depend on the `/etc/environment` setup done in [Pre-installation](../../../install/pre-installation.md).
 
-1. (`pit#`) Obtain the list of switch names and their IP addresses in a format that be used with copy/paste into the next command.
+1. (`pit#`) Obtain the list of switch names and their IP addresses in a format to use with copy/paste in the next command.
 
     ```bash
     jq '.Networks.NMN.ExtraProperties.Subnets | .[] | select(.FullName=="NMN Management Network Infrastructure").IPReservations | map( {name: .Name, target: .IPAddress })' \
@@ -71,7 +71,7 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
     ]
     ```
 
-1. (`pit#`) Update `customizations.yaml` with the list of switches, copy and paste the output from the previous command
+1. (`pit#`) Update `customizations.yaml` with the list of switches by copying and pasting the output from the previous command.
 
     * Create the new `prometheus-snmp-exporter` key.
 

--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -43,47 +43,52 @@ If the Prometheus SNMP Exporter or REDS hardware discovery emit errors related t
 
 In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must be configured with a list of management network switches to scrape metrics from.
 
-> **`NOTE`** All variables used within this page depend on the `/etc/environment` setup done in [Pre-installation](../../../install/pre-installation.md).
+> ***NOTE*** All variables used within this page depend on the `/etc/environment` setup done in [Pre-installation](../../../install/pre-installation.md).
 
-1. (`pit#`) Obtain the list of switches to use as targets using CANU.
+1. (`pit#`) Obtain the list of switch names and their IP addresses in a format that be used with copy/paste into the next command.
 
     ```bash
-    canu init --sls-file ${PITDATA}/prep/${SYSTEM_NAME}/sls_input_file.json --out -
+    jq '.Networks.NMN.ExtraProperties.Subnets | .[] | select(.FullName=="NMN Management Network Infrastructure").IPReservations | map( {name: .Name, target: .IPAddress })' \
+    "${PITDATA}/prep/${SYSTEM_NAME}/sls_input_file.json"
     ```
 
     Expected output looks similar to the following:
 
-    ```text
-    10.254.0.2
-    10.254.0.3
-    10.254.0.4
-    10.254.0.5
-    4 IP addresses saved to <stdout>
+    ```json
+    [
+      {
+        "name": "sw-spine-001",
+        "target": "10.252.0.2"
+      },
+      {
+        "name": "sw-spine-002",
+        "target": "10.252.0.3"
+      },
+      {
+        "name": "sw-leaf-bmc-001",
+        "target": "10.252.0.4"
+      }
+    ]
     ```
 
-1. (`pit#`) Update `customizations.yaml` with the list of switches.
+1. (`pit#`) Update `customizations.yaml` with the list of switches, copy and paste the output from the previous command
 
-    ```bash
-    yq write -s - -i ${PITDATA}/prep/site-init/customizations.yaml <<EOF
-    - command: update
-      path: spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
-      value:
-              serviceMonitor:
-                enabled: true
-                params:
-                - name: snmp1
-                  target: 10.252.0.2
-                - name: snmp2
-                  target: 10.252.0.3
-                - name: snmp3
-                  target: 10.252.0.4
-    EOF
-    ```
+    * Create the new `prometheus-snmp-exporter` key.
+
+        ```bash
+        yq4 eval -i '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter = {"serviceMonitor" : {"enabled": true, "params": []}}' "${PITDATA}/prep/site-init/customizations.yaml"
+        ```
+
+    * Merge `sls_input_file.json`'s switches into `customizations.yaml`.
+
+        ```bash
+        yq4 eval -i '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params |= '"$(jq '.Networks.NMN.ExtraProperties.Subnets | .[] | select(.FullName=="NMN Management Network Infrastructure").IPReservations | map( {name: .Name, target: .IPAddress })' "${PITDATA}/prep/${SYSTEM_NAME}/sls_input_file.json")"'' "${PITDATA}/prep/site-init/customizations.yaml"
+        ```
 
 1. (`pit#`) Review the SNMP Exporter configuration.
 
     ```bash
-    yq r ${PITDATA}/prep/site-init/customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
+    yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter' "${PITDATA}/prep/site-init/customizations.yaml"
     ```
 
     The expected output looks similar to:
@@ -91,13 +96,7 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
     ```yaml
     serviceMonitor:
       enabled: true
-      params:
-      - name: snmp1
-        target: 10.252.0.2
-      - name: snmp2
-        target: 10.252.0.3
-      - name: snmp3
-        target: 10.252.0.4
+      params: [{name: sw-spine-001, target: 10.252.0.2}, {name: sw-spine-002, target: 10.252.0.3}, {name: sw-leaf-bmc-001, target: 10.252.0.4}]
     ```
 
 The most common configuration parameters are specified in the following table. They must be set in the `customizations.yaml` file


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Use a more deterministic, and straight-forward method for updating `customizations.yaml` with `sls_input_file.json`'s switch targets.

This new method is less error prone, removing any need to copy-paste and munge inputs together.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
