### PR TITLE
CASMNET-2210 - generateCiliumLiveMigration.py does not generate rendered output in stated location

### DIFF
--- a/workflows/cilium/generateCiliumLiveMigration.py
+++ b/workflows/cilium/generateCiliumLiveMigration.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 #
-#  MIT License
+# MIT License
 #
-#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
-#  Permission is hereby granted, free of charge, to any person obtaining a
-#  copy of this software and associated documentation files (the "Software"),
-#  to deal in the Software without restriction, including without limitation
-#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#  and/or sell copies of the Software, and to permit persons to whom the
-#  Software is furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
 #
-#  The above copyright notice and this permission notice shall be included
-#  in all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
 #
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-#  OTHER DEALINGS IN THE SOFTWARE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 #
 
 import yaml

--- a/workflows/cilium/generateCiliumLiveMigration.py
+++ b/workflows/cilium/generateCiliumLiveMigration.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
   # Load templates file from templates folder
   env = Environment(loader = FileSystemLoader(this_dir),   trim_blocks=True, lstrip_blocks=True)
   template = env.get_template(template_file)
-  file=open(render_file, "w")
+  file=open(this_dir + "/" + render_file, "w")
   file.write(template.render(target_ncns=node_list, now=now))
   file.close()
   print("Workflow rendered in " + this_dir + "/" + render_file) 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The Cilium generateCiliumLiveMigration.py script does not output the rendered workflow to the stated directory.
```
ncn-m001:/mnt/developer/cspiller # /usr/share/doc/csm/workflows/cilium/generateCiliumLiveMigration.py
Generating workflow for nodes
['ncn-m001', 'ncn-m002', 'ncn-m003', 'ncn-w001', 'ncn-w002', 'ncn-w003', 'ncn-w004']
/usr/share/doc/csm/workflows/cilium
Workflow rendered in /usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml
```
The usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml file does not exist.
```
ncn-m001:/mnt/developer/cspiller # ls /usr/share/doc/csm/workflows/cilium/
cilium-live-migration.j2  generateCiliumLiveMigration.py
```
The file was instead generated to the current working directory
```
ncn-m001:/mnt/developer/cspiller # ls
cilium-live-migration.yaml
```

With this fix the file is now generated in the correct location.
```
ncn-m001:/mnt/developer/cspiller # /usr/share/doc/csm/workflows/cilium/generateCiliumLiveMigration.py
Generating workflow for nodes
['ncn-m001', 'ncn-m002', 'ncn-m003', 'ncn-w001', 'ncn-w002', 'ncn-w003', 'ncn-w004']
/usr/share/doc/csm/workflows/cilium
Workflow rendered in /usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml

ncn-m001:/mnt/developer/cspiller # ls
ncn-m001:/mnt/developer/cspiller # ls /usr/share/doc/csm/workflows/cilium/
cilium-live-migration.j2  cilium-live-migration.yaml  generateCiliumLiveMigration.py
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
