### PR TITLE
CASMINST-6849: Linting and minor fixes

### DIFF
--- a/operations/multi-tenancy/TenantAdminConfig.md
+++ b/operations/multi-tenancy/TenantAdminConfig.md
@@ -1,20 +1,19 @@
 # Tenant Administrator Configuration
 
-- [Tenant Administrator Configuration](#tenant-administrator-configuration)
-  - [Overview](#overview)
-  - [Cray CLI Integration](#cray-cli-integration)
-  - [Kubernetes OIDC API integration](#kubernetes-oidc-api-integration)
-  - [Tenant-specific Keycloak groups](#tenant-specific-keycloak-groups)
-  - [`Roles` and `Rolebindings`](#roles-and-rolebindings)
-  - [Retrieve an OIDC token](#retrieve-an-oidc-token)
-  - [Using `kubelogin`](#using-kubelogin)
+- [Overview](#overview)
+- [Cray CLI integration](#cray-cli-integration)
+- [Kubernetes OIDC API integration](#kubernetes-oidc-api-integration)
+- [Tenant-specific Keycloak groups](#tenant-specific-keycloak-groups)
+- [`Roles` and `Rolebindings`](#roles-and-rolebindings)
+- [Retrieve an OIDC token](#retrieve-an-oidc-token)
+- [Using `kubelogin`](#using-kubelogin)
 
 ## Overview
 
 This page describes how to configure a user as a `Tenant Administrator`, allowing that person to perform administrative functions on one or more tenants,
 without giving them the same permissions an `Infrastructure Administrator` would have.
 
-## Cray CLI Integration
+## Cray CLI integration
 
 When using the `cray` CLI for various operations specific to tenant-owned resources (Compute/Application Nodes), the CLI should be scoped to the appropriate tenant when `cray init` is executed.
 The CLI supports the optional `--tenant <tenant-name>` argument, which subsequently passes the `cray-tenant-name` value in the header for API requests to the respective service.
@@ -57,7 +56,7 @@ Below is an example of a YAML file which will give a user some basic permissions
 
 ```yaml
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tenant-admin-role
 rules:
@@ -69,7 +68,7 @@ rules:
     verbs: ["patch", "get", "watch", "list"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tenant-admin-rb-blue
   namespace: vcluster-blue
@@ -83,7 +82,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tenant-admin-tenants-blue-rb
   namespace: tenants
@@ -104,7 +103,9 @@ Note the reference to the Keycloak group `vcluster-blue-tenant-admin` in each of
 (`ncn-mw#`) The following command is an example of how to retrieve an OIDC token for interacting directly with the Kubernetes API:
 
 ```bash
-TOKEN=$(curl -k -s -d scope=openid -d response_type=id_token -d grant_type=password -d client_id=kubernetes-api-oidc-client -d password=<REDACTED> -d username=tenant-admin https://api-gateway.vshasta.io/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.id_token')
+TOKEN=$(curl -k -s -d scope=openid -d response_type=id_token -d grant_type=password \
+            -d client_id=kubernetes-api-oidc-client -d password=<REDACTED> -d username=tenant-admin \
+            https://api-gateway.vshasta.io/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.id_token')
 ```
 
 Decoding this token will illustrate the `groups` and `name` claims added by Keycloak:
@@ -115,44 +116,33 @@ This token can now be used by a the tenant administrator to interact with Kubern
 
 - (`ncn-mw#`) The following is an example of listing pods in the `vcluster-blue` namespace (which was specified in the `ClusterRole` above as allowed):
 
-  ```bash
-  curl -k -H "Authorization: Bearer $TOKEN"  https://kubernetes-api.vshasta.io:6443/api/v1/namespaces/vcluster-blue/pods
-  ```
-
-  Example output:
-
-  ```text
-  {
-    "kind": "PodList",
-    "apiVersion": "v1",
-    "metadata": {
-    "resourceVersion": "5860840"
-  },
-  "items": []
-  ```
+    ```bash
+    curl -k -H "Authorization: Bearer $TOKEN" https://kubernetes-api.vshasta.io:6443/api/v1/namespaces/vcluster-blue/pods
+    ```
 
 - (`ncn-mw#`) Note that this token could not be used to list pods in a different namespace (`services` for example):
 
     ```bash
-    curl -k -H "Authorization: Bearer $TOKEN"  https://kubernetes-api.vshasta.io:643/api/v1/namespaces/services/pods
+    curl -k -H "Authorization: Bearer $TOKEN" https://kubernetes-api.vshasta.io:643/api/v1/namespaces/services/pods
     ```
 
     Example output:
 
-    ```text
+    ```json
     {
-    "kind": "Status",
-    "apiVersion": "v1",
-    "metadata": {
-  
-    },
-    "status": "Failure",
-    "message": "pods is forbidden: User \"https://api-gateway.vshasta.io/keycloak/realms/shasta#tenant-admin\" cannot list resource \"pods\" in API group \"\" in the namespace \"services\"",
-    "reason": "Forbidden",
-    "details": {
-      "kind": "pods"
-    },
-    "code": 403
+      "kind": "Status",
+      "apiVersion": "v1",
+      "metadata": {
+
+      },
+      "status": "Failure",
+      "message": "pods is forbidden: User \"https://api-gateway.vshasta.io/keycloak/realms/shasta#tenant-admin\" cannot list resource \"pods\" in API group \"\" in the namespace \"services\"",
+      "reason": "Forbidden",
+      "details": {
+        "kind": "pods"
+      },
+      "code": 403
+    }
     ```
 
 ## Using `kubelogin`


### PR DESCRIPTION
Fixes a couple of minor errors:
* The multitenancy page uses the wrong RBAC version
* One IMS command example output does not match the command being run

Also linted both pages.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/5015
1.4: https://github.com/Cray-HPE/docs-csm/pull/5016
1.3: https://github.com/Cray-HPE/docs-csm/pull/5017
1.2: https://github.com/Cray-HPE/docs-csm/pull/5018
1.0: https://github.com/Cray-HPE/docs-csm/pull/5019