### PR TITLE
CASMINST-6854: IMS import/export: Log command-line arguments

### DIFF
--- a/scripts/operations/configuration/export_ims_data.py
+++ b/scripts/operations/configuration/export_ims_data.py
@@ -103,6 +103,8 @@ def main():
     logfile=os.path.join(LOG_DIR, datetime.datetime.now().strftime("%Y%m%d%H%M%S.log"))
     print(f"Detailed logging will be recorded to: {logfile}")
     logger.configure_logging(filename=logfile)
+    logging.debug("Command-line arguments: %s", sys.argv)
+    logging.debug("Parsed arguments: %s", parsed_args)
 
     try:
         export_options = ims_import_export.ExportOptions(

--- a/scripts/operations/configuration/import_ims_data.py
+++ b/scripts/operations/configuration/import_ims_data.py
@@ -138,6 +138,8 @@ def main():
     logfile=os.path.join(LOG_DIR, datetime.datetime.now().strftime("%Y%m%d%H%M%S.log"))
     print(f"Detailed logging will be recorded to: {logfile}")
     logger.configure_logging(filename=logfile)
+    logging.debug("Command-line arguments: %s", sys.argv)
+    logging.debug("Parsed arguments: %s", script_args)
 
     try:
         do_import(script_args)


### PR DESCRIPTION
Just add logging of the command-line arguments for the IMS import/export tools, to make detective work easier.

Backports:

CSM 1.3: https://github.com/Cray-HPE/docs-csm/pull/5051
CSM 1.5: https://github.com/Cray-HPE/docs-csm/pull/5052
CSM 1.6: https://github.com/Cray-HPE/docs-csm/pull/5053