### PR TITLE
CASMTRIAGE-6855 1.5 : Update test suite packages (missing /usr/share/doc/csm/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh)

### DIFF
--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Usage: upgrade-test-rpms.sh [--local]
+# If --local is not specified, upgrade the test RPMs on all NCNs
+# If --local is specified, upgrade the test RPMs just on the system where the script is being executed
+
+set -euo pipefail
+if [[ $# -eq 0 ]]; then
+
+  ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
+
+  echo "Installing updated versions of hpe-csm-goss-package csm-testing goss-servers craycli RPMs"
+  pdsh -S -b -w ${ncns} 'zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli'
+
+  echo "Enabling and restarting goss-servers"
+  pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl restart goss-servers'
+
+elif [[ $# -eq 1 && $1 == --local ]]; then
+
+  echo "Installing updated versions of hpe-csm-goss-package csm-testing goss-servers craycli RPMs"
+  zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli
+
+  echo "Enabling and restarting goss-servers"
+  systemctl enable goss-servers && systemctl restart goss-servers
+
+else
+
+  echo "usage: upgrade-test-rpms.sh [--local]" >&2
+  echo >&2
+  echo "ERROR: Invalid arguments" >&2
+  exit 1
+
+fi
+
+echo "SUCCESS"


### PR DESCRIPTION
# Description

Update test suite packages (missing /usr/share/doc/csm/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh)
Resolves [CASMTRIAGE-6855](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6855)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
