### PR TITLE
CASM-4669 Upload signatures along with images

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -83,7 +83,7 @@ function get_latest_tag_for_image() {
             | capture("^(?<v>[^-]+)(?:-(?<p>.*))?$") | [.v, .p // empty]
             | map(split(".") | map(opt(tonumber)))
             | .[1] |= (. // {});
-    .[0].Tags | sort_by(.|semver_cmp) | map(select(. != "csm-latest")) | last'
+    .[0].Tags | sort_by(.|semver_cmp) | map(select(. != "csm-latest" and (. | endswith(".sig") | not))) | last'
 }
 
 function get_filenames_referring_to_image() {


### PR DESCRIPTION
# Description

With container images being pushed into Nexus together with Sigstore attachments, a couple of changes is needed in upgrade process:

1. Nexus must be upgraded before most images can be uploaded into it. Current version of Nexus (3.38.1) is not capable of holding both multi-platform images and Sigstore attachments. This change adds pre-caching images and upgrade of `cray-nexus` chart to `prerequisites.sh`.
2. Sigstore attachments are visible in Nexus as additional tags of form `sha256-*.sig` in Nexus. This breaks logic of `update-tags.sh` script, which injects latest tag of certain images into workflow files. This change updates `update-tags.sh` to exclude signatures from tag list.

Testing performed full cycle install and upgrade on vShasta, with RPM created from dev branch:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/feature%2Fimage-signatures/13/pipeline

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
