### PR TITLE
CASM-4669 Include image signatures in csm tarball

### DIFF
--- a/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
+++ b/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -58,7 +58,8 @@ spec:
           > password `admin123`) in order to upload to the bootstrap registry, which
           > is listening on localhost:5000.
         command: |-
-          podman load -i /var/lib/cray/container-images/metal-nexus/skopeo-stable-latest.tar
+          podman load -i {{ getEnv "CSM_PATH" }}/vendor/skopeo.tar
+          podman tag skopeo:csm-{{ getEnv "CSM_RELEASE" }} quay.io/skopeo/stable:latest
 
           podman run --rm --network host -v {{ getEnv "CSM_PATH" }}/docker:/images:ro \
               quay.io/skopeo/stable sync --scoped --src dir --dest docker --dest-tls-verify=false --dest-creds admin:admin123 \


### PR DESCRIPTION
# Description

For proper handling of sigstore attachments, we need to ensure proper version and configuration of `skopeo` used for sync between CSM distro and Nexus. Such update had been made to vendored version of `skopeo`.

Tested multiple times by running RPM, compiled on dev branch, on vShasta.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
