### PR TITLE
CASMTRIAGE-6863 - Update Spire database airgap configuration to reflect that there are two PostgreSQL clusters

### DIFF
--- a/troubleshooting/known_issues/spire_database_airgap_configuration.md
+++ b/troubleshooting/known_issues/spire_database_airgap_configuration.md
@@ -25,6 +25,8 @@ Due to the way the resolver code works in certain versions of Alpine Linux, it m
 
 ## Solution
 
+### Update the `spire-postgres-pooler` deployment
+
 1. (`ncn-mw#`) Edit the `spire-postgres-pooler` deployment.
 
    Command:
@@ -55,6 +57,38 @@ Due to the way the resolver code works in certain versions of Alpine Linux, it m
 
    The `spire-postgres-pooler` pods will automatically restart to pick up the new value.
 
-**IMPORTANT:** This change will need to be reapplied if the `spire` Helm chart is re-installed.
+### Update the `cray-spire-postgres-pooler` deployment
+
+1. (`ncn-mw#`) Edit the `cray-spire-postgres-pooler` deployment.
+
+   Command:
+
+   ```bash
+   kubectl -n spire edit deployment cray-spire-postgres-pooler
+   ```
+
+1. Update the `PGHOST` environment variable to use the fully qualified domain name.
+
+   An example of the deployment before being edited:
+
+   ```yaml
+   containers:
+   - env:
+     - name: PGHOST
+       value: cray-spire-postgres
+   ```
+
+   Change `PGHOST` to:
+
+   ```yaml
+   containers:
+   - env:
+     - name: PGHOST
+       value: cray-spire-postgres.spire.svc.cluster.local
+   ```
+
+   The `cray-spire-postgres-pooler` pods will automatically restart to pick up the new value.
+
+**IMPORTANT:** This change will need to be reapplied if the `spire` or `cray-spire` Helm charts are re-installed.
 
 This will be resolved in a future CSM release when the PostgreSQL operator is upgraded to a newer version.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Update the Spire PostgreSQL air-gapped procedure to reflect that there are currently two spire instances deployed with two separate database clusters that need updating.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
