### PR TITLE
CASMPET-6926 1.6 : Fix unclear process in fix_failed_to_start_etcd_on_master process

### DIFF
--- a/operations/kubernetes/Fix_Failed_to_start_etcd_on_Master.md
+++ b/operations/kubernetes/Fix_Failed_to_start_etcd_on_Master.md
@@ -52,7 +52,7 @@ This procedure provides steps to recover from this issue.
        member id                 name          peer-urls
     ```
 
-    Using the values above, remove and re-add the member:
+    Using the values above, remove the member:
 
     ```bash
     etcdctl --endpoints https://127.0.0.1:2379 --cert /etc/kubernetes/pki/etcd/peer.crt --key /etc/kubernetes/pki/etcd/peer.key --cacert /etc/kubernetes/pki/etcd/ca.crt member remove 60a0d077eb0db20f
@@ -63,6 +63,8 @@ This procedure provides steps to recover from this issue.
     ```text
     Member 60a0d077eb0db20f removed from cluster f1c6e6ee71e931c3
     ```
+
+    Then re-add the member:
 
     ```bash
     etcdctl --endpoints https://127.0.0.1:2379 --cert /etc/kubernetes/pki/etcd/peer.crt --key /etc/kubernetes/pki/etcd/peer.key --cacert /etc/kubernetes/pki/etcd/ca.crt member add ncn-m001 --peer-urls=https://10.252.1.4:2380


### PR DESCRIPTION
# Description

Resolves CASMPET-6926 
Fix unclear process in fix_failed_to_start_etcd_on_master process

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
