### PR TITLE
CASMTRIAGE-6807-1.2 : DOCS: nexus_export_and_restore needs better check for existing Nexus backup job and PVC

### DIFF
--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -35,14 +35,63 @@ Taking the export can take multiple hours and Nexus will be unavailable for the 
 use 360 GiB on cluster), then Nexus would be unavailable for around 2 hours while the export was taking place. If the time required to backup is too long
 because of the size it will take follow the steps on [Nexus Space Cleanup](Nexus_Space_Cleanup.md).
 
-To get an export, run the export script on any master node where the latest CSM documentation is installed. See
-[Check for latest documentation](../../update_product_stream/index.md#check-for-latest-documentation).
+(`ncn-m#`) If an export has been taken previously, then it should be deleted before a new export is taken.
 
-> If an export has been taken previously, then it should be deleted before a new export is taken. See [Cleanup previous export](#cleanup-previous-export).
+Check for existing `nexus-bak` PVC. If found, it needs to be removed.
+
+```bash
+kubectl get pvc -n nexus nexus-bak
+```
+
+Example output:
+
+```text
+NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
+nexus-bak   Bound    pvc-7551d342-f976-48e1-bb91-1957b75dbc53   1000Gi     RWO            k8s-block-replicated   42d
+```
+
+Check for existing `nexus-backup` job. If found, it needs to be removed.
+
+```bash
+kubectl get jobs -n nexus nexus-backup
+```
+
+Example output:
+
+```text
+NAME           COMPLETIONS   DURATION   AGE
+nexus-backup   1/1           6h22m      42d
+```
+
+> See [Cleanup previous export](#cleanup-previous-export).
+
+To take an export of nexus, run the export script on any master node where the latest CSM documentation is installed. See
+[Check for latest documentation](../../update_product_stream/index.md#check-for-latest-documentation).
 
 ```bash
 ncn-m# /usr/share/doc/csm/scripts/nexus-export.sh
 ```
+
+Example output:
+
+```text
+Gibibytes available in cluster: 52418
+Gibibytes used in nexus-data: 434
+Gibibytes available in nexus-data: 566
+Space to be used from backup:  1302
+Creating PVC for Nexus backup, if needed
+Error from server (NotFound): persistentvolumeclaims "nexus-bak" not found
+persistentvolumeclaim/nexus-bak created
+Scaling Nexus deployment to 0
+deployment.apps/nexus scaled
+Starting backup, do not exit this script.
+Should be done around Fri 22 Mar 2024 06:29:03 PM UTC (7:14 from now)
+job.batch/nexus-backup created
+Waiting for the backup to finish.
+..............................
+```
+
+> A single "." will be output every 30 seconds until the export reports "Done".
 
 ## Restore
 


### PR DESCRIPTION
# Description
Resolves [CASMTRIAGE-6807](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6807) 
DOCS: nexus_export_and_restore needs better check for existing Nexus backup job and PVC
for release/1.2
# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
