### PR TITLE
CASMINST-6861: copy_ims_data_from_minio: Do not store files in /var/lib/etcd

### DIFF
--- a/scripts/operations/configuration/copy_ims_data_from_minio.py
+++ b/scripts/operations/configuration/copy_ims_data_from_minio.py
@@ -419,7 +419,6 @@ def create_local_directories(logfile_path: str) -> LocalDirList:
     """
     ims_export_dir = create_main_export_dir(logfile_path)
     local_dir_list = LocalDirList(ims_export_dir)
-    local_dir_list.add_dir(base_dir="/var/lib/etcd", min_gb=10)
     local_dir_list.add_dir(base_dir="/root", max_pct=70)
     local_dir_list.add_dir(base_dir="/var/lib/s3fs_cache", min_gb=1)
     local_dir_list.add_dir(base_dir="/metal/recovery", max_pct=75, require_1gb_avail=False)


### PR DESCRIPTION
Turns out they may get wiped out by the rapid rebuild process.

Backports:
CSM 1.5: https://github.com/Cray-HPE/docs-csm/pull/5088
CSM 1.4: https://github.com/Cray-HPE/docs-csm/pull/5089

No earlier backports needed.