### PR TITLE
CASMCVT-263 : Add a note to create bond0 network section.

### DIFF
--- a/install/Create_System_Configuration_Using_Cluster_Discovery_Service.md
+++ b/install/Create_System_Configuration_Using_Cluster_Discovery_Service.md
@@ -225,7 +225,7 @@ The following steps verify the status and lists the IP addresses of nodes, fabri
         // more nodes to follow - output truncated
         ```
 
-      > **NOTE**: If there is a failure in creating `bond0` network on any nodes in the `nodelist`, make sure to run the script again on only those particular nodes to create the `bond0` network.
+      > **NOTE**: If there is a failure in creating the `bond0` network on any nodes listed in the `nodelist`, make sure to run the script again on only those particular nodes to create the `bond0` network.
 
 1. (`pit#`) Verify the status and list the IP addresses of the fabric switches.
 

--- a/install/Create_System_Configuration_Using_Cluster_Discovery_Service.md
+++ b/install/Create_System_Configuration_Using_Cluster_Discovery_Service.md
@@ -225,6 +225,8 @@ The following steps verify the status and lists the IP addresses of nodes, fabri
         // more nodes to follow - output truncated
         ```
 
+      > **NOTE**: If there is a failure in creating `bond0` network on any nodes in the `nodelist`, make sure to run the script again on only those particular nodes to create the `bond0` network.
+
 1. (`pit#`) Verify the status and list the IP addresses of the fabric switches.
 
    ```bash


### PR DESCRIPTION
## Summary and Scope

This PR is a update to the CDS feature from CSM 1.5. It updates some bug fixes and so on and provides some corrective/troubleshooting instructions.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
              backwards incompatible

## Issues and Related PRs

* Resolves [CASMCVT-263](https://jira-pro.it.hpe.com:8443/browse/CASMCVT-263)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
