### PR TITLE
CASMTRIAGE-6648: Added note about test failure when switches are not configured

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -563,6 +563,20 @@ successfully.
    (for example, editing configuration or CSI inputs), then restart from the beginning of the
    [Initialize the LiveCD](Create_System_Configuration_Using_SHCD.md#6-initialize-the-livecd) procedure.
 
+   The following test failure may be ignored if the management network switches have not been configured.
+   This is often the case when the system is being installed with CSM for the first time.
+   Configuring switches is covered in the next topic.
+
+   ```text
+   Result: FAIL
+   Source: /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
+   Test Name: sls_input.json IPs Correct
+   Description: Extracts the switch IP addresses from sls_input.json and pings them to ensure they are accurate.
+   Test Summary: check_sls_file_ips: exit-status: Error: Command execution timed out (20s)
+   Execution Time: 0.000002214 seconds
+   Node: eniac-pit
+   ```
+
 1. Save the `prep` directory for re-use.
 
    This needs to be copied off the system and either stored in a secure location or in a secured Git repository.


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The tests fail when the switches are not configured, even though the next step is to configure the switches.

CASMTRIAGE-6648 

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
