### PR TITLE
CASMINST-6808 rel1.4

### DIFF
--- a/operations/iuf/stages/management_nodes_rollout.md
+++ b/operations/iuf/stages/management_nodes_rollout.md
@@ -157,7 +157,7 @@ Only follow the below steps for the nodes being upgraded, for `ncn-m001` or NCN 
 [`prepare-images` Artifacts created](prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` with a
 `configuration_group_name` value matching `Management_Master` or `Management_Storage`, whichever node type is being upgraded. These values will be used in the following steps.
 
-  1. (`ncn-mw#`) To update ncn-m001, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
+  1. (`ncn-mw#`) To update `ncn-m001`, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
 
       ```bash
       IMS_RESULTANT_IMAGE_ID=<value of final_image_id>

--- a/operations/iuf/stages/management_nodes_rollout.md
+++ b/operations/iuf/stages/management_nodes_rollout.md
@@ -157,7 +157,7 @@ Only follow the below steps for the nodes being upgraded, for `ncn-m001` or NCN 
 [`prepare-images` Artifacts created](prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` with a
 `configuration_group_name` value matching `Management_Master` or `Management_Storage`, whichever node type is being upgraded. These values will be used in the following steps.
 
-  1. (`ncn-mw#`) To update `ncn-m001`, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
+1. (`ncn-mw#`) To update `ncn-m001`, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
 
       ```bash
       IMS_RESULTANT_IMAGE_ID=<value of final_image_id>
@@ -167,14 +167,13 @@ Only follow the below steps for the nodes being upgraded, for `ncn-m001` or NCN 
           -p $IMS_RESULTANT_IMAGE_ID $XNAME
       ```
 
-  1. (`ncn-mw#`) To update the NCN storage nodes, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
+1. (`ncn-mw#`) To update the NCN storage nodes, set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in the previous step, then update the boot parameters in BSS.
 
       ```bash
       IMS_RESULTANT_IMAGE_ID=<value of final_image_id>
       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
           -p $IMS_RESULTANT_IMAGE_ID -s
       ```
-
 
 ## Upgrade NCN storage nodes into the customized image
 


### PR DESCRIPTION

# Description
  Change instructions for setting boot parameters in BSS for a given image id. The script assign-ncn-images.sh was recently added and this greatly simplifies the procedure.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams