### PR TITLE
CASMHMS-5630: Remove references to REDS service v1.5.1

### DIFF
--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -62,7 +62,6 @@ The following projects are not backed up as part of the automated solution:
 - Content Projection Service \(CPS\)
 - Heartbeat Tracking Daemon \(HBTD\)
 - HMS Notification Fanout Daemon \(HMNFD\)
-- River Endpoint Discovery Service \(REDS\)
 
 If these clusters become unhealthy, the process for rediscovering their data should be followed.
 See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -38,8 +38,6 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 - [CPS](#cps)
 - [FAS](#fas)
 - [HMNFD](#hmnfd)
-- [MEDS](#meds)
-- [REDS](#reds)
 
 ### BOS
 
@@ -95,11 +93,3 @@ Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their St
     ```bash
     pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
     ```
-
-### MEDS
-
-(`ncn-mw#`) Restart MEDS.
-
-```bash
-kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
-```

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -4,14 +4,14 @@ When an etcd cluster is not healthy, it needs to be rebuilt. During that process
 That data needs to be repopulated in order for the cluster to go back to a healthy state.
 
 - [Repopulate Data in etcd Clusters When Rebuilding Them](#repopulate-data-in-etcd-clusters-when-rebuilding-them)
-  - [Applicable services](#applicable-services)
-  - [Prerequisites](#prerequisites)
-  - [Procedures](#procedures)
-    - [BOS](#bos)
-    - [BSS](#bss)
-    - [CPS](#cps)
-    - [FAS](#fas)
-    - [HMNFD](#hmnfd)
+    - [Applicable services](#applicable-services)
+    - [Prerequisites](#prerequisites)
+    - [Procedures](#procedures)
+        - [BOS](#bos)
+        - [BSS](#bss)
+        - [CPS](#cps)
+        - [FAS](#fas)
+        - [HMNFD](#hmnfd)
 
 ## Applicable services
 

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -12,8 +12,6 @@ That data needs to be repopulated in order for the cluster to go back to a healt
     - [CPS](#cps)
     - [FAS](#fas)
     - [HMNFD](#hmnfd)
-    - [MEDS](#meds)
-    - [REDS](#reds)
 
 ## Applicable services
 
@@ -25,7 +23,6 @@ The following services need their data repopulated in the etcd cluster:
 - Firmware Action Service \(FAS\)
 - HMS Notification Fanout Daemon \(HMNFD\)
 - Mountain Endpoint Discovery Service \(MEDS\)
-- River Endpoint Discovery Service \(REDS\)
 
 ## Prerequisites
 

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -52,26 +52,7 @@ Boot preparation information for other product streams can be found in the follo
 
 ### BSS
 
-Data is repopulated in BSS when the REDS `init` job is run.
-
-1. (`ncn-mw#`) Get the current REDS job.
-
-    ```bash
-    kubectl get -o json -n services job/cray-reds-init |
-            jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
-    ```
-
-1. (`ncn-mw#`) Delete the `reds-client-init` job.
-
-    ```bash
-    kubectl delete -n services -f cray-reds-init.json
-    ```
-
-1. (`ncn-mw#`) Restart the `reds-client-init` job.
-
-    ```bash
-    kubectl apply -n services -f cray-reds-init.json
-    ```
+Restore BSS from the ETCD backup see [Restore an ETCD Cluster from a Backup](Restore_an_etcd_Cluster_from_a_Backup.md)
 
 ### CPS
 
@@ -121,12 +102,4 @@ Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their St
 
 ```bash
 kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
-```
-
-### REDS
-
-(`ncn-mw#`) Restart REDS.
-
-```bash
-kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
 ```


### PR DESCRIPTION
# Description

Removed references to REDS in the ETCD database and in restoring BSS.

CASMHMS-5630

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
