### PR TITLE
CASMPET-7075 source myenv variables before ncn-master rebuild

### DIFF
--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -25,6 +25,8 @@
 
 set -e
 basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+touch /etc/cray/upgrade/csm/myenv
+. /etc/cray/upgrade/csm/myenv
 . ${basedir}/../common/upgrade-state.sh
 trap 'err_report' ERR
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

**Problem**
When doing a master node upgrade, there is a state file which should track which steps have been completed. However, there are actually two state files created and certain steps get recorded in one file while other steps get recorded in a different file. This happens because when the file is first created, the script does not have access to the CSM_RELEASE varaible so the file created is in `csm-` directory. Later, the CSM_RELEASE variable has been exported so the log file used is `csm-1.x.x`. 

**Resolution**
At the very beginning of a master node rebuild, `/etc/cray/upgrade/csm/myenv` should be sourced so that the CSM_RELEASE variable is available and all state records go to a single file.

**Testing**
I tested this change on Beau. I edited the upgrade files and removed most steps. I left some steps but removed the logic and just putting echo statements in them. This way I could see where the steps were logged.

Without making any change to the script and running the steps I got the following logs.

```bash
ncn-m001:/etc/cray/upgrade/csm # cat csm-/ncn-m003/state
[2024-05-23 14:26:10] ENSURE_CSI_IS_INSTALLED
[2024-05-23 14:26:10] DRAIN_NODE
[2024-05-23 14:26:11] RESTORE_SAT_LOCAL_FILES
ncn-m001:/etc/cray/upgrade/csm # cat csm-1.5.0-rc.4/ncn-m003/state
[2024-05-23 14:26:11] FORCE_TIME_SYNC
[2024-05-23 14:26:11] CSI_VALIDATE_BSS_NTP
```
Steps from 'ncn-rebuild-master-nodes.sh' are logged in `csm-`
Steps from 'common/ncn-rebuild-common.sh' are logged in `csm-1.5.0-rc.4`.

I removed the logging files and then edited the 'ncn-rebuild-master-nodes.sh' as I did in this PR. The result was

```bash
ncn-m001:/etc/cray/upgrade/csm # cat csm-1.5.0-rc.4/ncn-m002/state
[2024-05-23 14:32:50] ENSURE_CSI_IS_INSTALLED
[2024-05-23 14:32:50] DRAIN_NODE
[2024-05-23 14:32:50] FORCE_TIME_SYNC
[2024-05-23 14:32:50] CSI_VALIDATE_BSS_NTP
[2024-05-23 14:32:50] RESTORE_SAT_LOCAL_FILES
ncn-m001:/etc/cray/upgrade/csm # ls | grep csm
csm-1.5.0-rc.4 
```

All steps were logged in the `csm-1.5.0-rc.4` directory and no `csm-` directory was created.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
