### PR TITLE
CASMTRIAGE-6969 update management-nodes-rollout docs with storage and masters having different CFS configs

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -298,7 +298,7 @@ Refer to that table and any corresponding product documents before continuing to
 
         Sample output for configuring multiple management nodes is:
 
-          ```bash
+          ```text
           Taking snapshot of existing minimal-management-23.11.0 configuration to /root/apply_csm_configuration.20240305_173700.vKxhqC backup-minimal-management-23.11.0.json
           Setting desired configuration, clearing state, clearing error count, enabling components in CFS
           desiredConfig = "minimal-management-23.11.0"

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -213,22 +213,17 @@ Refer to that table and any corresponding product documents before continuing to
 
 1. Rebuild the NCN worker nodes. Follow the procedure in section [3.3 NCN worker nodes](#33-ncn-worker-nodes) and then return to this procedure to complete the next step.
 
-1. Configure NCN master and NCN storage nodes.
+1. Configure NCN master nodes.
 
-    1. (`ncn-m#`) Create a comma-separated list of the xnames for all NCN master and NCN storage nodes and verify they are correct.
+    1. (`ncn-m#`) Create a comma-separated list of the xnames for all NCN master nodes and verify they are correct.
 
         ```bash
         MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
-        STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
-        MASTER_STORAGE_XNAMES="${MASTER_XNAMES},${STORAGE_XNAMES}"
         echo "Master node xnames: $MASTER_XNAMES"
-        echo "Storage node xnames: $STORAGE_XNAMES"
-        echo "Master and storage node xnames: $MASTER_STORAGE_XNAMES"
         ```
 
     1. Get the CFS configuration created for management nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created)
-       documentation to get the value for `configuration` for any image with a `configuration_group_name` value matching `Management_Master`,`Management_Worker`, or `Management_Storage` (since `configuration` is the same for all
-       management nodes).
+       documentation to get the value for `configuration` for the image with a `configuration_group_name` value matching `Management_Master`.
 
     1. (`ncn-m#`) Set `CFS_CONFIG_NAME` to the value for `configuration` found in the previous step.
 
@@ -236,11 +231,11 @@ Refer to that table and any corresponding product documents before continuing to
         CFS_CONFIG_NAME=<appropriate configuration value>
         ```
 
-    1. (`ncn-m#`) Apply the CFS configuration to NCN master nodes and NCN storage nodes.
+    1. (`ncn-m#`) Apply the CFS configuration to NCN master nodes.
 
         ```bash
         /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-        --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $MASTER_STORAGE_XNAMES --clear-state
+        --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $MASTER_XNAMES --clear-state
         ```
 
         Sample output for configuring multiple management nodes is:
@@ -265,6 +260,64 @@ Refer to that table and any corresponding product documents before continuing to
           [tags]
 
           desiredConfig = "management-23.11.0"
+          enabled = true
+          errorCount = 0
+          id = "x3702c0s16b0n0"
+          state = []
+
+          [tags]
+
+          Waiting for configuration to complete. 3 components remaining.
+          Configuration complete. 3 component(s) completed successfully.  0 component(s) failed.
+          ```
+
+1. Configure NCN storage nodes.
+
+    1. (`ncn-m#`) Create a comma-separated list of the xnames for all NCN storage nodes and verify they are correct.
+
+        ```bash
+        STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+        echo "Storage node xnames: $STORAGE_XNAMES"
+        ```
+
+    1. Get the CFS configuration created for management storage nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created)
+       documentation to get the value for `configuration` for the image with a `configuration_group_name` value matching `Management_Storage`.
+
+    1. (`ncn-m#`) Set `CFS_CONFIG_NAME` to the value for `configuration` found in the previous step.
+
+        ```bash
+        CFS_CONFIG_NAME=<appropriate configuration value>
+        ```
+
+    1. (`ncn-m#`) Apply the CFS configuration to NCN storage nodes.
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+        --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $STORAGE_XNAMES --clear-state
+        ```
+
+        Sample output for configuring multiple management nodes is:
+
+          ```bash
+          Taking snapshot of existing minimal-management-23.11.0 configuration to /root/apply_csm_configuration.20240305_173700.vKxhqC backup-minimal-management-23.11.0.json
+          Setting desired configuration, clearing state, clearing error count, enabling components in CFS
+          desiredConfig = "minimal-management-23.11.0"
+          enabled = true
+          errorCount = 0
+          id = "x3700c0s16b0n0"
+          state = []
+
+          [tags]
+
+          desiredConfig = "minimal-management-23.11.0"
+          enabled = true
+          errorCount = 0
+          id = "x3701c0s16b0n0"
+          state = []
+
+          [tags]
+
+          desiredConfig = "minimal-management-23.11.0"
           enabled = true
           errorCount = 0
           id = "x3702c0s16b0n0"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

During management-nodes-rollout without performing a CSM upgrade, storage nodes and master nodes are manually configured with CFS. The documented instructions configured both master nodes and storage nodes with the same configuration. This is incorrect as storage nodes have a different CFS configuration.

This PR updates the procedure so that both master nodes and storages nodes have their own CFS configuration step. This allows the nodes to be configured with different configurations.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
