### PR TITLE
CASMPET-7076 Add warm arpcache for System Recovery rapid_rebuild/basecamp

### DIFF
--- a/scripts/operations/system_recovery/rapid_rebuild.sh
+++ b/scripts/operations/system_recovery/rapid_rebuild.sh
@@ -149,6 +149,12 @@ if [[ $powerStatus =~ "is on" ]]; then
   err_exit "Not all NCNs have powered off"
 fi
 
+# Pre-populate the arp cache with the NCN NMN IP and MAC addresses based on /etc/dnsmasq.d/statics.conf
+while read -r mac ip ncn; do
+  echo "Adding arp cache entry for ${ncn} ip=${ip} mac=${mac}"
+  ip neigh add "${ip}" lladdr "${mac}" dev bond0.nmn0
+done < <(awk -F',' '/Bond/{ print $3" "$5" "$6 }' "${DNSFILE}")
+
 # Set the NCNs to PXE boot
 echo "$ncn_list" | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=efiboot
 


### PR DESCRIPTION
# Description
When rebuilding the NCNs from the System Recovery pit-disk. The basecamp call to get metadata will fail with 500 error due to arp cache issues. The arp cache needs to be pre-populated.

This was tested on UK Met TDSY system

[CASMPET-7076](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7076)

```
root@ncn-m001 2024-05-24 16:22:28 /usr/share/doc/csm/scripts/operations/system_recovery # ./rapid_rebuild.sh
...
Chassis Power Control: Down/Off
Adding arp cache entry for ncn-w004 ip=100.112.129.4 mac=14:02:ec:dd:40:a8
Adding arp cache entry for ncn-w003 ip=100.112.129.5 mac=14:02:ec:db:c7:08
Adding arp cache entry for ncn-w002 ip=100.112.129.6 mac=14:02:ec:df:a4:d8
Adding arp cache entry for ncn-w001 ip=100.112.129.7 mac=14:02:ec:e1:c7:08
Adding arp cache entry for ncn-s003 ip=100.112.129.8 mac=b4:7a:f1:7a:3f:ac
Adding arp cache entry for ncn-s002 ip=100.112.129.9 mac=b4:7a:f1:7a:3e:68
Adding arp cache entry for ncn-s001 ip=100.112.129.10 mac=b4:7a:f1:7a:40:ba
Adding arp cache entry for ncn-m003 ip=100.112.129.11 mac=b4:7a:f1:79:d1:00
Adding arp cache entry for ncn-m002 ip=100.112.129.12 mac=b4:7a:f1:7a:3d:6c
Adding arp cache entry for ncn-m001 ip=100.112.129.13 mac=14:02:ec:df:aa:78
...
```

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
