### PR TITLE
CASMTRIAGE-6797: Fixed stale links in known issues docs

### DIFF
--- a/troubleshooting/known_issues/SLS_Not_Working_During_Node_Rebuild.md
+++ b/troubleshooting/known_issues/SLS_Not_Working_During_Node_Rebuild.md
@@ -5,7 +5,7 @@ the SLS Postgres database gets into a bad state, causing SLS to become unhealthy
 
 **Note:** If encountering this during a CSM upgrade, then at this point of the upgrade process, the system has not yet upgraded the CSM services
 themselves. Because of that, the documentation for the source CSM version still applies, and this page includes links for both the current
-CSM version (1.3) and for the previous CSM version (1.2).
+CSM version (1.4) and for the previous CSM version (1.3).
 
 ## Detection
 
@@ -142,10 +142,10 @@ cray-sls-postgres   cray-sls   11        3      1Gi                             
 ```
 
 * If the `STATUS` is `SyncFailed`:
-  * If currently doing a CSM upgrade, then see
-    [(CSM 1.2) Postgres status `SyncFailed`](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
-  * Otherwise, see [Postgres status `SyncFailed`](../../operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
+    * If currently doing a CSM upgrade, then see
+      [(CSM 1.3) Postgres status `SyncFailed`](https://github.com/Cray-HPE/docs-csm/blob/release/1.3/operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
+    * Otherwise, see [Postgres status `SyncFailed`](../../operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
 * Otherwise, see the standard Postgres troubleshooting procedures for further avenues of investigation.
-  * If currently doing a CSM upgrade, then see
-    [(CSM 1.2) Troubleshoot Postgres Database](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/kubernetes/Troubleshoot_Postgres_Database.md).
-  * Otherwise, see [Troubleshoot Postgres Database](../../operations/kubernetes/Troubleshoot_Postgres_Database.md).
+    * If currently doing a CSM upgrade, then see
+      [(CSM 1.3) Troubleshoot Postgres Database](https://github.com/Cray-HPE/docs-csm/blob/release/1.3/operations/kubernetes/Troubleshoot_Postgres_Database.md).
+    * Otherwise, see [Troubleshoot Postgres Database](../../operations/kubernetes/Troubleshoot_Postgres_Database.md).


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
