### PR TITLE
CASMINST-6792 : Upgrade of kyverno-policy following cray-kyverno fails

### DIFF
--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,7 +397,7 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Upgrade of kyverno policy chart following cray kyverno chart fails with webhook timeout error
+* Upgrade of Kyverno policy chart following Cray Kyverno chart fails with webhook timeout error
 
   Kyverno-policy chart upgrade fails with webhook timeout errors due to default timeout value of 10 seconds.
   

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,9 +397,9 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Webhook timeout during Kyverno policies upgrade 
+* Upgrade of kyverno-policy following cray-kyverno fails with Webhook timeout error 
 
-  Kyverno policies upgrade will be unsuccessful with webhook timeout errors due to default timeout value of 10 second.
+  Kyverno-policy chart upgrade fails with webhook timeout errors due to default timeout value of 10 seconds.
   
   Error message snippet
   

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,7 +397,7 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Upgrade of "kyverno-policy" following "cray-kyverno" fails with webhook timeout error.
+* Upgrade of kyverno policy chart following cray kyverno chart fails with webhook timeout error
 
   Kyverno-policy chart upgrade fails with webhook timeout errors due to default timeout value of 10 seconds.
   

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,7 +397,7 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Webhook timeout during after Kyverno policies upgrade 
+* Webhook timeout during Kyverno policies upgrade 
 
   Kyverno policies upgrade will be unsuccessful with webhook timeout errors due to default timeout value of 10 second.
   
@@ -411,7 +411,7 @@ Example output:
   
   Workaround
   
-  The solution for timeout issue is to increase the webhook timeout value to 30 seconds from 10 seconds for all the Kyverno policies on the system.
+  The solution for timeout issue is, to increase the webhook timeout value to 30 seconds from 10 seconds for all the Kyverno policies on the system.
   
   The code snippet below can be used to increase the timeout value for all the Kyverno policies.
   

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,7 +397,7 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Upgrade of kyverno-policy following cray-kyverno fails with Webhook timeout error 
+* Upgrade of kyverno-policy following cray-kyverno fails with Webhook timeout error
 
   Kyverno-policy chart upgrade fails with webhook timeout errors due to default timeout value of 10 seconds.
   
@@ -415,7 +415,7 @@ Example output:
   
   The code snippet below can be used to increase the timeout value for all the Kyverno policies.
   
-  ```bash 
+  ```bash
   while read -r namespace resource_name; do
       echo "Patching policies.kyverno.io $namespace/$resource_name ..."
       kubectl -n "$namespace" patch "policies.kyverno.io/$resource_name" --type json -p="[{\"op\": \"replace\", \"path\": \"/spec/webhookTimeoutSeconds\", \"value\": 30}]" || true

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -397,7 +397,7 @@ Example output:
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)
 * [No event is generated in case of mutation policy being applied to a resource](https://github.com/kyverno/kyverno/issues/2160)
 * [Inaccurate annotations are created after applying the policy](https://github.com/kyverno/kyverno/issues/3473)
-* Upgrade of kyverno-policy following cray-kyverno fails with Webhook timeout error
+* Upgrade of "kyverno-policy" following "cray-kyverno" fails with webhook timeout error.
 
   Kyverno-policy chart upgrade fails with webhook timeout errors due to default timeout value of 10 seconds.
   


### PR DESCRIPTION
Upgrade of Kyverno policy following cray-kyverno fails with webhook timeout error message. The default timeout value is 10 seconds. Through the documentation we are recommending to increase the default value of 10 seconds to 30 seconds. The change is verified during upgrades and the timeout errors are not encountered as confirmed by Mikhail and Faiyaz.