### PR TITLE
CASMHMS-6162 - Documentation for Paradise Firmware Flashing with FAS

### DIFF
--- a/operations/firmware/FASUpdate_Script.md
+++ b/operations/firmware/FASUpdate_Script.md
@@ -57,9 +57,9 @@ Set `overrideDryrun` to true to do an actual update instead of a dryrun.
 * `--recipedir dir` : Directory containing the action recipe file (if not using the default directory).
 * `--xnames xname1,xname2` : List of BMC xnames to be updated. If not present, FAS will check all xnames.
 * `--overrideDryrun {true/false}` : Default false - Set to true to do an actual update run instead of a dryrun.
-* `--imageID imageID` : Update nodes to `imageID` instead of the latest firmware available.
-* `--watchtime sec` : Number of seconds to wait before outputting the summary status (default 30).
+* `--timeLimit sec` : Set the FAS time limit (time to wait for update verification) in seconds (default varies by recipe).
 * `--description des` : Overwrite the description field in the recipe file.
+* `--watchtime sec` : Number of seconds to wait before outputting the summary status (default 30).
 * `--url-fas url` : URL to access FAS (usually not needed).
 
 ## Sample `FASUpdate` script run

--- a/operations/firmware/FAS_Paradise.md
+++ b/operations/firmware/FAS_Paradise.md
@@ -1,0 +1,372 @@
+# Updating Foxconn Paradise Nodes with FAS
+
+Use the Firmware Action Service (FAS) to update the firmware on Foxconn Paradise devices. Each procedure includes the prerequisites and example recipes required to update the firmware.
+
+**NOTE:** Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
+Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to perform default updates to firmware and BIOS.
+
+## Prerequisites
+
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+See [Configure the Cray CLI](../configure_cray_cli.md).
+* The firmware images are loaded into S3 and to the TFTP server.
+See [Upload Paradise images to TFTP server](#upload-paradise-images-to-tftp-server)
+
+The following targets can be updated with FAS on Paradise Nodes:
+
+1. [`bmc_active`](#update-paradise-bmc_active-procedure)
+1. [`bios_active`](#update-paradise-bios_active-procedure)
+1. [`erot_active`](#update-paradise-erot_active-procedure)
+1. [`fpga_active`](#update-paradise-fpga_active-procedure)
+1. [`pld_active`](#update-paradise-pld_active-procedure)
+
+## Update Paradise `bmc_active` procedure
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `bmc_active` - use recipe `foxconn_nodeBMC_bmc.json`
+
+The BMC will reboot after the update is complete.
+
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+
+```json
+{
+"stateComponentFilter": {
+    "deviceTypes": [ "nodeBMC" ]
+  },
+"inventoryHardwareFilter": {
+    "manufacturer": "foxconn"
+    },
+"targetFilter": {
+    "targets": [ "bmc_active" ]
+  },
+"command": {
+    "version": "latest",
+    "tag": "default",
+    "overrideDryrun": false,
+    "restoreNotPossibleOverride": true,
+    "timeLimit": 1000,
+    "description": "Dryrun upgrade of Foxconn bmc_active"
+  }
+}
+```
+
+## Update Paradise `bios_active` procedure
+
+The nodes must be **OFF** before updating the BIOS
+
+**IMPORTANT:** After the update has completed, the nodes must be turned on and **REMAIN ON FOR AT LEAST 6 MINUTES**  
+
+**NOTE:** The version number reported by Redfish will NOT be updated until the node has fully booted.
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `bios_active` - use recipe `foxconn_nodeBMC_bios.json`
+
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+
+```json
+{
+"stateComponentFilter": {
+    "deviceTypes": [ "nodeBMC" ]
+  },
+"inventoryHardwareFilter": {
+    "manufacturer": "foxconn"
+    },
+"targetFilter": {
+    "targets": [ "bios_active" ]
+  },
+"command": {
+    "version": "latest",
+    "tag": "default",
+    "overrideDryrun": false,
+    "restoreNotPossibleOverride": true,
+    "timeLimit": 1000,
+    "description": "Dryrun upgrade of Foxconn bios_active"
+  }
+}
+```
+
+## Update Paradise `erot_active` procedure
+
+**NOTE:** After update of `erot_active` an AC power cycle is required for update to take affect.
+To do an AC power cycle, run the following command (ncn#).
+
+```bash
+ssh $(xname) "ipmitool raw 0x38 0x02"
+```
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `erot_active` - use recipe `foxconn_nodeBMC_erot.json`
+
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+
+```json
+{
+"stateComponentFilter": {
+    "deviceTypes": [ "nodeBMC" ]
+  },
+"inventoryHardwareFilter": {
+    "manufacturer": "foxconn"
+    },
+"targetFilter": {
+    "targets": [ "erot_active" ]
+  },
+"command": {
+    "version": "latest",
+    "tag": "default",
+    "overrideDryrun": false,
+    "restoreNotPossibleOverride": true,
+    "timeLimit": 1000,
+    "description": "Dryrun upgrade of Foxconn bios_active"
+  }
+}
+```
+
+## Update Paradise `fpga_active` procedure
+
+**NOTE:** After update of `fpga_active` an AC power cycle is required for update to take affect.
+To do an AC power cycle, run the following command (ncn#).
+
+```bash
+ssh $(xname) "ipmitool raw 0x38 0x02"
+```
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `fpga_active` - use recipe `foxconn_nodeBMC_fpga.json`
+
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+
+```json
+{
+"stateComponentFilter": {
+    "deviceTypes": [ "nodeBMC" ]
+  },
+"inventoryHardwareFilter": {
+    "manufacturer": "foxconn"
+    },
+"targetFilter": {
+    "targets": [
+        "fpga_active"
+    ]
+  },
+"command": {
+    "version": "latest",
+    "tag": "default",
+    "overrideDryrun": false,
+    "restoreNotPossibleOverride": true,
+    "timeLimit": 1000,
+    "description": "Dryrun upgrade of Foxconn bios_active"
+  }
+}
+```
+
+## Update Paradise `pld_active` procedure
+
+**IMPORTANT:** The update of the target `pld_active` should only be applied to blade 1 (i.e. x3000c0s3b1) - applying to other blades at the same time may cause issues.  To use the `FASUpdate.py script`, use the `--xnames` flag to specify b1.
+
+The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `pld_active` - use recipe `foxconn_nodeBMC_pld.json`
+
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+
+```json
+{
+"stateComponentFilter": {
+    "xnames": [ "x3000c0s3b1" ],
+    "deviceTypes": [ "nodeBMC" ]
+  },
+"inventoryHardwareFilter": {
+    "manufacturer": "foxconn"
+    },
+"targetFilter": {
+    "targets": [ "pld_active" ]
+  },
+"command": {
+    "version": "latest",
+    "tag": "default",
+    "overrideDryrun": false,
+    "restoreNotPossibleOverride": true,
+    "timeLimit": 1000,
+    "description": "Dryrun upgrade of Foxconn bios_active"
+  }
+}
+```
+
+## Update Paradise firmware using JSON file and Cray CLI
+
+**NOTE:** The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to perform default updates to firmware and BIOS. 
+
+1. Create a JSON file using the example recipe.
+
+2. Initiate a dry-run to verify the firmware that will be updated and the version it will update to.
+
+    1. (`ncn#`) Create the dry-run session.
+
+        The `overrideDryrun = false` value indicates that the command will do a dry run.
+
+        ```bash
+        cray fas actions create nodeBMC.json --format toml
+        ```
+
+        Example output:
+
+        ```toml
+        overrideDryrun = false
+        actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
+        ```
+
+    1. (`ncn#`) Describe the `actionID` for firmware update dry-run job.
+
+        Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
+
+        ```bash
+        cray fas actions describe {actionID} --format toml
+        ```
+
+        Example output:
+
+        ```toml
+        blockedBy = []
+        state = "completed"
+        actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
+        startTime = "2020-08-31 15:49:44.568271843 +0000 UTC"
+        snapshotID = "00000000-0000-0000-0000-000000000000"
+        endTime = "2020-08-31 15:51:35.426714612 +0000 UTC"
+
+        [command]
+        description = "Update Foxconn Node BMCs Dryrun"
+        tag = "default"
+        restoreNotPossibleOverride = true
+        timeLimit = 10000
+        version = "latest"
+        overrideDryrun = false
+        ```
+
+        If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
+
+        * Lists the nodes that have a valid image for updating:
+
+            ```toml
+            [operationSummary.succeeded]
+            ```
+
+        * Lists the nodes that will not be updated because they are already at the correct version:
+
+            ```toml
+            [operationSummary.noOperation]
+            ```
+
+        * Lists the nodes that had an error when attempting to update:
+
+            ```toml
+            [operationSummary.failed]
+            ```
+
+        * Lists the nodes that do not have a valid image for updating:
+
+            ```toml
+            [operationSummary.noSolution]
+            ```
+
+1. Update the firmware after verifying that the dry-run worked as expected. 
+
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
+
+        The following example is for the `nodeBMC.json` file. Update the following values:
+
+        ```json
+        "overrideDryrun":true,
+        "description":"Update Foxconn Node BMCs"
+        ```
+
+    1. (`ncn#`) Run the firmware update.
+
+        The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
+
+        ```bash
+        cray fas actions create nodeBMC.json --format toml
+        ```
+
+        Example output:
+
+        ```toml
+        overrideDryrun = true
+        actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
+        ```
+
+        The time it takes for a firmware action to finish varies. It can be a few minutes or over 20 minutes.
+
+        The BMC automatically reboots after the BMC firmware has been loaded.
+
+1. Retrieve the `operationID` and verify that the update is complete.
+
+    ```bash
+    cray fas actions describe {actionID} --format toml
+    ```
+
+    Example output:
+
+    ```toml
+    [operationSummary.failed]
+    [[operationSummary.failed.operationKeys]]
+    stateHelper = "unexpected change detected in firmware version. Expected nc.1.3.10-shasta-release.arm.2020-07-21T23:58:22+00:00.d479f59 got: nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
+    fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
+    xname = "x1005c6s4b0"
+    target = "BMC"
+    operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ```
+
+1. (`ncn#`) View more details for an operation using the `operationID` from the previous step.
+
+    Check the list of nodes for the `failed` or `completed` state.
+
+    ```bash
+    cray fas operations describe {operationID}
+    ```
+
+    For example:
+
+    ```bash
+    cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f" --format toml
+    ```
+
+    Example output:
+
+    ```toml
+    fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
+    fromTag = ""
+    fromImageURL = ""
+    endTime = "2020-08-31 16:40:13.464321212 +0000 UTC"
+    actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
+    startTime = "2020-08-31 16:28:01.228524446 +0000 UTC"
+    fromSemanticFirmwareVersion = ""
+    toImageURL = ""
+    model = "WNC_REV_B"
+    operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    fromImageID = "00000000-0000-0000-0000-000000000000"
+    target = "BMC"
+    toImageID = "39c0e553-281d-4776-b68e-c46a2993485e"
+    toSemanticFirmwareVersion = "1.3.10"
+    refreshTime = "2020-08-31 16:40:13.464325422 +0000 UTC"
+    blockedBy = []
+    toTag = ""
+    state = "failed"
+    stateHelper = "unexpected change detected in firmware version. Expected nc.1.3.10-shasta-release.arm.2020-07-21T23:58:22+00:00.d479f59 got: nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
+    deviceType = "NodeBMC"
+    ```
+
+    Once firmware and BIOS are updated, the compute nodes can be turned back on.
+
+## Upload Paradise images to TFTP server
+
+(`ncn#`) To check if a firmware is uploaded to the TFTP server:
+
+```bash
+kubectl -n services exec -it `kubectl get pods -n services -l app.kubernetes.io/instance=cms-ipxe -o custom-columns=NS:.metadata.name --no-headers | head -1` -- ls /shared_tftp
+```
+
+If the firmware file you need is not listed, run the following command to copy the file from S3 to the TFTP server (`ncn#`)
+
+```bash
+/usr/share/doc/csm/scripts/operations/firmware/upload_foxconn_images_tftp.py
+```

--- a/operations/firmware/FAS_Paradise.md
+++ b/operations/firmware/FAS_Paradise.md
@@ -1,6 +1,6 @@
-# Updating Foxconn Paradise Nodes with FAS
+# Updating `Foxconn` Paradise Nodes with FAS
 
-Use the Firmware Action Service (FAS) to update the firmware on Foxconn Paradise devices. Each procedure includes the prerequisites and example recipes required to update the firmware.
+Use the Firmware Action Service (FAS) to update the firmware on `Foxconn` Paradise devices. Each procedure includes the prerequisites and example recipes required to update the firmware.
 
 **NOTE:** Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
 If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
@@ -31,7 +31,7 @@ The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `bmc_acti
 
 The BMC will reboot after the update is complete.
 
-To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
 
 ```json
 {
@@ -65,7 +65,7 @@ The nodes must be **OFF** before updating the BIOS
 
 The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `bios_active` - use recipe `foxconn_nodeBMC_bios.json`
 
-To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
 
 ```json
 {
@@ -92,7 +92,7 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
 ## Update Paradise `erot_active` procedure
 
 **NOTE:** After update of `erot_active` an AC power cycle is required for update to take affect.
-To do an AC power cycle, run the following command (ncn#).
+To do an AC power cycle, run the following command (`ncn#`).
 
 ```bash
 ssh $(xname) "ipmitool raw 0x38 0x02"
@@ -100,7 +100,7 @@ ssh $(xname) "ipmitool raw 0x38 0x02"
 
 The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `erot_active` - use recipe `foxconn_nodeBMC_erot.json`
 
-To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
 
 ```json
 {
@@ -127,7 +127,7 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
 ## Update Paradise `fpga_active` procedure
 
 **NOTE:** After update of `fpga_active` an AC power cycle is required for update to take affect.
-To do an AC power cycle, run the following command (ncn#).
+To do an AC power cycle, run the following command (`ncn#`).
 
 ```bash
 ssh $(xname) "ipmitool raw 0x38 0x02"
@@ -135,7 +135,7 @@ ssh $(xname) "ipmitool raw 0x38 0x02"
 
 The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `fpga_active` - use recipe `foxconn_nodeBMC_fpga.json`
 
-To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
 
 ```json
 {
@@ -163,11 +163,11 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
 
 ## Update Paradise `pld_active` procedure
 
-**IMPORTANT:** The update of the target `pld_active` should only be applied to blade 1 (i.e. x3000c0s3b1) - applying to other blades at the same time may cause issues.  To use the `FASUpdate.py script`, use the `--xnames` flag to specify b1.
+**IMPORTANT:** The update of the target `pld_active` should only be applied to blade 1 (i.e. `x3000c0s3b1`) - applying to other blades at the same time may cause issues.  To use the `FASUpdate.py script`, use the `--xnames` flag to specify `b1`.
 
 The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to update `pld_active` - use recipe `foxconn_nodeBMC_pld.json`
 
-To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmaware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
+To update using a JSON file and the Cray CLI, use this example JSON file and follow the [Updating Paradise Firmware with JSON and the Cray CLI Procedure](#update-paradise-firmware-using-json-file-and-cray-cli)
 
 ```json
 {
@@ -194,11 +194,11 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
 
 ## Update Paradise firmware using JSON file and Cray CLI
 
-**NOTE:** The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to perform default updates to firmware and BIOS. 
+**NOTE:** The [`FASUpdate.py script`](FASUpdate_Script.md) can be used to perform default updates to firmware and BIOS.
 
 1. Create a JSON file using the example recipe.
 
-2. Initiate a dry-run to verify the firmware that will be updated and the version it will update to.
+1. Initiate a dry-run to verify the firmware that will be updated and the version it will update to.
 
     1. (`ncn#`) Create the dry-run session.
 
@@ -268,7 +268,7 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
             [operationSummary.noSolution]
             ```
 
-1. Update the firmware after verifying that the dry-run worked as expected. 
+1. Update the firmware after verifying that the dry-run worked as expected.
 
     1. Edit the JSON file and update the values so an actual firmware update can be run.
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -117,7 +117,7 @@ Previous versions did not contain the this firmware.
     "manufacturer": "cray"
     },
 "targetFilter": {
-    "targets": [ "Node0.AccUC", ]
+    "targets": [ "Node0.AccUC" ]
   },
 "command": {
     "version": "latest",

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -50,17 +50,13 @@ If the nodes are not off when the update command is issued, the update will get 
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"
-    ]
+    "deviceTypes": [ "nodeBMC" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
     },
 "targetFilter": {
-    "targets": [
-      "BMC"
-    ]
+    "targets": [ "BMC" ]
   },
 "command": {
     "version": "latest",
@@ -84,8 +80,7 @@ Previous versions did not contain the Redstone FPGA firmware.
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"    ]
+    "deviceTypes": [ "nodeBMC" ]
   },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
@@ -116,16 +111,13 @@ Previous versions did not contain the this firmware.
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"    ]
+    "deviceTypes": [ "nodeBMC" ]
   },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
     },
 "targetFilter": {
-    "targets": [
-      "Node0.AccUC",
-    ]
+    "targets": [ "Node0.AccUC", ]
   },
 "command": {
     "version": "latest",
@@ -144,8 +136,7 @@ Previous versions did not contain the this firmware.
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"    ]
+    "deviceTypes": [ "nodeBMC" ]
   },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
@@ -173,16 +164,13 @@ Previous versions did not contain the this firmware.
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"    ]
+    "deviceTypes": [ "nodeBMC" ]
   },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
     },
 "targetFilter": {
-    "targets": [
-      "Node0.AccVBIOS"
-    ]
+    "targets": [ "Node0.AccVBIOS" ]
   },
 "command": {
     "version": "latest",
@@ -214,8 +202,7 @@ It is also recommended that the nodes be powered back on after the updates are c
 {
 "stateComponentFilter": {
 
-    "deviceTypes": [
-      "nodeBMC"    ]
+    "deviceTypes": [ "nodeBMC" ]
   },
 "inventoryHardwareFilter": {
     "manufacturer": "cray"
@@ -423,14 +410,10 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
     "manufacturer": "cray"
     },
 "stateComponentFilter": {
-    "deviceTypes": [
-      "chassisBMC"
-    ]
+    "deviceTypes": [ "chassisBMC" ]
 },
 "targetFilter": {
-    "targets": [
-      "BMC"
-    ]
+    "targets": [ "BMC" ]
   },
 "command": {
     "version": "latest",
@@ -600,20 +583,14 @@ This procedure updates node controller \(nC\) firmware.
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "gigabyte"
     },
 "targetFilter": {
-    "targets": [
-      "BMC"
-    ]
+    "targets": [ "BMC" ]
   },
 "command": {
     "version": "latest",
@@ -651,21 +628,14 @@ Make sure to wait for the current firmware to be updated before starting a new F
 ```json
 {
 "stateComponentFilter": {
-
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "gigabyte"
     },
 "targetFilter": {
-    "targets": [
-      "BIOS"
-    ]
+    "targets": [ "BIOS" ]
   },
 "command": {
     "version": "latest",
@@ -691,20 +661,14 @@ Make sure to wait for the current firmware to be updated before starting a new F
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "hpe"
     },
 "targetFilter": {
-    "targets": [
-      "iLO 5"
-    ]
+    "targets": [ "iLO 5" ]
   },
 "command": {
     "version": "latest",
@@ -722,20 +686,14 @@ Make sure to wait for the current firmware to be updated before starting a new F
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "hpe"
     },
 "targetFilter": {
-    "targets": [
-      "iLO 6"
-    ]
+    "targets": [ "iLO 6" ]
   },
 "command": {
     "version": "latest",
@@ -758,20 +716,14 @@ Make sure to wait for the current firmware to be updated before starting a new F
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "NodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "NodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "hpe"
     },
 "targetFilter": {
-    "targets": [
-      "System ROM"
-    ]
+    "targets": [ "System ROM" ]
   },
 "command": {
     "version": "latest",
@@ -981,20 +933,14 @@ Due to networking, FAS cannot update `ncn-m001`. See [Updating Firmware on `ncn-
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "gigabyte"
     },
 "targetFilter": {
-    "targets": [
-      "BMC"
-    ]
+    "targets": [ "BMC" ]
   },
 "command": {
     "version": "latest",
@@ -1026,21 +972,14 @@ Make sure you have waited for the current firmware to be updated before starting
 ```json
 {
 "stateComponentFilter": {
-
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "gigabyte"
     },
 "targetFilter": {
-    "targets": [
-      "BIOS"
-    ]
+    "targets": [ "BIOS" ]
   },
 "command": {
     "version": "latest",
@@ -1066,20 +1005,14 @@ Make sure you have waited for the current firmware to be updated before starting
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "nodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "nodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "hpe"
     },
 "targetFilter": {
-    "targets": [
-      "iLO 5"
-    ]
+    "targets": [ "iLO 5" ]
   },
 "command": {
     "version": "latest",
@@ -1102,20 +1035,14 @@ Make sure you have waited for the current firmware to be updated before starting
 ```json
 {
 "stateComponentFilter": {
-    "deviceTypes": [
-      "NodeBMC"
-    ],
-    "xnames": [
-      "x3000c0s1b0"
-    ]
+    "deviceTypes": [ "NodeBMC" ],
+    "xnames": [ "x3000c0s1b0" ]
 },
 "inventoryHardwareFilter": {
     "manufacturer": "hpe"
     },
 "targetFilter": {
-    "targets": [
-      "System ROM"
-    ]
+    "targets": [ "System ROM" ]
   },
 "command": {
     "version": "latest",
@@ -1284,9 +1211,7 @@ Prerequisites:
    ```json
    {
       "stateComponentFilter":{
-         "deviceTypes":[
-            "nodeBMC"
-         ]
+         "deviceTypes":[ "nodeBMC" ]
       },
       "inventoryHardwareFilter":{
          "manufacturer":"cray"

--- a/scripts/operations/firmware/FASUpdate.py
+++ b/scripts/operations/firmware/FASUpdate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/firmware/FASUpdate.py
+++ b/scripts/operations/firmware/FASUpdate.py
@@ -127,6 +127,7 @@ def main():
     parser.add_argument("--recipedir", type=str, required=False, help="Specify the directory to find the recipes", default="")
     parser.add_argument("--xnames", type=str, required=False, help="List of xnames to update", default="")
     parser.add_argument("--imageID", type=str, required=False, help="image ID of image to flash to node", default="")
+    parser.add_argument("--timeLimit", type=int, required=False, help="Time limit for FAS run", default=0)
     parser.add_argument("--overrideDryrun", type=str2bool, required=False, help="Perform Dry or Real update", default=False)
     parser.add_argument("--watchtime", type=int, required=False, help="Time between actions status", default=30)
     parser.add_argument("--description", type=str, required=False, help="Overwrite description", default="")
@@ -198,6 +199,13 @@ def main():
             data["imageFilter"] = {}
         data["imageFilter"]["imageID"] = imageIDarg
         data["imageFilter"]["overrideImage"] = True
+
+# Create time limit override
+    timeLimitarg = args.timeLimit
+    if timeLimitarg > 0:
+        if "command" not in data:
+            data["command"] = {}
+        data["command"]["timeLimit"] = timeLimitarg
 
 # Update description
     if "command" not in data:

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_bios.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_bios.json
@@ -1,0 +1,23 @@
+{
+    "inventoryHardwareFilter": {
+        "manufacturer": "foxconn"
+    },
+    "stateComponentFilter": {
+        "deviceTypes": [
+          "NodeBMC"
+        ]
+    },
+    "targetFilter": {
+        "targets": [
+          "bios_active"
+        ]
+    },
+    "command": {
+        "version": "latest",
+        "tag": "default",
+        "overrideDryrun": false,
+        "restoreNotPossibleOverride": true,
+        "timeLimit": 1000,
+        "description": "Upgrade of Foxconn node bios_active"
+    }
+}

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_bmc.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_bmc.json
@@ -18,6 +18,6 @@
         "overrideDryrun": false,
         "restoreNotPossibleOverride": true,
         "timeLimit": 1000,
-        "description": "Upgrade of Foxconn node bios_active"
+        "description": "Upgrade of Foxconn node bmc_active"
     }
 }

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_bmc.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_bmc.json
@@ -1,0 +1,23 @@
+{
+    "inventoryHardwareFilter": {
+        "manufacturer": "foxconn"
+    },
+    "stateComponentFilter": {
+        "deviceTypes": [
+          "NodeBMC"
+        ]
+    },
+    "targetFilter": {
+        "targets": [
+          "bmc_active"
+        ]
+    },
+    "command": {
+        "version": "latest",
+        "tag": "default",
+        "overrideDryrun": false,
+        "restoreNotPossibleOverride": true,
+        "timeLimit": 1000,
+        "description": "Upgrade of Foxconn node bios_active"
+    }
+}

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_erot.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_erot.json
@@ -18,6 +18,6 @@
         "overrideDryrun": false,
         "restoreNotPossibleOverride": true,
         "timeLimit": 1000,
-        "description": "Upgrade of Foxconn node bios_active"
+        "description": "Upgrade of Foxconn node erot_active"
     }
 }

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_erot.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_erot.json
@@ -1,0 +1,23 @@
+{
+    "inventoryHardwareFilter": {
+        "manufacturer": "foxconn"
+    },
+    "stateComponentFilter": {
+        "deviceTypes": [
+          "NodeBMC"
+        ]
+    },
+    "targetFilter": {
+        "targets": [
+          "erot_active"
+        ]
+    },
+    "command": {
+        "version": "latest",
+        "tag": "default",
+        "overrideDryrun": false,
+        "restoreNotPossibleOverride": true,
+        "timeLimit": 1000,
+        "description": "Upgrade of Foxconn node bios_active"
+    }
+}

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_fpga.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_fpga.json
@@ -18,6 +18,6 @@
         "overrideDryrun": false,
         "restoreNotPossibleOverride": true,
         "timeLimit": 1000,
-        "description": "Upgrade of Foxconn node bios_active"
+        "description": "Upgrade of Foxconn node fpga_active"
     }
 }

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_fpga.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_fpga.json
@@ -1,0 +1,23 @@
+{
+    "inventoryHardwareFilter": {
+        "manufacturer": "foxconn"
+    },
+    "stateComponentFilter": {
+        "deviceTypes": [
+          "NodeBMC"
+        ]
+    },
+    "targetFilter": {
+        "targets": [
+          "fpga_active"
+        ]
+    },
+    "command": {
+        "version": "latest",
+        "tag": "default",
+        "overrideDryrun": false,
+        "restoreNotPossibleOverride": true,
+        "timeLimit": 1000,
+        "description": "Upgrade of Foxconn node bios_active"
+    }
+}

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_pld.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_pld.json
@@ -1,0 +1,23 @@
+{
+    "inventoryHardwareFilter": {
+        "manufacturer": "foxconn"
+    },
+    "stateComponentFilter": {
+        "deviceTypes": [
+          "NodeBMC"
+        ]
+    },
+    "targetFilter": {
+        "targets": [
+          "pld_active"
+        ]
+    },
+    "command": {
+        "version": "latest",
+        "tag": "default",
+        "overrideDryrun": false,
+        "restoreNotPossibleOverride": true,
+        "timeLimit": 1000,
+        "description": "Upgrade of Foxconn node bios_active"
+    }
+}

--- a/scripts/operations/firmware/recipes/foxconn_nodeBMC_pld.json
+++ b/scripts/operations/firmware/recipes/foxconn_nodeBMC_pld.json
@@ -18,6 +18,6 @@
         "overrideDryrun": false,
         "restoreNotPossibleOverride": true,
         "timeLimit": 1000,
-        "description": "Upgrade of Foxconn node bios_active"
+        "description": "Upgrade of Foxconn node pld_active"
     }
 }

--- a/scripts/operations/hardware_state_manager/FoxconnUserPass.py
+++ b/scripts/operations/hardware_state_manager/FoxconnUserPass.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#  MIT License
+#
+#  (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
+import json
+import sys
+import os
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+
+token = os.environ.get('TOKEN')
+if token is None or token == "":
+  print("Error environment variable TOKEN was not set")
+  print('Run the following to set the TOKEN:')
+  print('''export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \\
+  -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \\
+  -o jsonpath='{.data.client-secret}' | base64 -d` \\
+  https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \\
+  | jq -r '.access_token')
+  ''')
+  sys.exit(1)
+
+if len(sys.argv) < 2:
+  fcuser = input("Enter Foxconn BMC User : ")
+else:
+  fcuser = sys.argv[1]
+if len(sys.argv) < 3:
+  pword = input("Enter Foxconn BMC Password for user : " + fcuser + " : ")
+else:
+  pword = sys.argv[2]
+
+headers = {
+  'Content-Type': "application/json",
+  'cache-control': "no-cache",
+  'Authorization': f'Bearer {token}'
+}
+
+url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints"
+hsmret = requests.request("GET", url, headers=headers, verify=False)
+if hsmret.status_code != 200:
+  print("ERROR: Return Status Code: " + str(hsmret.status_code))
+  print(hsmret.json())
+  sys.exit(1)
+
+endpoints = hsmret.json()
+
+for ep in endpoints["RedfishEndpoints"]:
+  discoverStatus = ep["DiscoveryInfo"]["LastDiscoveryStatus"]
+  if discoverStatus != "DiscoverOK":
+    xname = ep["ID"]
+    print("------------------------------------------------------------")
+    print("Found " + xname + " with discovery status " + discoverStatus)
+    url = "https://"+xname+"/redfish/v1/"
+    try:
+      ret = requests.request("GET", url, verify=False)
+    except requests.exceptions.RequestException as e:
+      print("ERROR: could not communicate with " + xname)
+      print(e)
+      continue
+    if ret.status_code != 200:
+      print("ERROR: Return Status Code: " + str(ret.status_code))
+      print(ret.json())
+      continue
+    redfish = ret.json()
+    if "Vendor" in redfish:
+      vendor = redfish["Vendor"]
+      if vendor == "Foxconn":
+        print("UPDATE VAULT AUTHINCATION")
+        url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/" + xname
+        headers = {
+          'Content-Type': "application/json",
+          'cache-control': "no-cache",
+          'Authorization': f'Bearer {token}'
+        }
+        auth_payload = {
+          "ID":xname,
+          "User":fcuser,
+          "Password":pword
+        }
+        payload = json.dumps(auth_payload)
+        hsmret = requests.request("PATCH", url, data=payload, headers=headers, verify=False)
+        if hsmret.status_code != 200:
+          print("ERROR: Return Status Code: " + str(hsmret.status_code))
+          print(hsmret.json())
+    else:
+      print("Vendor not Foxconn, continuing")


### PR DESCRIPTION

# Description

Documentation for Paradise Firmware Flashing with FAS

CASMHMS-6162

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
