### PR TITLE
CASMHMS-6195 Added id option to cray hsm inventory redfishEndpoints update

### DIFF
--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -41,8 +41,8 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 1. (`ncn-mw#`) Temporarily disable the Redfish endpoints for `NodeBMCs` present in the blade.
 
     ```bash
-    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0
-    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
+    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0 --id x9000c3s0b0
+    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1 --id x9000c3s0b1
     ```
 
 ### 3. Clear Redfish event subscriptions from BMCs on the blade
@@ -128,7 +128,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     Disabling the slot prevents `hms-discovery` from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
 
     ```bash
-    cray hsm state components enabled update --enabled false x9000c3s0
+    cray hsm state components enabled update --enabled false x9000c3s0 --id x9000c3s0
     ```
 
 ### 7. Record MAC and IP addresses for nodes

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -15,8 +15,8 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 - Check the status of the HSN and record link status before the procedure.
 
 - The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
-  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
-  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
+    - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+    - Review the *HPE Cray EX Hand Pump User Guide H-6200*
 
 ## Procedure
 

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -25,7 +25,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    This example disables MEDS for the compute node in cabinet 1000, chassis 3, slot 0 (`x1000c3s0b0`). If there is more than 1 node card, in the blade specify each node card (`x1000c3s0b0`, `x1000c3s0b1`).
 
    ```bash
-   cray hsm inventory redfishEndpoints update --enabled false x1000c3s0b0
+   cray hsm inventory redfishEndpoints update --enabled false x1000c3s0b0 --id x1000c3s0b0
    ```
 
 1. Verify that the workload manager (WLM) is not using the affected nodes.
@@ -45,7 +45,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    This example shows cabinet 1000, chassis 3, slot 0 (`x1000c3s0`).
 
    ```bash
-   cray hsm state components enabled update --enabled false x1000c3s0
+   cray hsm state components enabled update --enabled false x1000c3s0 --id x1000c3s0
    ```
 
    Disabling the slot prevents `hms-discovery` from attempting to automatically power on slots. If the slot

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -102,8 +102,8 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 (`ncn-mw#`) Temporarily disable the Redfish endpoints for each compute node `NodeBMC`.
 
 ```bash
-cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0
-cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
+cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0 --id x9000c3s0b0
+cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1 --id x9000c3s0b1
 ```
 
 ### Source: Clear Redfish event subscriptions from BMCs on the blade
@@ -280,8 +280,8 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 Disabling chassis slot prevents `hms-discovery` from attempting to power them back on.
 
 ```bash
-cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0
-cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
+cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0 --id x1005c3s0b0
+cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1 --id x1005c3s0b1
 ```
 
 ### Destination: Clear Redfish event subscriptions from BMCs on the blade
@@ -369,7 +369,7 @@ curl -k -u root:PASSWORD -X POST -H 'Content-Type: application/json' -d \
 This example disables slot 0, chassis 3, in cabinet 1005.
 
 ```bash
-cray hsm state components enabled update --enabled false x1005c3s0
+cray hsm state components enabled update --enabled false x1005c3s0 --id x1005c3s0
 ```
 
 ### Destination: Record the NIC MAC and IP addresses
@@ -557,7 +557,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     The example enables slot 0, chassis 3, in cabinet 1005.
 
     ```bash
-    cray hsm state components enabled update --enabled true x1005c3s0
+    cray hsm state components enabled update --enabled true x1005c3s0 --id x1005c3s0
     ```
 
 1. (`ncn-mw#`) Power on the chassis slot.

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -4,9 +4,9 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
 - The two systems in this example are:
 
-  - Source system - Cray EX TDS cabinet `x9000` with a healthy EX425 blade (Windom dual-injection) in chassis 3, slot 0
+    - Source system - Cray EX TDS cabinet `x9000` with a healthy EX425 blade (Windom dual-injection) in chassis 3, slot 0
 
-  - Destination system - Cray EX cabinet `x1005` with a defective EX425 blade (Windom dual-injection) in chassis 3, slot 0
+    - Destination system - Cray EX cabinet `x1005` with a defective EX425 blade (Windom dual-injection) in chassis 3, slot 0
 
 - Substitute the correct component names (xnames) or other parameters in the command examples that follow.
 
@@ -81,8 +81,8 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
 - The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
 
-  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
-  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
+    - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+    - Review the *HPE Cray EX Hand Pump User Guide H-6200*
 
 ## Prepare the source system blade for removal
 

--- a/operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md
+++ b/operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md
@@ -78,7 +78,7 @@ LastDiscoveryStatus = "HTTPsGetFailed"
     If `Enabled = false` for the `RedfishEndpoint`, then it may indicate a network or firmware issue with the BMC.
 
     ```bash
-    cray hsm inventory redfishEndpoints update BMC_XNAME \
+    cray hsm inventory redfishEndpoints update BMC_XNAME --id BMC_XNAME \
                 --enabled true --rediscover-on-update true
     ```
 

--- a/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
+++ b/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
@@ -49,7 +49,7 @@ This type of problem can occur in the following scenarios:
 1. Update the credentials for the Redfish endpoint stored in Vault using Hardware State Manager (HSM):
 
     ```bash
-    cray hsm inventory redfishEndpoints update $BMC --user root --password $CURRENT_ROOT_PASSWORD 
+    cray hsm inventory redfishEndpoints update $BMC --id $BMC --user root --password $CURRENT_ROOT_PASSWORD
     ```
 
 1. Wait a few minutes for HSM to attempt to inventory the BMC:

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -182,7 +182,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
             continue
         fi
         echo "$RF: Updating credentials"
-        cray hsm inventory redfishEndpoints update ${RF} --user root --password ${CRED_PASSWORD}
+        cray hsm inventory redfishEndpoints update ${RF} --id ${RF} --user root --password ${CRED_PASSWORD}
     done
     ```
 
@@ -191,7 +191,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
     > Alternatively, use the following command on each BMC. Replace `BMC_XNAME` with the BMC component name (xname) to update the credentials:
     >
     > ```bash
-    > cray hsm inventory redfishEndpoints update BMC_XNAME --user root --password ${CRED_PASSWORD}
+    > cray hsm inventory redfishEndpoints update BMC_XNAME --id BMC_XNAME --user root --password ${CRED_PASSWORD}
     > ```
 
 1. Restart the `hms-discovery` Kubernetes CronJob.


### PR DESCRIPTION
# Description

This updates the docs to include the --id options when calling: cray hsm inventory redfishEndpoints update XNAME

CASMHMS-6195

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
