### PR TITLE
CASMPET-6912 fix file reference to adjust ceph pool quotas

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -49,6 +49,7 @@ StatefulSets
 15kw
 1GiB
 1TiB
+6TiB
 2-chassis
 2.0.0.L
 200Gbps

--- a/operations/utility_storage/Adjust_Ceph_Pool_Quotas.md
+++ b/operations/utility_storage/Adjust_Ceph_Pool_Quotas.md
@@ -26,7 +26,7 @@ Currently, only `smf` includes a quota.
 
     Example output:
 
-    ```
+    ```text
     RAW STORAGE:
       CLASS     SIZE       AVAIL      USED        RAW USED     %RAW USED
       ssd       21 TiB     21 TiB     122 GiB      134 GiB          0.62
@@ -69,16 +69,16 @@ Currently, only `smf` includes a quota.
     vim /etc/ansible/ceph-rgw-users/roles/ceph-pool-quotas/defaults/main.yml
     ```
 
-    Example ceph-pool-quotas.yml:
+    Example `ceph-pool-quotas.yml`:
 
-    ```
+    ```text
     ceph_pool_quotas:
       - pool_name: smf
         percent_of_total: .71 <-- Change this to desired percentage
         replication_factor: 2.0
     ```
 
-1. Run the ceph-pool-quotas.yml playbook from `ncn-s001`.
+1. Run the `ceph-pool-quotas.yml` playbook from `ncn-s001`.
 
     ```bash
     /etc/ansible/boto3_ansible/bin/ansible-playbook /etc/ansible/ceph-rgw-users/ceph-pool-quotas.yml
@@ -94,7 +94,7 @@ Currently, only `smf` includes a quota.
 
     Example output:
 
-    ```
+    ```text
     RAW STORAGE:
       CLASS     SIZE       AVAIL      USED        RAW USED     %RAW USED
       ssd       21 TiB     21 TiB     122 GiB      134 GiB          0.62
@@ -114,4 +114,3 @@ Currently, only `smf` includes a quota.
       smf                            10      19 TiB       7.88k      28 GiB      0.14       9.9 TiB     N/A               **7.4 TiB**           7.88k        9.4 GiB          19 GiB
       default.rgw.buckets.non-ec     11         0 B           0         0 B         0       9.9 TiB     N/A               N/A                   0            0 B             0 B
     ```
-

--- a/operations/utility_storage/Adjust_Ceph_Pool_Quotas.md
+++ b/operations/utility_storage/Adjust_Ceph_Pool_Quotas.md
@@ -66,7 +66,7 @@ Currently, only `smf` includes a quota.
     Do not exceed the percentage determined in the previous step.
 
     ```bash
-    vim /etc/ansible/ceph-rgw-users/ceph-pool-quotas.yml
+    vim /etc/ansible/ceph-rgw-users/roles/ceph-pool-quotas/defaults/main.yml
     ```
 
     Example ceph-pool-quotas.yml:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Right now, the [Adjust_Ceph_Pool_Quotas.md documentaion](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/operations/utility_storage/Adjust_Ceph_Pool_Quotas.md) is incorrect. Is suggests to edit '/etc/ansible/ceph-rgw-users/ceph-pool-quotas.yml ' which is the incorrect file. Instead, it should be editing '/etc/ansible/ceph-rgw-users/roles/ceph-pool-quotas/defaults/main.yml'.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
