### PR TITLE
CASMNET-2211 - Cilium migration workflow label is too long on larger systems

### DIFF
--- a/workflows/cilium/cilium-live-migration.j2
+++ b/workflows/cilium/cilium-live-migration.j2
@@ -8,7 +8,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  labels:
+  annotations:
     target-ncns:  {{ target_ncns|join('.') }}
   name: cilium-live-migration-{{ uid }}
 spec:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

On a system with more than 4 workers the label containing the list of nodes acted upon exceeds the maximum number of characters permitted for a label.
```
ncn-m001:~ # kubectl -n argo apply -f /usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml
The Workflow "cilium-live-migration-52713" is invalid: metadata.labels: Invalid value: "ncn-m001.ncn-m002.ncn-m003.ncn-w001.ncn-w002.ncn-w003.ncn-w004.ncn-w005": must be no more than 63 characters
```
This PR changes that label to be an annotation.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
