### PR TITLE
CASMTRIAGE-6773: Use correct field name for CFS v2

### DIFF
--- a/scripts/operations/configuration/monitor_comp_cfs_config_status.py
+++ b/scripts/operations/configuration/monitor_comp_cfs_config_status.py
@@ -82,7 +82,7 @@ def get_comp_status_map(id_list: List[str]) -> JsonDict:
     their config status
     """
     return {
-        comp["id"]: comp["configuration_status"] for comp in cfs.list_components(id_list=id_list) }
+        comp["id"]: comp["configurationStatus"] for comp in cfs.list_components(id_list=id_list) }
 
 
 class ComponentStatus:


### PR DESCRIPTION
Update script to use the correct field name for CFS v2

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6773

CSM 1.4 backport: https://github.com/Cray-HPE/docs-csm/pull/4823

No backport needed to earlier releases, as the script did not exist in them.
No backport needed to CSM 1.6, because the bug does not exist in that release (the script uses CFS v3)