### PR TITLE
CASMINST-6796 1.6 : Improve "NCN pre-reboot health checks" section

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -65,6 +65,8 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
         > done by running `kubectl delete po -n kube-system kube-multus-ds.. --force`. After executing this
         > command, re-running the `ncnHealthChecks` script should indicate that a new pod is in the `Running` state.
 
+        Remediate any reported failures before proceeding.
+
     1. (`ncn-m#`) Validate Postgres health.
 
         Run this on any master NCN. It will run a set of checks on every Postgres cluster.


### PR DESCRIPTION
# Description
Resolves [CASMINST-6796](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6796) for release/1.6

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
