### PR TITLE
CASMPET-7057 update loftsman manifest deploy template debug

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -108,12 +108,13 @@ spec:
                     else
                       echo "INFO Deploying loftman manifest ${manifest}"
                       manifest_deploy_output=$(loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts 2>&1)
-                      echo >&2 "DEBUG $manifest_deploy_output"
                       if [ $? -ne 0 ]; then
                         manifest_deploy_output=$(echo "$manifest_deploy_output" | sed -e 's/^/ERROR /')
                         echo "ERROR There was a problem deploying the loftsman manifest ${manifest}"
                         echo -e "ERROR <loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts> failed with\n\n $manifest_deploy_output"
                         exit_code=1
+                      else
+                        echo >&2 "DEBUG $manifest_deploy_output"
                       fi
                     fi
                     return $exit_code

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -68,6 +68,7 @@ spec:
               - name: scriptContent
                 value: |
                   #!/usr/bin/bash
+                  set +e
                   echo '{{inputs.parameters.global_params}}' > global.params.data
                   PRODUCT_NAME=$(cat global.params.data  | jq -r '.product_manifest.current_product.manifest.name')
                   if [[ -z "$PRODUCT_NAME" ]]; then
@@ -107,14 +108,11 @@ spec:
                       exit_code=1
                     else
                       echo "INFO Deploying loftman manifest ${manifest}"
-                      manifest_deploy_output=$(loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts 2>&1)
+                      loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts 2>&1
                       if [ $? -ne 0 ]; then
-                        manifest_deploy_output=$(echo "$manifest_deploy_output" | sed -e 's/^/ERROR /')
                         echo "ERROR There was a problem deploying the loftsman manifest ${manifest}"
-                        echo -e "ERROR <loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts> failed with\n\n $manifest_deploy_output"
+                        echo -e "ERROR <loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts> failed. Check argo logs."
                         exit_code=1
-                      else
-                        echo >&2 "DEBUG $manifest_deploy_output"
                       fi
                     fi
                     return $exit_code


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In the loftsman-manifest-deploy.yaml argo workflow template that is used with IUF, if a chart fails to deploy, IUF does not error. This is because the script runs with 'set -e' and exits immediately before printing logs.

The changes in this PR make the following improvements:
- 'Loftsman ship' prints output as charts are shipped. Previously, the user would have to wait until all charts are shipped, sometimes 30 min, before seeing any output
- Output is printed to the logs even if the chart fails

Previously, output in the argo UI and argo logs looked like this when a chart failed
```bash
INFO Deploying loftman manifest /etc/cray/upgrade/csm/media/iuf-install/sma-1.9.16/manifests/sma.yaml 2024-05-21T05:51:33.184735801Z 
{}
```

With this update, the output in the argo UI and argo logs now looks like this when a chart fails
```bash
INFO Deploying loftman manifest /etc/cray/upgrade/csm/media/lindsay-test/sma-1.9.16/manifests/sma.yaml
2024-05-21T17:30:14Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-conte
xt) command=ship
2024-05-21T17:30:14Z INF Initializing helm client object command=ship

...

2024-05-21T17:43:35Z ERR  error="Some charts did not release successfully, see above and/or the output log file for more info" command=ship
ERROR There was a problem deploying the loftsman manifest /etc/cray/upgrade/csm/media/lindsay-test/sma-1.9.16/manifests/sma.yaml
ERROR <loftsman ship --manifest-path /tmp/sma.yaml --charts-repo https://packages.local/repository/charts> failed. Check argo logs.
ERROR Unable to deploy manifest /etc/cray/upgrade/csm/media/lindsay-test/sma-1.9.16/manifests/sma.yaml for product sma
ERROR Loftsman manifest deployment failed
{}
```
The IUF CLI also has improved logging and now the IUF CLI looks like this. Previously, no Error messages were printed.
```bash
[sma-1-9-16-loftsman-manifest-deploy                      ]       Error releasing chart sma-opensearch v2.5.10: Shell error: Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress chart=sma-opensearch command=ship namespace=sma version=2.5.10
   [sma-1-9-16-loftsman-manifest-deploy                      ]       Error releasing chart sma-opensearch-dashboards v2.5.10: Shell error: Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress chart=sma-opensearch-dashboards command=ship namespace=services version=2.5.10
   [sma-1-9-16-loftsman-manifest-deploy                      ]       Error releasing chart sma-svc-init v1.19.8: Shell error: Error: UPGRADE FAILED: post-upgrade hooks failed: timed out waiting for the condition chart=sma-svc-init command=ship namespace=services version=1.19.8
   [sma-1-9-16-loftsman-manifest-deploy                      ]       Some charts did not release successfully, see above and/or the output log file for more info
   [sma-1-9-16-loftsman-manifest-deploy                      ]       There was a problem deploying the loftsman manifest /etc/cray/upgrade/csm/media/lindsay-test/sma-1.9.16/manifests/sma.yaml
   [sma-1-9-16-loftsman-manifest-deploy                      ]       Unable to deploy manifest /etc/cray/upgrade/csm/media/lindsay-test/sma-1.9.16/manifests/sma.yaml for product sma
   [sma-1-9-16-loftsman-manifest-deploy                      ]       Loftsman manifest deployment failed
   [sma-1-9-16-loftsman-manifest-deploy                      ]       <loftsman ship --manifest-path /tmp/sma.yaml --charts-repo https://packages.local/repository/charts> failed. Check argo logs.
```
<!--- 


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
