### PR TITLE
CASMINST-6817 add UAN to IUF products list that required mods to customizations

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -41,8 +41,8 @@ Once this step has completed:
 
 **`NOTE`** This section is only relevant for initial install workflows. Skip to the [next section](#3-execute-the-iuf-deliver-product-stage) if performing an upgrade.
 
-Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products. Refer to the
-"Install and Upgrade Framework" section of both the Slurm and PBS product documents to determine the actions that need to be performed to update `customizations.yaml`.
+Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products and the UAN product. Refer to the
+"Install and Upgrade Framework" section of the Slurm, PBS, and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
 
 Once this step has completed:
 


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

If this UAN procedure is needed, it should be done after the iuf process-media and pre-install-check and before the IUF deliver product stage since it needs to edit some data in customizations.yaml.  Best to do early in the process OR at the end of everything.   https://github.com/Cray-HPE/docs-uan/blob/release/uan-2.7/docs/portal/developer-portal/advanced/Enabling_K3s.md

In this PR, I have added to the IUF deliver-product workflow that the UAN documentation needs to be reviewed. @keopp-hpe is working on the UAN documentation to make sure it is correct. He is using ticket: [CASMUSER-3275](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3275).

This change is needed in CSM 1.4, 1.5, 1.6

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
