### PR TITLE
CASMTRIAGE-6769 release 1.4 add iuf_error_argument_list_too_long.md troubleshooting page

### DIFF
--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
@@ -1,4 +1,4 @@
-# IUF Error: 'exec /usr/local/bin/argoexec: argument list too long'
+# IUF Error: `exec /usr/local/bin/argoexec: argument list too long`
 
 Follow this procedure if an IUF step fails with the error: `exec /usr/local/bin/argoexec: argument list too long`.
 
@@ -47,7 +47,7 @@ reference the file.
 
 If the error happened in the `s3-upload` step, then edit the `/usr/share/doc/csm/workflows/iuf/operations/s3-upload/s3-upload-template.yaml`.
 
-Before making changes, the template will have the following script content. 
+Before making changes, the template will have the following script content.
 
 ```bash
 ...

--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
@@ -37,11 +37,11 @@ reference the file.
 
         1. Replace all instances of `echo '{{inputs.parameters.global_params}}'` with `cat global.params.data`.
 
-        1. Save the file and update the argo templates by running the following command.
+    1. `(ncn-m001#)` Save the file and update the argo templates by running the following command.
 
-            ```bash
-            /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
-            ```
+        ```bash
+        /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+        ```
 
 ## Example of editing a template
 

--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
@@ -10,8 +10,8 @@ Follow this procedure if an IUF step fails with the error: `exec /usr/local/bin/
     2024-03-11T20:41:03.980113Z ERR  [cpe-23-12-3-s3-upload          ] END s3-upload(0) [Failed]
     ```
 
-1. This error is due to the script in that template being too long. This can be fixed by not echoing 
-'{{inputs.parameters.global_params}}' in the template. Instead, write `global_params` to a file and then
+1. This error is due to the script in that template being too long. This can be fixed by not echoing
+`{{inputs.parameters.global_params}}` in the template. Instead, write `{{inputs.parameters.global_params}}` to a file and then
 reference the file.
 
     1. `(ncn-m001#)` Navigate to where the workflow templates files are located.

--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
@@ -1,6 +1,6 @@
 # IUF Error: 'exec /usr/local/bin/argoexec: argument list too long'
 
-Follow this procedure if an IUF step fails with the error 'exec /usr/local/bin/argoexec: argument list too long'.
+Follow this procedure if an IUF step fails with the error: `exec /usr/local/bin/argoexec: argument list too long`.
 
 1. Get the name of the template that failed. For example, in the error below the `s3-upload` template failed.
 
@@ -11,7 +11,7 @@ Follow this procedure if an IUF step fails with the error 'exec /usr/local/bin/a
     ```
 
 1. This error is due to the script in that template being too long. This can be fixed by not echoing 
-'{{inputs.parameters.global_params}}' in the template. Instead, write global params to a file and then
+'{{inputs.parameters.global_params}}' in the template. Instead, write `global_params` to a file and then
 reference the file.
 
     1. `(ncn-m001#)` Navigate to where the workflow templates files are located.
@@ -21,9 +21,9 @@ reference the file.
         ```
 
     1. `(ncn-m001#)` Edit the template where this error occured in the following way.
-        
+
         1. Search for where `echo '{{inputs.parameters.global_params}}'` is in the template. Below is an example of how it is used.
-        
+
             ```bash
             CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
             PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
@@ -50,6 +50,7 @@ If the error happened in the `s3-upload` step, then edit the `/usr/share/doc/csm
 Before making changes, the template will have the following script content. 
 
 ```bash
+...
 - - name: s3-upload
       templateRef:
         name: iuf-base-template
@@ -64,11 +65,13 @@ Before making changes, the template will have the following script content.
               PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
               PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
               VERSION=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.version')
+              ...
 ```
 
 After making the changes above, the resulting template should have the following script content.
 
 ```bash
+...
 - - name: s3-upload
       templateRef:
         name: iuf-base-template
@@ -84,4 +87,5 @@ After making the changes above, the resulting template should have the following
               PARENT_DIR=$(cat global.params.data | jq -r '.stage_params."process-media".current_product.parent_directory')
               PRODUCT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.name')
               VERSION=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.version')
+              ...
 ```

--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md
@@ -2,7 +2,7 @@
 
 Follow this procedure if an IUF step fails with the error: `exec /usr/local/bin/argoexec: argument list too long`.
 
-1. Get the name of the template that failed. For example, in the error below the `s3-upload` template failed.
+1. Get the name of the template that failed. For example, the `s3-upload` template failed in the following error.
 
     ```bash
     2024-03-11T20:40:54.348210Z INFO [cpe-23-12-3-s3-upload          ] BEG s3-upload(0)
@@ -10,9 +10,8 @@ Follow this procedure if an IUF step fails with the error: `exec /usr/local/bin/
     2024-03-11T20:41:03.980113Z ERR  [cpe-23-12-3-s3-upload          ] END s3-upload(0) [Failed]
     ```
 
-1. This error is due to the script in that template being too long. This can be fixed by not echoing
-`{{inputs.parameters.global_params}}` in the template. Instead, write `{{inputs.parameters.global_params}}` to a file and then
-reference the file.
+1. Resolve the error by not echoing`{{inputs.parameters.global_params}}` in the template.
+    Instead, write `{{inputs.parameters.global_params}}` to a file and then reference the file.
 
     1. `(ncn-m001#)` Navigate to where the workflow templates files are located.
 
@@ -22,7 +21,7 @@ reference the file.
 
     1. `(ncn-m001#)` Edit the template where this error occured in the following way.
 
-        1. Search for where `echo '{{inputs.parameters.global_params}}'` is in the template. Below is an example of how it is used.
+        1. Search for where `echo '{{inputs.parameters.global_params}}'` is in the template. The following is an example of how it is used.
 
             ```bash
             CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
@@ -45,7 +44,7 @@ reference the file.
 
 ## Example of editing a template
 
-If the error happened in the `s3-upload` step, then edit the `/usr/share/doc/csm/workflows/iuf/operations/s3-upload/s3-upload-template.yaml`.
+If the error happened in the `s3-upload` step, then edit the `/usr/share/doc/csm/workflows/iuf/operations/s3-upload/s3-upload-template.yaml` file.
 
 Before making changes, the template will have the following script content.
 

--- a/troubleshooting/known_issues/iuf_error_argument_list_too_long.md 
+++ b/troubleshooting/known_issues/iuf_error_argument_list_too_long.md 
@@ -1,0 +1,87 @@
+# IUF Error: 'exec /usr/local/bin/argoexec: argument list too long'
+
+Follow this procedure if an IUF step fails with the error 'exec /usr/local/bin/argoexec: argument list too long'.
+
+1. Get the name of the template that failed. For example, in the error below the `s3-upload` template failed.
+
+    ```bash
+    2024-03-11T20:40:54.348210Z INFO [cpe-23-12-3-s3-upload          ] BEG s3-upload(0)
+    2024-03-11T20:40:55.385227Z DBG  [cpe-23-12-3-s3-upload          ]       2024-03-11T20:40:54.569036586Z exec /usr/local/bin/argoexec: argument list too long
+    2024-03-11T20:41:03.980113Z ERR  [cpe-23-12-3-s3-upload          ] END s3-upload(0) [Failed]
+    ```
+
+1. This error is due to the script in that template being too long. This can be fixed by not echoing 
+'{{inputs.parameters.global_params}}' in the template. Instead, write global params to a file and then
+reference the file.
+
+    1. `(ncn-m001#)` Navigate to where the workflow templates files are located.
+
+        ```bash
+        cd /usr/share/doc/csm/workflows/iuf/operations/
+        ```
+
+    1. `(ncn-m001#)` Edit the template where this error occured in the following way.
+        
+        1. Search for where `echo '{{inputs.parameters.global_params}}'` is in the template. Below is an example of how it is used.
+        
+            ```bash
+            CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
+            PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
+            ```
+
+        1. Before the first line containing `echo '{{inputs.parameters.global_params}}'`, echo `global_params` to a file.
+
+            ```bash
+            echo '{{inputs.parameters.global_params}}' > global.params.data
+            ```
+
+        1. Replace all instances of `echo '{{inputs.parameters.global_params}}'` with `cat global.params.data`.
+
+        1. Save the file and update the argo templates by running the following command.
+
+            ```bash
+            /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+            ```
+
+## Example of editing a template
+
+If the error happened in the `s3-upload` step, then edit the `/usr/share/doc/csm/workflows/iuf/operations/s3-upload/s3-upload-template.yaml`.
+
+Before making changes, the template will have the following script content. 
+
+```bash
+- - name: s3-upload
+      templateRef:
+        name: iuf-base-template
+        template: shell-script
+      arguments:
+        parameters:
+          - name: dryRun
+            value: false
+          - name: scriptContent
+            value: |
+              CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
+              PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
+              PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
+              VERSION=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.version')
+```
+
+After making the changes above, the resulting template should have the following script content.
+
+```bash
+- - name: s3-upload
+      templateRef:
+        name: iuf-base-template
+        template: shell-script
+      arguments:
+        parameters:
+          - name: dryRun
+            value: false
+          - name: scriptContent
+            value: |
+              echo '{{inputs.parameters.global_params}}' > global.params.data
+              CONTENT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest')
+              PARENT_DIR=$(cat global.params.data | jq -r '.stage_params."process-media".current_product.parent_directory')
+              PRODUCT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.name')
+              VERSION=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.version')
+```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In CSM 1.5, we have seen the error 'exec /usr/local/bin/argoexec: argument list too long'. This has not been seen in CSM 1.4. We are adding a troubleshooting page to CSM 1.4 of steps to fix this issue in case it is seen in CSM 1.4.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
