### PR TITLE
CASMTRIAGE-7017: Modify gateway test to use BOS v2 endpoint instead of BOS v1

### DIFF
--- a/operations/network/Gateway_Testing.md
+++ b/operations/network/Gateway_Testing.md
@@ -183,7 +183,7 @@ Token successfully retrieved at https://api-gw-service-nmn.local/keycloak/realms
 
 ------------- api-gw-service-nmn.local -------------------
 api-gw-service-nmn.local is reachable
-PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 200
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v2/sessions - 200
 PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 200
 PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 200
 PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v3/sessions - 200
@@ -208,7 +208,7 @@ SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/
 
 ------------- api.cmn.eniac.dev.cray.com -------------------
 api.cmn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 200
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v2/sessions - 200
 PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
 PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 200
 PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v3/sessions - 200
@@ -238,7 +238,7 @@ can is not reachable and is not expected to be
 
 ------------- api.chn.eniac.dev.cray.com -------------------
 api.chn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -267,7 +267,7 @@ Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/rea
 
 ------------- api-gw-service-nmn.local -------------------
 api-gw-service-nmn.local is reachable
-PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 200
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v2/sessions - 200
 PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 200
 PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 200
 PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v3/sessions - 200
@@ -292,7 +292,7 @@ SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/
 
 ------------- api.cmn.eniac.dev.cray.com -------------------
 api.cmn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 200
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v2/sessions - 200
 PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
 PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 200
 PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v3/sessions - 200
@@ -322,7 +322,7 @@ can is not reachable and is not expected to be
 
 ------------- api.chn.eniac.dev.cray.com -------------------
 api.chn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -355,7 +355,7 @@ Token successfully retrieved at https://auth.chn.eniac.dev.cray.com/keycloak/rea
 
 ------------- api-gw-service-nmn.local -------------------
 api-gw-service-nmn.local is reachable
-PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 403
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v2/sessions - 403
 PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 403
 PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 403
 PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v3/sessions - 403
@@ -380,7 +380,7 @@ SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/
 
 ------------- api.cmn.eniac.dev.cray.com -------------------
 api.cmn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 403
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v2/sessions - 403
 PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 403
 PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 403
 PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v3/sessions - 403
@@ -410,7 +410,7 @@ can is not reachable and is not expected to be
 
 ------------- api.chn.eniac.dev.cray.com -------------------
 api.chn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -474,7 +474,7 @@ cmn is not reachable and is not expected to be
 
 ------------- api.can.eniac.dev.cray.com -------------------
 api.can.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.can.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.can.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.can.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -499,7 +499,7 @@ SKIP - [sma-telemetry]: https://api.can.eniac.dev.cray.com/apis/sma-telemetry-ap
 
 ------------- api.chn.eniac.dev.cray.com -------------------
 api.chn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -536,7 +536,7 @@ cmn is not reachable and is not expected to be
 
 ------------- api.can.eniac.dev.cray.com -------------------
 api.can.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.can.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.can.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.can.eniac.dev.cray.com/apis/cfs/v3/sessions - 404
@@ -561,7 +561,7 @@ SKIP - [sma-telemetry]: https://api.can.eniac.dev.cray.com/apis/sma-telemetry-ap
 
 ------------- api.chn.eniac.dev.cray.com -------------------
 api.chn.eniac.dev.cray.com is reachable
-PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v2/sessions - 404
 PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
 PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
 PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v3/sessions - 404

--- a/operations/network/Gateway_Testing.md
+++ b/operations/network/Gateway_Testing.md
@@ -157,12 +157,12 @@ The results of running the tests will show the following:
 
 - Retrieval of a token on the CMN network; the token is used to get SLS data, which determines which user network is configured
   on the system.
-  - If CMN is not accessible, then the test will get the user network from the command line.
+    - If CMN is not accessible, then the test will get the user network from the command line.
 - For each of the test networks defined in `gateway-test-defn.yaml`:
-  - Retrieval of a token on the network under test.
-  - It will attempt to access each of the services with the token and check the expected results.
-    - It will show `PASS` or `FAIL` depending on the expected response for the service and the token being used.
-    - It will show `SKIP` for services that are not expected to be installed on the system.
+    - Retrieval of a token on the network under test.
+    - It will attempt to access each of the services with the token and check the expected results.
+        - It will show `PASS` or `FAIL` depending on the expected response for the service and the token being used.
+        - It will show `SKIP` for services that are not expected to be installed on the system.
 - The return code of `gateway-test.py` will be non-zero if any of the tests within it fail.
 
 ### Running from an NCN with CHN as the user network

--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@ ingress_api_services:
   gateways: ["services-gateway","customer-admin-gateway"]
   project: CSM
 - name: cray-bos
-  path: apis/bos/v1/session 
+  path: apis/bos/v2/sessions 
   port: 443
   expected-result: 200
   namespace: services


### PR DESCRIPTION
BOS v1 has been removed from CSM 1.6. The gateway test still tries to access one of its endpoints, which causes the test to fail. This PR changes the test (and its example output in the documentation) to use the corresponding BOS v2 endpoint instead. I tested this change on starlord (where the problem was reported) and verified that this fixes the problem and the test passes.

No backports needed as BOS v1 still existed prior to CSM 1.6.