### PR TITLE
CASMTRIAGE-6704: Add known issue with spire postgres

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -5,8 +5,8 @@ This document provides links to troubleshooting information for services and fun
 * [Helpful tips for navigating the CSM repository](#helpful-tips-for-navigating-the-csm-repository)
 * [Known issues](#known-issues)
 * [Booting](#booting)
-  * [UAN boot issues](#uan-boot-issues)
-  * [Compute node boot issues](#compute-node-boot-issues)
+    * [UAN boot issues](#uan-boot-issues)
+    * [Compute node boot issues](#compute-node-boot-issues)
 * [Configuration management](#configuration-management)
 * [ConMan](#conman)
 * [Customer Management Network (CMN)](#customer-management-network-cmn)
@@ -133,6 +133,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Restore Spire Postgres without a Backup](../operations/spire/Restore_Spire_Postgres_without_a_Backup.md)
 * [Spire Database Cluster DNS Lookup Failure](known_issues/spire_database_lookup_error.md)
 * [Spire Failing to Start on NCNs](../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
+* [Spire Server Report Database is in Recovery](known_issues/spire_server_database_recovery.md)
 
 ## User Access service UAS
 

--- a/troubleshooting/known_issues/spire_server_database_recovery.md
+++ b/troubleshooting/known_issues/spire_server_database_recovery.md
@@ -1,0 +1,42 @@
+# Spire Server Reports Database is in Recovery
+
+## Description
+
+There is a known issue where when the PostgreSQL cluster changes leader the cluster can enter
+a silent failure state where clients report the cluster is in recovery while it is not.
+This leads to clients not able to transact with the cluster leading to errors.
+
+## Symptoms
+
+* The `spire-server` or `cray-spire-server` pods may be in a `CrashLoopBackOff` state.
+* The `spire-agent` or `cray-spire-agent` pods may be in a `CrashLoopBackOff` state.
+* Services may fail to acquire tokens from the `spire-server` or `cray-spire-server`.
+* The `spire-server` or `cray-spire-server` pods contain the following error in the logs.
+
+  ```text
+  2024-02-04T22:57:25.145365496Z time="2024-02-04T22:57:25Z" level=error msg="Could not generate TLS config for gRPC client" address="10.47.0.0:63042" error="get bundle from datastore: datastore-sql: pq: cannot set transaction read-write mode during recovery" subsystem_name=endpoints
+  ```
+
+* The `spire-agent` or `cray-spire-agent` pods contain the following error in the logs.
+
+    ```text
+    time="2024-02-26T22:24:55Z" level=error msg="Agent crashed" error="failed to get SVID: error getting attestation response from SPIRE server: rpc error: code = Internal desc = failed to attest: k8s-sat: unable to get agent info: rpc error: code = Unknown desc = datastore-sql: pq: cannot set transaction read-write mode during recovery"
+    ```
+
+## Solution
+
+1. (`ncn-mw#`) Restart the Postgres cluster
+
+    * If the `spire-server` has the errors, restart the `spire-postgres` `statefulset`
+
+      ```bash
+      kubectl -n spire rollout restart statefulset spire-postgres
+      ```
+
+    * If the `cray-spire-server` has the errors, restart the `cray-spire-postgres` `statefulset`
+
+      ```bash
+      kubectl -n spire rollout restart statefulset cray-spire-postgres
+      ```
+
+1. (`ncn-mw#`) Wait for the cluster to restart and check the logs to ensure there is no more errors

--- a/troubleshooting/known_issues/spire_server_database_recovery.md
+++ b/troubleshooting/known_issues/spire_server_database_recovery.md
@@ -25,18 +25,18 @@ This leads to clients not able to transact with the cluster leading to errors.
 
 ## Solution
 
-1. (`ncn-mw#`) Restart the Postgres cluster
+1. (`ncn-mw#`) Restart the Postgres cluster.
 
-    * If the `spire-server` has the errors, restart the `spire-postgres` `statefulset`
+    * If the `spire-server` has the errors, restart the `spire-postgres` `statefulset`.
 
       ```bash
       kubectl -n spire rollout restart statefulset spire-postgres
       ```
 
-    * If the `cray-spire-server` has the errors, restart the `cray-spire-postgres` `statefulset`
+    * If the `cray-spire-server` has the errors, restart the `cray-spire-postgres` `statefulset`.
 
       ```bash
       kubectl -n spire rollout restart statefulset cray-spire-postgres
       ```
 
-1. (`ncn-mw#`) Wait for the cluster to restart and check the logs to ensure there is no more errors
+1. (`ncn-mw#`) Wait for the cluster to restart and check the logs to ensure that there is no more errors.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Adds an additional known issue where spire-postgres can get into a silent error state that breaks connections from clients. This is due to an upstream postgres bug that is not been addressed.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
