### PR TITLE
CASMHMS-6195 Added workaround to cray hsm inventory redfishEndpoints update

### DIFF
--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -41,8 +41,8 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 1. (`ncn-mw#`) Temporarily disable the Redfish endpoints for `NodeBMCs` present in the blade.
 
     ```bash
-    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0
-    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
+    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0 --id x9000c3s0b0 --hostname x9000c3s0b0
+    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1 --id x9000c3s0b1 --hostname x9000c3s0b1
     ```
 
 ### 3. Clear Redfish event subscriptions from BMCs on the blade

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -25,7 +25,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    This example disables MEDS for the compute node in cabinet 1000, chassis 3, slot 0 (`x1000c3s0b0`). If there is more than 1 node card, in the blade specify each node card (`x1000c3s0b0`, `x1000c3s0b1`).
 
    ```bash
-   cray hsm inventory redfishEndpoints update --enabled false x1000c3s0b0
+   cray hsm inventory redfishEndpoints update --enabled false x1000c3s0b0 --id x1000c3s0b0 --hostname x1000c3s0b0
    ```
 
 1. Verify that the workload manager (WLM) is not using the affected nodes.

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -102,8 +102,8 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 (`ncn-mw#`) Temporarily disable the Redfish endpoints for each compute node `NodeBMC`.
 
 ```bash
-cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0
-cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
+cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0 --id x9000c3s0b0 --hostname x9000c3s0b0
+cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1 --id x9000c3s0b1 --hostname x9000c3s0b1
 ```
 
 ### Source: Clear Redfish event subscriptions from BMCs on the blade
@@ -280,8 +280,8 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 Disabling chassis slot prevents `hms-discovery` from attempting to power them back on.
 
 ```bash
-cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0
-cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
+cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0 --id x1005c3s0b0 --hostname x1005c3s0b0
+cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1 --id x1005c3s0b1 --hostname x1005c3s0b1
 ```
 
 ### Destination: Clear Redfish event subscriptions from BMCs on the blade

--- a/operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md
+++ b/operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md
@@ -79,6 +79,7 @@ LastDiscoveryStatus = "HTTPsGetFailed"
 
     ```bash
     cray hsm inventory redfishEndpoints update BMC_XNAME \
+                --id BMC_XNAME --hostname BMC_XNAME \
                 --enabled true --rediscover-on-update true
     ```
 

--- a/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
+++ b/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
@@ -49,7 +49,7 @@ This type of problem can occur in the following scenarios:
 1. Update the credentials for the Redfish endpoint stored in Vault using Hardware State Manager (HSM):
 
     ```bash
-    cray hsm inventory redfishEndpoints update $BMC --user root --password $CURRENT_ROOT_PASSWORD 
+    cray hsm inventory redfishEndpoints update $BMC --user root --password $CURRENT_ROOT_PASSWORD --id $BMC --hostname $BMC
     ```
 
 1. Wait a few minutes for HSM to attempt to inventory the BMC:

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -182,7 +182,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
             continue
         fi
         echo "$RF: Updating credentials"
-        cray hsm inventory redfishEndpoints update ${RF} --user root --password ${CRED_PASSWORD}
+        cray hsm inventory redfishEndpoints update ${RF} --user root --password ${CRED_PASSWORD} --id ${RF} --hostname ${RF}
     done
     ```
 
@@ -191,7 +191,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
     > Alternatively, use the following command on each BMC. Replace `BMC_XNAME` with the BMC component name (xname) to update the credentials:
     >
     > ```bash
-    > cray hsm inventory redfishEndpoints update BMC_XNAME --user root --password ${CRED_PASSWORD}
+    > cray hsm inventory redfishEndpoints update BMC_XNAME --user root --password ${CRED_PASSWORD} --id BMC_XNAME --hostname BMC_XNAME
     > ```
 
 1. Restart the `hms-discovery` Kubernetes CronJob.

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -9,11 +9,11 @@ product documentation. To update Slingshot switch BMCs, refer to "Change Rosetta
 This procedure provisions only the default Redfish `root` account passwords. It does not modify Redfish accounts that have been added after an initial system installation.
 
 - [Updating the Liquid-Cooled EX Cabinet CEC with Default Credentials after a CEC Password Change](#updating-the-liquid-cooled-ex-cabinet-cec-with-default-credentials-after-a-cec-password-change)
-  - [Prerequisites](#prerequisites)
-  - [Procedure](#procedure)
-    - [1. Update the default credentials used by MEDS for new hardware](#1-update-the-default-credentials-used-by-meds-for-new-hardware)
-    - [2. Update credentials for existing EX hardware in the system](#2-update-credentials-for-existing-ex-hardware-in-the-system)
-    - [3. Reapply BMC settings if a `StatefulReset` was performed on any BMC](#3-reapply-bmc-settings-if-a-statefulreset-was-performed-on-any-bmc)
+    - [Prerequisites](#prerequisites)
+    - [Procedure](#procedure)
+        - [1. Update the default credentials used by MEDS for new hardware](#1-update-the-default-credentials-used-by-meds-for-new-hardware)
+        - [2. Update credentials for existing EX hardware in the system](#2-update-credentials-for-existing-ex-hardware-in-the-system)
+        - [3. Reapply BMC settings if a `StatefulReset` was performed on any BMC](#3-reapply-bmc-settings-if-a-statefulreset-was-performed-on-any-bmc)
 
 ## Prerequisites
 

--- a/scripts/operations/node_management/remove_gigabyte_cmc.sh
+++ b/scripts/operations/node_management/remove_gigabyte_cmc.sh
@@ -81,7 +81,7 @@ echo "=================================================="
 # Remove from HSM
 ## Disable the Redfish Endpoint
 echo "Disabling Redfish Endpoint in HSM: ${CMC_XNAME}"
-cray hsm inventory redfishEndpoints update "${CMC_XNAME}" --enabled false --id "${CMC_XNAME}"
+cray hsm inventory redfishEndpoints update "${CMC_XNAME}" --enabled false --id "${CMC_XNAME}" --hostname "${CMC_XNAME}"
 
 ## Remove from state components
 echo "Deleting component from HSM State Components: ${CMC_XNAME}"

--- a/scripts/operations/node_management/remove_standard_rack_node.sh
+++ b/scripts/operations/node_management/remove_standard_rack_node.sh
@@ -99,7 +99,7 @@ echo "=================================================="
 
 ## Disable the Redfish Endpoint
 echo "Disabling Redfish Endpoint in HSM: ${BMC_XNAME}"
-cray hsm inventory redfishEndpoints update "${BMC_XNAME}" --enabled false --id "${BMC_XNAME}"
+cray hsm inventory redfishEndpoints update "${BMC_XNAME}" --enabled false --id "${BMC_XNAME}" --hostname "${BMC_XNAME}"
 
 ## Remove from state components
 for XNAME in "$NODE_XNAME" "$BMC_XNAME" "${NODE_ENCLOSURE_XNAME}"; do


### PR DESCRIPTION
# Description

This updates the docs to include the --hostname and --id options when calling: cray hsm inventory redfishEndpoints update XNAME

The cray cli in 1.5.0 requires the --hostname option and the --id option. In 1.5.1 and later only the --id option is required

CASMHMS-6195

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
