### PR TITLE
CASMTRIAGE-6700-release-1.4 source myenv file at beginning of CSM 1.4 upgade

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -25,6 +25,7 @@
 
 set -e
 basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+. /etc/cray/upgrade/csm/myenv
 . ${basedir}/../common/upgrade-state.sh
 trap 'err_report' ERR
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
The CSM storage node upgrade uses two different files to keep track of the state of the upgrade, instead of the 1 file it should use. The node upgrade state file should be `/etc/cray/upgrade/csm/csm-1.4.0/ncn-s00x` but instead `/etc/cray/upgrade/csm/csm-/ncn-s00x` is used sometimes when the script doesn't have the CSM_RELEASE varaible. Sourcing the myenv file at the beginning of the upgrade will ensure the correct file is used for the whole upgrade.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
