### PR TITLE
CASMPET-6777-1.4 : System Recovery rapid_rebuild and rapid_reinstall scripts

### DIFF
--- a/scripts/operations/system_recovery/rapid_rebuild.sh
+++ b/scripts/operations/system_recovery/rapid_rebuild.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -o pipefail
+
+# Print an error message and exit
+function err_exit {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Must run from m001
+if [[ $(hostname) != "ncn-m001" ]]; then
+  err_exit "Must be run on m001"
+fi
+
+# Remove any strings 'registry.local' or 'packages.local' from any lines in /etc/hosts
+# Add or replace the pit line to include 'registry.local' and 'packages.local'
+cp /etc/hosts /etc/hosts."$(date +%Y%m%d_%H%M%S)"
+IP=$(grep ncn-m001.nmn /etc/hosts | awk '{print $1}')
+pitregistry="${IP}      pit.nmn pit registry.local packages.local"
+sed -i -E -e 's/registry.local//g' -e 's/packages.local//g' /etc/hosts
+grep -q pit /etc/hosts && sed -i "s/.*pit.*/${pitregistry}/" /etc/hosts || echo ${pitregistry} >> /etc/hosts
+
+# Exit if required services are not running -- dnsmasq will be checked later
+systemctl is-active --quiet nexus.service \
+  && systemctl is-active --quiet minio.service \
+  && systemctl is-active --quiet basecamp.service \
+  && systemctl is-active --quiet apache2.service \
+  && systemctl is-active --quiet conman.service \
+  && systemctl is-active --quiet apparmor.service \
+  && echo "Pit disk services are running" || err_exit "Not all pit disk services are running"
+
+# Check that needed environment variables are set
+env_vars=("IPMI_PASSWORD" "SYSTEM_NAME")
+for each in "${env_vars[@]}"; do
+  if [ -z "${!each}" ]; then
+    err_exit "$each is not defined"
+  fi
+done
+
+# Reset all the NCN keys
+truncate --size=0 /root/.ssh/known_hosts 2>&1
+grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts
+
+# Disable/stop etcd on m001 and delete the database
+systemctl disable --now etcd.service
+rm -rf /var/lib/etcd/*
+
+# Temporary backup of files
+mkdir -p /tmp/backup_kubernetes
+mv /etc/kubernetes/* /tmp/backup_kubernetes/
+
+# Remove files in /etc/ceph from m001
+rm -rf /etc/ceph/*
+
+# Unmount /etc/cray/upgrade/csm on m001
+umount /etc/cray/upgrade/csm --force
+
+# Remove the all master and worker NCNs from the kubernetes cluster
+pdsh -b -w "$(grep -oP '(ncn-m\w+|ncn-w\w+)' /etc/hosts | sort -u | tr -t '\n' ',')" 'kubeadm reset -f'
+
+# Remove the kube-ipvs0 link -- https://github.com/k3s-io/k3s/issues/5643
+pdsh -b -w "$(grep -oP '(ncn-m\w+|ncn-w\w+)' /etc/hosts | sort -u | tr -t '\n' ',')" 'ip link delete kube-ipvs0'
+
+# Now that k8s is shutdown, start dnsmasq and setup the squash fs links
+systemctl start dnsmasq.service
+
+# Set network config for PIT/dnsmasq on m001
+sed -i 's/^NETCONFIG_DNS_POLICY=.*/NETCONFIG_DNS_POLICY="auto"/' /etc/sysconfig/network/config
+sed -i -E 's/NETCONFIG_DNS_FORWARDER="\w+"/NETCONFIG_DNS_FORWARDER="dnsmasq"/' /etc/sysconfig/network/config
+netconfig update -f
+
+# Setup links for NCN boot images and check DHCP
+/root/bin/set-sqfs-links.sh
+
+# Fix links for worker NCN images
+echo "Updating boot artifact links for NCN worker nodes..."
+pushd /var/www || err_exit "Failed changing directory to /var/www"
+# shellcheck disable=SC2045
+for WDIR in $(ls -d ncn-w*); do
+  echo "Updating boot artifact links for $WDIR..."
+  pushd $WDIR || err_exit "Failed changing directory to $(pwd)/$WDIR"
+  # Modify links to point to worker images
+  for art in kernel initrd.img.xz rootfs; do
+    new_target=$(ls -l $art | awk '{ print $NF }' | sed 's#/data/k8s/#/data/worker/#') || err_exit "Error parsing symbolic link: $(pwd)/$art"
+    [[ -n $new_target ]] || err_exit "Error finding target of symbolic link $(pwd)/$art"
+    [[ -f $new_target ]] || err_exit "File does not exist: $(pwd)/$new_target"
+    ln -snf $new_target $art || err_exit "Command failed: ln -snf $new_target $art"
+  done
+  popd || err_exit "Failed changing directory back to /var/www"
+done
+popd || err_exit "Failed returning to previous directory"
+
+# Edit /etc/dnsmasq.d/statics.conf on m001 for pit nexus
+DNSFILE="/etc/dnsmasq.d/statics.conf"
+NMNIP=$(grep ncn-m001.nmn /etc/hosts | awk '{print $1}')
+pitnexus="host-record=registry,registry.local,packages,packages.local,${NMNIP} # pit nexus"
+sed -i "s/.*registry.*/${pitnexus}/" ${DNSFILE}
+systemctl restart dnsmasq.service
+
+# Edit m001 /etc/hosts to comment out ipv6 entry for ncn-m001 (.e.g. ::1 drax-ncn-m001.local drax-ncn-m001 ncn-m001 x3000c0s1b0n0)
+sed -i '/^::1 '"${SYSTEM_NAME}"'/s/^/#/' /etc/hosts
+
+# Exit if dnsmasq service is not running
+systemctl is-active --quiet dnsmasq.service \
+  && echo "Pit disk dnsmasq service is running" || err_exit "Pit disk dnsmasq service is not running"
+
+export mtoken='ncn-m(?!001)\w+-mgmt'
+export stoken='ncn-s\w+-mgmt'
+export wtoken='ncn-w\w+-mgmt'
+USERNAME=$(whoami)
+export USERNAME
+
+# Power off the NCNs (excluding ncn-m001)
+ncn_list="$(grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u)"
+echo "$ncn_list" | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
+
+# Wait for the NCNs to power off before powering back on. Exit if any NCNs still report as on after 1 minute.
+count=0
+powerStatus=$(echo "$ncn_list" | xargs -i ipmitool -I lanplus -U $USERNAME -E -H {} power status)
+while [[ $count -lt 6 ]] && [[ $powerStatus =~ "is on" ]]; do
+  sleep 10
+  powerStatus=$(echo "$ncn_list" | xargs -i ipmitool -I lanplus -U $USERNAME -E -H {} power status)
+  count=$((count + 1))
+done
+if [[ $powerStatus =~ "is on" ]]; then
+  err_exit "Not all NCNs have powered off"
+fi
+
+# Set the NCNs to PXE boot
+echo "$ncn_list" | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=efiboot
+
+# Power on and rebuild the NCNs
+echo "$ncn_list" | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on

--- a/scripts/operations/system_recovery/rapid_reinstall.sh
+++ b/scripts/operations/system_recovery/rapid_reinstall.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Print an error message and exit
+function err_exit {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Must run from m001
+if [[ $(hostname) != "ncn-m001" ]]; then
+  err_exit "Must be run on m001"
+fi
+
+# Yapl must be installed
+rpm -qi yapl > /dev/null 2>&1 || err_exit "Yapl must be installed"
+
+# Check that needed environment variables are set
+env_vars=("CSM_RELEASE" "SYSTEM_NAME")
+for each in "${env_vars[@]}"; do
+  if [ -z "${!each}" ]; then
+    err_exit "$each must be defined"
+  fi
+done
+
+export PITDATA=/var/www/ephemeral
+export CSM_PATH="${PITDATA}/csm-${CSM_RELEASE}"
+export SLS_INPUT_FILE=${PITDATA}/prep/${SYSTEM_NAME}/sls_input_file.json
+
+# Reset all the NCN keys
+truncate --size=0 /root/.ssh/known_hosts 2>&1
+grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts
+
+# Copy the k8s admin conf from m002
+scp ncn-m002:/etc/kubernetes/admin.conf /etc/kubernetes/admin.conf
+cp /etc/kubernetes/admin.conf $HOME/.kube/config
+
+# Clear the whole IPVS routing table on m001 (this may have been setup if kube-proxy was ever running on m001).
+# This will allow for m001 to use unbound once it is running in the k8s cluster.
+ipvsadm --clear
+
+# Start the CSM install
+pushd /usr/share/doc/csm/install/scripts/csm_services || err_exit "Failed changing directory to /usr/share/doc/csm/install/scripts/csm_services"
+if ! yapl -f install1thru4.yaml execute --no-cache; then
+  err_exit "Address any errors above and re-run rapid_reinstall.sh"
+fi
+
+# Edit the host file to move from the pit nexus to k8s nexus for packages.local and registry.local.
+# This is needed before step5 where k8s nexus is setup.
+UNBOUNDIP=10.92.100.71
+ncnregistry="${UNBOUNDIP}    registry.local packages.local"
+sed -i "s/.*registry.*/${ncnregistry}/" /etc/hosts
+
+# Complete the CSM install
+yapl -f install5thru7.yaml execute --no-cache
+popd || err_exit "Failed returning to previous directory"
+
+# Post install WARs
+# If the keycloak users-localize job failed, re-run it.
+if kubectl get job -l app.kubernetes.io/instance=cray-keycloak-users-localize -n services --no-headers | grep -q "1/1"; then
+  echo "Keycloak users-localize job completed"
+else
+  echo "Keycloak users-localize job failed -- re running ..."
+  LOCALIZE_JOB=$(kubectl -n services get jobs -l app.kubernetes.io/name=cray-keycloak-users-localize -o name)
+  kubectl -n services get "${LOCALIZE_JOB}" -o json | jq 'del(.spec.selector)' \
+    | jq 'del(.spec.template.metadata.labels."controller-uid")' \
+    | kubectl replace --force -f -
+  kubectl -n services wait "${LOCALIZE_JOB}" --for=condition=complete --timeout=15m
+fi
+
+# Create base BSS Global boot parameters
+# https://github.com/Cray-HPE/docs-csm/blob/release/1.4/install/install_csm_services.md#2-create-base-bss-global-boot-parameters
+TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+  -d client_id=admin-client \
+  -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
+  https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+export TOKEN
+curl -i -k -H "Authorization: Bearer ${TOKEN}" -X PUT \
+  https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
+  --data '{"hosts":["Global"]}'
+
+SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=spire-update-bss -o name)
+kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
+  | jq 'del(.spec.template.metadata.labels."controller-uid")' \
+  | kubectl replace --force -f -
+kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m


### PR DESCRIPTION
# Description
Resolves CASMPET-6777 for release/1.4
System Recovery scripts for rapid_rebuild and rapid_reinstall
Tested on wasp and being tested in UKMet/TDSY

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
