### PR TITLE
CASMINST-6826 Patch NCN images on Fresh Install

### DIFF
--- a/upgrade/1.4.4/scripts/storage-in-place-patch.sh
+++ b/upgrade/1.4.4/scripts/storage-in-place-patch.sh
@@ -133,7 +133,7 @@ grep -qxF '\''install qedr /bin/true'\'' /etc/modprobe.d/disabled-modules.conf |
 omit_drivers=()
 if [ -f /etc/dracut.conf.d/99-csm-ansible.conf ]; then
   . /etc/dracut.conf.d/99-csm-ansible.conf
-  if [[ "${omit_drivers[@]}" =~ qedr ]]; then
+  if [[ "${omit_drivers[*]}" =~ qedr ]]; then
     :
   else
     sed -i -E '\''s/^omit_drivers\+=" ?/omit_drivers+=" qedr /'\'' /etc/dracut.conf.d/99-csm-ansible.conf


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->    
Apply the CSM 1.4.4 patch to the NCN images while they are being modified by `ncn-image-modification.sh`.
    
- Blacklist `qedr` from the SquashFS
- Blacklist `qedr` from the initrd
- (Kubernetes only) Update the QLogic driver
- (Kubernetes only) Update the Kernel
- (Kubernetes only) Tell Zypper to purge the old Kernel on next boot
- (Kubernetes only) Remove the `fastlinq.conf` dracut configuration file
      installed by the new QLogic driver
- (Kubernetes only) Force add `qed`, `qede`, `qedf`, and `qedi` to the
      inird and SquashFS

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
