### PR TITLE
CASMTRIAGE-6826: Prevent error when initializing S3 client

### DIFF
--- a/scripts/operations/configuration/python_lib/s3.py
+++ b/scripts/operations/configuration/python_lib/s3.py
@@ -57,11 +57,7 @@ def s3_client_kwargs() -> JsonDict:
     resp = api_requests.put_retry_validate_return_json(url=STS_TOKEN_URL, expected_status_codes=201,
                                                        add_api_token=True)
     creds = resp["Credentials"]
-    kwargs = { kname: creds[cname] for cname, kname in CREDS_TO_KWARGS.items() }
-    # The Cray CLI sets the following field to an empty string, and if it's good enough for the
-    # Cray CLI, then it's good enough for me
-    kwargs["region_name"] = ""
-    return kwargs
+    return { kname: creds[cname] for cname, kname in CREDS_TO_KWARGS.items() }
 
 
 class S3Url(str):


### PR DESCRIPTION
Starting in CSM 1.5, the S3 client complains if an empty region argument is specified. But just not specifying the region at all works fine. I've tested this on CSM 1.4 as well, and while it works there if you specify the empty region, it's also cool with it not being specified at all. So that's what I've gone with.

Backports:
https://github.com/Cray-HPE/docs-csm/pull/4901
https://github.com/Cray-HPE/docs-csm/pull/4902
https://github.com/Cray-HPE/docs-csm/pull/4903