### PR TITLE
CASMINST-6845 `ncn-image-modification.sh` (CAST-35697, CAST-35717, CAST-35715, CASMTRIAGE-6944)

### DIFF
--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -437,19 +437,42 @@ function csm_144_patch {
   )
   local add_drivers=()
   local omit_drivers=()
-  local rpms=(
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/x86_64/qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150400.22-1.sles15sp4.x86_64.rpm"
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/x86_64/kernel-default-devel-${kernel_version}.x86_64.rpm"
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/x86_64/kernel-default-${kernel_version}.x86_64.rpm"
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/noarch/kernel-devel-${kernel_version}.noarch.rpm"
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/noarch/kernel-macros-${kernel_version}.noarch.rpm"
-    "${CSM_PATH}/rpm/cray/csm/sle-15sp4/x86_64/kernel-syms-${kernel_version}.x86_64.rpm"
-  )
+  local rpms=()
+  local tar_path
 
-  if [ ! -d "${CSM_PATH}" ]; then
-    echo >&2 "CSM_PATH does not exist, or was not defined."
+  if [ -n "$CSM_PATH" ]; then
+    if [ ! -d "${CSM_PATH}" ]; then
+      echo >&2 "CSM_PATH was defined but does not exist [$CSM_PATH]"
+    else
+      tar_path="${CSM_PATH}"
+    fi
+  fi
+  if [ -z "${tar_path}" ]; then
+    if [ -n "${CSM_DISTDIR}" ]; then
+      if [ ! -d "${CSM_DISTDIR}" ]; then
+        echo >&2 "CSM_DISTDIR was defined but does not exist [$CSM_DISTDIR]"
+      else
+        tar_path="${CSM_DISTDIR}"
+      fi
+    fi
+  fi
+  if [ -z "${tar_path}" ]; then
+    echo >&2 "Failed to resolve path to extracted tarball! CSM_PATH nor CSM_DISTDIR were found in the environment!"
     return 1
   fi
+  if [ ! -d "${tar_path}" ]; then
+    echo >&2 "Extracted tarball resolved to ${tar_path} but this path does not exist!"
+    return 1
+  fi
+  rpms=(
+    "${tar_path}/rpm/cray/csm/sle-15sp4/x86_64/qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150400.22-1.sles15sp4.x86_64.rpm"
+    "${tar_path}/rpm/cray/csm/sle-15sp4/x86_64/kernel-default-devel-${kernel_version}.x86_64.rpm"
+    "${tar_path}/rpm/cray/csm/sle-15sp4/x86_64/kernel-default-${kernel_version}.x86_64.rpm"
+    "${tar_path}/rpm/cray/csm/sle-15sp4/noarch/kernel-devel-${kernel_version}.noarch.rpm"
+    "${tar_path}/rpm/cray/csm/sle-15sp4/noarch/kernel-macros-${kernel_version}.noarch.rpm"
+    "${tar_path}/rpm/cray/csm/sle-15sp4/x86_64/kernel-syms-${kernel_version}.x86_64.rpm"
+  )
+
   echo "Patching images for CSM 1.4.4 ... "
   for squash in "${SQUASH_PATHS[@]}"; do
     (

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -659,19 +659,21 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
 
     echo "Uploading Kubernetes images..."
     export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
-    export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}-${arch}.xz"
     # do not quote this glob.  bash will add single ticks (') around it, preventing expansion later
-    resolve_kernel_glob=$(echo ${artdir}/kubernetes/*-${arch}.kernel)
-    export IMS_KERNEL_FILENAME=$resolve_kernel_glob
+    IMS_INITRD_FILENAME=$(echo ${artdir}/kubernetes/initrd*.xz)
+    IMS_KERNEL_FILENAME=$(echo ${artdir}/kubernetes/*.kernel)
+    export IMS_INITRD_FILENAME
+    export IMS_KERNEL_FILENAME
     K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
     [[ -n ${K8S_IMS_IMAGE_ID} ]] && [[ ${K8S_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
 
     echo "Uploading Ceph images..."
     export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs"
-    export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}-${arch}.xz"
     # do not quote this glob.  bash will add single ticks (') around it, preventing expansion later
-    resolve_kernel_glob=$(echo ${artdir}/storage-ceph/*-${arch}.kernel)
-    export IMS_KERNEL_FILENAME=$resolve_kernel_glob
+    IMS_INITRD_FILENAME=$(echo ${artdir}/storage-ceph/initrd*.xz)
+    IMS_KERNEL_FILENAME=$(echo ${artdir}/storage-ceph/*.kernel)
+    export IMS_INITRD_FILENAME
+    export IMS_KERNEL_FILENAME
     STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
     [[ -n ${STORAGE_IMS_IMAGE_ID} ]] && [[ ${STORAGE_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
     set +o pipefail

--- a/upgrade/scripts/upgrade/upload-ncn-images.sh
+++ b/upgrade/scripts/upgrade/upload-ncn-images.sh
@@ -82,19 +82,21 @@ UUID_REGEX='^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F
 
 echo "Uploading Kubernetes images..."
 export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
-export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}-${arch}.xz"
 # do not quote this glob.  bash will add single ticks (') around it, preventing expansion later
-resolve_kernel_glob=$(echo ${artdir}/kubernetes/*-${arch}.kernel)
-export IMS_KERNEL_FILENAME=$resolve_kernel_glob
+IMS_INITRD_FILENAME=$(echo ${artdir}/kubernetes/initrd*.xz)
+IMS_KERNEL_FILENAME=$(echo ${artdir}/kubernetes/*.kernel)
+export IMS_INITRD_FILENAME
+export IMS_KERNEL_FILENAME
 K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
 [[ -n ${K8S_IMS_IMAGE_ID} ]] && [[ ${K8S_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
 
 echo "Uploading Ceph images..."
 export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs"
-export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}-${arch}.xz"
 # do not quote this glob.  bash will add single ticks (') around it, preventing expansion later
-resolve_kernel_glob=$(echo ${artdir}/storage-ceph/*-${arch}.kernel)
-export IMS_KERNEL_FILENAME=$resolve_kernel_glob
+IMS_INITRD_FILENAME=$(echo ${artdir}/storage-ceph/initrd*.xz)
+IMS_KERNEL_FILENAME=$(echo ${artdir}/storage-ceph/*.kernel)
+export IMS_INITRD_FILENAME
+export IMS_KERNEL_FILENAME
 STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
 [[ -n ${STORAGE_IMS_IMAGE_ID} ]] && [[ ${STORAGE_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
 set +o pipefail


### PR DESCRIPTION
# Description

The `ncn-image-modification.sh` script's `csm_144_patch` function relies on `CSM_PATH`, that is only set during fresh installations. When `ncn-image-modification.sh` is invoked by `prerequisites.sh` or `upload-ncn-images.sh` during an upgrade, `CSM_PATH` is not set. This causes the script to fail.

- Fix the script so that it checks whether `CSM_PATH` or `CSM_DISTDIR` are set (respective to install and upgrade), allowing the script to resolve th extracted tarball in both scenarios.
- Fix initrd and kernel resolution after `csm_144_patch` function runs in `ncn-image-modification.sh`

Fixes:
- CAST-35697
- CAST-35717
- CAST-35715
- CASMTRIAGE-6944
- CASMINST-6845

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.