### PR TITLE
CASMTRIAGE-6813-release-1.5 add troubleshooting page for NotADirectoryError seen in IUF

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -66,6 +66,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Test Failures Due To No Discovered Compute Nodes In HSM](known_issues/test_failures_no_discovered_computes_in_hsm.md)
 - [Velero Version Mismatch](known_issues/velero_version_mismatch.md)
 - [wait for unbound hang](known_issues/wait_for_unbound_hang.md)
+- [IUF fails with 'Not a directory: /etc/cray/upgrade/csm/media/...'](known_issues/iuf_error_not_a_directory.md)
 
 ## Booting
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -66,7 +66,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Test Failures Due To No Discovered Compute Nodes In HSM](known_issues/test_failures_no_discovered_computes_in_hsm.md)
 - [Velero Version Mismatch](known_issues/velero_version_mismatch.md)
 - [wait for unbound hang](known_issues/wait_for_unbound_hang.md)
-- [IUF fails with 'Not a directory: /etc/cray/upgrade/csm/media/...'](known_issues/iuf_error_not_a_directory.md)
+- [IUF fails with `Not a directory: /etc/cray/upgrade/csm/media/...`](known_issues/iuf_error_not_a_directory.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/iuf_error_not_a_directory.md
+++ b/troubleshooting/known_issues/iuf_error_not_a_directory.md
@@ -1,4 +1,4 @@
-# IUF fails with 'Not a directory: /etc/cray/upgrade/csm/media/...'
+# IUF fails with `Not a directory: /etc/cray/upgrade/csm/media/...`
 
 ## Error
 
@@ -26,7 +26,7 @@ Error Summary:
 
 This error occurs because product documentation tar files have different structures than product tar files.
 Certain product documentation tar files extract files directly into the media directory. This can cause
-the 'NotADirectoryError' error in the IUF-CLI. This problem has been fixed in the IUF-CLI rpm version 1.5.12 which is in CSM 1.5.1 and more recent releases.
+the `NotADirectoryError` error in the IUF-CLI. This problem has been fixed in the IUF-CLI rpm version 1.5.12 which is in CSM 1.5.1 and more recent releases.
 For the fix for CSM 1.4.X and CSM 1.5.0, please refer to the work around below.
 
 ## Work Around

--- a/troubleshooting/known_issues/iuf_error_not_a_directory.md
+++ b/troubleshooting/known_issues/iuf_error_not_a_directory.md
@@ -1,0 +1,35 @@
+# IUF fails with 'Not a directory: /etc/cray/upgrade/csm/media/...'
+
+## Error
+
+The following error can be seen when running the IUF stages 'process-media' and 'deliver-product'.
+
+```bash
+...
+INFO [IUF SESSION: update-products-lauqr                ] BEG Started at 2024-03-23 02:32:13.608312
+ERR  An unexpected error occurred: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/update-products/Slingshot_Hardware_Guide.pdf'
+Traceback (most recent call last):
+  File "iuf.py", line 879, in <module>
+  File "iuf.py", line 867, in main
+  File "iuf.py", line 333, in process_install
+  File "lib/Activity.py", line 956, in run_stages
+  File "lib/Activity.py", line 1146, in run_stage
+  File "lib/Activity.py", line 1109, in watch_next_wf
+NotADirectoryError: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/update-products/Slingshot_Hardware_Guide.pdf'
+[2325025] Failed to execute script 'iuf' due to unhandled exception!
+
+Error Summary:
+   An unexpected error occurred: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/update-products/Slingshot_Hardware_Guide.pdf'
+```
+
+## Problem Description
+
+This error occurs because product documentation tar files have different structures than product tar files.
+Certain product documentation tar files extract files directly into the media directory. This can cause
+the 'NotADirectoryError' error in the IUF-CLI. This problem has been fixed in the IUF-CLI rpm version 1.5.12 which is in CSM 1.5.1 and more recent releases.
+For the fix for CSM 1.4.X and CSM 1.5.0, please refer to the work around below.
+
+## Work Around
+
+Move all product documentation tar files to a directory outside of the media directory being used by the IUF activity.
+The media directory for the IUF activity should now only contain product tar files.

--- a/troubleshooting/known_issues/iuf_error_not_a_directory.md
+++ b/troubleshooting/known_issues/iuf_error_not_a_directory.md
@@ -27,7 +27,7 @@ Error Summary:
 This error occurs because product documentation tar files have different structures than product tar files.
 Certain product documentation tar files extract files directly into the media directory. This can cause
 the `NotADirectoryError` error in the IUF-CLI. This problem has been fixed in the IUF-CLI rpm version 1.5.12 which is in CSM 1.5.1 and more recent releases.
-For the fix for CSM 1.4.X and CSM 1.5.0, please refer to the work around below.
+For the fix for CSM 1.4.X and CSM 1.5.0, refer to the following workaround.
 
 ## Work Around
 


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

 NotADirectoryError error has been seen in the IUF-CLI. This has been fixed by CASMTRIAGE-6813 in CSM 1.5.1 and CSM 1.6. This PR adds a troubleshooting page for this issue so that a work around can be performed in CSM 1.4.X and CSM 1.5.0.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
