### PR TITLE
CASMTRIAGE-6835 Fix error reporting in prerequisites.sh

### DIFF
--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -103,13 +103,13 @@ function err_report() {
 
   # ignore some internal expected errors
   local ignoreCmd="cray artifacts list config-data"
-  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
+  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l || true)
   if [[ ${shouldIgnore} -eq 1 ]]; then
     return 0
   fi
 
   ignoreCmd="https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history"
-  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
+  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l || true)
   if [[ ${shouldIgnore} -eq 1 ]]; then
     return 0
   fi


### PR DESCRIPTION
# Description

If `set -o pipefail` is executed in `prerequisites.sh` script and then some other error happens, `err_report` function does not behave properly. It terminates on `ignoreCmd` validation, without printing any error message (as the rest of function body is ignored).

This change makes `ignoreCmd` verification fail safe.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
