### PR TITLE
CASMTRIAGE-6875: Clarify which WLM documentation to use for WLM backups before upgrading CSM

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -508,9 +508,14 @@ Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data).
 
 ## Stage 0.4 - Backup workload manager data
 
-To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
-the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the
-`HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
+To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures for the workload manager in use,
+using the backup procedures for the currently installed version of the workload manager (not the target version of the upgrade, if the WLM is also being upgraded).
+The resulting backup data should be stored in a safe location off of the system. See the following links for the backup procedures:
+
+- For PBS, see `8.1 Backup PBS home directory` in
+  [HPE Portable Batch System Installation Guide: CSM on HPE Cray EX Systems (`S-8055`)](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=dp00004161en_us).
+- For Slurm, see `8.1 Backup Slurm accounting database` and `8.3 Backup Slurm spool directory` in
+  [HPE Slurm Installation Guide: CSM on HPE Cray EX Systems (`S-8058`)](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=dp00004162en_us).
 
 If performing an upgrade of CSM and additional HPE Cray EX software products using the IUF,
 return to the [Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)


### PR DESCRIPTION
CSM 1.6 version of: https://github.com/Cray-HPE/docs-csm/pull/5003