### PR TITLE
CASMTRIAGE-6982: Add workaround for product catalog upgrade error

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -64,6 +64,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Test Failures Due To No Discovered Compute Nodes In HSM](known_issues/test_failures_no_discovered_computes_in_hsm.md)
 * [Velero Version Mismatch](known_issues/velero_version_mismatch.md)
 * [wait for unbound hang](known_issues/wait_for_unbound_hang.md)
+* [Product Catalog Upgrade Error](known_issues/product_catalog_upgrade_error.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/product_catalog_upgrade_error.md
+++ b/troubleshooting/known_issues/product_catalog_upgrade_error.md
@@ -1,4 +1,4 @@
-# `cray-product-catalog` upgrade error 
+# Product Catalog Upgrade Error
 
 - [Description](#description)
 - [Workaround](#workaround)
@@ -7,27 +7,27 @@
 
 During a system upgrade it is possible to encounter the following error during the "Upgrade Services" stage while running `upgrade.sh`:
 
-```
+```text
 Error releasing chart cray-product-catalog v1.8.3: Shell error: Error: UPGRADE FAILED: pre-upgrade hooks failed: timed out waiting for the condition chart=cray-product-catalog command=ship namespace=services version=1.8.3
 ```
 
-This can occur for any version of the product catalog, only occurs on systems where many product versions have been installed.
+This can occur for any version of the product catalog, but it only occurs on systems where many product versions have been installed.
 
 ## Workaround
 
-1. (`ncn-mw#`) Backup the current data to a file:
+1. (`ncn-mw#`) Backup the current data to a file.
 
     ```bash
     kubectl get cm -n services cray-product-catalog -o yaml > cray-product-catalog-backup.yaml
     ```
 
-1. (`ncn-mw#`) Delete the contents of the "data:" stanza in the product catalog:
+1. (`ncn-mw#`) Delete the contents of the `data:` stanza in the product catalog.
 
     ```bash
     kubectl patch cm -n services cray-product-catalog -p '{ "data": null }'
     ```
 
-1. (`ncn-mw#`) Delete the "cpc-backup" configmap, if it exists (it's okay if it does not exist).
+1. (`ncn-mw#`) Delete the `cpc-backup` ConfigMap, if it exists (it is okay if it does not exist).
 
     ```bash
     kubectl delete cm -n services cpc-backup
@@ -35,7 +35,7 @@ This can occur for any version of the product catalog, only occurs on systems wh
 
 1. (`ncn-mw#`) Upgrade the chart as usual.
 
-1. (`ncn-mw#`) Edit the configmap and add back in the 'data:' stanza from the file saved in step #1:
+1. (`ncn-mw#`) Edit the ConfigMap and add back in the `data:` stanza from the file saved in the earlier step.
 
     ```bash
     kubectl edit cm -n services cray-product-catalog

--- a/troubleshooting/known_issues/product_catalog_upgrade_error.md
+++ b/troubleshooting/known_issues/product_catalog_upgrade_error.md
@@ -1,0 +1,42 @@
+# `cray-product-catalog` upgrade error 
+
+- [Description](#description)
+- [Workaround](#workaround)
+
+## Description
+
+During a system upgrade it is possible to encounter the following error during the "Upgrade Services" stage while running `upgrade.sh`:
+
+```
+Error releasing chart cray-product-catalog v1.8.3: Shell error: Error: UPGRADE FAILED: pre-upgrade hooks failed: timed out waiting for the condition chart=cray-product-catalog command=ship namespace=services version=1.8.3
+```
+
+This can occur for any version of the product catalog, only occurs on systems where many product versions have been installed.
+
+## Workaround
+
+1. (`ncn-mw#`) Backup the current data to a file:
+
+    ```bash
+    kubectl get cm -n services cray-product-catalog -o yaml > cray-product-catalog-backup.yaml
+    ```
+
+1. (`ncn-mw#`) Delete the contents of the "data:" stanza in the product catalog:
+
+    ```bash
+    kubectl patch cm -n services cray-product-catalog -p '{ "data": null }'
+    ```
+
+1. (`ncn-mw#`) Delete the "cpc-backup" configmap, if it exists (it's okay if it does not exist).
+
+    ```bash
+    kubectl delete cm -n services cpc-backup
+    ```
+
+1. (`ncn-mw#`) Upgrade the chart as usual.
+
+1. (`ncn-mw#`) Edit the configmap and add back in the 'data:' stanza from the file saved in step #1:
+
+    ```bash
+    kubectl edit cm -n services cray-product-catalog
+    ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Adds a workaround for cray-product-catalog upgrade errors

Relates to:
- CASMTRIAGE-6982

Backports:
- 1.5: https://github.com/Cray-HPE/docs-csm/pull/5104
- 1.4: https://github.com/Cray-HPE/docs-csm/pull/5105
- 1.3: https://github.com/Cray-HPE/docs-csm/pull/5106
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
