### PR TITLE
CASMUSER-3239: Marking UAS/UAI as deprecated in CSM 1.5.2 for removal in CSM 1.6

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -956,6 +956,7 @@ host_path
 id_rsa.pub
 image_id
 Image_list
+image_list
 imagename
 loginShell
 K8s
@@ -963,6 +964,7 @@ k8s
 Mibibytes
 Millicpus
 mount_path
+my-configmap
 opt_ports
 parameterization
 passwd
@@ -971,12 +973,15 @@ priority_class_name
 public_ip
 publickey
 publickey_str
+resource_config
 resource_id
 root_get
 secretName
 service_account
+service_name
 ssh
 SSHd
+uai
 uais
 uai_age
 UAIClass
@@ -984,9 +989,12 @@ uai_compute_network
 uai_connect_string
 uai_creation_class
 uai_host
+uai_id
+uai_image
 uai_img
 uai_list
 uai_message
+uai_msg
 uai_name
 uai_portmap
 uai-priority
@@ -997,10 +1005,12 @@ UAS_mgr_info
 uidNumber
 update_uas_class_admin
 update_uas_image_admin
+update_uas_resource_admin
 update_uas_volume_admin
 volume_description
 volume_id
 volume_list
+volume_mounts
 volumename
 
 
@@ -1184,9 +1194,11 @@ keep-alives
 ssh
 sshd
 hostkey
+kubeconfig
 kubectl
 Xauthority
 Xeyes
+xeyes
 
 - operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
 macvlans

--- a/.spelling
+++ b/.spelling
@@ -911,6 +911,98 @@ vsx-pair
 
 # Per-file spelling exceptions. Please keep this section sorted in order by filepath, to help make it easier to
 # see if a file already is listed.
+# 
+# UAS/UAI are deprecated, so putting spelling exceptions here for easy removal later.
+- api/uas-mgr.md
+250Mi
+additionalProperties
+bearerAuth
+class_id
+config_map
+cpu
+create_uai
+create_uai_admin
+create_uas_class_admin
+create_uas_image_admin
+create_uas_resource_admin
+create_uas_volume_admin
+default_image
+delete_all_uais
+delete_local_config_admin
+delete_uai_by_name
+delete_uais_admin
+delete_uas_class_admin
+delete_uas_image_admin
+delete_uas_resource_admin
+delete_uas_volume_admin
+DirectoryOrCreate
+get_all_uais
+get_uai_admin
+get_uais_admin
+get_uais_for_user
+get_uas_class_admin
+get_uas_classes_admin
+get_uas_image_admin
+get_uas_images_admin
+get_uas_images
+get_uas_mgr_info
+get_uas_resource_admin
+get_uas_resources_admin
+get_uas_volume_admin
+get_uas_volumes_admin
+gidNumber
+homeDirectory
+host_path
+id_rsa.pub
+image_id
+Image_list
+imagename
+loginShell
+K8s
+k8s
+Mibibytes
+Millicpus
+mount_path
+opt_ports
+parameterization
+passwd
+passwd_str
+priority_class_name
+public_ip
+publickey
+publickey_str
+resource_id
+root_get
+secretName
+service_account
+ssh
+SSHd
+uais
+uai_age
+UAIClass
+uai_compute_network
+uai_connect_string
+uai_creation_class
+uai_host
+uai_img
+uai_list
+uai_message
+uai_name
+uai_portmap
+uai-priority
+uai_status
+uas
+UAS_MGR
+UAS_mgr_info
+uidNumber
+update_uas_class_admin
+update_uas_image_admin
+update_uas_volume_admin
+volume_description
+volume_id
+volume_list
+volumename
+
 
 - background/ncn_kernel.md
 initramFS
@@ -921,6 +1013,8 @@ initramFS
 bs
 # To allow Site Init
 Init
+# To allow UAI-on-UAN
+UAI-on-UAN
 
 - operations/observability/Observability.md
 IaC
@@ -1050,6 +1144,63 @@ thanos
 Thanos
 thanos
 
+- operations/UAS_user_and_admin_topics/Customize_the_Broker_UAI_Image.md
+Entrypoint
+entrypoint
+entrypoint.sh
+sshd
+UAI_ONE_SHOT
+
+- operations/UAS_user_and_admin_topics/Legacy_Mode_User-Driven_UAI_Management.md
+ContainerCreating
+
+- operations/UAS_user_and_admin_topics/Modify_a_UAI_Class.md
+bb28a35a-6cbc-4c30-84b0-6050314af76b
+
+- operations/UAS_user_and_admin_topics/README.md
+ContainersCreating
+cray
+kubectl
+macvlans
+sssd
+sssd.conf
+
+- operations/UAS_user_and_admin_topics/Retrieve_UAI_Image_Registration_Information.md
+imagename
+
+- operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md
+ContainerCreating
+uai-creation-class
+
+- operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md
+sssd
+sssd.conf
+
+- operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md
+entrypoint
+
+- operations/UAS_user_and_admin_topics/Troubleshoot_UAS_Issues.md
+keep-alives
+ssh
+sshd
+hostkey
+kubectl
+Xauthority
+Xeyes
+
+- operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
+macvlans
+
+- operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
+macvlan
+
+-  operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+macvlans
+
+- operations/UAS_user_and_admin_topics/UAS_Limitations.md
+containerd
+LoadBalancer
+NodePorts
 - RELEASE_NOTES.md
 5.x
 Antero

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ scripts, revision control with git, configuration management with Ansible, YAML,
    * System Configuration Service
    * System Layout Service
    * System Management Health
