### PR TITLE
CASMINST-6846: Upgrade path clarifications

### DIFF
--- a/upgrade/1.4.1/README.md
+++ b/upgrade/1.4.1/README.md
@@ -6,8 +6,15 @@
 
 ## Introduction
 
-This document guides an administrator through the patch update to Cray Systems Management `v1.4.1` from `v1.4.0`.
-If upgrading from CSM `v1.3.4` directly to `v1.4.1`, follow the procedures described in [Upgrade CSM](../README.md) instead.
+This document guides an administrator through the patch update to Cray Systems Management `v1.4.1`
+from CSM `v1.4.0`. If upgrading from CSM `v1.3.x`,  then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`, then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+
+Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
+consider upgrading to the latest recent CSM `v1.4` patch release. See
+[CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements
 

--- a/upgrade/1.4.1/README.md
+++ b/upgrade/1.4.1/README.md
@@ -13,7 +13,7 @@ In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`
 described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
 
 Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
-consider upgrading to the latest recent CSM `v1.4` patch release. See
+consider upgrading to the latest CSM `v1.4` patch release. See
 [CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -6,9 +6,15 @@
 
 ## Introduction
 
-This document guides an administrator through the patch update to Cray Systems Management `v1.4.2` from `v1.4.0`
-or `1.4.1`. If upgrading from CSM `v1.3.x` directly to `v1.4.2`, follow the procedures described
-in [Upgrade CSM](../README.md) instead.
+This document guides an administrator through the patch update to Cray Systems Management `v1.4.2`
+from an earlier patch version of CSM `v1.4`. If upgrading from CSM `v1.3.x`,  then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`, then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+
+Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
+consider upgrading to the latest recent CSM `v1.4` patch release. See
+[CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -13,7 +13,7 @@ In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`
 described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
 
 Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
-consider upgrading to the latest recent CSM `v1.4` patch release. See
+consider upgrading to the latest CSM `v1.4` patch release. See
 [CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements

--- a/upgrade/1.4.3/README.md
+++ b/upgrade/1.4.3/README.md
@@ -6,9 +6,15 @@
 
 ## Introduction
 
-This document guides an administrator through the patch update to Cray Systems Management `v1.4.3` from `v1.4.0`, `v1.4.1`,
-or `1.4.2`. If upgrading from CSM `v1.3.x` directly to `v1.4.3`, follow the procedures described
-in [Upgrade CSM](../README.md) instead.
+This document guides an administrator through the patch update to Cray Systems Management `v1.4.3`
+from an earlier patch version of CSM `v1.4`. If upgrading from CSM `v1.3.x`,  then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`, then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+
+Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
+consider upgrading to the latest recent CSM `v1.4` patch release. See
+[CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements
 

--- a/upgrade/1.4.3/README.md
+++ b/upgrade/1.4.3/README.md
@@ -13,7 +13,7 @@ In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`
 described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
 
 Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
-consider upgrading to the latest recent CSM `v1.4` patch release. See
+consider upgrading to the latest CSM `v1.4` patch release. See
 [CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements

--- a/upgrade/1.4.4/README.md
+++ b/upgrade/1.4.4/README.md
@@ -12,9 +12,10 @@ described in [CSM major/minor version upgrade](../README.md#csm-majorminor-versi
 In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`, then follow the procedures
 described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
 
-Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
-consider upgrading to the latest recent CSM `v1.4` patch release. See
-[CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
+If there are more recent CSM `v1.4` patch versions available, note that there is no need to perform
+intermediate CSM `v1.4` patch upgrades. Instead, consider upgrading to the latest CSM `v1.4`
+patch release. See [CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full
+list of patch versions.
 
 ## Bug fixes and improvements
 

--- a/upgrade/1.4.4/README.md
+++ b/upgrade/1.4.4/README.md
@@ -7,9 +7,14 @@
 ## Introduction
 
 This document guides an administrator through the patch update to Cray Systems Management `v1.4.4`
-from `v1.4.0`, `v1.4.1`,
-`v1.4.2`, or `v1.4.3`. If upgrading from CSM `v1.3.x` directly to `v1.4.4`, follow the procedures described
-in [Upgrade CSM](../README.md) instead.
+from an earlier patch version of CSM `v1.4`. If upgrading from CSM `v1.3.x`,  then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+In the unusual situation of upgrading from a pre-release version of CSM `v1.4.0`, then follow the procedures
+described in [CSM major/minor version upgrade](../README.md#csm-majorminor-version-upgrade) instead.
+
+Also note that there is no need to perform intermediate CSM `v1.4` patch upgrades. Instead,
+consider upgrading to the latest recent CSM `v1.4` patch release. See
+[CSM patch version upgrade](../README.md#csm-patch-version-upgrade) for the full list of patch versions.
 
 ## Bug fixes and improvements
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -3,7 +3,23 @@
 There are several alternative procedures to perform an upgrade of Cray Systems Management (CSM)
 software. Choose the appropriate procedure from the sections below.
 
-## Option 1: Upgrade CSM with additional HPE Cray EX software products
+* [CSM major/minor version upgrade](#csm-majorminor-version-upgrade)
+    * [Option 1: Upgrade CSM with additional HPE Cray EX software products](#option-1-upgrade-csm-with-additional-hpe-cray-ex-software-products)
+    * [Option 2: Upgrade only additional HPE Cray EX software products](#option-2-upgrade-only-additional-hpe-cray-ex-software-products)
+    * [Option 3: Upgrade only CSM](#option-3-upgrade-only-csm)
+* [CSM patch version upgrade](#csm-patch-version-upgrade)
+
+## CSM major/minor version upgrade
+
+Follow one of these procedures when upgrading from CSM 1.3 to CSM 1.4 (regardless of patch version).
+(Additionally, in the unusual situation of upgrading from a pre-release version of CSM 1.4.0, then one of these
+procedure should be followed.)
+
+There is no need to upgrade from CSM 1.3 to CSM 1.4.0, and then separately upgrade from CSM 1.4.0 to the
+latest patch release. The procedures in this section can be used to upgrade from CSM 1.3 directly to the
+latest patch release of CSM 1.4.
+
+### Option 1: Upgrade CSM with additional HPE Cray EX software products
 
 To perform an upgrade of CSM along with additional HPE Cray EX software products, see the
 [Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
@@ -12,17 +28,32 @@ procedure.
 This is the most common procedure to follow, and it should be used when performing an upgrade from
 one HPC CSM software recipe to another.
 
-## Option 2: Upgrade only additional HPE Cray EX software products
+### Option 2: Upgrade only additional HPE Cray EX software products
 
 To perform an upgrade of only the additional HPE Cray EX software products without
 simultaneously upgrading CSM itself, see the
 [Install or upgrade additional products with IUF](../operations/iuf/workflows/install_or_upgrade_additional_products_with_iuf.md)
 procedure.
 
-## Option 3: Upgrade only CSM
+### Option 3: Upgrade only CSM
 
 To perform an upgrade of only CSM, see the [Upgrade Only CSM](Upgrade_Only_CSM.md) procedure.
 
 This option applies to CSM-only systems and systems which have additional HPE Cray EX software
 products installed, as long as those additional products are not also being upgraded. This is an
 uncommon upgrade scenario.
+
+## CSM patch version upgrade
+
+Follow one of these procedures when upgrading from CSM 1.4 to a newer patch version of CSM 1.4.
+(The one exception is in the unusual situation of upgrading from a pre-release version of CSM 1.4.0;
+in that case, follow the [CSM major/minor version upgrade](#csm-majorminor-version-upgrade)
+procedures).
+
+There is no need to perform intermediate CSM 1.4 patch upgrades. Instead, consider upgrading to the latest
+CSM 1.4 patch release.
+
+* [CSM 1.4.1 Patch Installation Instructions](1.4.1/README.md)
+* [CSM 1.4.2 Patch Installation Instructions](1.4.2/README.md)
+* [CSM 1.4.3 Patch Installation Instructions](1.4.3/README.md)
+* [CSM 1.4.4 Patch Installation Instructions](1.4.4/README.md)

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -2,7 +2,7 @@
 
 > **Reminders:**
 >
-> - CSM 1.3.0 or higher is required in order to upgrade to CSM 1.4.0.
+> - CSM 1.3.0 or higher is required in order to upgrade to CSM 1.4.
 > - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 >   [Relevant troubleshooting links for upgrade-related issues](Upgrade_Management_Nodes_and_CSM_Services.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
@@ -41,6 +41,8 @@ after a break, always be sure that a typescript is running before proceeding.
 ## Stage 0.1 - Prepare assets
 
 1. (`ncn-m001#`) Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
+
+   > If upgrading to a patch version of CSM 1.4, be sure to specify the correct patch version number when setting this variable.
 
    ```bash
    export CSM_RELEASE=1.4.0

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -42,7 +42,7 @@ after a break, always be sure that a typescript is running before proceeding.
 
 1. (`ncn-m001#`) Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
-   > If upgrading to a patch version of CSM 1.4, be sure to specify the correct patch version number when setting this variable.
+   > If upgrading to a patch version of CSM, be sure to specify the correct patch version number when setting this variable.
 
    ```bash
    export CSM_RELEASE=1.4.0

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -125,8 +125,8 @@ For additional reference material on the upgrade processes and scripts mentioned
    [2021-07-22 20:58:39] INSTALL_NEW_CONSOLE
    ```
 
-  - See the inline comment above on how to rerun a single step.
-  - In order to rerun the whole upgrade of a node, delete its state file.
+    - See the inline comment above on how to rerun a single step.
+    - In order to rerun the whole upgrade of a node, delete its state file.
 
 - Skip a step after running it manually
 

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -1,10 +1,15 @@
-# CSM 1.3.0 or later to 1.4.0 Upgrade Process
+# CSM 1.3 to 1.4 Upgrade Process
 
 ## Introduction
 
-This document guides an administrator through the upgrade of Cray Systems Management from version 1.3 to version 1.4. When upgrading a system, follow this top-level file
-from top to bottom. The content on this top-level page is meant to be terse. For additional reference material on the upgrade processes and scripts
-mentioned explicitly on this page, see [resource material](resource_material/README.md).
+This document guides an administrator through the upgrade of Cray Systems Management from version 1.3 to version 1.4.
+This procedure works for all patch versions of the source and target CSM releases.
+
+This procedure is also the correct one to follow in the unusual situation of upgrading from a pre-release version of CSM 1.4.0
+to a newer version of CSM 1.4.
+
+When upgrading a system, follow this top-level file from top to bottom. The content on this top-level page is meant to be terse.
+For additional reference material on the upgrade processes and scripts mentioned explicitly on this page, see [resource material](resource_material/README.md).
 
 ## Important notes
 


### PR DESCRIPTION
This PR attempts to clarify the valid and recommended procedures to follow when upgrading to a new CSM release. Notably it attempts to reduce confusion about when to follow the patch upgrade process versus the full-fat upgrade process.

CSM 1.5 backport: https://github.com/Cray-HPE/docs-csm/pull/4989
CSM 1.6 backport: https://github.com/Cray-HPE/docs-csm/pull/4990

In theory I could make backports for earlier CSM versions, but I'm always a bit leery when it comes to altering the upgrade docs, so I'm keeping it to the more recent CSM vintages.