### PR TITLE
CASMTRIAGE-6769 IUF templates only use global_params max 1 time

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -68,20 +68,21 @@ spec:
               - name: scriptContent
                 value: |
                   #!/usr/bin/bash
-                  PRODUCT_NAME=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
+                  echo '{{inputs.parameters.global_params}}' > global.params.data
+                  PRODUCT_NAME=$(cat global.params.data  | jq -r '.product_manifest.current_product.manifest.name')
                   if [[ -z "$PRODUCT_NAME" ]]; then
                     echo "ERROR Product name not found in the product manifest. Rerun with valid product tarball from 'process-media' stage"
                     exit 1
                   fi
 
-                  JSON_CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
+                  JSON_CONTENT=$(cat global.params.data  | jq -r '.product_manifest.current_product.manifest')
                   LOFTSMAN_ENTRIES=$(echo "$JSON_CONTENT" | jq '.content.loftsman | length')
                   if [[ -z "$LOFTSMAN_ENTRIES" ]]; then
                       echo "ERROR Cannot access loftsman context for $PRODUCT. Rerun with valid product tarball from 'process-media' stage"
                       exit 1
                   fi
 
-                  PARENT_PATH=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
+                  PARENT_PATH=$(cat global.params.data  | jq -r '.stage_params."process-media".current_product.parent_directory')
                   if [ ! -d $PARENT_PATH ]; then
                       echo "ERROR Cannot access product directory for $PRODUCT. Rerun with valid product tarball from 'process-media' stage"
                       exit 1

--- a/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-rollout.yaml
@@ -108,11 +108,12 @@ spec:
                 - name: scriptContent
                   value: |
                     echo "INFO This stage will start a new Argo workflow with a name containing 'ncn-lifecycle-rebuild'."
-                    prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+                    prepare_images_ouput=$(cat global.params.data | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
                     image=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Storage")) | .[].final_image_id' | tr -d '"')
                     configuration=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Storage")) | .[].configuration' | tr -d '"')
 
-                    limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
                     rebuild_set=""
                     if [[ -n $(echo $limit_management_nodes | grep 'Management_Storage') ]]; then
                       for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do

--- a/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
@@ -119,7 +119,8 @@ spec:
                     fi
 
                     TARGET_NCN=ncn-m002
-                    limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
                     if [[ -z $(echo $limit_management_nodes | grep 'Management_Master') ]]; then
                       if [[ -z $(echo $limit_management_nodes | grep "$TARGET_NCN" ) ]]; then
                          echo "NOTICE ${TARGET_NCN} was not included in --limit-management-rollout. Not rebuilding ${TARGET_NCN}."
@@ -134,7 +135,7 @@ spec:
 
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    prepare_images_output=$(cat global.params.data | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
                     config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
 
                     echo "DEBUG Updating CFS config $config on $TARGET_NCN ($TARGET_XNAME)"
@@ -230,7 +231,8 @@ spec:
                     fi
 
                     TARGET_NCN=ncn-m003
-                    limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
                     if [[ -z $(echo $limit_management_nodes | grep 'Management_Master') ]]; then
                       if [[ -z $(echo $limit_management_nodes | grep "$TARGET_NCN" ) ]]; then
                          echo "NOTICE ${TARGET_NCN} was not included in --limit-management-rollout. Not rebuilding ${TARGET_NCN}."
@@ -245,7 +247,7 @@ spec:
 
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    prepare_images_output=$(cat global.params.data | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
                     config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
 
                     echo "DEBUG Updating CFS config $config on $TARGET_NCN ($TARGET_XNAME)"

--- a/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
@@ -107,8 +107,9 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
                 - name: scriptContent
                   value: |
-                    limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
-                    percent_rollout=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.concurrent_management_rollout_percentage')
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
+                    percent_rollout=$(cat global.params.data | jq -r '.input_params.concurrent_management_rollout_percentage')
                     total_worker_nodes=$(kubectl get node --selector='!node-role.kubernetes.io/master' --no-headers=true | awk '{print $1}' | tr "\n", " ")
                     array_total_worker_nodes=($total_worker_nodes)
                     num_total_worker_nodes=${#array_total_worker_nodes[@]}

--- a/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
+++ b/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
+++ b/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
@@ -68,10 +68,11 @@ spec:
               value: false
             - name: scriptContent
               value: |
-                CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
-                PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
-                PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
-                VERSION=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.version')
+                echo '{{inputs.parameters.global_params}}' > global.params.data
+                CONTENT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest')
+                PARENT_DIR=$(cat global.params.data | jq -r '.stage_params."process-media".current_product.parent_directory')
+                PRODUCT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.name')
+                VERSION=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.version')
 
                 if [[ "${CONTENT,,}" == "null" ]] || [[ "$CONTENT" == "" ]]; then
                     echo "ERROR No products found. IUF requires at least one product. Please place at least one valid product tarball in {{inputs.parameters.global_params.media_dir}} and start again from the 'process-media' stage"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

We hit 'exec /usr/local/bin/argoexec: argument list too long'. This happens when the argo script is too long. This is partially an argo problem: https://github.com/argoproj/argo-workflows/issues/7586. In some of our argo templates, we make the script longer than necessary because we print 'global_params', a very large json string, multiple times. Instead, we should write global_params to a file and reference that. 

This same problem has been hit before in the loftsman-manifest-upload-template.yaml and was fixed the same way. That PR is here: https://github.com/Cray-HPE/docs-csm/pull/4538/files#diff-3ffc793f89ebeab3e91edcb3e5d2f7a8f922f333aef5a5d44f3a95f6e7429afb

This was seen on a CSM 1.5.0 upgrade on Tyr in the s3-upload-template. The fix to s3-upload-template was tested on Tyr.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
