### PR TITLE
CASMINST-6852: Add restarts of CFS deployments to CSM upgrade scripts

### DIFF
--- a/upgrade/scripts/common/restart-cfs.sh
+++ b/upgrade/scripts/common/restart-cfs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Restart CFS deployments to avoid CASMINST-6852
+
+set -e -o pipefail
+
+function err_exit {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+function run_cmd {
+  "$@" || err_exit "Command failed with rc $?: $*"
+}
+
+CFS_DEPLOYMENTS="cray-cfs-api, cray-cfs-batcher, cray-cfs-operator, cfs-trust, cfs-hwsync-agent, cfs-ara"
+
+# First wait until all CFS pods are running (or timeout if this has not happened after 10 minutes)
+WAIT_MINUTES=10
+
+# Get tempfile
+TEMPFILE=$(mktemp)
+
+echo "$(date) Waiting for all CFS pods to be Running"
+
+let CFS_RUNNING_TIMEOUT=SECONDS+WAIT_MINUTES*60
+while true; do
+  run_cmd kubectl get pods -l "app.kubernetes.io/instance in (${CFS_DEPLOYMENTS})" -n services --no-headers > "${TEMPFILE}"
+  [[ -s ${TEMPFILE} ]] || err_exit "Command gave no output: kubectl get pods -l 'app.kubernetes.io/instance in (${CFS_DEPLOYMENTS})' -n services --no-headers"
+  grep -qv Running "${TEMPFILE}" || break
+  [[ ${SECONDS} -le ${CFS_RUNNING_TIMEOUT} ]] || err_exit "Not all CFS pods running even after waiting ${WAIT_MINUTES} minutes"
+  sleep 10
+done
+
+echo "$(date) Initiating rolling restarts of all CFS deployments"
+
+# Now do restarts
+run_cmd kubectl rollout restart deployment -n services ${CFS_DEPLOYMENTS//,/}
+
+echo "$(date) Waiting for all CFS deployments to complete rolling restarts"
+
+# And wait for them to complete successfully
+for DEP in ${CFS_DEPLOYMENTS//,/}; do
+  run_cmd kubectl rollout status deployment -n services ${DEP}
+done
+
+echo "$(date) All CFS deployment restarts completed"

--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -153,6 +153,9 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+# Restart CFS deployments to avoid CASMINST-6852
+"${basedir}/../common/restart-cfs.sh"
+
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."
 GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-post-csm-service-upgrade-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1422,6 +1422,9 @@ for chart_name in "${CHARTS[@]}"; do
   do_upgrade_csm_chart "${chart_name}" sysmgmt.yaml
 done
 
+# Restart CFS deployments to avoid CASMINST-6852
+"${locOfScript}/../common/restart-cfs.sh"
+
 # Ensure kata containers hypervisor file has the list of annotations required for CSM 1.5 CASMTRIAGE-6414
 for node in $(kubectl get nodes | grep -E "^ncn-w[0-9]" | awk '{ print $1 }'); do
   ssh "${node}" "sed -i 's/\[\"enable_iommu\"\]/[\"enable_iommu\", \"virtio_fs_extra_args\", \"default_memory\", \"kernel_params\", \"cpu_features\"]/' /opt/kata/share/defaults/kata-containers/configuration-qemu.toml"


### PR DESCRIPTION
We don't know the root cause, but we have seen issues multiple times during CSM upgrades where the CFS deployments needed to be restarted in order to fully pick up the new service versions. This PR modifies the two scripts where the CFS deployments can be upgraded, and adds a step at the end to restart them, which should hopefully avoid the issues we have been seeing. The service restarts only take a minute or two, so it should not substantially increase the upgrade time.

CSM 1.6 backport: https://github.com/Cray-HPE/docs-csm/pull/5037