### PR TITLE
CASMINST-6833: Document BOSv2/SAT/cmsdev limitation in CSM 1.5.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -218,3 +218,6 @@ see [Removals](introduction/deprecated_features/README.md#removals)
         * `v1.48`, `v1.50`, `v1.69` or `v2.84` for DL325 / DL385 BIOS.
         * C38 for Gigabyte BIOS.
     * Update will be in CSM 1.5.1.
+* On large systems, BOS v2 sessions, some CSM health checks, and SAT status may not work properly, because of a failed interaction with CFS.
+    * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
+    * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/operations/README.md
+++ b/operations/README.md
@@ -137,6 +137,7 @@ Use the Boot Orchestration Service \(BOS\) to boot, configure, and shut down col
         - [Troubleshoot Compute Node Boot Issues Using Kubernetes](boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Using_Kubernetes.md)
         - [Log File Locations and Ports Used in Compute Node Boot Troubleshooting](boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
         - [Troubleshoot Compute Node Boot Issues Related to Slow Boot Times](boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
+        - [CFS V2 Failures On Large Systems](../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md)
 - [Customize iPXE Binary Names](boot_orchestration/Customize_iPXE_Binary_Names.md)
 - [Edit the iPXE Embedded Boot Script](boot_orchestration/Edit_the_iPXE_Embedded_Boot_Script.md)
 - [Redeploy the iPXE and TFTP Services](boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md)
@@ -247,6 +248,7 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
     - [Troubleshoot CFS Session Failed](configuration_management/Troubleshoot_CFS_Session_Failed.md)
     - [Troubleshoot CFS Session Failing to Complete](configuration_management/Troubleshoot_CFS_Session_Failing_to_Complete.md)
     - [Troubleshoot CFS Sessions Failing to Start](configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md)
+    - [CFS V2 Failures On Large Systems](../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md)
 - [Exporting and Importing CFS Data](configuration_management/Exporting_and_Importing_CFS_Data.md)
 - [CFS API Details](../api/cfs.md)
 - [Version Control Service \(VCS\)](configuration_management/Version_Control_Service_VCS.md)
@@ -812,6 +814,7 @@ components. In CSM 1.3 and newer, the `sat` command is available on the Kubernet
 product stream.
 
 - [System Admin Toolkit in CSM](sat/sat_in_csm.md)
+- [CFS V2 Failures On Large Systems](../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md)
 
 ## Install and Upgrade Framework (IUF)
 

--- a/operations/boot_orchestration/BOS_API_Versions.md
+++ b/operations/boot_orchestration/BOS_API_Versions.md
@@ -45,3 +45,8 @@ These operators monitor nodes individually, not as a group, allowing each node t
 If no version is specified, the BOS CLI defaults to the `v2` endpoints. `cray bos <command>` defaults to `cray bos v2 <command>`. This is a change from the previous release.
 To avoid compatibility issues when the CLI's default version changes, scripts using the CLI should always explicitly specify a version.
 The behavior of defaulting to a version when the version parameter is omitted is a convenience intended for interactive use and is not intended for scripts.
+
+## Known issues
+
+In CSM 1.5.0 on large systems, BOS v2 sessions may not work because of a failed interaction with CFS. For more information, see
+[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/operations/boot_orchestration/Manage_a_BOS_Session.md
+++ b/operations/boot_orchestration/Manage_a_BOS_Session.md
@@ -9,6 +9,7 @@ To find the API versions of any commands listed, add `-vvv` to the end of the CL
 * [List all sessions](#list-all-sessions)
 * [Show details for a session](#show-details-for-a-session)
 * [Delete a session](#delete-a-session)
+* [Known issues](#known-issues)
 
 ## Create a new v2 session
 
@@ -214,3 +215,8 @@ For more information, see
 ```bash
 cray bos v1 session delete <BOS_SESSION_ID>
 ```
+
+## Known issues
+
+In CSM 1.5.0 on large systems, BOS v2 sessions may not work properly because of a failed interaction with CFS.
+For more information, see [CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/operations/boot_orchestration/Sessions.md
+++ b/operations/boot_orchestration/Sessions.md
@@ -6,6 +6,7 @@ When creating a session, both the operation and session template are required pa
 
 * [BOS sessions in v2](#bos-sessions-in-v2)
   * [Sessions and status](#sessions-and-status)
+  * [Known issues](#known-issues)
 * [BOS sessions in v1](#bos-sessions-in-v1)
   * [BOA functionality](#boa-functionality)
   * [BOS v1 session limitations](#bos-v1-session-limitations)
@@ -29,6 +30,11 @@ Session in BOS v2 are constructs intended to help users track an operation acros
 A session will continue to track a component until the component reaches its desired state and is disabled or until another sessions takes over managing that component.
 Additional status information is also available for sessions to track information such as how many components are at each step in the process.
 See [View the Status of a BOS Session](View_the_Status_of_a_BOS_Session.md) for more information.
+
+### Known issues
+
+In CSM 1.5.0 on large systems, BOS v2 sessions may not work properly because of a failed interaction with CFS.
+For more information, see [CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
 
 ## BOS sessions in v1
 

--- a/operations/boot_orchestration/Sessions.md
+++ b/operations/boot_orchestration/Sessions.md
@@ -5,11 +5,11 @@ Sessions provide a way to track the status of many nodes at once as they perform
 When creating a session, both the operation and session template are required parameters.
 
 * [BOS sessions in v2](#bos-sessions-in-v2)
-  * [Sessions and status](#sessions-and-status)
-  * [Known issues](#known-issues)
+    * [Sessions and status](#sessions-and-status)
+    * [Known issues](#known-issues)
 * [BOS sessions in v1](#bos-sessions-in-v1)
-  * [BOA functionality](#boa-functionality)
-  * [BOS v1 session limitations](#bos-v1-session-limitations)
+    * [BOA functionality](#boa-functionality)
+    * [BOS v1 session limitations](#bos-v1-session-limitations)
 
 ## BOS sessions in v2
 

--- a/operations/boot_orchestration/View_the_Status_of_a_BOS_Session.md
+++ b/operations/boot_orchestration/View_the_Status_of_a_BOS_Session.md
@@ -5,6 +5,7 @@ The Boot Orchestration Service \(BOS\) supports a status endpoint that reports d
 * [BOS v2 session status](#bos-v2-session-status)
     * [View the status of a v2 session](#view-the-status-of-a-v2-session)
     * [Session status details](#session-status-details)
+    * [Known issues](#known-issues)
 * [BOS v1 session status](#bos-v1-session-status)
     * [Metadata](#metadata)
     * [View the status of a v1 session](#view-the-status-of-a-v1-session)
@@ -84,6 +85,11 @@ This timestamp will initially be `null` and will be set when the session ends.
 #### `duration`
 
 This lists the duration of the session in `h:mm:ss`. While the session is running, this will be the current duration, and the value is locked-in when the session completes.
+
+### Known issues
+
+In CSM 1.5.0 on large systems, BOS v2 sessions may not work because of a failed interaction with CFS. For more information, see
+[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
 
 ## BOS v1 session status
 

--- a/operations/configuration_management/CFS_Global_Options.md
+++ b/operations/configuration_management/CFS_Global_Options.md
@@ -124,6 +124,8 @@ The following are the CFS global options:
   In this case users should switch to the v3 API to take advantage of paging.
   This number can be increased through the v3 API to allow more records to be returned through the v2 API, but this risks causing calls to fail due to memory constraints.
 
+  On CSM 1.5.0 systems, also see [CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
+
 * **`default_playbook`**
 
   > **WARNING:** This option is deprecated and read-only in the v3 CFS API. It can only be modified using CFS v2.

--- a/operations/configuration_management/Paging_CFS_Records.md
+++ b/operations/configuration_management/Paging_CFS_Records.md
@@ -84,3 +84,8 @@ def iter_components(**kwargs):
         if not next_parameters:
             break
 ```
+
+## Known issues
+
+The addition of paging caused problems for some services and products in CSM 1.5.0. For more information, see
+[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/operations/configuration_management/Troubleshoot_CFS_Issues.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Issues.md
@@ -62,3 +62,9 @@ The following playbooks are available, and can be specified as the configuration
 * `debug_fail` - This playbook immediately fails, which can be used with the `debug_on_failure` flag to create a quick debugging Ansible environment.
 * `debug_facts` - This playbook gather and prints the facts for all available targets.
 * `debug_noop` - This playbook will not gather facts or perform any tasks and is useful for skipping past the Ansible container for debugging.
+
+## Known issues
+
+Although not technically a problem with CFS itself, in CSM 1.5.0 on large systems, some products or
+services may report errors with CFS. For more details on this, see
+[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/operations/sat/sat_in_csm.md
+++ b/operations/sat/sat_in_csm.md
@@ -55,3 +55,8 @@ gateway with `sat auth`). To complete the initial configuration of SAT, refer to
 If the full SAT product stream is not being installed, it is recommended that you uninstall old versions of the
 SAT product stream to avoid confusion in the output of `sat showrev`. For more information,
 refer to **SAT Uninstall and Downgrade** in the SAT documentation.
+
+## Known issues
+
+In CSM 1.5.0, SAT status may give CFS errors on large systems. For more information, see
+[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -67,6 +67,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [wait for unbound hang](known_issues/wait_for_unbound_hang.md)
 - [IUF fails with `Not a directory: /etc/cray/upgrade/csm/media/...`](known_issues/iuf_error_not_a_directory.md)
 - [Hang Listing BOS V1 Sessions](known_issues/Hang_Listing_BOS_V1_Sessions.md)
+- [CFS V2 Failures On Large Systems](known_issues/CFS_V2_Failures_On_Large_Systems.md)
 
 ## Booting
 
@@ -83,11 +84,13 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Troubleshooting Using Kubernetes](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Using_Kubernetes.md)
 - [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
 - [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
+- [CFS V2 Failures On Large Systems](known_issues/CFS_V2_Failures_On_Large_Systems.md)
 
 ## Configuration management
 
 - [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md)
 - [Incrementally Configuring Images](incrementally_configuring_images.md)
+- [CFS V2 Failures On Large Systems](known_issues/CFS_V2_Failures_On_Large_Systems.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md
+++ b/troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md
@@ -1,0 +1,183 @@
+# CFS V2 Failures On Large Systems
+
+This page describes a known issue in CSM 1.5. Most of it will be fixed in CSM 1.5.1,
+and all of it will be fixed in CSM 1.6.0.
+
+> Some commands on this page require the Cray CLI to be configured.
+> See [Configure the Cray CLI](../../operations/configure_cray_cli.md).
+
+* [Overview](#overview)
+* [Impacted systems](#impacted-systems)
+* [Symptoms](#symptoms)
+    * [`cmsdev` CFS test failures](#cmsdev-cfs-test-failures)
+    * [BOS v2 sessions not progressing](#bos-v2-sessions-not-progressing)
+    * [SAT status CFS error](#sat-status-cfs-error)
+* [Workaround](#workaround)
+* [Fix](#fix)
+
+## Overview
+
+CSM 1.5 introduces [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+v3, featuring paging of API responses. This limits the size of responses from some CFS endpoints to a
+user-configurable value (`1000` by default). When using CFS v3 endpoints, if a response exceeds this number of
+items, then it will include information that can be used to perform subsequent API queries, to get additional
+pages of response data. When using CFS v2 endpoints, however, paging is not supported; if a response
+from a v2 endpoint exceeds the configured default page size, then it will respond with an error.
+
+In CSM 1.5, some CSM services can encounter situations where their calls to CFS fail because
+of this. The known examples of this are:
+
+* `cmsdev` CFS test
+* [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) v2 sessions
+* [System Admin Toolkit (SAT)](../../glossary.md#system-admin-toolkit-sat) status
+
+For more information on the CFS paging feature, see
+[Paging CFS Records](../../operations/configuration_management/Paging_CFS_Records.md).
+
+## Impacted systems
+
+This will only happen on systems where the total number of components in CFS is larger than
+the CFS default page size.
+
+1. (`ncn-mw#`) Display the current CFS default page size:
+
+    ```bash
+    cray cfs v3 options list --format json | jq -r '.default_page_size'
+    ```
+
+    Example output:
+
+    ```text
+    1000
+    ```
+
+1. (`ncn-mw#`) Display the total number of components in CFS:
+
+    ```bash
+    cray cfs v3 components list --limit 10000000 --format json | jq '.components | length'
+    ```
+
+    Example output:
+
+    ```text
+    570
+    ```
+
+If the CFS default page size is greater than or equal to the number of components in CFS, then the
+system should not be impacted by this issue.
+
+## Symptoms
+
+### `cmsdev` CFS test failures
+
+The `cmsdev` CFS test includes a calls to CFS v2 that are impacted by this issue. This is indicated
+by lines like the following in the test output:
+
+```text
+ERROR (run tag qdthp-cfs): GET https://api-gw-service-nmn.local/apis/cfs/v2/components: expected status code 200, got 400
+ERROR (run tag qdthp-cfs): CLI command (cfs components list --format json) failed with exit code 2
+```
+
+### BOS v2 sessions not progressing
+
+The BOS v2 status operator is responsible for progressing BOS v2 sessions, and it includes a call to
+CFS that is impacted by this issue. As a consequence, BOS v2 sessions will not carry out their work.
+Note that this will happen regardless of the number of nodes involved in the BOS v2 session -- the
+problem only depends on the total number of components in CFS.
+
+(`ncn-mw#`) This problem can be confirmed by looking at the BOS status operator logs while a BOS v2
+session is running.
+
+```bash
+kubectl logs -n services -l app.kubernetes.io/name=cray-bos-operator-status
+```
+
+Lines resembling the following confirm that this problem is happening:
+
+```text
+2024-03-28 17:54:20,658 - ERROR   - bos.operators.base - Unhandled exception detected: 400 Client Error: Bad Request for url: http://cray-cfs-api/v2/components
+Traceback (most recent call last):
+  File "/usr/lib/python3.11/site-packages/bos/operators/base.py", line 99, in run
+    self._run()
+  File "/usr/lib/python3.11/site-packages/bos/operators/status.py", line 74, in _run
+    cfs_states = self._get_cfs_components()
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.11/site-packages/bos/operators/status.py", line 100, in _get_cfs_components
+    cfs_data = get_cfs_components()
+               ^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.11/site-packages/bos/operators/utils/clients/cfs.py", line 45, in get_components
+    response.raise_for_status()
+  File "/usr/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
+    raise HTTPError(http_error_msg, response=self)
+requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://cray-cfs-api/v2/components
+```
+
+For more information on the BOS v2 operators (including the status operator), see
+[BOS operators](../../operations/boot_orchestration/BOS_Services.md#bos-operators).
+
+### SAT status CFS error
+
+(`ncn-mw#`) To populate its CFS fields, SAT status makes a call which is impacted by this issue.
+
+```bash
+sat status --cfs-fields
+```
+
+If the beginning of the output includes an error resembling the following, then the system is impacted by this issue:
+
+```text
+WARNING: Could not retrieve status information from CFS; Failed to query CFS for component information: GET request to URL 'https://api-gw-service-nmn.local/apis/cfs/v2/components' failed with status code 400: Bad Request. The response size is too large Detail: The response size exceeds the default_page_size.  Use the v3 API to page through the results.
+```
+
+For more information on SAT, see [SAT in CSM](../../operations/sat/sat_in_csm.md).
+
+## Workaround
+
+This problem can be avoided by adjusting the CFS default page size to a larger value.
+
+1. (`ncn-mw#`) Figure out how many CFS components exist on the system.
+
+    ```bash
+    NUM_CFS_COMPONENTS=$(cray cfs v3 components list --limit 10000000 --format json | jq '.components | length')
+    echo $NUM_CFS_COMPONENTS
+    ```
+
+    Example output:
+
+    ```text
+    2600
+    ```
+
+1. (`ncn-mw#`) Optionally, increase this number, in case more hardware is added to the system.
+
+    ```bash
+    let NUM_CFS_COMPONENTS+=200
+    echo $NUM_CFS_COMPONENTS
+    ```
+
+    Example output:
+
+    ```text
+    2800
+    ```
+
+1. (`ncn-mw#`) Set the CFS v3 default page size to this value.
+
+    ```bash
+    cray cfs v3 options update --default-page-size "${NUM_CFS_COMPONENTS}" --format json | jq -r '.default_page_size'
+    ```
+
+    The output should match the new desired value.
+
+    ```text
+    2800
+    ```
+
+Note that for large enough numbers of components, the `cray-cfs-api` Kubernetes pods (in the `services` namespace)
+may encounter crashes because of memory use. In that case, the memory limits of the CFS pods can be increased to avoid that.
+For information on how to do that, see [Increase Pod Resource Limits](../../operations/kubernetes/Increase_Pod_Resource_Limits.md).
+
+## Fix
+
+This problem will be fixed in BOS and `cmsdev` in CSM 1.5.1.
+This problem will be fixed in SAT in CSM 1.6.0.

--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -5,6 +5,7 @@
 - [Known issues with SMS tests](#known-issues-with-sms-tests)
     - [Cray CLI](#cray-cli)
     - [BOS subtest hangs](#bos-subtest-hangs)
+    - [CFS components errors](#cfs-components-errors)
 
 ## SMS test execution
 
@@ -57,3 +58,15 @@ See the following for more information:
 On systems where too many BOS v1 sessions exist, the `cmsdev` test will hang when trying to
 list BOS v1 sessions. See [Hang Listing BOS V1 Sessions](Hang_Listing_BOS_V1_Sessions.md) for more
 information.
+
+### CFS components errors
+
+On CSM 1.5.0 systems with a lot of nodes, the CFS subtest may report errors that look similar to
+the following:
+
+```text
+ERROR (run tag qdthp-cfs): GET https://api-gw-service-nmn.local/apis/cfs/v2/components: expected status code 200, got 400
+ERROR (run tag qdthp-cfs): CLI command (cfs components list --format json) failed with exit code 2
+```
+
+For more details, see [CFS V2 Failures On Large Systems](CFS_V2_Failures_On_Large_Systems.md).


### PR DESCRIPTION
This documents a known issue in CSM 1.5.0 that is fixed in CSM 1.5.1. It provides an explanation of the problem, how to verify that it is happening, and how to workaround it. It also provides links to the issue in relevant places where an admin will hopefully encounter it.

No backports, as this is 1.5.0 only.