### PR TITLE
CASMTRIAGE-6686: Document hms-discovery timeout workaround when many switches are missing

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1054,6 +1054,7 @@ thanos
 5.x
 Antero
 Expat-15
+Blanca
 
 - troubleshooting/known_issues/antero_node_NID_allocation.md
 # To allow Site Init

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -227,6 +227,6 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * On large systems, [BOS](glossary.md#boot-orchestration-service-bos) v2 sessions, some CSM health checks, and SAT status may not work properly, because of a failed interaction with CFS.
     * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
-* On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
+* It has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
     * For more information, including a workaround, see [hms-discovery Timeout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
     * This is expected to be fixed in CSM 1.6.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -208,7 +208,7 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * This affects the HFP script `post-deliver-product.sh` which will hang when the FAS Loader crashes. Rerunning the script will be required.
     * IUF procedure calls the `post-deliver-product.sh` script and may require restarting that IUF process.
     * This is expected to be fixed in CSM 1.5.1.
-* [Power Control Service (PCS)](glossary.md#power-control-service-pcs) is unable to place power caps on `Blanca Peak` (`ex254n`) and Parry Peak (`ex255a`) compute nodes
+* [Power Control Service (PCS)](glossary.md#power-control-service-pcs) is unable to place power caps on Blanca Peak (`ex254n`) and Parry Peak (`ex255a`) compute nodes
     * To workaround this issue, use [Cray Advanced Platform Monitoring and Control (CAPMC)](glossary.md#cray-advanced-platform-monitoring-and-control-capmc) to place power
       caps on these node types
     * Issue is fixed in CSM 1.5.1
@@ -227,6 +227,6 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * On large systems, [BOS](glossary.md#boot-orchestration-service-bos) v2 sessions, some CSM health checks, and SAT status may not work properly, because of a failed interaction with CFS.
     * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
-* It has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
+* The hms-discovery job may fail to finish when trying to communicate with non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
     * For more information, including a workaround, see [hms-discovery Timeout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
     * This is expected to be fixed in CSM 1.6.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -229,4 +229,4 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
 * The hms-discovery job may fail to finish when trying to communicate with non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
     * For more information, including a workaround, see [hms-discovery Timeout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
-    * This is expected to be fixed in CSM 1.6.0.
+    * This issue is expected to be fixed in CSM 1.6.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -212,6 +212,7 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * To workaround this issue, use [Cray Advanced Platform Monitoring and Control (CAPMC)](glossary.md#cray-advanced-platform-monitoring-and-control-capmc) to place power
       caps on these node types
     * Issue is fixed in CSM 1.5.1
+    * For more information, including a workaround, see [PCS Power Capping Blanca Peak and Parry Peak](troubleshooting/known_issues/PCS_Power_Capping_Blanca_Peak_and_Parry_Pea.md).
 * `cray-tftp-upload`
     * The `cray-tftp-upload` script errors out because of a change to the `ipxe` pods and the TFTP repository.
     * This error affects the `cray-upload-recovery-images` script.
@@ -226,3 +227,6 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * On large systems, [BOS](glossary.md#boot-orchestration-service-bos) v2 sessions, some CSM health checks, and SAT status may not work properly, because of a failed interaction with CFS.
     * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
+* On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
+    * For more information, including a workaround, see [Cray Advanced Platform Monitoring and Control (CAPMC)](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
+    * This is expected to be fixed in CSM 1.6.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -228,5 +228,5 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
 * On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
-    * For more information, including a workaround, see [hms-discovery Timout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
+    * For more information, including a workaround, see [hms-discovery Timeout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
     * This is expected to be fixed in CSM 1.6.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -212,7 +212,7 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * To workaround this issue, use [Cray Advanced Platform Monitoring and Control (CAPMC)](glossary.md#cray-advanced-platform-monitoring-and-control-capmc) to place power
       caps on these node types
     * Issue is fixed in CSM 1.5.1
-    * For more information, including a workaround, see [PCS Power Capping Blanca Peak and Parry Peak](troubleshooting/known_issues/PCS_Power_Capping_Blanca_Peak_and_Parry_Pea.md).
+    * For more information, including a workaround, see [PCS Power Capping Blanca Peak and Parry Peak](troubleshooting/known_issues/PCS_Power_Capping_Blanca_Peak_and_Parry_Peak.md).
 * `cray-tftp-upload`
     * The `cray-tftp-upload` script errors out because of a change to the `ipxe` pods and the TFTP repository.
     * This error affects the `cray-upload-recovery-images` script.
@@ -228,5 +228,5 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * Most of this will be fixed in CSM 1.5.1. The remainder will be fixed in CSM 1.6.0.
     * For more information, including a workaround, see [CFS V2 Failures On Large Systems](troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
 * On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
-    * For more information, including a workaround, see [Cray Advanced Platform Monitoring and Control (CAPMC)](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
+    * For more information, including a workaround, see [hms-discovery Timout Due to Missing Switches](troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md)
     * This is expected to be fixed in CSM 1.6.0.

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -20,8 +20,6 @@ Should hms-discovery be found to not complete in such an environment, this speci
     ... "msg":"Failed to get port map for management switch!", ..., "error":"failed to perform bulk get: read udp 10.38.0.46:55957->10.254.0.18:161: i/o timeout" ...
     ```
 
-    In order to be considered a duplicate of the problem described here, there should be at least several of these matching logs.
-
 # Workaround
 
 If this problem is encountered, it can be worked around by increasing the activeDeadlineSeconds value in the hms-discovery deployment.

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -1,4 +1,4 @@
-# Discover Timeout Due to Missing Switches
+# hms-discovery Timeout Due to Missing Switches
 
 ## Overview
 
@@ -8,19 +8,19 @@ On systems with a large number of non-existent network switches, it has been obs
 
 Should hms-discovery be found to not complete in such an environment, this specific problem can be diagnosed as follows:
 
-1. (`ncn-mw#`) Dump the logs for the failed hms-discover jobs:
+1. (`ncn-mw#`) Dump the logs for the failed hms-discovery jobs.  Example:
 
     ```bash
     kubectl -n services logs hms-discovery-28483755-mgvxn -f --timestamps
     ```
 
-1. (`ncn-mw#`) Look for messages that look similar to the following (example log is abbreviated heavily for illustrative purposes):
+1. (`ncn-mw#`) Look for messages similar to the following.  This example is abbreviated heavily for illustrative purposes:
 
     ```text
     ... "msg":"Failed to get port map for management switch!", ..., "error":"failed to perform bulk get: read udp 10.38.0.46:55957->10.254.0.18:161: i/o timeout" ...
     ```
 
-In order to be considered a duplicate of the problem described here, there should be at least several of these matching logs.
+    In order to be considered a duplicate of the problem described here, there should be at least several of these matching logs.
 
 # Workaround
 
@@ -52,7 +52,7 @@ If this problem is encountered, it can be worked around by increasing the active
     cray hsm inventory redfishEndpoints list --type RouterBMC --format json | jq -c '.RedfishEndpoints[] | {ID,DiscoveryInfo}'
     ```
 
-A switch was not discovered properly if it is not showing as "DiscoverOK" in this output.
+    A switch was not discovered properly if it is not showing as "DiscoverOK" in this output.
 
 1. (`ncn-mw#`) Force re-discovery of the failed switches:
 

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -1,0 +1,65 @@
+# Discover Timeout Due to Missing Switches
+
+## Overview
+
+On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
+
+# Symptoms and Diagnosis
+
+Should hms-discovery be found to not complete in such an environment, this specific problem can be diagnosed as follows:
+
+1. (`ncn-mw#`) Dump the logs for the failed hms-discover jobs:
+
+    ```bash
+    kubectl -n services logs hms-discovery-28483755-mgvxn -f --timestamps
+    ```
+
+1. (`ncn-mw#`) Look for messages that look similar to the following (example log is abbreviated heavily for illustrative purposes):
+
+    ```text
+    ... "msg":"Failed to get port map for management switch!", ..., "error":"failed to perform bulk get: read udp 10.38.0.46:55957->10.254.0.18:161: i/o timeout" ...
+    ```
+
+In order to be considered a duplicate of the problem described here, there should be at least several of these matching logs.
+
+# Workaround
+
+If this problem is encountered, it can be worked around by increasing the activeDeadlineSeconds value in the hms-discovery deployment.
+
+1. (`ncn-mw#`) Edit the hms-discovery deployment:
+
+    ```bash
+    kubectl edit cronjob -n services hms-discovery
+    ```
+
+1. (`ncn-mw#`) In the edit session for the deployment, look for the following line:
+
+    ```text
+    activeDeadlineSeconds: 300
+    ```
+
+1. (`ncn-mw#`) Update it from 300 (5 min) to something much larger like 30000 (500 min):
+
+    ```text
+    activeDeadlineSeconds: 30000
+    ```
+
+1. (`ncn-mw#`) Save your changes.  The next hms-discovery job will have its timeout extended.
+
+1. (`ncn-mw#`) Gather a list of switches that were not discovered properly:
+
+    ```bash
+    cray hsm inventory redfishEndpoints list --type RouterBMC --format json | jq -c '.RedfishEndpoints[] | {ID,DiscoveryInfo}'
+    ```
+
+A switch was not discovered properly if it is not showing as "DiscoverOK" in this output.
+
+1. (`ncn-mw#`) Force re-discovery of the failed switches:
+
+    ```bash
+    cray hsm inventory discover create --xnames <COMMA_SEPERATED_XNAME_LIST> --force true
+    ```
+
+# Fix
+
+This issue is expected to be fixed in the CSM 1.6 release.

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -7,7 +7,7 @@ This may happen when incrementally building up a new system and running CSM prio
 
 ## Symptoms and Diagnosis
 
-Should hms-discovery be found to not complete in such an environment, this specific problem can be diagnosed as follows:
+If hms-discovery does not complete in such an environment, this specific problem can be diagnosed as follows:
 
 1. (`ncn-mw#`) Dump the logs for the failed hms-discovery jobs.  Example:
 

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches. This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
+On systems with a large number of non-existent network switches, it has been observed that the hms-discovery job may fail to finish due to spending too much time trying to communicate with the non-existent switches.
+This may happen when incrementally building up a new system and running CSM prior to completion of the full hardware installation.
 
-# Symptoms and Diagnosis
+## Symptoms and Diagnosis
 
 Should hms-discovery be found to not complete in such an environment, this specific problem can be diagnosed as follows:
 
@@ -20,7 +21,7 @@ Should hms-discovery be found to not complete in such an environment, this speci
     ... "msg":"Failed to get port map for management switch!", ..., "error":"failed to perform bulk get: read udp 10.38.0.46:55957->10.254.0.18:161: i/o timeout" ...
     ```
 
-# Workaround
+## Workaround
 
 If this problem is encountered, it can be worked around by increasing the `activeDeadlineSeconds` value in the hms-discovery deployment.
 
@@ -58,6 +59,6 @@ If this problem is encountered, it can be worked around by increasing the `activ
     cray hsm inventory discover create --xnames <COMMA_SEPERATED_XNAME_LIST> --force true
     ```
 
-# Fix
+## Fix
 
 This issue is expected to be fixed in the CSM 1.6 release.

--- a/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
+++ b/troubleshooting/known_issues/hms_discovery_timeout_due_to_missing_switches.md
@@ -22,7 +22,7 @@ Should hms-discovery be found to not complete in such an environment, this speci
 
 # Workaround
 
-If this problem is encountered, it can be worked around by increasing the activeDeadlineSeconds value in the hms-discovery deployment.
+If this problem is encountered, it can be worked around by increasing the `activeDeadlineSeconds` value in the hms-discovery deployment.
 
 1. (`ncn-mw#`) Edit the hms-discovery deployment:
 


### PR DESCRIPTION
# Description

- Documented hms-discovery timeout issue and workaround when many switches are missing
- Created link to PCS troubleshooting document from prior entry in the release notes

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
