### PR TITLE
CASMTRIAGE-6942 Do not remove spaces

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1123,7 +1123,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     for ncn_xname in "${NCN_XNAMES[@]}"; do
 
       params=$(cray bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[] |."params"' \
-        | sed -E 's/ ip=hsn[0-9]+:auto6 //g' \
+        | sed -E 's/ip=hsn[0-9]+:auto6//g' \
         | tr -d \")
 
       if ! cray bss bootparameters update --hosts "${ncn_xname}" \


### PR DESCRIPTION
Amendment to #4868.

Do not remove any spaces, this will fix multiple cases:
- Removing ip=hsn\d+:auto6` when it is the leading argument in the boot paremeters.
- Breaking boots by joining the surrounding boot parameters together (CASMTRIAGE-6942)
