### PR TITLE
CASMINST-6807 Wait condition after worker rebuild [1.5]

### DIFF
--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -80,42 +80,14 @@ spec:
           dependencies:
             - wait-for-postgres-operator
           templateRef:
-            name: kubectl-and-curl-template
-            template: shell-script
+            name: wait-for-sls
+            template: wait-for-sls
           arguments:
             parameters:
               - name: dryRun
                 value: "{{inputs.parameters.dryRun}}"
-              - name: scriptContent
-                value: |
-                  echo "Sleeping for 60s to let terminated pods start terminate ..."
-                  sleep 60
-                  count=0
-                  total=120
-                  sleep=5
-                  echo "Waiting for SLS to become operational"
-                  # SLS may not be operational due to issues with DNS resolution after worker drain
-                  while true; do
-                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                      -d client_id=admin-client \
-                      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-                    TARGET_NCN={{inputs.parameters.targetNcn}}
-                    TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
-                        jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                    if [ -n "${TARGET_XNAME}" ]; then
-                      echo "SLS is up"
-                      break
-                    else
-                      if [ "${count}" == "${total}" ]; then
-                        echo "SLS is down after ${total} checks, giving up ..."
-                        exit 1
-                      fi
-                      count=$(($count + 1))
-                      echo "SLS is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
-                      sleep $sleep
-                    fi
-                  done
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
         - name: update-bss
           dependencies:
           - wait-for-sls

--- a/workflows/templates/wait-for-sls.yaml
+++ b/workflows/templates/wait-for-sls.yaml
@@ -1,0 +1,74 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: wait-for-sls
+  namespace: argo
+spec:
+  templates:
+    - name: wait-for-sls
+      inputs:
+        parameters:
+          - name: targetNcn
+          - name: dryRun
+      dag:
+        tasks:
+        - name: wait-for-sls
+          templateRef:
+            name: kubectl-and-curl-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  count=0
+                  total=120
+                  sleep=5
+                  echo "Waiting for SLS to become operational"
+                  # SLS may not be operational due to issues with DNS resolution after worker drain, or
+                  # token invalidated by keycloak if keycloak is still recovering.
+                  while true; do
+                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                      -d client_id=admin-client \
+                      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token' || true)
+                    TARGET_NCN={{inputs.parameters.targetNcn}}
+                    TARGET_XNAME=$(test -n "${TOKEN}" && curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                        jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname" || true)
+                    if [ -n "${TARGET_XNAME}" ]; then
+                      echo "SLS is up"
+                      break
+                    else
+                      if [ "${count}" == "${total}" ]; then
+                        echo "SLS is down after ${total} checks, giving up ..."
+                        exit 1
+                      fi
+                      count=$(($count + 1))
+                      echo "SLS is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
+                      sleep $sleep
+                    fi
+                  done

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -280,6 +280,18 @@ spec:
                       fi
                       sleep 5
                   done
+        - name: wait-for-sls
+          dependencies:
+            - wait-for-k8s
+          templateRef:
+            name: wait-for-sls
+            template: wait-for-sls
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
         - name: "cray-cli-init"
           dependencies:
             - wait-for-cloud-init


### PR DESCRIPTION
# Description

Resolves CASMINST-6807.

Sometimes after worker rebuild post-rebuild tasks fail, because keycloak may have temporary malfunction after worker was just added (specifically, it may rejected previously issued tokens). This change adds wait condition, which expects entire sequence of steps to work: 
* generate token
* use this token to get xname from SLS API

We actually have this type of condition after worker drain (but before reboot). This change moves condition implementation to separate template, and calls this template in 2 places - after drain before rebuild, and after rebuild.

Testing: tested multiple times in vShasta upgrade pipeline, no issues detected.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