-   * UAS User And Admin Topics
+   * UAS User And Admin Topics - Deprecated
    * Utility Storage
    * Validate CSM Health
 

--- a/api/README.md
+++ b/api/README.md
@@ -14,4 +14,4 @@
  * [Hardware State Manager API v2](./smd.md)
  * [Cray STS Token Generator v1](./sts.md)
  * [TAPMS Tenant Status API v1](./tapms-operator.md)
- * [User Access Service v1](./uas-mgr.md)
+ * [User Access Service v1 - Deprecated](./uas-mgr.md)

--- a/api/uas-mgr.md
+++ b/api/uas-mgr.md
@@ -2,6 +2,8 @@
 
 <h1 id="user-access-service">User Access Service v1</h1>
 
+**NOTE:** User Access Service v1 is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
 The User Access Service (UAS) creates and deletes

--- a/glossary.md
+++ b/glossary.md
@@ -752,6 +752,8 @@ manage the switch power, [HSN](#high-speed-network-hsn) ASIC, and FPGA interface
 
 ## User Access Instance (UAI)
 
+**NOTE:** The User Access Instance is deprecated in CSM 1.5.2, and will be removed in CSM 1.6. The UAI experience is migrating to a new UAI-on-UAN implementation under the USS product.
+
 The User Access Instance (UAI) is a lightweight, disposable platform that runs under Kubernetes orchestration
 on worker nodes. The UAI provides a single user containerized environment for users on a Cray Ex system to
 develop, build, and execute their applications on the HPE Cray EX [compute node](#compute-node-cn). See [UAN](#user-access-node-uan) for another
@@ -767,6 +769,8 @@ develop, build, and execute their applications on the HPE Cray EX [compute node]
 way for users to gain access. Some sites refer to their UANs as Login nodes.
 
 ## User Access Service (UAS)
+
+**NOTE:** The User Access Service is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
 
 The User Access Service (UAS) is a containerized service managed by Kubernetes that enables users to
 create and run user applications inside a [UAI](#user-access-instance-uai). UAS runs on a [management node](#management-nodes) that is acting as a

--- a/operations/README.md
+++ b/operations/README.md
@@ -36,7 +36,7 @@ The following administrative topics can be found in this guide:
     - [MetalLB in BGP-mode](#metallb-in-bgp-mode)
 - [Spire](#spire)
 - [Update firmware with FAS](#update-firmware-with-fas)
-- [User Access Service (UAS)](#user-access-service-uas)
+- [User Access Service (UAS) - Deprecated](#user-access-service-uas)
 - [System Admin Toolkit (SAT)](#system-admin-toolkit-sat)
 - [Install and Upgrade Framework (IUF)](#install-and-upgrade-framework-iuf)
 - [Backup and recovery](#backup-and-recovery)
@@ -732,7 +732,9 @@ stream to update firmware on other components.
 - [Updating Firmware without FAS](firmware/Updating_Firmware_without_FAS.md)
 - [Update iLO 5 firmware above `v2.78`](firmware/FAS_Update_iLO5_2.78.md)
 
-## User Access Service (UAS)
+## User Access Service (UAS) - Deprecated
+
+**NOTE:** The User Access Service is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
 
 The User Access Service \(UAS\) is a containerized service managed by Kubernetes that enables application developers to create and run user applications. Users launch
 a User Access Instance \(UAI\) using the `cray` command. Users can also transfer data between the Cray system and external systems using the UAI.

--- a/operations/UAS_user_and_admin_topics/Add_a_Volume_to_UAS.md
+++ b/operations/UAS_user_and_admin_topics/Add_a_Volume_to_UAS.md
@@ -1,5 +1,7 @@
 # Add a Volume to UAS
 
+**NOTE:** UAS is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 This procedure registers and configures a volume in UAS so that the volume can be mounted in UAIs.
 
 See [List Volumes Registered in UAS](List_Volumes_Registered_in_UAS.md) for examples of valid volume configurations. Refer to [Elements of a UAI](Elements_of_a_UAI.md) for descriptions of the volume configuration fields and values.

--- a/operations/UAS_user_and_admin_topics/Broker_Mode_UAI_Management.md
+++ b/operations/UAS_user_and_admin_topics/Broker_Mode_UAI_Management.md
@@ -1,5 +1,7 @@
 # Broker Mode UAI Management
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 A Broker UAI is a special kind of UAI whose job is not to host users directly but to accept attempts to reach a UAI, locate or create a UAI for the user making the attempt, and then pass the user's connection on to the correct UAI.
 Multiple Broker UAIs can be created, each serving users with UAIs of a different classes. This makes it possible to set up UAIs for varying workflows and environments as needed. The following illustrates a system using the Broker mode of UAI management:
 

--- a/operations/UAS_user_and_admin_topics/Choosing_UAI_Resource_Settings.md
+++ b/operations/UAS_user_and_admin_topics/Choosing_UAI_Resource_Settings.md
@@ -1,5 +1,7 @@
 # Choosing UAI Resource Settings
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 The [Resource Specifications](Resource_Specifications.md) and [UAI Classes](UAI_Classes.md) sections describe how to set up resource specifications to be used with UAIs.
 Refer to those sections for all procedures and specific data structures associated with resources. In this section the question of how and why to configure UAI resources is addressed.
 While Kubernetes resource requests and limits can be used for other things, this section focuses on memory requests and limits and CPU requests and limits. Other resource types are outside the scope of this discussion.

--- a/operations/UAS_user_and_admin_topics/Common_UAI_Config.md
+++ b/operations/UAS_user_and_admin_topics/Common_UAI_Config.md
@@ -1,5 +1,7 @@
 # Common UAI Configuration
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 This section provides guidance on common UAI configuration activities.
 Specific procedures and settings are covered elsewhere, but each topic provides links to the appropriate information as well as guidance on using that particular configuration.
 

--- a/operations/UAS_user_and_admin_topics/Configure_End-User_UAI_Classes_for_Broker_Mode.md
+++ b/operations/UAS_user_and_admin_topics/Configure_End-User_UAI_Classes_for_Broker_Mode.md
@@ -1,5 +1,7 @@
 # Configure End-User UAI Classes for Broker Mode
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Each UAI broker will create and manage a single class of End-User UAIs. A site using the Broker Mode of UAI management must create a Brokered End-User UAI Class for each distinct type of End-User UAI it wants served by a Broker UAI.
 Information on what should be configured for a Brokered End-User UAI Class can be found in [UAI Classes](UAI_Classes.md).
 

--- a/operations/UAS_user_and_admin_topics/Configure_UAIs_in_UAS.md
+++ b/operations/UAS_user_and_admin_topics/Configure_UAIs_in_UAS.md
@@ -1,5 +1,7 @@
 # Configure UAIs in UAS
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 The sub-topics in this section cover the four main elements of UAI configuration in UAS, and provide Links to procedures for listing, adding, examining, updating, and deleting each kind of element.
 
 Options for the elements of a UAI are maintained in the UAS configuration. The following can be configured in UAS:

--- a/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
@@ -1,5 +1,7 @@
 # Configure a Broker UAI Class
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Configuring a Broker UAI class consists of the following actions:
 
 * Create volumes to hold any site-specific authentication, SSH, or other configuration required

--- a/operations/UAS_user_and_admin_topics/Configure_a_Default_UAI_Class_for_Legacy_Mode.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Default_UAI_Class_for_Legacy_Mode.md
@@ -1,5 +1,7 @@
 # Configure a Default UAI Class for Legacy Mode
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Using a default UAI class is optional but recommended for any site using the legacy UAI management mode that wants to have some control over UAIs created by users. UAI classes used for this purpose need to have certain minimum configuration in them:
 
 * The `image_id` field set to identify the image used to construct UAIs

--- a/operations/UAS_user_and_admin_topics/Create_UAIs_From_Specific_UAI_Images_in_Legacy_Mode.md
+++ b/operations/UAS_user_and_admin_topics/Create_UAIs_From_Specific_UAI_Images_in_Legacy_Mode.md
@@ -1,5 +1,7 @@
 # Create UAIs From Specific UAI Images in Legacy Mode
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 A user can create a UAI from a specific UAI image (assuming no default UAI class exists) using a command of the form:
 
 ```text

--- a/operations/UAS_user_and_admin_topics/Create_a_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Create_a_UAI.md
@@ -1,5 +1,7 @@
 # Create a UAI
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 The UAS allows either administrators or authorized users using the [Legacy Mode](Legacy_Mode_User-Driven_UAI_Management.md) of UAI management to create UAIs. This section shows both methods.
 
 It is rare that an an administrator would hand-craft an End-User UAI using this administrative procedure, but it is possible. This is, however, the procedure used to create Broker UAIs for [Broker Mode UAI Management](Broker_Mode_UAI_Management.md).

--- a/operations/UAS_user_and_admin_topics/Create_a_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Create_a_UAI_Class.md
@@ -1,5 +1,7 @@
 # Create a UAI Class
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Add a new User Access Instance (UAI) class to the User Access Service (UAS) so that the class can be used to configure UAIs.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Create_a_UAI_Resource_Specification.md
+++ b/operations/UAS_user_and_admin_topics/Create_a_UAI_Resource_Specification.md
@@ -1,5 +1,7 @@
 # Create a UAI Resource Specification
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Add a resource specification to UAS. Once added, a resource specification can be used to request or limit specific resource consumption on a host node or gain access to host node features managed by Kubernetes resources.
 The examples in this documentation focus on memory and CPU usage, but Kubernetes does use resources in some configurations to manage access to other kinds of resources.
 

--- a/operations/UAS_user_and_admin_topics/Create_a_UAI_with_Additional_Ports.md
+++ b/operations/UAS_user_and_admin_topics/Create_a_UAI_with_Additional_Ports.md
@@ -1,5 +1,7 @@
 # Create a UAI with Additional Ports
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 In legacy mode UAI creation, an option is available to expose UAI ports to the customer user network in addition to the port used for SSH access. These ports are restricted to ports 80, 443, and 8888.
 This procedure allows a user or administrator to create a new UAI with these additional ports.
 

--- a/operations/UAS_user_and_admin_topics/Create_and_Use_Default_UAIs_in_Legacy_Mode.md
+++ b/operations/UAS_user_and_admin_topics/Create_and_Use_Default_UAIs_in_Legacy_Mode.md
@@ -1,5 +1,7 @@
 # Create and Use Default UAIs in Legacy Mode
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Create a UAI using the default UAI image or the default UAI class in legacy mode.
 
 ## Procedure

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -1,5 +1,7 @@
 # Customize End-User UAI Images
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 The provided end-user UAI image is a basic UAI image that includes an up-to-date version of the SLES Linux distribution. It provides an entry point to using UAIs and an easy way for administrators to experiment with UAS configurations.
 To support building software to be run in compute nodes, or other HPC and Analytics workflows, it is necessary to create a custom end-user UAI image and use that.
 

--- a/operations/UAS_user_and_admin_topics/Customize_the_Broker_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Customize_the_Broker_UAI_Image.md
@@ -1,5 +1,7 @@
 # Customize the Broker UAI Image
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 The Broker UAI image that comes with UAS is the image used to construct Broker UAIs.
 
 The key pieces of the Broker UAI image are:

--- a/operations/UAS_user_and_admin_topics/Delete_a_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Delete_a_UAI.md
@@ -1,5 +1,7 @@
 # Delete a UAI
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 There are two procedures described here. The first shows how an administrator can manually delete arbitrary UAIs or delete UAIs belonging to a given user or created using a given [UAI Class](UAI_Classes.md). The second shows how an authorized user on can delete UAIs created in the [legacy UIA creation mode](Legacy_Mode_User-Driven_UAI_Management.md).
 
 When a UAI is deleted, any running WLM sessions associated with the owner of the UAI are left intact and can be interacted with through future UAIs owned by the same user or from UANs.

--- a/operations/UAS_user_and_admin_topics/Delete_a_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Delete_a_UAI_Class.md
@@ -1,5 +1,7 @@
 # Delete a UAI Class
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Delete a UAI class. After deletion, the class will no longer be available for creation of UAIs. Existing UAIs are unaffected.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Delete_a_UAI_Image_Registration.md
+++ b/operations/UAS_user_and_admin_topics/Delete_a_UAI_Image_Registration.md
@@ -1,5 +1,7 @@
 # Delete a UAI Image Registration
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Unregister a UAI image from UAS.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Delete_a_UAI_Resource_Specification.md
+++ b/operations/UAS_user_and_admin_topics/Delete_a_UAI_Resource_Specification.md
@@ -1,5 +1,7 @@
 # Delete a UAI Resource Specification
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Delete a specific UAI resource specification using the `resource_id` of that specification. Once deleted, UAIs will no longer be able to use that specification for creation. Existing UAIs are not affected by the change.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Delete_a_Volume_Configuration.md
+++ b/operations/UAS_user_and_admin_topics/Delete_a_Volume_Configuration.md
@@ -1,5 +1,7 @@
 # Delete a Volume Configuration
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Delete an existing volume configuration. This procedure does not delete the underlying object referred to by the UAS volume configuration.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Elements_of_a_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Elements_of_a_UAI.md
@@ -1,5 +1,7 @@
 # Elements of a UAI
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 All UAIs can have the following attributes associated with them:
 
 * A required container image

--- a/operations/UAS_user_and_admin_topics/End_User_UAIs.md
+++ b/operations/UAS_user_and_admin_topics/End_User_UAIs.md
@@ -1,5 +1,7 @@
 # End-User UAIs
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 UAIs used for interactive logins are called End-User UAIs. End-User UAIs can be seen as lightweight User Access Nodes (UANs), but there are important differences between UAIs and UANs.
 
 End-User UAIs are not dedicated hardware like UANs. They are implemented as containers orchestrated by Kubernetes, which makes them subject to Kubernetes scheduling and resource management rules.

--- a/operations/UAS_user_and_admin_topics/Examine_a_UAI_Using_a_Direct_Administrative_Command.md
+++ b/operations/UAS_user_and_admin_topics/Examine_a_UAI_Using_a_Direct_Administrative_Command.md
@@ -1,5 +1,7 @@
 # Examine a UAI Using a Direct Administrative Command
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Print out information about a UAI.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Legacy_Mode_User-Driven_UAI_Management.md
+++ b/operations/UAS_user_and_admin_topics/Legacy_Mode_User-Driven_UAI_Management.md
@@ -1,5 +1,7 @@
 # Legacy Mode User-Driven UAI Management
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 In the legacy mode, users create and manage their own UAIs through the Cray CLI. A user may create, list, and delete only UAIs owned by the user.
 The user may not create a UAI for another user, nor may the user see or delete UAIs owned by another user.
 Once created, the information describing the UAI gives the user the information needed to reach the UAI using SSH and log into it.

--- a/operations/UAS_user_and_admin_topics/List_Available_UAI_Classes.md
+++ b/operations/UAS_user_and_admin_topics/List_Available_UAI_Classes.md
@@ -1,5 +1,7 @@
 # List Available UAI Classes
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 View all the details of every available UAI class. Use this information to select a class to apply to one or more UAIs.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/List_Available_UAI_Images_in_Legacy_Mode.md
+++ b/operations/UAS_user_and_admin_topics/List_Available_UAI_Images_in_Legacy_Mode.md
@@ -1,5 +1,7 @@
 # List Available UAI Images in Legacy Mode
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 A user can list the UAI images available for creating a UAI with a command of the form:
 
 ```bash

--- a/operations/UAS_user_and_admin_topics/List_Registered_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/List_Registered_UAI_Images.md
@@ -1,5 +1,7 @@
 # List Registered UAI Images
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Administrators can use the `cray uas admin config images list` command to see the list of registered images. This command also displays the UAS registration information about each image.
 
 While Registering a UAI image name with UAS is necessary for UAIs to use the image, simply registering the image is not sufficient.

--- a/operations/UAS_user_and_admin_topics/List_UAI_Resource_Specifications.md
+++ b/operations/UAS_user_and_admin_topics/List_UAI_Resource_Specifications.md
@@ -1,5 +1,7 @@
 # List UAI Resource Specifications
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Obtain a list of all the UAI resource specifications registered with UAS.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/List_UAIs.md
+++ b/operations/UAS_user_and_admin_topics/List_UAIs.md
@@ -1,5 +1,7 @@
 # List UAIs
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 There are two ways to list UAIs in UAS. One of these is an administrative action and provides access to all currently running UAIs.
 The other is associated with the [Legacy UAI Management](Legacy_Mode_User-Driven_UAI_Management.md) mode and provides authorized users access to their own UAIs. Both of these are shown here.
 

--- a/operations/UAS_user_and_admin_topics/List_UAS_Information.md
+++ b/operations/UAS_user_and_admin_topics/List_UAS_Information.md
@@ -1,5 +1,7 @@
 # List UAS Version Information
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Use the `cray uas mgr-info list` command to determine the version and service name of UAS.
 
 ## List UAS Version with `cray uas mgr-info list`

--- a/operations/UAS_user_and_admin_topics/List_Volumes_Registered_in_UAS.md
+++ b/operations/UAS_user_and_admin_topics/List_Volumes_Registered_in_UAS.md
@@ -1,5 +1,7 @@
 # List Volumes Registered in UAS
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 List the details of all volumes registered in UAS with the `cray uas admin config volumes list` command. Use this command to obtain the `volume_id` value of volume, which is required for other UAS administrative commands.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Log_in_to_a_Broker_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Log_in_to_a_Broker_UAI.md
@@ -1,5 +1,7 @@
 # Log in to a Broker UAI
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 SSH to log into a Broker UAI and reach the End-User UAIs on demand.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Modify_a_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Modify_a_UAI_Class.md
@@ -1,5 +1,7 @@
 # Modify a UAI Class
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Update a UAI class with a modified configuration.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Obtain_Configuration_of_a_UAS_Volume.md
+++ b/operations/UAS_user_and_admin_topics/Obtain_Configuration_of_a_UAS_Volume.md
@@ -1,5 +1,7 @@
 # Obtain the Configuration of a UAS Volume
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 View the configuration information of a specific UAS volume. This procedure requires the `volume_ID` of that volume.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/README.md
+++ b/operations/UAS_user_and_admin_topics/README.md
@@ -1,5 +1,9 @@
 # User Access Service (UAS)
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
+User Access Instances \(UAIs\) are part of HPE Cray User Services Software (USS) beginning with the USS 1.1.0 release. See the USS 1.1.0 documentation for more information on UAI.
+
 The User Access Service \(UAS\) is a service that manages User Access Instances \(UAIs\) which are containerized services under Kubernetes that provide application developers and users with a lightweight login environment in which to create and run user applications. UAIs run on non-compute nodes \(NCN\), specifically Kubernetes Worker nodes.
 
 At a high level, there are two ways to configure UAS with respect to allowing users access to UAIs. The standard configuration involves the use of [Broker UAIs](Broker_Mode_UAI_Management.md) through which users establish SSH login sessions. When a login session is established to a Broker UAI the Broker UAI either locates or creates a new UAI on behalf of the user and forwards the user's SSH connection to that UAI. A [legacy configuration](Legacy_Mode_User-Driven_UAI_Management.md) requires users to create their own UAIs through the `cray` CLI. Once a UAI is created in this way, the users can use SSH to log into the UAI directly. The legacy configuration will soon be deprecated. Sites using it should migrate to the Broker UAI based configuration.

--- a/operations/UAS_user_and_admin_topics/Register_a_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Register_a_UAI_Image.md
@@ -1,5 +1,7 @@
 # Register a UAI Image
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Register a UAI image with UAS. Registration tells UAS where to locate the image and whether to use the image as the default for UAIs.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Reset_the_UAS_Configuration_to_Original_Installed_Settings.md
+++ b/operations/UAS_user_and_admin_topics/Reset_the_UAS_Configuration_to_Original_Installed_Settings.md
@@ -1,5 +1,7 @@
 # Clear UAS Configuration
 
+**NOTE:** UAI is deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 **WARNING:** The procedure described here will remove all UAS configuration including some configuration that is installed upon installation / upgrade of the HPE Cray EX system.
 If this procedure is used, the `update-uas` Helm chart must be removed and re-deployed to restore the full HPE provided configuration.
 This procedure should only be used in an extreme situation where the UAS configuration has become corrupted to the point where it can no longer be managed.

--- a/operations/UAS_user_and_admin_topics/Resource_Specifications.md
+++ b/operations/UAS_user_and_admin_topics/Resource_Specifications.md
@@ -1,5 +1,7 @@
 # Resource Specifications
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Kubernetes uses [resource limits and resource requests](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource), to manage the system resources available to pods.
 Because UAIs run as pods under Kubernetes, UAS takes advantage of Kubernetes to manage the system resources available to UAIs.
 

--- a/operations/UAS_user_and_admin_topics/Retrieve_Resource_Specification_Details.md
+++ b/operations/UAS_user_and_admin_topics/Retrieve_Resource_Specification_Details.md
@@ -1,5 +1,7 @@
 # Retrieve Resource Specification Details
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Display a specific resource specification using the `resource_id` of that specification.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Retrieve_UAI_Image_Registration_Information.md
+++ b/operations/UAS_user_and_admin_topics/Retrieve_UAI_Image_Registration_Information.md
@@ -1,5 +1,7 @@
 # Retrieve UAI Image Registration Information
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Use this procedure to obtain the default and imagename values for a registered UAI image. This procedure can also be used to confirm that a specific image ID is still registered with UAS.
 
 This procedure returns the same information as [List Registered UAI Images](List_Registered_UAI_Images.md), but only for one image.

--- a/operations/UAS_user_and_admin_topics/Setting_UAI_Timeouts.md
+++ b/operations/UAS_user_and_admin_topics/Setting_UAI_Timeouts.md
@@ -1,5 +1,7 @@
 # Setting UAI Timeouts
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 The procedures and specific values used for setting UAI timeouts are explained in the [UAI Classes](UAI_Classes.md) section. Please refer to that section.
 
 On systems where UAIs are used as part of normal user activities, the number of UAIs can grow large. Stale UAIs (i.e. UAIs that sit idle for long periods of time) can prevent creation of fresh UAIs for users who are actually active on the system.

--- a/operations/UAS_user_and_admin_topics/Setting_Up_Multi-Replica_Brokers.md
+++ b/operations/UAS_user_and_admin_topics/Setting_Up_Multi-Replica_Brokers.md
@@ -1,5 +1,7 @@
 # Broker UAI Resiliency and Load Balancing
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Broker UAI resiliency and load balancing is achieved through the use of Multi-Replica Broker UAIs.
 The procedures and data involved in configuring a UAI Class to create Multi-Replica Broker UAIs can be found in [UAI Classes](UAI_Classes.md).
 This page describes some of the reasons to use Multi-Replica Broker UAIs and some of the implications of doing so.

--- a/operations/UAS_user_and_admin_topics/Special_Purpose_UAIs.md
+++ b/operations/UAS_user_and_admin_topics/Special_Purpose_UAIs.md
@@ -1,5 +1,7 @@
 # Special Purpose UAIs
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Even though most UAIs are End-User UAIs, [UAI classes](UAI_Classes.md) make it possible to construct UAIs to serve special purposes that are not strictly end-user oriented.
 
 One kind of special purpose UAI is the [Broker UAI](Broker_Mode_UAI_Management.md), which provides on demand End-User UAI launch and management.

--- a/operations/UAS_user_and_admin_topics/Start_a_Broker_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Start_a_Broker_UAI.md
@@ -1,5 +1,7 @@
 # Start a Broker UAI
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Create a Broker UAI after a Broker UAI class has been created.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
@@ -1,5 +1,7 @@
 # Troubleshoot Broker UAI SSSD Cannot Use `/etc/sssd/sssd.conf`
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 ## Symptom
 
 A Broker UAI has been created using an SSSD configuration in a secret and volume as described in [Configure a Broker UAI Class](Configure_a_Broker_UAI_Class.md), but logging into the Broker UAI does not work.

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
@@ -1,5 +1,7 @@
 # Troubleshoot Common Mistakes when Creating a Custom End-User UAI Image
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 There are several problems that may occur while making or working with custom end-user UAI images.
 The following are some basic troubleshooting questions to ask:
 

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Duplicate_Mount_Paths_in_a_UAI.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Duplicate_Mount_Paths_in_a_UAI.md
@@ -1,5 +1,7 @@
 # Troubleshoot Duplicate Mount Paths in a UAI
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 If a user attempts to create a UAI in the legacy mode and cannot create the UAI at all, a good place to look is at volumes. Duplicate `mount_path` specifications in the list of volumes in a UAI will cause a failure that looks like this:
 
 ```bash

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Missing_or_Incorrect_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Missing_or_Incorrect_UAI_Images.md
@@ -1,5 +1,7 @@
 # Troubleshoot Missing or Incorrect UAI Images
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 If a UAI shows a `uai_status` of `Waiting` and a `uai_msg` of `ImagePullBackOff`, that indicates that the UAI or the UAI class is configured to use an image that is not in the image registry.
 
 Either obtaining and pushing the image to the image registry, or correcting the name or version of the image in the UAS configuration will usually resolve this.

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md
@@ -1,5 +1,7 @@
 # Troubleshoot Stale Brokered UAIs
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 When a Broker UAI terminates and restarts, the SSH key used to forward SSH sessions to End-User UAIs changes (this is a known problem) and subsequent Broker UAIs are unable to forward sessions to End-User UAIs.
 The symptom of this is that a user logging into a Broker UAI will receive a password prompt from the End-User UAI and be unable to log in even if providing the correct password.
 To fix this, remove the stale End-User UAIs and allow the Broker UAI to recreate them. The easy way to do this is to use the command specifying the uai-creation-class identifier from the Broker's UAI class.

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAS / CLI Authentication Issues
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Several troubleshooting steps related to authentication in a UAI.
 
 ## Internal Server Error

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Stuck_in_ContainerCreating.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Stuck_in_ContainerCreating.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAI Stuck in `ContainerCreating`
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Resolve an issue causing UAIs to show a `uai_status` field of `Waiting`, and a `uai_msg` field of `ContainerCreating`.
 It is possible that this is just a matter of starting the UAI taking longer than normal, perhaps as it pulls in a new UAI image from a registry. If the issue persists for a long time, it is worth investigating.
 

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAIs by Viewing Log Output
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Sometimes a UAI will come up and run but will not work correctly. It is possible to see errors reported by elements of the UAI entrypoint script using the `kubectl logs` command.
 
 ## Procedure

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_with_Administrative_Access.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_with_Administrative_Access.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAIs with Administrative Access
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Sometimes there is no better way to figure out a problem with a UAI than to get inside it and look around as an administrator. This is done using `kubectl exec` to start a shell
 inside the running container as `root` (in the container). With this an administrator can diagnose problems, make changes to the running UAI, and find solutions. It is important
 to remember that any change made inside a UAI is transitory. These changes only last as long as the UAI is running. To make a permanent change, either the UAI image has to be

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_Issues.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_Issues.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAS Issues
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 This section provides examples of some commands that can be used to troubleshoot UAS-related issues.
 
 ## Troubleshoot Connection Issues

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_by_Viewing_Log_Output.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_by_Viewing_Log_Output.md
@@ -1,5 +1,7 @@
 # Troubleshoot UAS by Viewing Log Output
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 At times there will be problems with UAS. Usually this takes the form of errors showing up on CLI commands that are not immediately interpretable as some sort of input error.
 It is sometimes useful to examine the UAS service logs to find out what is wrong.
 

--- a/operations/UAS_user_and_admin_topics/UAI_Classes.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Classes.md
@@ -1,5 +1,7 @@
 # UAI Classes
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 UAI Classes provide templates for the creation of UAIs. They permit precise configuration of the behavior, volumes, resources, and other elements of the UAI.
 When a UAI is created using a UAI Class, it is configured to use exactly what that UAI Class has in it at the time the UAI was created.
 UIA Classes permit Broker UAIs to create different kinds of UAIs based on the UAI Creation Class setting of the Broker UAI.

--- a/operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
@@ -1,5 +1,7 @@
 # UAI Host Node Selection
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 When selecting UAI host nodes, it is a good idea to take into account the amount of combined load users and system services will bring to those nodes.
 UAIs run by default at a lower priority than system services on worker nodes which means that, if the combined load exceeds the capacity of the nodes, Kubernetes will eject UAIs and/or refuse to schedule them to protect system services.
 This can be disruptive or frustrating for users. This section explains how to identify the currently configured UAI host nodes and how to adjust that selection to meet the needs of users.

--- a/operations/UAS_user_and_admin_topics/UAI_Host_Nodes.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Host_Nodes.md
@@ -1,5 +1,7 @@
 # UAI Host Nodes
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 UAIs run as Kubernetes pods on Kubernetes worker nodes.
 UAS provides a [a mechanism using Kubernetes labels](UAI_Host_Node_Selection.md) to prevent UAIs from running on a specific worker nodes, but any Kubernetes node that is not labeled to prevent UAIs from running on it is considered eligible to host UAIs.
 The administrator of a given site may control the set of UAI host nodes by labeling Kubernetes worker nodes appropriately.

--- a/operations/UAS_user_and_admin_topics/UAI_Image_Customization.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Image_Customization.md
@@ -1,5 +1,7 @@
 # UAI Image Customization
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 This section covers common customizations of both End-User UAIs and Broker UAIs.
 
 Refer to the following topics for more information:

--- a/operations/UAS_user_and_admin_topics/UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Images.md
@@ -1,5 +1,7 @@
 # UAI Images
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 There are three kinds of UAI images used by UAS:
 
 * A pre-packaged Broker UAI image provided with the UAS

--- a/operations/UAS_user_and_admin_topics/UAI_Management.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Management.md
@@ -1,5 +1,7 @@
 # UAI Management
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 UAS supports two manual methods and one automated method of UAI management:
 
 * Direct administrative UAI management

--- a/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
@@ -1,5 +1,7 @@
 # UAI Network Attachment Customization
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 The UAI network attachment configuration flows from the Cray Site Initializer (CSI) localization data through `customizations.yaml` into the UAS Helm chart and, ultimately, into Kubernetes in the form of a "network-attachment-definition".
 
 This section describes the data at each of those stages to show how the final network attachment gets created.

--- a/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
@@ -1,5 +1,7 @@
 # UAI macvlans Network Attachments
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 UAIs need to be able to reach compute nodes across the HPE Cray EX internal networks. When the compute node networks are structured as multiple subnets, this requires routing from the UAIs to those subnets.
 The default route in a UAI goes to the public network through the Customer Access Network (CAN) so that will not work for reaching compute nodes.
 To solve this problem, UAS installs Kubernetes Network Attachments within the Kubernetes `user` namespace. One of these network attachments is used by UAIs.

--- a/operations/UAS_user_and_admin_topics/UAS_Limitations.md
+++ b/operations/UAS_user_and_admin_topics/UAS_Limitations.md
@@ -1,5 +1,7 @@
 # UAS Limitations
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Functionality that is currently not supported while using UAS.
 
 ## Functionality Not Currently Supported by the User Access Service

--- a/operations/UAS_user_and_admin_topics/UAS_and_UAI_Health_Checks.md
+++ b/operations/UAS_user_and_admin_topics/UAS_and_UAI_Health_Checks.md
@@ -1,5 +1,7 @@
 # UAS and UAI Legacy Mode Health Checks
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Check the health of UAS and UAI to validate installation / upgrade of an HPE Cray EX system. This is a legacy mode procedure that can be run at installation / upgrade time to make sure that the following are true:
 
 * UAS is installed and running correctly

--- a/operations/UAS_user_and_admin_topics/Update_a_Resource_Specification.md
+++ b/operations/UAS_user_and_admin_topics/Update_a_Resource_Specification.md
@@ -1,5 +1,7 @@
 # Update a Resource Specification
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Modify a specific UAI resource specification using the `resource_id` of that specification.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Update_a_UAI_Image_Registration.md
+++ b/operations/UAS_user_and_admin_topics/Update_a_UAI_Image_Registration.md
@@ -1,5 +1,7 @@
 # Update a UAI Image Registration
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Modify the UAS registration information of a UAI image.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Update_a_UAS_Volume.md
+++ b/operations/UAS_user_and_admin_topics/Update_a_UAS_Volume.md
@@ -1,5 +1,7 @@
 # Update a UAS Volume
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Modify the configuration of an already-registered UAS volume. Almost any part of the configuration of a UAS volume can be modified.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/View_a_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/View_a_UAI_Class.md
@@ -1,5 +1,7 @@
 # View a UAI Class
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Display all the information for a specific UAI class by referencing its class ID.
 
 ## Prerequisites

--- a/operations/UAS_user_and_admin_topics/Volumes.md
+++ b/operations/UAS_user_and_admin_topics/Volumes.md
@@ -1,5 +1,7 @@
 # Volumes
 
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
+
 Volumes provide a way to connect UAIs to external data, whether they be Kubernetes managed objects, external file systems or files, host node files and directories, or remote networked data to be used within the UAI.
 
 The following are examples of how volumes are commonly used by UAIs:

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -13,7 +13,7 @@ The following services are backed up daily \(one week of backups retained\) as p
 - Boot Orchestration Service \(BOS\)
 - Boot Script Service \(BSS\)
 - Firmware Action Service \(FAS\)
-- User Access Service \(UAS\)
+- User Access Service \(UAS\) - Deprecated
 
 (`ncn-mw#`) Run the following command on any Kubernetes master or worker node in order to list the backups for a specific project.
 In the example below, the backups for BSS are listed.

--- a/operations/security_and_authentication/API_Authorization.md
+++ b/operations/security_and_authentication/API_Authorization.md
@@ -18,6 +18,8 @@ Authorized for every possible REST API endpoint.
 
 ## `user`
 
+**NOTE:** UAS and User Access Instances are deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
+
 Authorized for a subset of endpoints to allow users to create and use [User Access Instances (UAIs)](../../glossary.md#user-access-instance-uai),
 run jobs, view job results, and use capsules.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -38,7 +38,7 @@ Each section of this health check document provides links to relevant troublesho
     - [4.3 External SSH access test execution](#43-external-ssh-access-test-execution)
 - [5. Booting CSM `barebones` image](#5-booting-csm-barebones-image)
     - [5.1 Run the test script](#51-run-the-test-script)
-- [6. UAS/UAI tests](#6-uasuai-tests)
+- [6. UAS/UAI tests - Deprecated](#6-uasuai-tests)
     - [6.1 Validate the basic UAS installation](#61-validate-the-basic-uas-installation)
     - [6.2 Validate UAI creation](#62-validate-uai-creation)
     - [6.3 Test UAI gateway health](#63-test-uai-gateway-health)
@@ -540,6 +540,8 @@ cray.barebones-boot-test: INFO     Successfully completed barebones image boot t
 ```
 
 ## 6. UAS/UAI tests
+
+**NOTE** UAS/UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6.
 
 The commands in this section require that the [Cray CLI is configured](#0-cray-command-line-interface) on nodes where the commands are being executed.
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -17,7 +17,7 @@ This document provides links to troubleshooting information for services and fun
 - [Node management](#node-management)
 - [Security and authentication](#security-and-authentication)
 - [Spire](#spire)
-- [User Access service UAS](#user-access-service-uas)
+- [User Access service UAS - Deprecated](#user-access-service-uas)
 - [Utility storage](#utility-storage)
 
 ## Helpful tips for navigating the CSM repository
@@ -163,6 +163,8 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Spire Server Report Database is in Recovery](known_issues/spire_server_database_recovery.md)
 
 ## User Access service UAS
+
+**NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
 
 - [Viewing UAI Log Output](../operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md)
 - [Stale Brokered UAIs](../operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md)


### PR DESCRIPTION
This PR is to add note lines to the UAS and UAI related documents indicating that UAS/UAI is deprecated in CSM-1.5.2 and will be removed from CSM-1.6.

This PR resolves CASMUSER-3239 for CSM-1.5.2.
