### PR TITLE
CASMTRIAGE-6817 adding missing --media-dir command line option in IUF

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -59,7 +59,7 @@ Refer to that table and any corresponding product documents before continuing to
     (`ncn-m001#`) Execute the `deliver-product` stage.
 
     ```bash
-    iuf -a ${ACTIVITY_NAME} run -r deliver-product
+    iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -r deliver-product
     ```
 
 Once this step has completed:


### PR DESCRIPTION
# Description
The IUF deliver-product stage is missing the required argument to find $MEDIA_DIR.
added missing --media-dir command line option in IUF

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
