### PR TITLE
CASMCMS-8922: Include additional S3 artifacts in IMS import/export tool

### DIFF
--- a/operations/image_management/Exporting_and_Importing_IMS_Data.md
+++ b/operations/image_management/Exporting_and_Importing_IMS_Data.md
@@ -1,6 +1,7 @@
 # Exporting and Importing IMS Data
 
-IMS public keys, images, and recipes, including associated artifacts stored in Ceph S3, can be exported and imported
+IMS public keys, images, and recipes, including associated artifacts stored in Ceph
+[Simple Storage Service (S3)](../../glossary.md#simple-storage-service-s3), can be exported and imported
 using an automated script.
 
 - [Prerequisites](#prerequisites)
@@ -9,15 +10,17 @@ using an automated script.
 
 ## Prerequisites
 
-- Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to system management services.
-  - See [Configure the Cray CLI](../configure_cray_cli.md).
+- Ensure that the [Cray CLI (`cray`)](../../glossary.md#cray-cli-cray) is authenticated and configured to talk to system management services.
+    - See [Configure the Cray CLI](../configure_cray_cli.md).
 - The latest CSM documentation RPM must be installed on the node where the procedure is being performed.
-  - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+    - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 
 ## Export
 
 (`ncn-mw#`) The `export_ims_data.py` script will create a tar file backup of the contents of IMS and
-the associated S3 artifacts.
+the associated S3 artifacts. In addition, it backs up any S3 artifacts whose links are found in
+[Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) session templates,
+[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) boot parameters, or the Cray product catalog.
 
 > - This tar file may be very large, depending on how many images are in IMS. By default the script
 >   will create the tar file in the current directory. If desired, an alternative directory may be
@@ -31,13 +34,14 @@ the associated S3 artifacts.
 On success, the final lines of output will resemble the following:
 
 ```text
-2023-10-13 16:30:27 INFO     Data saved to tar archive: /root/export-ims-data-20231013161618.084854-naswhadt.tar
-2023-10-13 16:30:27 INFO     DONE!
+Data saved to tar archive: /root/export-ims-data-20231013161618.084854-naswhadt.tar
+DONE!
 ```
 
 ## Import
 
 The `import_ims_data.py` script can be used to import the previously exported IMS public keys, images, and recipes.
+It also imports the backed up S3 artifacts.
 
 There are three types of imports possible:
 
@@ -77,6 +81,6 @@ There are three types of imports possible:
 On success, the final lines of output will resemble the following:
 
 ```text
-2023-10-13 16:58:47 INFO     Waiting for rolling restart to complete (this may take a few minutes)
-2023-10-13 17:00:11 INFO     DONE!
+Waiting for rolling restart to complete (this may take a few minutes)
+DONE!
 ```

--- a/scripts/operations/configuration/python_lib/ims_import.py
+++ b/scripts/operations/configuration/python_lib/ims_import.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -249,6 +249,11 @@ def do_import(tarfile_dir: str,
     """
     if not exported_data.ims_data.any_images_keys_recipes:
         logging.info("No IMS data to import")
+
+        # But there may be S3 artifacts to upload
+        logging.info("Uploading S3 artifacts (if any)")
+        exported_data.update_s3(tarfile_dir)
+
         return
 
     # Update current IMS data with exported IMS data

--- a/scripts/operations/configuration/python_lib/s3.py
+++ b/scripts/operations/configuration/python_lib/s3.py
@@ -23,29 +23,29 @@
 #
 """Shared Python function library: S3"""
 
-import base64
 import datetime
 import json
 import logging
-import os
-from typing import Dict
+from typing import Dict, List
 from urllib.parse import urlparse
 import warnings
 
 import boto3
+import botocore.exceptions
 
+from . import api_requests
 from . import common
-from . import k8s
 from .types import JsonDict
 
-S3_CREDS_SECRET_NAME = "ims-s3-credentials"
 
-# Mapping from the boto3 client kwargs field names to the Kubernetes secret field names
-S3_CREDS_SECRET_FIELDS = {
-    "endpoint_url": "s3_endpoint",
-    "aws_access_key_id": "access_key",
-    "aws_secret_access_key": "secret_key",
-    "verify": "ssl_validate" }
+STS_TOKEN_URL = f"{api_requests.API_GW_BASE_URL}/apis/sts/token"
+
+# Mapping from the STS Credentials field names to the boto3 client kwargs names
+CREDS_TO_KWARGS = {
+    "AccessKeyId": "aws_access_key_id",
+    "SecretAccessKey": "aws_secret_access_key",
+    "SessionToken": "aws_session_token",
+    "EndpointURL": "endpoint_url" }
 
 
 def s3_client_kwargs() -> JsonDict:
@@ -53,35 +53,15 @@ def s3_client_kwargs() -> JsonDict:
     Decode the S3 credentials from the Kubernetes secret, and return
     the kwargs needed to initialize the boto3 client.
     """
-    secret_data = k8s.Client().get_secret_data(name=S3_CREDS_SECRET_NAME, namespace="default")
-    logging.debug("Reading fields from Kubernetes secret '%s'", S3_CREDS_SECRET_NAME)
-    encoded_s3_secret_fields = { field: secret_data[secret_field]
-                                 for field, secret_field in S3_CREDS_SECRET_FIELDS.items() }
-    logging.debug("Decoding fields from Kubernetes secret '%s'", S3_CREDS_SECRET_NAME)
-    kwargs = { field: base64.b64decode(encoded_field).decode()
-               for field, encoded_field in encoded_s3_secret_fields.items() }
-    # Need to convert the 'verify' field to boolean if it is false
-    if not kwargs["verify"] or kwargs["verify"].lower() in ('false', 'off', 'no', 'f', '0'):
-        kwargs["verify"] = False
-
-    # And if Verify is false, then we need to make sure that our endpoint isn't https, since
-    # it will use SSL verification regardless if the endpoint is https
-    if kwargs["verify"] is False and kwargs["endpoint_url"][:6] == "https:":
-        kwargs["endpoint_url"] = f"http:{kwargs['endpoint_url'][6:]}"
-
+    logging.debug("Contacting STS to obtain S3 credentials")
+    resp = api_requests.put_retry_validate_return_json(url=STS_TOKEN_URL, expected_status_codes=201,
+                                                       add_api_token=True)
+    creds = resp["Credentials"]
+    kwargs = { kname: creds[cname] for cname, kname in CREDS_TO_KWARGS.items() }
+    # The Cray CLI sets the following field to an empty string, and if it's good enough for the
+    # Cray CLI, then it's good enough for me
+    kwargs["region_name"] = ""
     return kwargs
-
-
-def s3_client():
-    """
-    Initialize the boto3 client and return it
-    """
-    client_kwargs = s3_client_kwargs()
-    logging.debug("Getting boto3 S3 client")
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=boto3.compat.PythonDeprecationWarning)
-        bclient = boto3.client('s3', **client_kwargs)
-    return bclient
 
 
 class S3Url(str):
@@ -100,12 +80,86 @@ class S3Url(str):
         self.key = parsed.path.lstrip('/') + '?' + parsed.query if parsed.query else parsed.path.lstrip('/')
         self.bucket = parsed.netloc
 
+    @classmethod
+    def from_bucket_and_key(cls, bucket: str, key: str) -> "S3Url":
+        """
+        Create a new S3 URL object from the bucket and key
+        """
+        return cls(f"s3://{bucket}/{key}")
+
+
+class S3Client:
+    """
+    Wrapper for the boto3 S3 client
+    """
+
+    def __init__(self):
+        client_kwargs = s3_client_kwargs()
+        logging.debug("Getting boto3 S3 client")
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=boto3.compat.PythonDeprecationWarning)
+            self.s3_cli = boto3.client('s3', **client_kwargs)
+
+
+    def list_artifacts(self, bucket_name: str) -> list:
+        """
+        Queries S3 to list contents of the specified bucket. Makes additional queries if
+        response is truncated. Returns a combined list of the artifacts.
+        """
+        logging.debug("Quering S3 for contents of '%s' bucket", bucket_name)
+        resp = self.s3_cli.list_objects_v2(Bucket=bucket_name)
+        logging.debug("S3 returned list of %d artifacts in '%s' bucket", resp["KeyCount"],
+                      bucket_name)
+        artifact_list = []
+        if resp["KeyCount"] > 0:
+            artifact_list.extend(resp["Contents"])
+        page_num=1
+        while resp["IsTruncated"]:
+            page_num+=1
+            logging.debug("Quering S3 for contents of '%s' bucket (page %d)", bucket_name, page_num)
+            resp = self.s3_cli.list_objects_v2(Bucket=bucket_name,
+                                               ContinuationToken=resp["NextContinuationToken"])
+            logging.debug("S3 returned list of %d artifacts in '%s' bucket", resp["KeyCount"],
+                          bucket_name)
+            if resp["KeyCount"] > 0:
+                artifact_list.extend(resp["Contents"])
+
+        logging.debug("Returning combined list of %d artifacts", len(artifact_list))
+        return artifact_list
+
+
+    def list_buckets(self) -> list:
+        """
+        Queries S3 for a list of all buckets, and returns this list.
+        
+        Technically this is all of the buckets belonging to the authenticated user.
+        In the case of CSM, all buckets should be created by this user. If any other
+        buckets exist, they are not our concern.
+        """
+        logging.debug("Quering S3 for list of buckets")
+        resp = self.s3_cli.list_buckets()
+        logging.debug("S3 returned list of %d buckets", len(resp["Buckets"]))
+        return resp["Buckets"]
+
+
+    def artifact_exists(self, bucket_name: str, key: str) -> bool:
+        """
+        Returns True if the artifact exists in S3 and we have access to it.
+        Returns False otherwise
+        """
+        try:
+            self.s3_cli.head_object(Bucket=bucket_name, Key=key)
+        except botocore.exceptions.ClientError:
+            return False
+        return True
+
 
 def create_artifact(s3_url: S3Url, source_path: str) -> JsonDict:
     """
     Uploads the specified S3 artifact from the specified path
     """
-    command = ['cray', 'artifacts', 'create', s3_url.bucket, s3_url.key, source_path, '--format', 'json']
+    command = ['cray', 'artifacts', 'create', s3_url.bucket, s3_url.key, source_path, '--format',
+               'json']
     return json.loads(common.run_command(command))
 
 
@@ -137,21 +191,7 @@ def list_artifacts(bucket_name: str) -> JsonDict:
     """
     Queries S3 to list contents of the specified bucket and returns the response
     """
-    s3_cli = s3_client()
-    logging.debug("Quering S3 for contents of '%s' bucket", bucket_name)
-    resp = s3_cli.list_objects_v2(Bucket=bucket_name)
-    logging.debug("S3 returned list of %d artifacts in '%s' bucket", len(resp["Contents"]),
-                  bucket_name)
-    artifact_list = resp["Contents"]
-    page_num=1
-    while resp["IsTruncated"]:
-        page_num+=1
-        logging.debug("Quering S3 for contents of '%s' bucket (page %d)", bucket_name, page_num)
-        resp = s3_cli.list_objects_v2(Bucket=bucket_name,
-                                      ContinuationToken=resp["NextContinuationToken"])
-        logging.debug("S3 returned list of %d artifacts in '%s' bucket", len(resp["Contents"]),
-                      bucket_name)
-        artifact_list.extend(resp["Contents"])
+    artifact_list = S3Client().list_artifacts(bucket_name)
 
     # Convert the datetime fields in the artifacts to strings, since we need them to be
     # JSON serializable
@@ -162,11 +202,20 @@ def list_artifacts(bucket_name: str) -> JsonDict:
             continue
         if "RestoreExpiryDate" not in art["RestoreStatus"]:
             continue
-        if isinstance(art["RestoreStatus"]["RestoreExpiryDate"], datetime.datetime):
-            art["RestoreStatus"]["RestoreExpiryDate"] = str(art["RestoreStatus"]["RestoreExpiryDate"])
+        if not isinstance(art["RestoreStatus"]["RestoreExpiryDate"], datetime.datetime):
+            continue
+        art["RestoreStatus"]["RestoreExpiryDate"] = str(art["RestoreStatus"]["RestoreExpiryDate"])
 
     # Return a response in the same format as the Cray CLI would
     return { "artifacts": artifact_list }
+
+
+def list_buckets() -> List[str]:
+    """
+    Return the list of names of all S3 buckets.
+    """
+    # Generate the bucket list. Sadly, it will not include skydiving.
+    return [ bucket["Name"] for bucket in S3Client().list_buckets() ]
 
 
 def bucket_artifact_map(list_artifacts_response: JsonDict) -> Dict[str, JsonDict]:


### PR DESCRIPTION
# Description

The main purpose of this change is to modify the IMS import/export tool so that it also covers additional (non-IMS) artifacts in S3 -- specifically ones whose S3 paths are listed in BOS session templates, BSS boot parameters, or Cray product catalog entries.

Secondarily, this PR modifies these tools so that they log to a file as well as to the console, to aid in debugging.

I have tested these changes on wasp and the UKMet TDSY system.

Backports:
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/4759
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/4760
* 1.6: https://github.com/Cray-HPE/docs-csm/pull/4761
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
