### PR TITLE
CASMTRIAGE-6796 Remove `ip=hsn*:auto6` Kernel arguments

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -270,6 +270,7 @@ Mellanox
 MetalFS
 MetalLB
 MetalLB's
+metal-ipxe
 Mi100
 Motivair
 Multus

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -355,23 +355,23 @@ These variables will need to be set for many procedures within the CSM installat
    Expected output looks similar to the following (the versions in the example below may differ). There should be **no** errors.
 
    ```text
-   = PIT Identification = COPY/CUT START =======================================
-   VERSION=a9d5138-1694719577775
-   TIMESTAMP=2023-09-14_19:26:17
-   CRAY-Site-Init build signature...
-   Build Commit   : 78867e48bc5b5f6df5df2f4e2f274f92b7476c05-heads-v1.32.2
-   Build Time     : 2023-08-18T19:34:01Z
-   Go Version     : go1.19
-   Version        : v1.32.2
-   Platform       : linux/amd64
-   canu-1.7.6-1.x86_64
-   ilorest-4.2.0.0-20.x86_64
-   metal-basecamp-1.2.6-1.x86_64
-   metal-ipxe-2.4.6-1.noarch
-   metal-init-1.4.6-1.noarch
-   metal-nexus-1.3.1-3.38.0_1.x86_64
-   metal-observability-1.0.9-1.x86_64
-   = PIT Identification = COPY/CUT END =========================================
+    = PIT Identification = COPY/CUT START =======================================
+    VERSION=ed97205-1706718622724
+    TIMESTAMP=2024-01-31_16:30:22
+    CRAY-Site-Init build signature...
+    Build Commit   : c9a07e366151a72be71d168061d08bd97da5344c-heads-v1.32.4
+    Build Time     : 2023-10-20T14:53:30Z
+    Go Version     : go1.19
+    Version        : v1.32.4
+    Platform       : linux/amd64
+    canu-1.8.0-1.x86_64
+    ilorest-4.2.0.0-20.x86_64
+    metal-basecamp-1.2.6-1.x86_64
+    metal-ipxe-2.4.7-1.noarch
+    metal-init-1.4.6-1.noarch
+    metal-nexus-1.3.1-3.38.0_1.x86_64
+    metal-observability-1.0.9-1.x86_64
+    = PIT Identification = COPY/CUT END =========================================
    ```
 
 ## 2. Download and extract the CSM Tarball
@@ -411,6 +411,11 @@ These variables will need to be set for many procedures within the CSM installat
    tar -zxvf  "${PITDATA}/csm-${CSM_RELEASE}.tar.gz" -C ${PITDATA}
    ```
 
+1. (`pit#`) ***CSM 1.5.0 Only*** At this time, the metal-ipxe 1.5.0 pre-install hotfix is required. Please review the current field notices for the hotfix.
+   This hotfix will insert a new metal-ipxe RPM into the extracted tarball.
+
+    > ***NOTE*** CSM 1.5.1 and later do NOT need to run this. The metal-ipxe RPM is already included in their tarballs.
+
 1. (`pit#`) Install/update the RPMs necessary for the CSM installation.
 
    > ***NOTE*** `--no-gpg-checks` is used because the repository contained within the tarball does not provide a GPG key.
@@ -422,9 +427,10 @@ These variables will need to be set for many procedures within the CSM installat
        > - `cray-site-init` provides `csi`, a tool for creating and managing configurations, as well as
        >   orchestrating the [handoff and deploy of the final non-compute node](deploy_final_non-compute_node.md).
        > - `metal-init` provides several scripts in `/root/bin` used for fresh installations.
+       > - `metal-ipxe` provides boot parameters for the NCNs, as well as EFI binaries for PXE/iPXE/HTTP booting.
 
        ```bash
-       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/noos" --no-gpg-checks update -y cray-site-init metal-init
+       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/noos" --no-gpg-checks update -y cray-site-init metal-init metal-ipxe
        ```
 
 1. (`pit#`) Get the artifact versions.
