### PR TITLE
CASMTRIAGE-6809: Update BOS function name in IMS export tool

### DIFF
--- a/scripts/operations/configuration/python_lib/ims_import_export/exported_data.py
+++ b/scripts/operations/configuration/python_lib/ims_import_export/exported_data.py
@@ -341,7 +341,7 @@ def get_all_s3_links_from_bos_session_templates() -> S3UrlList:
         s3_links.append(s3_url)
 
     logging.info("Scanning BOS session templates for S3 artifact links")
-    for template in bos.list_v2_session_templates():
+    for template in bos.list_session_templates():
         template_name = template["name"]
         try:
             boot_sets = template["boot_sets"]


### PR DESCRIPTION
In CSM 1.6, with the removal of BOS v1, the BOS module (`scripts/operations/configurations/python_lib/bos.py`) changed the `list_v2_session_templates` function name to `list_session_templates`. This PR updates the IMS export tool to use the correct function name.

No backports needed as the function name change happened only in CSM 1.6