### PR TITLE
CASMTRIAGE-6738: avoid operator error for node reboot

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -31,11 +31,11 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
 
 * The `kubectl` command is installed.
 * The Cray command line interface is configured on at least one NCN.
-  * See [Configure the Cray CLI](../configure_cray_cli.md).
+    * See [Configure the Cray CLI](../configure_cray_cli.md).
 * The latest CSM documentation is installed, if rebooting `ncn-m001` or any worker nodes.
-  * If rebooting `ncn-m001`, then the latest CSM documentation must be installed on `ncn-m001`.
-  * If rebooting a worker node, then the latest CSM documentation must be installed on some master or worker node.
-  * See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+    * If rebooting `ncn-m001`, then the latest CSM documentation must be installed on `ncn-m001`.
+    * If rebooting a worker node, then the latest CSM documentation must be installed on some master or worker node.
+    * See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 
 ## NCN pre-reboot health checks
 
@@ -378,10 +378,10 @@ Before rebooting NCNs:
 
     1. If booting from disk is desired, then [set the boot order](../../background/ncn_boot_workflow.md#setting-boot-order).
 
-    1. (`ncn-w#`) Reboot the selected node.
+    1. (`ncn-mw#`) Reboot the selected node.
 
          ```bash
-        shutdown -r now
+        pdsh -w <node to be rebooted> 'shutdown -r now'
         ```
 
         **`IMPORTANT:`** If the node does not shut down after 5 minutes, then proceed with the power reset below.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When rebooting a NCN node, the instruction in its current form could make the administrator reboot a wrong node accidentally. This PR makes the administrator explicitly specify the node name to avoid the mistake.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