@@ -490,23 +496,23 @@ These variables will need to be set for many procedures within the CSM installat
    Expected output looks similar to the following (the versions in the example below may differ). There should be **no** errors.
 
    ```text
-   = PIT Identification = COPY/CUT START =======================================
-   VERSION=a9d5138-1694719577775
-   TIMESTAMP=2023-09-14_19:26:17
-   CRAY-Site-Init build signature...
-   Build Commit   : 78867e48bc5b5f6df5df2f4e2f274f92b7476c05-heads-v1.32.2
-   Build Time     : 2023-08-18T19:34:01Z
-   Go Version     : go1.19
-   Version        : v1.32.2
-   Platform       : linux/amd64
-   canu-1.7.6-1.x86_64
-   ilorest-4.2.0.0-20.x86_64
-   metal-basecamp-1.2.6-1.x86_64
-   metal-ipxe-2.4.6-1.noarch
-   metal-init-1.4.6-1.noarch
-   metal-nexus-1.3.1-3.38.0_1.x86_64
-   metal-observability-1.0.9-1.x86_64
-   = PIT Identification = COPY/CUT END =========================================
+    = PIT Identification = COPY/CUT START =======================================
+    VERSION=ed97205-1706718622724
+    TIMESTAMP=2024-01-31_16:30:22
+    CRAY-Site-Init build signature...
+    Build Commit   : c9a07e366151a72be71d168061d08bd97da5344c-heads-v1.32.4
+    Build Time     : 2023-10-20T14:53:30Z
+    Go Version     : go1.19
+    Version        : v1.32.4
+    Platform       : linux/amd64
+    canu-1.8.0-1.x86_64
+    ilorest-4.2.0.0-20.x86_64
+    metal-basecamp-1.2.6-1.x86_64
+    metal-ipxe-2.4.8-1.noarch
+    metal-init-1.4.6-1.noarch
+    metal-nexus-1.3.1-3.38.0_1.x86_64
+    metal-observability-1.0.9-1.x86_64
+    = PIT Identification = COPY/CUT END =========================================
    ```
 
 ## 3. Create system configuration

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1091,6 +1091,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
 
+
     # As boot parameters are added or removed, update these arrays.
     # NOTE: bootparameters_to_delete should contain keys only, nothing should have "=<value>" appended to it.
     bootparameters_to_set=("split_lock_detect=off" "psi=1" "rd.live.squashimg=rootfs" "rd.live.overlay.thin=0" "rd.live.dir=${CSM_RELEASE}")
@@ -1103,6 +1104,44 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     for bootparameter in "${bootparameters_to_set[@]}"; do
       csi handoff bss-update-param --set "${bootparameter}"
     done
+
+  # Get a list of NCNs.
+  if IFS=$'\n' read -rd '' -a NCN_XNAMES; then
+    :
+  fi <<< "$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join("\n")')"
+
+  # If no NCNs are found we should exit, otherwise if forces its way forward then NCNs will be missing critical packages.
+  if [ "${#NCN_XNAMES[@]}" -eq '0' ]; then
+    echo >&2 'No NCN xnames were found in HSM! Aborting.'
+    exit 1
+  fi
+
+  params=""
+  error=0
+  printf "% -15s: " "$xname"
+
+  # Loop through one at a time. If `--limit` isn't provided, we will error out on the 'Global' key.
+  for ncn_xname in "${NCN_XNAMES[@]}"; do
+
+    params=$(cray bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[] |."params"' \
+      | sed -E 's/ ip=hsn[0-9]+:auto6 //g' \
+      | tr -d \")
+
+    if ! cray bss bootparameters update --hosts "${ncn_xname}" \
+      --params "${params}" > /dev/null 2>&1; then
+      echo "ERROR - Failed to update boot parameters for $xname! Skipping ..."
+      error=1
+      continue
+    fi
+    echo 'OK'
+  done
+  if [ "$error" -ne 0 ]; then
+    echo >&2 "Errors were detected, please inspect the scripts output."
+    exit 1
+  else
+    echo "Successfully updated boot parameters for [${#NCN_XNAMES[@]}] xname(s):"
+    printf "\t%s\n" "${NCN_XNAMES[@]}"
+  fi
 
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Remove parameters for the HSN interfaces during dracut to avoid upping them and potentially toggling their CARRIER flag.

This addresses a condition where cloud-init selects an undesirable interface during its init-local stage, where it iterates through NICs until it finds one with a CARRIER flag. Since the HSN does not provide DHCP/DNS for the management network, and may not even be active during an NCN deployment, if cloud-init selects an HSN NIC it will fail DHCP.

Contextually speaking, the network configuration that is obtained during dracut is not fully carried over into the rootfs after the initramFS is deallocated. The IP and routing assigned to the NIC will persist, but the DNS configuration (which is stored in `/etc/resolv.conf` in both the initramFS and rootFS) is not preserved. This means that until something DHCPs again in the rootfs, that IP connectivity may work but DNS resolution will not.

This has been happening unbeknownst to us, at least without repercussions for a long time, it has only mattered for CSM 1.5 after the completion of MTL-2000. MTL-2000 added a dependency on DNS before our `runcmd` scripts are executed. If cloud-init init-local fails to setup DNS, then cloud-init modules that depend on DNS will fail.

By removing these `ip=hsn*` parameters, we cease attempting to UP the HSN NICs. Thus the HSN NICs will not show a CARRIER flag, and cloud-init will omit them when searching for a usable NIC.

This does not need to be backported to 1.6, but it could for consistency so I will make one.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
