### PR TITLE
CASMTRIAGE-6711: allow pending pods after worker drain

### DIFF
--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -53,7 +53,7 @@ spec:
                   if [[ $res -eq 0 ]]; then
                     csi automate ncn kubernetes --action delete-ncn --ncn {{inputs.parameters.targetNcn}} --kubeconfig mykubeconfig/admin.conf
                   fi
-        - name: wait-for-pods
+        - name: wait-for-postgres-operator
           dependencies:
             - drain
           templateRef:
@@ -65,25 +65,60 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  echo "Sleeping for 60 seconds to allow pod migration to commence"
+                  while true; do
+                    numOfRunningPgOperatorPod=$(kubectl get pods -n services -l app.kubernetes.io/name=postgres-operator | grep "Running" | wc -l)
+                    if [[ $numOfRunningPgOperatorPod -ne 1 ]];then
+                      echo "ERROR - Postgres Operator is not running yet"
+                      sleep 5
+                      continue
+                    else
+                      echo "Postgres Operator is running"
+                      break
+                    fi
+                  done
+        - name: wait-for-sls
+          dependencies:
+            - wait-for-postgres-operator
+          templateRef:
+            name: kubectl-and-curl-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  echo "Sleeping for 60s to let terminated pods start terminate ..."
                   sleep 60
-                  echo "Waiting for nexus ..."
-                  kubectl wait --for=condition=ready pod -l app=nexus -n nexus --timeout=30m
-                  echo "Waiting for keycloak ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=keycloak -n services --timeout=30m
-                  echo "Waiting for postgresql-operator ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgres-operator -n services --timeout=30m
-                  echo "Waiting for cray-sls ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-sls -n services --timeout=30m
-                  echo "Waiting for cray-tftp ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-tftp -n services --timeout=30m
-                  echo "Waiting for cray-scsd ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-scsd -n services --timeout=30m
-                  echo "Waiting for cray-smd ..."
-                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-smd -n services --timeout=30m
+                  count=0
+                  total=120
+                  sleep=5
+                  echo "Waiting for SLS to become operational"
+                  # SLS may not be operational due to issues with DNS resolution after worker drain
+                  while true; do
+                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                      -d client_id=admin-client \
+                      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                    TARGET_NCN={{inputs.parameters.targetNcn}}
+                    TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                        jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                    if [ -n "${TARGET_XNAME}" ]; then
+                      echo "SLS is up"
+                      break
+                    else
+                      if [ "${count}" == "${total}" ]; then
+                        echo "SLS is down after ${total} checks, giving up ..."
+                        exit 1
+                      fi
+                      count=$(($count + 1))
+                      echo "SLS is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
+                      sleep $sleep
+                    fi
+                  done
         - name: update-bss
           dependencies:
-          - wait-for-pods
+          - wait-for-sls
           templateRef:
             name: kubectl-and-curl-template
             template: shell-script


### PR DESCRIPTION
# Description

This is essentially revert of commit 69b829cb76b45616a3b1457a68d72d994d82efd3 and replacing it with different kind of wait condition. After node drain, there may be pods stuck in state "Pending" due to node/pod affinity rules, so we can't use `kubectl wait` to wait for all such pods to come up. Instead, we will wait for SLS service to become operational. There may be different reasons behind temporary SLS downtime after node drain, such as temporary DNS resolution issues or errors in istio-ingress-gateway. Operational SLS is needed for next step (`update-bss`).

Change is tested multiple times in vShasta 1.4 > 1.5 and 1.5 > 1.6 upgrade scenarios.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
