### PR TITLE
CASMINST-6806: Reduce confusion in upgrade stage 0.3 and updating NCN boot parameters

### DIFF
--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -22,9 +22,9 @@ This procedure is referenced from operational procedures that occur after CSM in
 ## Prerequisites
 
 * The Cray CLI must be configured and authenticated.
-  * See [Configure the Cray CLI](../configure_cray_cli.md).
+    * See [Configure the Cray CLI](../configure_cray_cli.md).
 * SAT must be configured and authenticated.
-  * See [SAT documentation](../sat/sat_in_csm.md#sat-documentation).
+    * See [SAT documentation](../sat/sat_in_csm.md#sat-documentation).
 
 ## Procedure
 
@@ -78,8 +78,8 @@ procedure below.
 
    ```bash
    IMS_IMAGE_ID=$(cray bss bootparameters list --name "${NODE_XNAME}" --format json | \
-                        jq -r '.[0].params' | \
-                        sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
+                     jq -r '.[0].params' | \
+                     sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
    echo "${IMS_IMAGE_ID}"
    ```
 
@@ -117,8 +117,8 @@ the booted node.
 
    ```bash
    IMS_IMAGE_ID=$(ssh "${BOOTED_NODE}" sed \
-                            "'s#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#'" \
-                            /proc/cmdline)
+                    "'s#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#'" \
+                    /proc/cmdline)
    echo "${IMS_IMAGE_ID}"
    ```
 
@@ -358,115 +358,67 @@ new customized image.
 
 1. (`ncn-mw#`) Set an environment variable for the IMS image ID.
 
-   * If executing this step in the context of
-     [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-     of the CSM upgrade procedure, use the appropriate IMS image ID environment variable set in that procedure.
-
-     > ***NOTE*** To target both master and worker nodes at the same time, use the following:
-     >
-     > ```bash
-     > /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
-     >     -mw \
-     >     -p "$MASTER_IMAGE_ID"
-     > ```
-
-     1. Update master management nodes:
-
-       ```bash
-       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
-           -m \
-           -p "$MASTER_IMAGE_ID"
-       ```
-
-     1. Update storage management nodes:
-
-       ```bash
-       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
-           -s \
-           -p "$STORAGE_IMAGE_ID"
-       ```
-
-     1. Update worker management nodes:
-
-       ```bash
-       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
-           -w \
-           -p "$WORKER_IMAGE_ID"
-       ```
-
-     1. Return to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-
-   * If executing this step in the context of the entire procedure on this page, then use the
-     `IMS_RESULTANT_IMAGE_ID` set in the previous step,
-     [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
-
-     ```bash
-     NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
-     ```
-
-1. (`ncn-mw#`) Determine the component names (xnames) for the management nodes which will boot from the new image.
-
-   > In this example, the xname for `ncn-w001` is being found.
+   > If executing this step in the context of the entire procedure on this page, then use the
+   > `IMS_RESULTANT_IMAGE_ID` set in the previous step,
+   > [3. Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
 
    ```bash
-   ssh ncn-w001 cat /etc/cray/xname
+   NEW_IMS_IMAGE_ID="${IMS_RESULTANT_IMAGE_ID}"
    ```
 
-1. (`ncn-mw#`) Update boot parameters for a management node.
+1. Update the boot parameters of the management nodes using the `assign-ncn-images.sh` script. It can
+   be used to update the boot parameters for all management nodes in particular categories (master, worker,
+   or storage), or it can be used to update the boot parameters for specific management nodes.
 
-    1. Get the existing `metal.server` setting for the component name (xname) of the node of interest.
+   * Update the boot parameters for all master and worker nodes
 
-       ```bash
-       XNAME=<node-xname>
-       METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
-           | awk -F 'metal.server=' '{print $2}' \
-           | awk -F ' ' '{print $1}')
-       echo "${METAL_SERVER}"
-       ```
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+         -mw -p "${NEW_IMS_IMAGE_ID}"
+      ```
 
-    1. Create updated boot parameters that point to the new artifacts.
+   * Update the boot parameters for all master nodes
 
-       1. Set the path to the artifacts in S3.
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+         -m -p "${NEW_IMS_IMAGE_ID}"
+      ```
 
-          ***NOTE*** This uses the `NEW_IMS_IMAGE_ID` variable set in an earlier step.
+   * Update the boot parameters for all worker nodes
 
-          ```bash
-          S3_ARTIFACT_PATH="boot-images/${NEW_IMS_IMAGE_ID}"
-          echo "${S3_ARTIFACT_PATH}"
-          ```
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+         -w -p "${NEW_IMS_IMAGE_ID}"
+      ```
 
-       1. Set the new `metal.server` value.
+   * Update the boot parameters for all storage nodes
 
-          ```bash
-          NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
-          echo "${NEW_METAL_SERVER}"
-          ```
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+         -s -p "${NEW_IMS_IMAGE_ID}"
+      ```
 
-       1. Determine the modified boot parameters for the node.
+   * Update the boot parameters for specific management nodes
 
-          ```bash
-          PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-              sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-              tr -d \")
-          echo "${PARAMS}"
-          ```
+      1. Determine the component names (xnames) of the management nodes whose boot parameters are to be updated.
 
-          In the output of the `echo` command, verify that the value of `metal.server` is
-          correctly set to the value of `${NEW_METAL_SERVER}`.
+         One option to determine the xname of a node is to read the `/etc/cray/xname` file on it:
 
-    1. Update BSS with the new boot parameters.
+         ```bash
+         ssh ncn-w001 cat /etc/cray/xname
+         ```
 
-       ```bash
-       cray bss bootparameters update --hosts "${XNAME}" \
-           --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
-           --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
-           --params "${PARAMS}" && echo SUCCESS || echo ERROR
-       ```
+      1. Run the script to update their boot parameters.
+
+         > In the following example, be sure to replace the `<xname>` placeholder strings with the actual xnames of the
+         > management nodes whose boot parameters are to be updated.
+
+         ```bash
+         /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+            -p "${NEW_IMS_IMAGE_ID}" <xname1> <xname2> ...
+         ```
 
 ## Next steps
-
-If a particular step of this procedure is being performed as part of a CSM upgrade, then return
-to [Stage 0.3 - Update management node CFS configuration and customize worker node image](../../upgrade/Stage_0_Prerequisites.md#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image).
 
 If this procedure is being performed as an operational task outside the context of an install or upgrade,
 then proceed to [Rebuild NCNs](../node_management/Rebuild_NCNs/Rebuild_NCNs.md)

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -9,20 +9,20 @@
 Stage 0 has several critical procedures which prepare the environment and verify if the environment is ready for the upgrade.
 
 - [Stage 0 - Prerequisites and Preflight Checks](#stage-0---prerequisites-and-preflight-checks)
-  - [Start typescript](#start-typescript)
-  - [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
-    - [Direct download](#direct-download)
-    - [Manual copy](#manual-copy)
-  - [Stage 0.2 - Prerequisites](#stage-02---prerequisites)
-  - [Stage 0.3 - Update management node CFS configuration and customize worker node image](#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-    - [Option 1: Upgrade of CSM and additional products](#option-1-upgrade-of-csm-and-additional-products)
-    - [Option 2: Upgrade of CSM on system with additional products](#option-2-upgrade-of-csm-on-system-with-additional-products)
-    - [Option 3: Upgrade of CSM on CSM-only system](#option-3-upgrade-of-csm-on-csm-only-system)
-  - [Stage 0.4 - Backup workload manager data](#stage-04---backup-workload-manager-data)
-  - [Stage 0.5 - Upgrade Ceph and stop local Docker registries](#stage-05---upgrade-ceph-and-stop-local-docker-registries)
-  - [Stage 0.6 - Enable `Smartmon` Metrics on Storage NCNs](#stage-06---enable-smartmon-metrics-on-storage-ncns)
-  - [Stop typescript](#stop-typescript)
-  - [Stage completed](#stage-completed)
+    - [Start typescript](#start-typescript)
+    - [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
+        - [Direct download](#direct-download)
+        - [Manual copy](#manual-copy)
+    - [Stage 0.2 - Prerequisites](#stage-02---prerequisites)
+    - [Stage 0.3 - Update management node CFS configuration and customize worker node image](#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
+        - [Option 1: Upgrade of CSM and additional products](#option-1-upgrade-of-csm-and-additional-products)
+        - [Option 2: Upgrade of CSM on system with additional products](#option-2-upgrade-of-csm-on-system-with-additional-products)
+        - [Option 3: Upgrade of CSM on CSM-only system](#option-3-upgrade-of-csm-on-csm-only-system)
+    - [Stage 0.4 - Backup workload manager data](#stage-04---backup-workload-manager-data)
+    - [Stage 0.5 - Upgrade Ceph and stop local Docker registries](#stage-05---upgrade-ceph-and-stop-local-docker-registries)
+    - [Stage 0.6 - Enable `Smartmon` Metrics on Storage NCNs](#stage-06---enable-smartmon-metrics-on-storage-ncns)
+    - [Stop typescript](#stop-typescript)
+    - [Stage completed](#stage-completed)
 
 ## Start typescript
 
@@ -425,7 +425,7 @@ example showing how to find the IUF activity.
    sat bootprep run --vars-file session_vars.yaml management-bootprep.yaml
    ```
 
-1. Gather the CFS configuration name, and the IMS image names from the output of `sat bootprep`.
+1. (`ncn-m001#`) Gather the CFS configuration name, and the IMS image names from the output of `sat bootprep`.
 
    `sat bootprep` will print a report summarizing the CFS configuration and IMS images it created.
    For example:
@@ -451,101 +451,102 @@ example showing how to find the IUF activity.
    +-----------------------------+--------------------------------------+--------------------------------------+-----------------------------+----------------------------+
    ```
 
-   Save the name of the CFS configurations:
+   1. Save the names of the CFS configurations from the `configuration` column:
 
-   ```bash
-   export KUBERNETES_CFS_CONFIG_NAME=""
-   ```
+      > Note that the storage node configuration might be titled `minimal-management-` or `storage-` depending on the value
+      > set in the sat `bootprep` file.
+      >
+      > The following uses the values from the example output above. Be sure to modify them
+      > to match the actual values.
 
-   ```bash
-   export STORAGE_CFS_CONFIG_NAME=""
-   ```
+      ```bash
+      export KUBERNETES_CFS_CONFIG_NAME="management-22.4.0-csm-x.y.z"
+      export STORAGE_CFS_CONFIG_NAME="storage-22.4.0-csm-x.y.z"
+      ```
 
-   Note that the storage node configuration might be titled `minimal-management-` or `storage-` depending on the value
-   set in the sat `bootprep` file.
+   1. Save the name of the IMS images from the `final_image_id` column:
 
-   Save the name of the IMS images from the `final_image_id` column:
+      > The following uses the values from the example output above. Be sure to modify them
+      > to match the actual values.
 
-   ```bash
-   export MASTER_IMAGE_ID=""
-   ```
+      ```bash
+      export MASTER_IMAGE_ID="a22fb912-22be-449b-a51b-081af2d7aff6"
+      export WORKER_IMAGE_ID="241822c3-c7dd-44f8-98ca-0e7c7c6426d5"
+      export STORAGE_IMAGE_ID="79ab3d85-274d-4d01-9e2b-7c25f7e108ca"
+      ```
 
-   ```bash
-   export WORKER_IMAGE_ID=""
-   ```
+1. (`ncn-m001#`) Assign the images to the management nodes in BSS.
 
-   ```bash
-   export STORAGE_IMAGE_ID=""
-   ```
+   - Master management nodes:
 
-1. Assign the images to the management nodes in BSS.
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -m -p "$MASTER_IMAGE_ID"
+      ```
 
-   Perform the procedure in [4. Update management node boot parameters](../operations/configuration_management/Management_Node_Image_Customization.md#4-update-management-node-boot-parameters)
-   for master, worker, and storage nodes.
+   - Storage management nodes:
 
-   Note that the procedure must be followed three times: once for master nodes with
-   `MASTER_IMAGE_ID`, once for worker nodes with `WORKER_IMAGE_ID`, and once for storage nodes with
-   `STORAGE_IMAGE_ID`.
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -s -p "$STORAGE_IMAGE_ID"
+      ```
 
-   Do not proceed to the next steps in the linked procedure. Return here when finished with the
-   single step that updates the management node boot parameters.
+   - Worker management nodes:
 
-1. Assign the CFS configuration to the management nodes.
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -w -p "$WORKER_IMAGE_ID"
+      ```
 
-   This command deliberately only sets the desired configuration of the components in CFS. It
+1. (`ncn-m001#`) Assign the CFS configuration to the management nodes.
+
+   This deliberately only sets the desired configuration of the components in CFS. It
    disables the components and does not clear their configuration states or error counts. When the
    nodes are rebooted to their new images later in the CSM upgrade, they will automatically be
    enabled in CFS, and node personalization will occur.
   
-    1. `(ncn-m001)` Apply the appropriate CFS configuration to worker nodes and master nodes.
+   1. Get the xnames of the master and worker management nodes.
 
-        Get master nodes' and worker nodes' xnames.
-
-        ```bash
-        WORKER_XNAMES=$(cray hsm state components list --role Management --subrole Worker --type Node --format json |
+      ```bash
+      WORKER_XNAMES=$(cray hsm state components list --role Management --subrole Worker --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")')
-        MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json |
+      MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")')
-        echo "${MASTER_XNAMES},${WORKER_XNAMES}"
-        ```
+      echo "${MASTER_XNAMES},${WORKER_XNAMES}"
+      ```
 
-        Apply the CFS configuration to master nodes and worker nodes using the xnames and CFS configuration name found in the previous steps.
+   1. Apply the CFS configuration to master nodes and worker nodes using the xnames and CFS configuration name found in the previous steps.
 
-        ```bash
-        /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-            --no-config-change --config-name "${KUBERNETES_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
-            --xnames ${MASTER_XNAMES},${WORKER_XNAMES}
-        ```
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+          --no-config-change --config-name "${KUBERNETES_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
+          --xnames ${MASTER_XNAMES},${WORKER_XNAMES}
+      ```
 
-        Successful output will end with the following:
+      Successful output will end with the following:
 
-        ```text
-        All components updated successfully.
-        ```
+      ```text
+      All components updated successfully.
+      ```
 
-    1. `(ncn-m001)` Apply the appropriate CFS configuration to storage nodes.
+   1. Get the xnames of the storage management nodes.
 
-        Get storage nodes' xnames.
-
-        ```bash
-        STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json |
+      ```bash
+      STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")')
-        echo $STORAGE_XNAMES
-        ```
+      echo $STORAGE_XNAMES
+      ```
 
-        Apply the CFS configuration to storage nodes using the xnames and CFS configuration name found in the previous steps.
+   1. Apply the CFS configuration to storage nodes using the xnames and CFS configuration name found in the previous steps.
 
-        ```bash
-        /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-            --no-config-change --config-name "${STORAGE_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
-            --xnames ${STORAGE_XNAMES}
-        ```
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+          --no-config-change --config-name "${STORAGE_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
+          --xnames ${STORAGE_XNAMES}
+      ```
 
-        Successful output will end with the following:
+      Successful output will end with the following:
 
-        ```text
-        All components updated successfully.
-        ```
+      ```text
+      All components updated successfully.
+      ```
 
 Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data).
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -7,17 +7,17 @@
 - [Stage 1.1 - Master node image upgrade](#stage-11---master-node-image-upgrade)
 - [Argo workflows](#argo-workflows)
 - [Stage 1.2 - Worker node image upgrade](#stage-12---worker-node-image-upgrade)
-  - [Option 1 - Serial upgrade](#option-1---serial-upgrade)
-  - [Option 2 - Parallel upgrade (Tech preview)](#option-2---parallel-upgrade-tech-preview)
-    - [Restrictions](#restrictions)
-    - [Example](#example)
+    - [Option 1 - Serial upgrade](#option-1---serial-upgrade)
+    - [Option 2 - Parallel upgrade (Tech preview)](#option-2---parallel-upgrade-tech-preview)
+        - [Restrictions](#restrictions)
+        - [Example](#example)
 - [Stage 1.3 - `ncn-m001` upgrade](#stage-13---ncn-m001-upgrade)
-  - [Stop typescript on `ncn-m001`](#stop-typescript-on-ncn-m001)
-  - [Backup artifacts on `ncn-m001`](#backup-artifacts-on-ncn-m001)
-  - [Move to `ncn-m002`](#move-to-ncn-m002)
-  - [Start typescript on `ncn-m002`](#start-typescript-on-ncn-m002)
-  - [Prepare `ncn-m002`](#prepare-ncn-m002)
-  - [Upgrade `ncn-m001`](#upgrade-ncn-m001)
+    - [Stop typescript on `ncn-m001`](#stop-typescript-on-ncn-m001)
+    - [Backup artifacts on `ncn-m001`](#backup-artifacts-on-ncn-m001)
+    - [Move to `ncn-m002`](#move-to-ncn-m002)
+    - [Start typescript on `ncn-m002`](#start-typescript-on-ncn-m002)
+    - [Prepare `ncn-m002`](#prepare-ncn-m002)
+    - [Upgrade `ncn-m001`](#upgrade-ncn-m001)
 - [Stage 1.4 - Upgrade `weave` and `multus`](#stage-14---upgrade-weave-and-multus)
 - [Stage 1.5 - `coredns` anti-affinity](#stage-15---coredns-anti-affinity)
 - [Stage 1.6 - Complete Kubernetes upgrade](#stage-16---complete-kubernetes-upgrade)
@@ -49,7 +49,7 @@ after a break, always be sure that a typescript is running before proceeding.
    ```
 
    > **`NOTE`** The `root` user password for the node may need to be reset after it is rebooted.
-   > Ensure file `/etc/cray/upgrade/csm/myenv` has entries for `STORAGE_IMS_IMAGE_ID`, `K8S_IMS_IMAGE_ID`, `CSM_ARTI_DIR` and `CSM_RELEASE`.
+   > Ensure file `/etc/cray/upgrade/csm/myenv` has entries for `CSM_ARTI_DIR` and `CSM_RELEASE`.
 
 1. Repeat the previous step for each other master node **excluding `ncn-m001`**, one at a time.
 
@@ -63,7 +63,7 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 > **`NOTE`** One of the Argo steps (`wait-for-cfs`) will prevent the upgrade of a worker node from proceeding if the CFS component status for that worker is in an `Error` state, and this must be fixed in order for the upgrade to continue.
 The following steps can be used to reset the component state in CFS (replace `XNAME` below with the `XNAME` for the worker node:
 
-```text
+```bash
 cray cfs components update --error-count 0 <XNAME>
 cray cfs components update --state '[]' <XNAME>
 ```


### PR DESCRIPTION
1. Remove pointer from stage 0,3 to separate page for updating NCN boot parameters. Instead, insert the 3 appropriate commands directly into stage 0.3
2. Update the Management Node Image Customization page to reflect that it is no longer linked from that procedure. Also, remove no-longer-needed steps that the `assign-ncn-images.sh` script does.
3. Remove erroneous stage 1 statement about IMS ID variables.
4. Fix some minor linting issues

CSM 1.5: https://github.com/Cray-HPE/docs-csm/pull/4784
CSM 1.6: https://github.com/Cray-HPE/docs-csm/pull/4785