### PR TITLE
CASMPET-6979 fix command getting active_mgr_version in storage node upgrade

### DIFF
--- a/workflows/templates/storage.add-node-to-ceph.yaml
+++ b/workflows/templates/storage.add-node-to-ceph.yaml
@@ -104,7 +104,7 @@ spec:
                         ssh ${TARGET_NCN} podman pull $image
                     done
                     active_mgr=$(ceph mgr dump | jq -r .active_name)
-                    active_mgr_version=$(ceph orch ps -f json | jq --arg MGR $active_mgr '.[] | select(.daemon_name | contains($MGR)) | .version' | tr -d '"')
+                    active_mgr_version=$(ceph orch ps -f json | jq --arg MGR mgr.$active_mgr '.[] | select(.daemon_name | contains($MGR)) | .version' | tr -d '"')
                     ssh ${TARGET_NCN} podman pull "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v${active_mgr_version}"
           - name: copy-ceph-pub
             templateRef:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
An edge case was hit on Rocket. For some reason, the mgr ceph daemons do not have a random string at the end of their name. Their names are 

mgr.ncn-s001
mgr.ncn-s002
mgr.ncn-s003.qwflht

This means that when the storage node upgrade tried to get the version for the active mgr, it search for all Ceph daemons that contained the node name only. For example, if mgr.ncn-s002 was the active mgr daemon, the upgrade searched for versions of daemons with the name ncn-s002. This happens to be many different daemons.

The fix in this PR make the command look for daemons with the name mgr.ncn-s002 which results in getting only the correct version.

This error is an EDGE CASE and I am not sure how Rocket go into this position.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
