### PR TITLE
Added csm-node-heartbeat to release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,7 @@ documentation improvements. This page lists some of the highlights.
 * Multitenancy: Enable Tenant ID + Tenant Admin `AuthZ` Awareness for API Ingress (OPA policy)
 * Multitenancy: Enable Tenant ID + Tenant Admin `AuthZ` Awareness for API Ingress
 * Multitenancy: BOS Support for boot, reboot, node power on and off in tenant
+* Transitioned from `cray-heartbeat` to `csm-node-heartbeat`
 
 ### New Hardware Support
 


### PR DESCRIPTION
# Description

CSM took over building and packaging of cray-heartbeat (now csm-node-heartbeat)
@rfrost-hpe requested that I add csm-node-heartbeat to the release notes. 

Relates to:
- https://github.com/Cray-HPE/docs-csm/pull/4566

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.