### PR TITLE
CASMHMS-6135: Update docs for multiple ipxe pods

### DIFF
--- a/operations/boot_orchestration/Edit_the_iPXE_Embedded_Boot_Script.md
+++ b/operations/boot_orchestration/Edit_the_iPXE_Embedded_Boot_Script.md
@@ -69,18 +69,20 @@ This procedure requires administrative privileges.
             kubectl create -f /root/cray-ipxe-bss-ipxe.yaml
             ```
 
-2. Delete the iPXE pod to ensure the updated ConfigMap will be used.
+2. Delete the iPXE pods to ensure the updated ConfigMap will be used.
 
     1. Find the pod ID.
 
         ```bash
         kubectl -n services get pods|grep cray-ipxe
-        cray-ipxe-5dddfc65f-qfmrr           2/2     Running        2       39h
+        cray-ipxe-aarch64-5cdd74f889-wrkj7  2/2     Running        0       10d
+        cray-ipxe-x86-64-5b88cb79c-wb22l    2/2     Running        0       10d
+
         ```
 
     2. Delete the pod.
 
-        Replace CRAY-IPXE\_POD\_ID with the value returned in the previous step. In this example, the pod ID is `cray-ipxe-5dddfc65f-qfmrr`.
+        Replace CRAY-IPXE\_POD\_ID with the value returned in the previous step. In this example, the pod IDs are `cray-ipxe-aarch64-5cdd74f889-wrkj7' and 'cray-ipxe-x86-64-5b88cb79c-wb22l`.
 
         ```bash
         kubectl -n services delete pod CRAY-IPXE_POD_ID

--- a/operations/boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md
+++ b/operations/boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md
@@ -19,7 +19,8 @@ This procedure requires administrative privileges.
     Example output:
 
     ```text
-    cray-ipxe                                   1/1     1            1           22m
+    cray-ipxe-aarch64                           1/1     1            1           22m
+    cray-ipxe-x86-64                            1/1     1            1           22m
     cray-tftp                                   3/3     3            3           28m
     ```
 
@@ -27,7 +28,8 @@ This procedure requires administrative privileges.
 
     ```bash
     kubectl -n services delete deployment cray-tftp
-    kubectl -n services delete deployment cray-ipxe
+    kubectl -n services delete deployment cray-ipxe-aarch64
+    kubectl -n services delete deployment cray-ipxe-x86-64
     ```
 
 1. Check the status of Ceph.
@@ -214,13 +216,13 @@ This procedure requires administrative privileges.
 
     This may take another couple of minutes while it is creating the files.
 
-    1. Find the iPXE pod ID.
+    1. Find the iPXE pod IDs.
 
         ```bash
         kubectl get pods -n services --no-headers -o wide | grep cray-ipxe | awk '{print $1}'
         ```
 
-    1. Log into the pod using the iPXE pod ID.
+    1. Log into the pods using the iPXE pod ID.
 
         ```bash
         kubectl exec -n services -it IPXE_POD_ID /bin/sh

--- a/operations/boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md
+++ b/operations/boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md
@@ -212,7 +212,7 @@ This procedure requires administrative privileges.
     loftsman helm upgrade cms-ipxe loftsman/cms-ipxe
     ```
 
-1. (`ncn-mw#`) Log into the iPXE pod and verify the iPXE file was created.
+1. (`ncn-mw#`) Log into each iPXE pod and verify the iPXE file was created.
 
     This may take another couple of minutes while it is creating the files.
 
@@ -222,7 +222,7 @@ This procedure requires administrative privileges.
         kubectl get pods -n services --no-headers -o wide | grep cray-ipxe | awk '{print $1}'
         ```
 
-    1. Log into the pods using the iPXE pod ID.
+    1. Log into the iPXE pods using their IDs.
 
         ```bash
         kubectl exec -n services -it IPXE_POD_ID /bin/sh

--- a/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
@@ -120,7 +120,7 @@ See [Check for latest documentation](../../../update_product_stream/README.md#ch
         | `mgmt1`   | `98:03:9b:bb:a9:95` | `--mac-mgmt1=98:03:9b:bb:a9:95` |
         | `hsn0`    | `ec:0d:9a:d4:2b:d8` | `--mac-hsn0=ec:0d:9a:d4:2b:d8`  |
 
-   1. Power off the NCN.
+    1. Power off the NCN.
 
         ```bash
         ipmitool -I lanplus -U root -E -H "${BMC_IP}" chassis power off

--- a/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
@@ -41,14 +41,14 @@ See [Check for latest documentation](../../../update_product_stream/README.md#ch
     1. Take note of the last timestamp in the `cray-ipxe` log.
 
         ```bash
-        kubectl -n services logs -l app.kubernetes.io/name=cray-ipxe -c cray-ipxe
+        kubectl -n services logs -l app.kubernetes.io/instance=cms-ipxe
         ```
 
     1. Wait for the updated iPXE binary to be built.
 
         ```bash
         sleep 30
-        kubectl -n services logs -l app.kubernetes.io/name=cray-ipxe -c cray-ipxe -f
+        kubectl -n services logs -l app.kubernetes.io/instance=cms-ipxe -f
         ```
 
         The following output means that a new iPXE binary has been built:


### PR DESCRIPTION
# Description

There are multiple places in the docs that need to reflect that there are now multiple cray-ipxe pods: cray-ipxe-aarch64 and cray-ipxe-x86-64.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.