### PR TITLE
CASMTRIAGE-7027: Many changes to full system power down/up procedures

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -600,6 +600,7 @@ prebuilt
 preempted
 preemptively
 provisioners
+PXEboot
 redis
 re-architecting
 ReadOnly

--- a/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
+++ b/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
@@ -91,7 +91,7 @@ The returned output includes the date and time of the latest backup for each ser
 that the service is not backed up automatically. Create a manual backup for that service by following the
 [Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
 
-## Check backup status for a specific etcd cluster 
+## Check backup status for a specific etcd cluster
 
 (`ncn-mw#`) Run the following command to list the backups for a specific project.
 In the example below, the backups for BSS are listed.
@@ -114,4 +114,3 @@ cray-bss/etcd.backup_v7210_2020-02-03-20:45:48
 The returned output includes the date and time of the latest backup for this etcd cluster. If a recent backup is not included, it is an indication
 that the service is not backed up automatically. Create a manual backup for that service by following the
 [Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
-

--- a/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
+++ b/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
@@ -5,6 +5,8 @@ Services that are not backed up automatically will need to be manually rediscove
 
 - [Clusters with automated backups](#clusters-with-automated-backups)
 - [Clusters without automated backups](#clusters-without-automated-backups)
+- [Check status of etcd cluster backups](#check-status-of-etcd-cluster-backups)
+- [Check backup status for a specific etcd cluster](#check-backup-status-for-a-specific-etcd-cluster)
 
 ## Clusters with automated backups
 
@@ -16,7 +18,82 @@ The following services are backed up daily \(one week of backups retained\) as p
 - Firmware Action Service \(FAS\)
 - User Access Service \(UAS\)
 
-(`ncn-mw#`) Run the following command on any Kubernetes master or worker node in order to list the backups for a specific project.
+If these clusters are lacking a recent backup, create a manual backup for that service by following the
+[Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
+
+## Clusters without automated backups
+
+The following projects are not backed up as part of the automated solution:
+
+- Content Projection Service \(CPS\)
+- Heartbeat Tracking Daemon \(HBTD\)
+- HMS Notification Fanout Daemon \(HMNFD\)
+- River Endpoint Discovery Service \(REDS\)
+
+If these clusters become unhealthy, the process for rediscovering their data should be followed.
+See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
+
+## Check status of etcd cluster backups
+
+(`ncn-mw#`) To view all available etcd backups across all clusters
+
+```bash
+/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_backups_check
+```
+
+Example output:
+
+```text
+**************************************************************************
+
+=== List automated etcd backups on system. ===
+=== Etcd Clusters with Automatic Etcd Back-ups Configured: ===
+=== BOS, BSS, CRUS, and FAS ===
+=== May want to ensure that automated back-ups are up to-date ===
+=== and that automated back-ups continue after NCN worker reboot. ===
+=== Clusters without Automated Backups: ===
+=== HBTD, HMNFD, REDS, UAS & CPS ===
+=== Automatic backups generated after cluster has been running 24 hours. ===
+=== date; kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c boto3 -- list_backups <cluster> ; ===
+Fri 07 Jun 2024 08:22:48 PM UTC
+
+-- cray-bos -- backups
+cray-bos/etcd.backup_v1906358_2024-06-01-18:40:10
+cray-bos/etcd.backup_v1911014_2024-06-02-18:40:10
+cray-bos/etcd.backup_v1915722_2024-06-03-18:40:10
+cray-bos/etcd.backup_v1920319_2024-06-04-18:40:10
+cray-bos/etcd.backup_v1924894_2024-06-05-18:40:10
+cray-bos/etcd.backup_v1929230_2024-06-06-18:40:10
+cray-bos/etcd.backup_v1933567_2024-06-07-18:40:10
+cray-bos/post_install.backup_2023-01-09-12:01:35
+cray-bos/post_upgrade.backup_2023-09-06-19:58:11
+PASS: backup found less than 24 hours old.
+
+-- cray-bss -- backups
+cray-bss/etcd.backup_v3365197_2024-06-01-18:03:17
+cray-bss/etcd.backup_v3369567_2024-06-02-18:03:17
+cray-bss/etcd.backup_v3374611_2024-06-03-18:03:17
+cray-bss/etcd.backup_v3382276_2024-06-04-18:03:17
+cray-bss/etcd.backup_v3389117_2024-06-05-18:03:17
+cray-bss/etcd.backup_v3395127_2024-06-06-18:03:17
+cray-bss/etcd.backup_v3401174_2024-06-07-18:03:17
+cray-bss/post_install.backup_2023-01-09-12:01:36
+cray-bss/post_upgrade.backup_2023-09-06-19:58:12
+PASS: backup found less than 24 hours old.
+
+[...]
+
+ --- PASSED --- 
+
+```
+
+The returned output includes the date and time of the latest backup for each service. If a recent backup for any service is not included, it is an indication
+that the service is not backed up automatically. Create a manual backup for that service by following the
+[Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
+
+## Check backup status for a specific etcd cluster 
+
+(`ncn-mw#`) Run the following command to list the backups for a specific project.
 In the example below, the backups for BSS are listed.
 
 ```bash
@@ -34,47 +111,7 @@ cray-bss/etcd.backup_v5771_2020-02-02-20:45:48
 cray-bss/etcd.backup_v7210_2020-02-03-20:45:48
 ```
 
-(`ncn-mw#`) To view all available backups across all projects:
-
-```bash
-kubectl exec -it -n operators \
-    $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
-    -c boto3 -- list_backups ""
-```
-
-Example output:
-
-```text
-bare-metal/etcd-backup-2020-02-03-14-40-07.tar.gz
-bare-metal/etcd-backup-2020-02-03-14-50-03.tar.gz
-bare-metal/etcd-backup-2020-02-03-15-00-10.tar.gz
-bare-metal/etcd-backup-2020-02-03-15-10-06.tar.gz
-bare-metal/etcd-backup-2020-02-03-15-30-05.tar.gz
-bare-metal/etcd-backup-2020-02-03-15-40-01.tar.gz
-bare-metal/etcd-backup-2020-02-03-15-50-08.tar.gz
-cray-bos/etcd.backup_v1200_2020-02-03-20:45:48
-cray-bos/etcd.backup_v240_2020-01-30-20:44:34
-cray-bos/etcd.backup_v480_2020-01-31-20:44:34
-cray-bos/etcd.backup_v720_2020-02-01-20:45:48
-cray-bos/etcd.backup_v960_2020-02-02-20:45:48
-cray-bss/etcd.backup_v1450_2020-01-30-20:44:41
-cray-bss/etcd.backup_v4183_2020-02-01-20:45:48
-
-[...]
-```
-
-The returned output includes the date and time of the latest backup for each service. If a recent backup for any service is not included, it is an indication
+The returned output includes the date and time of the latest backup for this etcd cluster. If a recent backup is not included, it is an indication
 that the service is not backed up automatically. Create a manual backup for that service by following the
 [Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
 
-## Clusters without automated backups
-
-The following projects are not backed up as part of the automated solution:
-
-- Content Projection Service \(CPS\)
-- Heartbeat Tracking Daemon \(HBTD\)
-- HMS Notification Fanout Daemon \(HMNFD\)
-- River Endpoint Discovery Service \(REDS\)
-
-If these clusters become unhealthy, the process for rediscovering their data should be followed.
-See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).

--- a/operations/kubernetes/Check_the_Health_and_Balance_of_etcd_Clusters.md
+++ b/operations/kubernetes/Check_the_Health_and_Balance_of_etcd_Clusters.md
@@ -1,8 +1,7 @@
 # Check the Health and Balance of etcd Clusters
 
 Check to see if all of the etcd clusters have healthy pods, are balanced, and have a healthy cluster database.
-There needs to be the same number of pods running on each worker node for the etcd clusters to be balanced.
-If the number of pods is not the same for each worker node, the cluster is not balanced.
+A balanced etcd cluster has at least three pods which are running on different worker nodes.
 
 Any clusters that do not have healthy pods will need to be rebuilt. Kubernetes cluster data will not be stored as efficiently when etcd clusters are not balanced.
 

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -36,57 +36,107 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 
 1. (`ncn-m#`) Check the power status in liquid-cooled cabinets before shutdown.
 
-    This example shows liquid-cooled cabinets 1000 - 1003.
+    Either use `sat status` or `cray capmc` to check. The `State` should be `Off` for every Chassis.
 
-    ```bash
-    cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
-    ```
+    1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
+
+       ```bash
+       sat status --types Chassis
+       ```
+
+       Example output.
+
+       ```text
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | x1020c0 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c1 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c2 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c3 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c4 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c5 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c6 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c7 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       ```
+
+    1. (`ncn-m001#`) Check the power status with CAPMC.
+
+        This example shows liquid-cooled cabinets 1000 - 1003.
+
+        ```bash
+        cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
+        ```
 
 1. (`ncn-m#`) Check the power status for nodes in the standard racks before shutdown.
 
-    This example shows nodes in cabinets 3001 - 3003.
+    Either use `sat status` or `cray capmc` to check. The `State` should be `Off` for every node.
 
-    ```bash
-    cray capmc get_xname_status create --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
-    ```
+    1. (`ncn-m001#`) Check the power status for every `River` node which is not a management node.
 
-    The `get_xname_status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
+       ```bash
+       sat status --filter class=river --filter role!=management --filter enabled=true --hsm-fields
+       ```
 
-    The command does not filter nonexistent component names \(xnames\) and displays an error when invalid component names are specified. Use `--filter` `show_all` option to filter all the output:
+       Example output.
 
-    ```bash
-    cray capmc get_xname_status create --filter show_all --format json
-    ```
+       ```text
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
+       | xname          | Type | NID      | State   | Flag  | Enabled | Arch | Class | Role        | SubRole    | Net Type |
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
+       | x3000c0s14b0n0 | Node | 49168832 | Off     | OK    | True    | X86  | River | Application | UAN        | Sling    |
+       | x3000c0s16b0n0 | Node | 49168896 | Off     | OK    | True    | X86  | River | Application | LNETRouter | Sling    |
+       | x3000c0s18b0n0 | Node | 49168960 | Off     | OK    | True    | X86  | River | Application | LNETRouter | Sling    |
+       | x3000c0s20b1n0 | Node | 1        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b2n0 | Node | 2        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b3n0 | Node | 3        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b4n0 | Node | 4        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       ```
 
-    Example output:
+    1. (`ncn-m001#`) Check the power status with CAPMC.
+       This example shows nodes in cabinets 3001 - 3003.
 
-    ```json
-    {
-      "e": 0,
-      "err_msg": "",
-      "off": [
-        "x3000c0s19b0n0",
-        "x3000c0s20b0n0",
-        "x3000c0s22b0n0",
-        "x3000c0s24b0n0",
-        "x3000c0s27b1n0",
-        "x3000c0s27b2n0",
-        "x3000c0s27b3n0",
-        "x3000c0s27b4n0"
-      ],
-      "on": [
-        "x3000c0r15e0",
-        "x3000c0s2b0n0",
-        "x3000c0s3b0n0",
-        "x3000c0s4b0n0",
-        "x3000c0s5b0n0",
-        "x3000c0s6b0n0",
-        "x3000c0s7b0n0",
-        "x3000c0s8b0n0",
-        "x3000c0s9b0n0"
-      ]
-    }
-    ```
+       ```bash
+       cray capmc get_xname_status create --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
+       ```
+
+       The `get_xname_status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
+
+       The command does not filter nonexistent component names \(xnames\) and displays an error when invalid component names are specified. Use `--filter` `show_all` option to filter all the output:
+
+       ```bash
+       cray capmc get_xname_status create --filter show_all --format json
+       ```
+
+       Example output:
+
+       ```json
+       {
+         "e": 0,
+         "err_msg": "",
+         "off": [
+           "x3000c0s19b0n0",
+           "x3000c0s20b0n0",
+           "x3000c0s22b0n0",
+           "x3000c0s24b0n0",
+           "x3000c0s27b1n0",
+           "x3000c0s27b2n0",
+           "x3000c0s27b3n0",
+           "x3000c0s27b4n0"
+         ],
+         "on": [
+           "x3000c0r15e0",
+           "x3000c0s2b0n0",
+           "x3000c0s3b0n0",
+           "x3000c0s4b0n0",
+           "x3000c0s5b0n0",
+           "x3000c0s6b0n0",
+           "x3000c0s7b0n0",
+           "x3000c0s8b0n0",
+           "x3000c0s9b0n0"
+         ]
+       }
+       ```
 
 ### Shut down cabinet power
 

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -208,7 +208,6 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 compute nodes or management nodes, then the power off of the PDU circuits in these cabinets should be delayed until the external
 file systems have been confirmed to be cleanly shut down. See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 
-
 1. Set each cabinet PDU circuit breaker to `OFF`.
 
     A slotted screwdriver may be required to open PDU circuit breakers.

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -204,6 +204,11 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 ### Power off standard rack PDU circuit breakers
 
+**CAUTION:** If any of the external Lustre or SpectrumScale (GPFS) file systems are in air-cooled cabinets shared with air-cooled
+compute nodes or management nodes, then the power off of the PDU circuits in these cabinets should be delayed until the external
+file systems have been confirmed to be cleanly shut down. See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
+
+
 1. Set each cabinet PDU circuit breaker to `OFF`.
 
     A slotted screwdriver may be required to open PDU circuit breakers.

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -58,6 +58,8 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
        | x1020c5 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
        | x1020c6 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
        | x1020c7 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       ...
+       +---------+---------+-------+------+---------+------+----------+----------+
        ```
 
     1. (`ncn-m001#`) Check the power status with CAPMC.
@@ -91,6 +93,8 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
        | x3000c0s20b2n0 | Node | 2        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
        | x3000c0s20b3n0 | Node | 3        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
        | x3000c0s20b4n0 | Node | 4        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       ...
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
        ```
 
     1. (`ncn-m001#`) Check the power status with CAPMC.

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -204,7 +204,7 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 ### Power off standard rack PDU circuit breakers
 
-**CAUTION:** If any of the external Lustre or SpectrumScale (GPFS) file systems are in air-cooled cabinets shared with air-cooled
+**CAUTION:** If any of the external Lustre or Spectrum Scale (GPFS) file systems are in air-cooled cabinets shared with air-cooled
 compute nodes or management nodes, then the power off of the PDU circuits in these cabinets should be delayed until the external
 file systems have been confirmed to be cleanly shut down. See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -50,14 +50,14 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
        +---------+---------+-------+------+---------+------+----------+----------+
        | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
        +---------+---------+-------+------+---------+------+----------+----------+
-       | x1020c0 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c1 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c2 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c3 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c4 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c5 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c6 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c7 | Chassis | Off    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c0 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c1 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c2 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c3 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c4 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c5 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c6 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c7 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
        ```
 
     1. (`ncn-m001#`) Check the power status with CAPMC.

--- a/operations/power_management/Power_Off_Storage_Cabinets.md
+++ b/operations/power_management/Power_Off_Storage_Cabinets.md
@@ -4,7 +4,9 @@ Power off storage nodes and management switches in standard racks.
 
 ## Power off standard rack PDU circuit breakers
 
-**CAUTION:** The Lustre or SpectrumScale (GPFS) file systems on nodes and switches in storage cabinets should only be powered off once it has been confirmed that the filesystems have been cleanly shut down.  See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
+**CAUTION:** The Lustre or SpectrumScale (GPFS) file systems on nodes and switches in storage cabinets should only
+be powered off once it has been confirmed that the filesystems have been cleanly shut down.  See the procedures in
+[Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 
 1. Set each cabinet PDU circuit breaker to `OFF`.
 

--- a/operations/power_management/Power_Off_Storage_Cabinets.md
+++ b/operations/power_management/Power_Off_Storage_Cabinets.md
@@ -4,8 +4,8 @@ Power off storage nodes and management switches in standard racks.
 
 ## Power off standard rack PDU circuit breakers
 
-**CAUTION:** The Lustre or SpectrumScale (GPFS) file systems on nodes and switches in storage cabinets should only
-be powered off once it has been confirmed that the filesystems have been cleanly shut down.  See the procedures in
+**CAUTION:** The Lustre or Spectrum Scale (GPFS) file systems on nodes and switches in storage cabinets should only
+be powered off once it has been confirmed that the filesystems have been cleanly shut down. See the procedures in
 [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 
 1. Set each cabinet PDU circuit breaker to `OFF`.

--- a/operations/power_management/Power_Off_Storage_Cabinets.md
+++ b/operations/power_management/Power_Off_Storage_Cabinets.md
@@ -1,0 +1,19 @@
+# Power Off Storage Cabinets
+
+Power off storage nodes and management switches in standard racks.
+
+## Power off standard rack PDU circuit breakers
+
+**CAUTION:** The Lustre or SpectrumScale (GPFS) file systems on nodes and switches in storage cabinets should only be powered off once it has been confirmed that the filesystems have been cleanly shut down.  See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
+
+1. Set each cabinet PDU circuit breaker to `OFF`.
+
+    A slotted screwdriver may be required to open PDU circuit breakers.
+
+1. To power off Motivair liquid-cooled chilled doors and CDUs, locate the power off switch on the CDU control panel and set it to `OFF`.
+
+    Refer to vendor documentation for the chilled-door cooling system for power control procedures when chilled doors are installed on standard racks.
+
+## Next step
+
+Return to [System Power Off Procedures](System_Power_Off_Procedures.md) and continue with next step.

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -92,7 +92,7 @@ power-on command from Cray System Management \(CSM\) software.
    cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[1,3,5,7] --format json
    ```
 
-1. (`ncn-m001#`) (ncn-m#) Check the power status for every liquid-cooled cabinet Chassis.
+1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
 
    The `State` should be `On` for every Chassis.
 

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -41,6 +41,21 @@ power-on command from Cray System Management \(CSM\) software.
 
    ![PSU Status LEDs](../../img/operations/PSU_Status.svg)
 
+1. (`ncn-m001#`) Unsuspend the `hms-discovery cronjob` to re-enable the `hms-discovery` job.
+
+   ```bash
+   kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
+   ```
+
+   Example output.
+
+   `ACTIVE` = `1` and `SUSPEND` = `False` in the output indicates that the job has been unsuspended:
+
+   ```text
+   NAME             SCHEDULE      SUSPEND   ACTIVE   LAST   SCHEDULE  AGE
+   hms-discovery    */3 * * * *   False       1      41s              33d
+   ```
+
 1. (`ncn-m001#`) Use the System Admin Toolkit \(`sat`\) to power on liquid-cooled cabinets, chassis, and slots.
 
    ```console
@@ -75,6 +90,30 @@ power-on command from Cray System Management \(CSM\) software.
    cray capmc xname_on create --xnames x[1000-1003]c[0-7] --format json
    cray capmc xname_on create --xnames x[1000-1003]c[0-7]s[0-7] --format json
    cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[1,3,5,7] --format json
+   ```
+
+1. (`ncn-m001#`) (ncn-m#) Check the power status for every liquid-cooled cabinet Chassis.
+
+   The `State` should be `On` for every Chassis.
+
+   ```bash
+   sat status --types Chassis
+   ```
+
+   Example output.
+
+   ```text
+   +---------+---------+-------+------+---------+------+----------+----------+
+   | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
+   +---------+---------+-------+------+---------+------+----------+----------+
+   | x1020c0 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c1 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c2 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c3 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c4 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c5 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c6 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c7 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
    ```
 
 ### Power On Standard Rack PDU Circuit Breakers

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -41,7 +41,7 @@ power-on command from Cray System Management \(CSM\) software.
 
    ![PSU Status LEDs](../../img/operations/PSU_Status.svg)
 
-1. (`ncn-m001#`) Unsuspend the `hms-discovery cronjob` to re-enable the `hms-discovery` job.
+1. (`ncn-m001#`) Unsuspend the `hms-discovery cronjob`.
 
    ```bash
    kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
@@ -49,12 +49,14 @@ power-on command from Cray System Management \(CSM\) software.
 
    Example output.
 
-   `ACTIVE` = `1` and `SUSPEND` = `False` in the output indicates that the job has been unsuspended:
-
    ```text
    NAME             SCHEDULE      SUSPEND   ACTIVE   LAST   SCHEDULE  AGE
-   hms-discovery    */3 * * * *   False       1      41s              33d
+   hms-discovery    */3 * * * *   False     1        41s              33d
    ```
+
+   A value of `False` in the `SUSPEND` column indicates that the cronjob is no longer suspended. A
+   value of `1` in the `Active` column indicates that a Kubernetes job is currently running for the
+   cronjob.
 
 1. (`ncn-m001#`) Use the System Admin Toolkit \(`sat`\) to power on liquid-cooled cabinets, chassis, and slots.
 
@@ -114,6 +116,8 @@ power-on command from Cray System Management \(CSM\) software.
    | x1020c5 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
    | x1020c6 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
    | x1020c7 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   ...
+   +---------+---------+-------+------+---------+------+----------+----------+
    ```
 
 ### Power On Standard Rack PDU Circuit Breakers

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -55,7 +55,7 @@ power-on command from Cray System Management \(CSM\) software.
    ```
 
    A value of `False` in the `SUSPEND` column indicates that the cronjob is no longer suspended. A
-   value of `1` in the `Active` column indicates that a Kubernetes job is currently running for the
+   value of `1` in the `ACTIVE` column indicates that a Kubernetes job is currently running for the
    cronjob.
 
 1. (`ncn-m001#`) Use the System Admin Toolkit \(`sat`\) to power on liquid-cooled cabinets, chassis, and slots.

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -7,6 +7,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 ## Prerequisites
 
 * All compute cabinet PDUs, servers, and switches must be powered on.
+* All external file systems, such as Lustre or SpectrumScale (GPFS), should be available to be mounted by clients
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section
   of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 
@@ -119,6 +120,10 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
        ```
 
        Each system might have many different queue names. There is no default queue name.
+
+1. If the servers providing external external Lustre or SpectrumScale (GPFS) file systems have been powering up in parallel
+to the CSM system, ensure that they are ready to be mounted by clients before continuing to the next step which boots
+the UANs and compute nodes.
 
 1. (`ncn-m001#`) List detailed information about the available boot orchestration service \(BOS\) session template names.
 

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -7,7 +7,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 ## Prerequisites
 
 * All compute cabinet PDUs, servers, and switches must be powered on.
-* All external file systems, such as Lustre or SpectrumScale (GPFS), should be available to be mounted by clients
+* All external file systems, such as Lustre or Spectrum Scale (GPFS), should be available to be mounted by clients
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section
   of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 
@@ -241,7 +241,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 
        Each system might have many different queue names. There is no default queue name.
 
-1. If the servers providing external external Lustre or SpectrumScale (GPFS) file systems have been powering up in parallel
+1. If the servers providing external external Lustre or Spectrum Scale (GPFS) file systems have been powering up in parallel
 to the CSM system, ensure that they are ready to be mounted by clients before continuing to the next step which boots
 the UANs and compute nodes.
 

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -296,7 +296,6 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 
       In this example, two of the application Gateway nodes have a `State` of `Off` which means that they did not power on
       and two of the compute nodes have a `State` of `On` which means they powered on but failed to boot to multi-user Linux.
-      
 
    1. (`ncn-m001#`) Check the BOS fields from `sat status`, but exclude the nodes which have `Most Recent BOS Session`
        set to `Missing`. This will exclude the management nodes because they are never booted with BOS.

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -99,6 +99,27 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
     Offline Switches:
     ```
 
+1. If any workload manager queues were disabled during the power off procedure, enable them.
+   Follow the vendor workload manager documentation to enable queues for running jobs on compute nodes.
+   After compute nodes boot and configure, they will become available in the workload manager.
+
+    1. For Slurm, see the `scontrol` man page.
+
+       If any queues were disabled during the power off procedure, enable them.  
+
+    1. For PBS Professional, see the `qstat` and `qmgr` man pages.
+
+       Below is an example to list the available queues, enable a specific queue named `workq`, and check
+       that the queue has been enabled:
+
+       ```bash
+       qstat -q
+       qmgr -c 'set queue workq enabled = True'
+       qmgr -c 'list queue workq enabled'
+       ```
+
+       Each system might have many different queue names. There is no default queue name.
+
 1. (`ncn-m001#`) List detailed information about the available boot orchestration service \(BOS\) session template names.
 
     Identify the BOS session template names (such as `"compute-23.7.0"` or `uan-23.7.0`), and choose the appropriate compute and UAN node templates for the power on and boot.
@@ -379,3 +400,4 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 ## Next step
 
 Return to [System Power On Procedures](System_Power_On_Procedures.md) and continue with next step.
+gi

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -74,7 +74,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
        ```bash
        kubectl exec -it -n services "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" -c slingshot-fabric-manager -- bash
        ```
-   
+
     1. (`slingshot-fabric-manager>`) Correct SSH file permissions.
 
        ```bash

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -241,7 +241,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 
        Each system might have many different queue names. There is no default queue name.
 
-1. If the servers providing external external Lustre or Spectrum Scale (GPFS) file systems have been powering up in parallel
+1. If the servers providing external Lustre or Spectrum Scale (GPFS) file systems have been powering up in parallel
 to the CSM system, ensure that they are ready to be mounted by clients before continuing to the next step which boots
 the UANs and compute nodes.
 

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -400,4 +400,3 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 ## Next step
 
 Return to [System Power On Procedures](System_Power_On_Procedures.md) and continue with next step.
-gi

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -143,7 +143,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
    1. (`slingshot-fabric-manager>`) Reboot the switches and reset their ASICs.
 
       ```bash
-      date; fmn-reset-switch -k -i $SWITCHES ; sleep 3m; date;  fmn-reset-switch -r -i $SWITCHES; sleep 3m; date
+      date; fmn-reset-switch -k -i $SWITCHES; sleep 3m; date; fmn-reset-switch -r -i $SWITCHES; sleep 3m; date
       ```
 
    1. (`slingshot-fabric-manager>`) Check whether the switches are online now.

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -280,7 +280,7 @@ Some systems are configured with lazy mounts that do not have this requirement f
 
     To resolve the space issue, see [Troubleshoot Ceph OSDs Reporting Full](../utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md).
 
-1. (`ncn-m001#`) Manually mount S3 filesystems on the master and worker nodes. These nodes try
+1. (`ncn-m001#`) Manually mount S3 and Ceph filesystems on the master and worker nodes. These nodes try
     to mount several S3 filesystems when they are booted. Since Ceph is not available during boot
     time, this workaround is required. The `boot-images` S3 filesystem is required for CPS pods
     to successfully start on worker nodes.
@@ -308,16 +308,13 @@ Some systems are configured with lazy mounts that do not have this requirement f
 1. (`ncn-m001#`) Correct the SDU collection link.
 
     If SDU has been configured on a master node, correct the `collection` link now that its `fuse.s3fs` filesystem is mounted from Ceph storage nodes.
-    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target. This command checks all master nodes but changes them and restarts `cray-sdu-rda` only if needed.
+    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead of `collection-local`. This command checks all master nodes but changes them and restarts `cray-sdu-rda` only if needed.
 
     ```bash
     pdsh -w ncn-m00[1-3]  '(cd /var/opt/cray/sdu; if [ -L "collection" ]; then if [ "$(readlink collection)" = "collection-local" ]; then rm collection; ln -s collection-mount collection; systemctl restart cray-sdu-rda; fi; fi)'
     ```
 
 1. (`ncn-m001#`) Check that `spire` pods have started.
-
-    **Note:** Because no containers are running, all pods first transition to an `Error` state. The `Error` state indicates that their containers were stopped. The `kubelet` on each node
-    restarts the containers for each pod. The `RESTARTS` column of the `kubectl get pods -A` command increments as each pod progresses through the restart sequence.
 
     Monitor the status of the `spire-jwks` pods to ensure they restart and enter the `Running` state.
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -286,7 +286,7 @@ Some systems are configured with lazy mounts that do not have this requirement f
     to successfully start on worker nodes.
 
     ```bash
-    pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g')  "awk '{ if (\$3 == \"fuse.s3fs\" || \$3 == \"ceph\") { print \$2; }}' /etc/fstab | xargs -I {} -n 1 sh -c \"mountpoint {} || mount {}\"" | dshbak -c
+    pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g') "awk '{ if (\$3 == \"fuse.s3fs\" || \$3 == \"ceph\") { print \$2; }}' /etc/fstab | xargs -I {} -n 1 sh -c \"mountpoint {} || mount {}\"" | dshbak -c
     ```
 
     Example output:
@@ -308,7 +308,7 @@ Some systems are configured with lazy mounts that do not have this requirement f
 1. (`ncn-m001#`) Correct the SDU collection link.
 
     If SDU has been configured on a master node, correct the `collection` link now that its `fuse.s3fs` filesystem is mounted from Ceph storage nodes.
-    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target.  This command checks all master nodes but changes them and restarts `cray-sdu-rda` only if needed.
+    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target. This command checks all master nodes but changes them and restarts `cray-sdu-rda` only if needed.
 
     ```bash
     pdsh -w ncn-m00[1-3]  '(cd /var/opt/cray/sdu; if [ -L "collection" ]; then if [ "$(readlink collection)" = "collection-local" ]; then rm collection; ln -s collection-mount collection; systemctl restart cray-sdu-rda; fi; fi)'

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -294,6 +294,15 @@ Verify that the Lustre file system is available from the management cluster.
     /var/lib/cps-local/boot-images is a mountpoint
     ```
 
+1. (`ncn-m001#`) Correct the SDU collection link.
+
+    If SDU has been configured on a master node, correct the `collection` link now that its `fuse.s3fs` filesystem is mounted from Ceph storage nodes.
+    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target.  This command checks all master nodes but changes them and restarts cray-sdu-rda only if needed.
+
+    ```bash
+    pdsh -w ncn-m00[1-3]  '(cd /var/opt/cray/sdu; if [ -L "collection" ]; then if [ "$(readlink collection)" = "collection-local" ]; then rm collection; ln -s collection-mount collection; systemctl restart cray-sdu-rda; fi; fi)'
+    ```
+
 1. (`ncn-m001#`) Monitor the status of the management cluster and which pods are restarting (as indicated by either a `Running` or `Completed` state).
 
     ```bash

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -170,9 +170,12 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
      pdsh -w $(grep "nmn ncn-" /etc/hosts | awk '{print $3}' | xargs | sed 's/ /,/g') uptime
     ```
 
-### Verify access to Lustre file system
+### Verify Access to External File Systems
 
-Verify that the Lustre file system is available from the management cluster.
+If the worker nodes host User Access Instance (UAI) pods or normally mount the external Lustre or SpectrumScale (GPFS) file systems,
+then verify that the external file system is ready to be mounted by the worker nodes.
+
+Some systems are configured with lazy mounts that do not have this requirement for the worker nodes.
 
 ### Start Kubernetes and other services
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -172,7 +172,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 ### Verify Access to External File Systems
 
-If the worker nodes host User Access Instance (UAI) pods or normally mount the external Lustre or SpectrumScale (GPFS) file systems,
+If the worker nodes host User Access Instance (UAI) pods or normally mount the external Lustre or Spectrum Scale (GPFS) file systems,
 then verify that the external file system is ready to be mounted by the worker nodes.
 
 Some systems are configured with lazy mounts that do not have this requirement for the worker nodes.
@@ -464,7 +464,7 @@ Some systems are configured with lazy mounts that do not have this requirement f
 
 1. (`ncn-m001#`) Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
 
-    **Note:** The `systemctl` command run on each node may have `exit code 3` reported, this does not indicate a problem with `cfs-state-reporter` on that node.
+    **Note:** The `systemctl` command run on each node may have `exit code 3` reported. This does not indicate a problem with `cfs-state-reporter` on that node.
 
     ```bash
     pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g') systemctl status cfs-state-reporter | grep "Active: activating"

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -297,7 +297,7 @@ Verify that the Lustre file system is available from the management cluster.
 1. (`ncn-m001#`) Correct the SDU collection link.
 
     If SDU has been configured on a master node, correct the `collection` link now that its `fuse.s3fs` filesystem is mounted from Ceph storage nodes.
-    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target.  This command checks all master nodes but changes them and restarts cray-sdu-rda only if needed.
+    Change the link target of `/var/opt/cray/sdu/collection` to `collection-mount` instead to have `collection-local` as the link target.  This command checks all master nodes but changes them and restarts `cray-sdu-rda` only if needed.
 
     ```bash
     pdsh -w ncn-m00[1-3]  '(cd /var/opt/cray/sdu; if [ -L "collection" ]; then if [ "$(readlink collection)" = "collection-local" ]; then rm collection; ln -s collection-mount collection; systemctl restart cray-sdu-rda; fi; fi)'

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -234,24 +234,15 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
     1. Check HSN status.
 
-        Determine the name of the `slingshot-fabric-manager` pod:
+       Run `fmn-show-status` in the `slingshot-fabric-manager` pod and save the output to a file.
+
 
         ```bash
-        kubectl get pods -l app.kubernetes.io/name=slingshot-fabric-manager -n services
-        ```
-
-        Example output:
-
-        ```text
-        NAME                                        READY   STATUS    RESTARTS   AGE
-        slingshot-fabric-manager-5dc448779c-d8n6q   2/2     Running   0          4d21h
-        ```
-
-        Run `fmn_status` in the `slingshot-fabric-manager` pod and save the output to a file:
-
-        ```bash
-        kubectl exec -it -n services slingshot-fabric-manager-5dc448779c-d8n6q \
-                     -c slingshot-fabric-manager -- fmn_status --details | tee -a fabric.status
+        kubectl exec -it -n services \
+            "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager \
+            -n services --no-headers | head -1 | awk '{print $1}')" \
+             -c slingshot-fabric-manager -- fmn-show-status --details \
+           | tee -a fmn-show-status-details.txt
         ```
 
     1. Check management switches to verify they are reachable.

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -236,7 +236,6 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
        Run `fmn-show-status` in the `slingshot-fabric-manager` pod and save the output to a file.
 
-
         ```bash
         kubectl exec -it -n services \
             "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager \

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -128,6 +128,36 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       * See [Renew Etcd Certificate](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
       * See [Update Client Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
+1. (`ncn-mw#`) Check for a recent backup of Nexus data.
+
+   **Note:** Doing the Nexus backup may take multiple hours with Nexus being unavailable for the entire time.
+
+   Check whether an export PVC called `nexus-bak` exists and is recent.
+
+   ```bash
+   kubectl get pvc -n nexus
+   ```
+
+   Example output:
+
+   ```text
+   NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
+   nexus-bak    Bound    pvc-09b6efe6-18e3-4681-8103-53590ad49d04   1000Gi     RWO            k8s-block-replicated   293d
+   nexus-data   Bound    pvc-bce9db69-d1a6-491d-89fc-d458c92f2895   1000Gi     RWX            ceph-cephfs-external   518d
+   ```
+
+   This output shows that the `nexus-bak` PVC was created 293 days ago.
+
+   * If there is no `nexus-bak` PVC, then use this Nexus export procedure to create one. This procedure does check that
+   there is enough space available for the copy of the `nexus-data` PVC and provides guidance on how to clean up space if
+   necessary or reduce the size of the existing `nexus-data` PVC.
+   See [Nexus Export](../package_repository_management/Nexus_Export_and_Restore.md#Export).
+
+   * If there is an existing `nexus-bak` PVC, but it is too old or the age is not recent enough to include the most recent
+   software update or otherwise not considered valid, then use the Nexus cleanup procedure before the export procedure.
+   See [Nexus Cleanup](../package_repository_management/Nexus_Export_and_Restore.md#Cleanup), then see
+   [Nexus Export](../package_repository_management/Nexus_Export_and_Restore.md#Export).
+
 1. (`ncn-mw#`) Determine which Boot Orchestration Service \(BOS\) templates to use to shut down compute nodes and UANs.
 
    There will be separate session templates for UANs and computes nodes.

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -383,6 +383,10 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
     There is no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
 
+1. Notify users and operations staff about the upcoming full system power off.
+
+   The notification method will vary by system, but might be email, messaging applications, `/etc/motd` on UANs, `wall` commands on UANs, etc.
+
 1. Follow the vendor workload manager documentation to drain processes running on compute nodes.
 
     1. For Slurm, see the `scontrol` man page.

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -397,7 +397,18 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
        scontrol update NodeName=ALL State=DRAIN Reason="Shutdown"
        ```
 
-    1. For PBS Professional, see the `pbsnodes` man page.
+    1. For PBS Professional, see the `qstat` and `qmgr` man pages.
+
+       Below is an example to list the available queues, disable a specific queue named `workq`, and check
+       that the queue has been disabled:
+
+       ```bash
+       qstat -q
+       qmgr -c 'set queue workq enabled = False'
+       qmgr -c 'list queue workq enabled'
+       ```
+
+       Each system might have many different queue names. There is no default queue name.
 
 ## Next step
 

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -146,7 +146,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
       ```
 
    1. (`ncn-m001#`) Check the HSM state from `sat status`of the compute and application nodes, but not the management nodes.
-      All the nodes should be in the `Off` state after the previous sat bootsys shutdown step, unless they are disabled in HSM,
+      All the nodes should be in the `Off` state after the previous `sat bootsys shutdown` step, unless they are disabled in HSM,
       shown as `False` in the `Enabled` column of output from this SAT command.
 
       A node will progress through HSM states in this order: `Ready`, `Standby`, `Off`.

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -189,11 +189,11 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 
 1. If any external filesystems are mounted on the worker nodes, unmount them.
 
-   Lustre, SpectrumScale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the group_vars
+   Lustre, SpectrumScale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the g`roup_vars`
    directory structure, such as `group_vars/all/filesystems.yml` or `group_vars/Management_Worker/filesystems.yml`. These steps
-   will run the `cos-config-management` Ansible playboork `configure_fs_unload.yml` using the variables set in `filesystems.yml`.
+   will run the `cos-config-management` Ansible playbook `configure_fs_unload.yml` using the variables set in `filesystems.yml`.
 
-   1. (`ncn-m#`) Copy the dvs_reload_ncn script from ncn-w001 to a master node.
+   1. (`ncn-m#`) Copy the `dvs_reload_ncn script` from `ncn-w001` to a master node.
 
    ```bash
    scp ncn-w001:/opt/cray/dvs/default/sbin/dvs_reload_ncn /tmp
@@ -214,7 +214,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 
    1. (`ncn-m#`) Set variable for the configuration assigned to worker nodes found in the previous step.
 
-   ```
+   ```bash
    CONFIGURATION=
    echo $CONFIGURATION
    ```

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -10,6 +10,11 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 
 ## Procedure
 
+1. If this system mounts an external SpectrumScale (GPFS) file system on the compute nodes and UANs, then follow the site procedures
+to ensure that the file system and its quorum nodes are quiesced before shutting down the nodes which have it mounted.
+
+   The quorum nodes might be on worker nodes or on application nodes.
+
 1. (`ncn-mw#`) List detailed information about the available boot orchestration service \(BOS\) session template names.
 
    Identify the BOS session template names such as `compute-23.7.0` and `uan-23.7.0`, and choose the appropriate compute and UAN node templates for the shutdown.

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -10,7 +10,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 
 ## Procedure
 
-1. If this system mounts an external SpectrumScale (GPFS) file system on the compute nodes and UANs, then follow the site procedures
+1. If this system mounts an external Spectrum Scale (GPFS) file system on the compute nodes and UANs, then follow the site procedures
 to ensure that the file system and its quorum nodes are quiesced before shutting down the nodes which have it mounted.
 
    The quorum nodes might be on worker nodes or on application nodes.
@@ -194,7 +194,7 @@ to ensure that the file system and its quorum nodes are quiesced before shutting
 
 1. If any external filesystems are mounted on the worker nodes, unmount them.
 
-   Lustre, SpectrumScale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the g`roup_vars`
+   Lustre, Spectrum Scale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the `group_vars`
    directory structure, such as `group_vars/all/filesystems.yml` or `group_vars/Management_Worker/filesystems.yml`. These steps
    will run the `cos-config-management` Ansible playbook `configure_fs_unload.yml` using the variables set in `filesystems.yml`.
 

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -146,38 +146,29 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
       ```
 
    1. (`ncn-m001#`) Check the HSM state from `sat status`of the compute and application nodes, but not the management nodes.
+      All the nodes should be in the `Off` state after the previous sat bootsys shutdown step, unless they are disabled in HSM,
+      shown as `False` in the `Enabled` column of output from this SAT command.
 
       A node will progress through HSM states in this order: `Ready`, `Standby`, `Off`.
 
       ```bash
-      sat status --filter role!=management --hsm-fields
+      sat status --filter role!=management --hsm-fields --filter state!=off
       ```
 
       Example output:
 
       ```text
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
-      | xname          | Type | NID      | State | Flag | Enabled | Arch | Class | Role        | SubRole   | Net Type |
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
-      | x3209c0s13b0n0 | Node | 52593056 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s15b0n0 | Node | 52593120 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s17b0n0 | Node | 52593184 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s19b0n0 | Node | 52593248 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s22b0n0 | Node | 52593344 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
-      | x3209c0s23b0n0 | Node | 52593376 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
-      | x9002c1s0b0n0  | Node | 1000     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b0n1  | Node | 1001     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n0  | Node | 1002     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n1  | Node | 1003     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n0  | Node | 1004     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n1  | Node | 1005     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n0  | Node | 1006     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n1  | Node | 1007     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n0  | Node | 1008     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n1  | Node | 1009     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n0  | Node | 1010     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n1  | Node | 1011     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
+      | xname          | Type | NID      | State  | Flag | Enabled | Arch | Class     | Role        | SubRole   | Net Type |
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
+      | x3000c0s13b0n0 | Node | 52593056 | Ready  | OK   | True    | X86  | River     | Application | UAN       | Sling    |
+      | x3000c0s15b0n0 | Node | 52593120 | Standby| OK   | True    | X86  | River     | Application | UAN       | Sling    |
+      | x3001c0s22b0n0 | Node | 52593344 | Ready  | OK   | True    | X86  | River     | Application | Gateway   | Sling    |
+      | x1002c1s0b0n0  | Node | 1000     | Standby| OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1002c3s2b0n0  | Node | 1008     | On     | OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1004c1s2b0n1  | Node | 1009     | Ready  | OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1005c7s2b1n0  | Node | 1010     | Standby| OK   | False   | X86  | Mountain  | Compute     | Compute   | Sling    |
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
       ```
 
 ## Next Steps

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -212,6 +212,14 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "CRAY UEFI OS 0"| cut -c 5-8)' | dshbak -c
    ```
 
+1. (`ncn-m001#`) Unmount ceph and fuse.s3fs filesystems from master and worker nodes.
+
+   ```bash
+   pdsh -w ncn-m001,$MASTERS,$WORKERS 'mount -t ceph|egrep -v kubelet; umount /etc/cray/upgrade/csm' | dshbak -c
+   pdsh -w ncn-m001,$MASTERS 'mount -t fuse.s3fs |egrep -v kubelet; umount /var/opt/cray/sdu/collection-mount; umount  /var/opt/cray/config-data' | dshbak -c
+   pdsh -w $WORKERS 'mount -t fuse.s3fs ; fusermount -u /var/lib/cps-local/boot-images;  umount  /var/lib/cps-local/boot-images; pkill s3fs' | dshbak -c 
+   ```
+
 1. (`ncn-m001#`) Shut down and power off all management NCNs except `ncn-m001`.
 
     This command requires input for the IPMI username and password for the management nodes.

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -103,7 +103,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    pdsh -w ncn-m001,$MASTERS,$WORKERS 'zypper -n install psmisc'
    ```
 
-1. If the worker nodes have been supporting the containerized User Access Instance (UAI) pods, then the DVS-mounted
+1. If the worker nodes have been supporting the containerized User Access Instance (UAI) pods, then the DVS mounted
    Cray Programming Environment (CPE) and Analytics filesystems should be unmounted.
 
    1. (`ncn-m001#`) Unmount the CPE content on the worker nodes.
@@ -117,7 +117,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
       1. (`ncn-m001#`) Checkout analytics-config-management from VCS.
 
         > If the `git clone` command fails to find the `analytics-config-management` repository in VCS, then Analytics
-        > is not installed and the rest of thes steps can be ignored.
+        > is not installed and the rest of these steps can be ignored.
 
          ```bash
          export git_pwd=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -204,6 +204,14 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    If the process continues to report errors due to `Failed to stop containers`, then iterate on the above step. Each iteration should reduce the number of containers running. If necessary,
    containers can be manually stopped using `crictl stop CONTAINER`. If containers are stopped manually, then re-run the above procedure to complete any final steps in the process.
 
+1. (`ncn-m001#`) Adjust boot order for management NCNs so the next boot will use disk.
+   This ensures that when the node is powered up again it will boot from disk rather than attempting
+   to PXEboot before the services to support that are available.
+
+   ```bash
+   pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "CRAY UEFI OS 0"| cut -c 5-8)' | dshbak -c
+   ```
+
 1. (`ncn-m001#`) Shut down and power off all management NCNs except `ncn-m001`.
 
     This command requires input for the IPMI username and password for the management nodes.

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -95,6 +95,14 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    WORKERS=$(kubectl get nodes | grep ncn-w | awk '{print $1}' | sort -u | xargs | sed 's/ /,/g'); echo WORKERS=$WORKERS
    ```
 
+1. (`ncn-m001#`) Install tools that will help to find processes preventing filesystem unmounting.
+
+   The `psmisc` rpm includes these tools: fuser, killall, peekfd, prtstat, pslog, pstree. 
+
+   ```bash
+   pdsh -w ncn-m001,$MASTERS,$WORKERS 'zypper -n install psmisc'
+   ```
+
 1. (`ncn-m001#`) Shut down platform services.
 
    > NOTE: There are some interactive questions which need answers before the shutdown process can progress.

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -41,13 +41,13 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
 1. To check the health and status of the management cluster before shutdown, see the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md).
 
-1. Check the health and backup etcd clusters:
+1. Check the health and backup status of etcd clusters:
 
-   1. Determine which etcd clusters must be backed up and if they are healthy.
+   1. Determine whether the etcd clusters are healthy.
 
       Review [Check the Health and Balance of etcd Clusters](../kubernetes/Check_the_Health_and_Balance_of_etcd_Clusters.md).
 
-   1. Backup etcd clusters.
+   1. Check the status of etcd cluster backups and make backups if missing.
 
       See [Backups for etcd-operator Clusters](../kubernetes/Backups_for_etcd-operator_Clusters.md).
 

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -212,6 +212,18 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    If the process continues to report errors due to `Failed to stop containers`, then iterate on the above step. Each iteration should reduce the number of containers running. If necessary,
    containers can be manually stopped using `crictl stop CONTAINER`. If containers are stopped manually, then re-run the above procedure to complete any final steps in the process.
 
+1. (`ncn-m001#`) Unload DVS and Lnet kernel modules from worker nodes.
+
+   > This step helps to avoid error messages in the console log while Linux is shutting down similar to 
+   > "DVS: task XXX exiting on a signal"
+
+   ```bash
+   pdsh -w $WORKERS 'lsmod | egrep "^dvs\s+"; rm -rf /run/dvs; \
+      echo quiesce / > /sys/fs/dvs/quiesce; modprobe -r dvs; sleep 5; \
+      modprobe -r dvsipc dvsipc_lnet dvsproc; lsmod | egrep "^lnet\s"; \
+      lsmod | egrep "^lustre\s"; systemctl stop lnet; lsmod | egrep "^lnet\s"'
+   ```
+
 1. (`ncn-m001#`) Adjust boot order for management NCNs so the next boot will use disk.
    This ensures that when the node is powered up again it will boot from disk rather than attempting
    to PXEboot before the services to support that are available.

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -212,10 +212,9 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    If the process continues to report errors due to `Failed to stop containers`, then iterate on the above step. Each iteration should reduce the number of containers running. If necessary,
    containers can be manually stopped using `crictl stop CONTAINER`. If containers are stopped manually, then re-run the above procedure to complete any final steps in the process.
 
-1. (`ncn-m001#`) Unload DVS and Lnet kernel modules from worker nodes.
+1. (`ncn-m001#`) Unload DVS and `Lnet` kernel modules from worker nodes.
 
-   > This step helps to avoid error messages in the console log while Linux is shutting down similar to 
-   > "DVS: task XXX exiting on a signal"
+   > This step helps to avoid error messages in the console log while Linux is shutting down similar to "DVS: task XXX exiting on a signal"
 
    ```bash
    pdsh -w $WORKERS 'lsmod | egrep "^dvs\s+"; rm -rf /run/dvs; \

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -280,7 +280,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    to PXE boot before the services to support that are available.
 
    ```bash
-   pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "CRAY UEFI OS 0"| cut -c 5-8)' | dshbak -c
+   pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "UEFI OS" | head -1 | cut -c 5-8)' | dshbak -c
    ```
 
 1. (`ncn-m001#`) Unmount `ceph` and `fuse.s3fs` filesystems from master and worker nodes.

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -212,7 +212,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "CRAY UEFI OS 0"| cut -c 5-8)' | dshbak -c
    ```
 
-1. (`ncn-m001#`) Unmount ceph and fuse.s3fs filesystems from master and worker nodes.
+1. (`ncn-m001#`) Unmount `ceph` and `fuse.s3fs` filesystems from master and worker nodes.
 
    ```bash
    pdsh -w ncn-m001,$MASTERS,$WORKERS 'mount -t ceph|egrep -v kubelet; umount /etc/cray/upgrade/csm' | dshbak -c

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -97,7 +97,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
 1. (`ncn-m001#`) Install tools that will help to find processes preventing filesystem unmounting.
 
-   The `psmisc` rpm includes these tools: fuser, killall, peekfd, prtstat, pslog, pstree. 
+   The `psmisc` rpm includes these tools: `fuser`, `killall`, `peekfd`, `prtstat`, `pslog`, `pstree`.
 
    ```bash
    pdsh -w ncn-m001,$MASTERS,$WORKERS 'zypper -n install psmisc'

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -277,7 +277,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
 1. (`ncn-m001#`) Adjust boot order for management NCNs so the next boot will use disk.
    This ensures that when the node is powered up again it will boot from disk rather than attempting
-   to PXEboot before the services to support that are available.
+   to PXE boot before the services to support that are available.
 
    ```bash
    pdsh -w ncn-m001,$MASTERS,$STORAGE,$WORKERS 'efibootmgr -n $(efibootmgr | grep "CRAY UEFI OS 0"| cut -c 5-8)' | dshbak -c

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -90,12 +90,14 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 1. (`ncn-m001#`) Set variables as comma-separated lists for the three types of management NCNs.
 
    ```bash
-   MASTERS="ncn-m002,ncn-m003"
-   STORAGE=$(ceph orch host ls | grep ncn-s | awk '{print $1}' | xargs | sed 's/ /,/g')
-   WORKERS=$(kubectl get nodes | grep ncn-w | awk '{print $1}' | sort -u | xargs | sed 's/ /,/g')
+   MASTERS="ncn-m002,ncn-m003"; echo MASTERS=$MASTERS
+   STORAGE=$(ceph orch host ls | grep ncn-s | awk '{print $1}' | xargs | sed 's/ /,/g'); echo STORAGE=$STORAGE
+   WORKERS=$(kubectl get nodes | grep ncn-w | awk '{print $1}' | sort -u | xargs | sed 's/ /,/g'); echo WORKERS=$WORKERS
    ```
 
 1. (`ncn-m001#`) Shut down platform services.
+
+   > NOTE: There are some interactive questions which need answers before the shutdown process can progress.
 
    ```bash
    sat bootsys shutdown --stage platform-services
@@ -214,8 +216,10 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
    1. Shutdown management NCNs.
 
+      > NOTE: There are some interactive questions which need answers before the shutdown process can progress.
+
       ```bash
-      sat bootsys shutdown --stage ncn-power --ncn-shutdown-timeout 900
+      sat bootsys shutdown --stage ncn-power --ncn-shutdown-timeout 1200
       ```
 
       Example output:
@@ -274,6 +278,14 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
       ```bash
       screen -x 26745.SAT-console-ncn-w003-mgmt
       ```
+
+      > NOTE: There may be many messages like this in the console logs for worker nodes and master nodes.
+      > There are no special actions to address these errors.
+      > 
+      > Example console log output:
+      > ```
+      > [76266.056108][T2394731] libceph: connect (1)100.96.129.14:6789 error -101
+      > ```
 
    1. (`ncn-m001#`) Check the power off status of management NCNs.
 

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -281,9 +281,10 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
       > NOTE: There may be many messages like this in the console logs for worker nodes and master nodes.
       > There are no special actions to address these errors.
-      > 
+      >
       > Example console log output:
-      > ```
+      >
+      > ```bash
       > [76266.056108][T2394731] libceph: connect (1)100.96.129.14:6789 error -101
       > ```
 

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -29,7 +29,7 @@ To save management switch configuration settings, refer to [Save Management Netw
 
 ## Power Off System Cabinets
 
-If any of the external file systems are in air-cooled cabinets shared with air-cooled compute nodes or management nodes, then 
+If any of the external file systems are in air-cooled cabinets shared with air-cooled compute nodes or management nodes, then
 the power off of the PDU circuits in these cabinets should be delayed until the external Lustre or SpectrumScale (GPFS) file
 systems have been cleanly shut down.
 

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -21,7 +21,7 @@ To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down a
 
 To power off the external Lustre file system (ClusterStor), refer to [Power Off the External Lustre File System](Power_Off_the_External_Lustre_File_System.md).
 
-To power off the external SpectrumScale (GPFS) file system, refer to site procedures.
+To power off the external Spectrum Scale (GPFS) file system, refer to site procedures.
 
 ## Save Management Network Switch Settings
 
@@ -30,7 +30,7 @@ To save management switch configuration settings, refer to [Save Management Netw
 ## Power Off System Cabinets
 
 If any of the external file systems are in air-cooled cabinets shared with air-cooled compute nodes or management nodes, then
-the power off of the PDU circuits in these cabinets should be delayed until the external Lustre or SpectrumScale (GPFS) file
+the power off of the PDU circuits in these cabinets should be delayed until the external Lustre or Spectrum Scale (GPFS) file
 systems have been cleanly shut down.
 
 To power off standard rack and liquid-cooled cabinet PDUs, refer to [Power Off Compute Cabinets](Power_Off_Compute_Cabinets.md).

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -17,21 +17,29 @@ To make sure that the system is healthy before power off and all the information
 
 To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Compute and User Access Nodes](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
 
+## Power Off the External File Systems
+
+To power off the external Lustre file system (ClusterStor), refer to [Power Off the External Lustre File System](Power_Off_the_External_Lustre_File_System.md).
+
+To power off the external SpectrumScale (GPFS) file system, refer to site procedures.
+
 ## Save Management Network Switch Settings
 
 To save management switch configuration settings, refer to [Save Management Network Switch Configuration Settings](Save_Management_Network_Switch_Configurations.md).
 
 ## Power Off System Cabinets
 
+If any of the external file systems are in air-cooled cabinets shared with air-cooled compute nodes or management nodes, then 
+the power off of the PDU circuits in these cabinets should be delayed until the external Lustre or SpectrumScale (GPFS) file
+systems have been cleanly shut down.
+
 To power off standard rack and liquid-cooled cabinet PDUs, refer to [Power Off Compute Cabinets](Power_Off_Compute_Cabinets.md).
+
+To power off standard racks which have only storage nodes and switches, refer to [Power Off Storage Cabinets](Power_Off_Storage_Cabinets.md).
 
 ## Shut Down the Management Kubernetes Cluster
 
 To shut down the management Kubernetes cluster, refer to [Shut Down and Power Off the Management Kubernetes Cluster](Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md).
-
-## Power Off the External Lustre File System
-
-To power off the external Lustre file system (ClusterStor), refer to [Power Off the External Lustre File System](Power_Off_the_External_Lustre_File_System.md).
 
 ## `Lockout Tagout` Facility Power
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -22,9 +22,15 @@ cabinets are powered on, wait at least 10 minutes for systems to initialize.
 
 After all the system cabinets are powered on, be sure that all management network and Slingshot network switches are powered on, and that there are no error LEDS or hardware failures.
 
-## Power on the external Lustre file system
+## Power On the External File Systems
 
 To power on an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
+
+To power on the external SpectrumScale (GPFS) file system, refer to site procedures.
+
+**Note:** If the external file systems are not mounted on worker nodes, then the power on of them can continue in parallel with
+the power on and boot of the Kubernetes management cluster and the power on of the compute cabinets, but must be completed
+before beginning to power on and boot the compute nodes and User Access Nodes (UANs). 
 
 ## Power on and boot the Kubernetes management cluster
 
@@ -34,7 +40,9 @@ To power on the management cabinet and bring up the management Kubernetes cluste
 
 To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On Compute Cabinets](Power_On_Compute_Cabinets.md).
 
-## Power on and boot compute nodes and user access nodes \(UANs\)
+## Power on and boot compute nodes and User Access Nodes \(UANs\)
+
+**Note:** Ensure that the external Lustre and SpectrumScale (GPFS) filesystems are available before starting to boot the compute nodes and UANs.
 
 To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to users.
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -26,10 +26,10 @@ After all the system cabinets are powered on, be sure that all management networ
 
 To power on an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
 
-To power on the external SpectrumScale (GPFS) file system, refer to site procedures.
+To power on the external Spectrum Scale (GPFS) file system, refer to site procedures.
 
-**Note:** If the external file systems are not mounted on worker nodes, then the power on of them can continue in parallel with
-the power on and boot of the Kubernetes management cluster and the power on of the compute cabinets, but must be completed
+**Note:** If the external file systems are not mounted on worker nodes, then continue to power them in parallel with
+the power on and boot of the Kubernetes management cluster and the power on of the compute cabinets. This must be completed
 before beginning to power on and boot the compute nodes and User Access Nodes (UANs).
 
 ## Power on and boot the Kubernetes management cluster
@@ -42,7 +42,7 @@ To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On 
 
 ## Power on and boot compute nodes and User Access Nodes \(UANs\)
 
-**Note:** Ensure that the external Lustre and SpectrumScale (GPFS) filesystems are available before starting to boot the compute nodes and UANs.
+**Note:** Ensure that the external Lustre and Spectrum Scale (GPFS) filesystems are available before starting to boot the compute nodes and UANs.
 
 To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to users.
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -30,7 +30,7 @@ To power on the external SpectrumScale (GPFS) file system, refer to site procedu
 
 **Note:** If the external file systems are not mounted on worker nodes, then the power on of them can continue in parallel with
 the power on and boot of the Kubernetes management cluster and the power on of the compute cabinets, but must be completed
-before beginning to power on and boot the compute nodes and User Access Nodes (UANs). 
+before beginning to power on and boot the compute nodes and User Access Nodes (UANs).
 
 ## Power on and boot the Kubernetes management cluster
 


### PR DESCRIPTION
CASMTRIAGE-7027: Many changes to full system power down/up procedures

# Description

Several smaller changes are included in the branch for CASMTRIAGE-7027:
- CASMTRIAGE-7028: Correct SDU collection directory mountpoint
- CASMTRIAGE-7029:Adjust preparation step to check HSN status to be single command line
- CASMTRIAGE-7033: filter sat status command to remove nodes in Off state
- CASMTRIAGE-7032: Added power down steps to disable PBS queues.  Added reminder to enable Slurm and PBS queues during power up
- CASMTRIAGE-7031: Added Preparation step to warn users and operations staff of impending system power down
- CASMTRIAGE-7037: Update env variables to allow better copy/pasting of variables to 2nd window, adjust ncn-shutdown-timeout to 1200, include warning about libceph error messages in console logs for worker and master nodes
CASMTRIAGE-7043: Set NCN efibootmgr nextboot to be disk before powering them off
CASMTRIAGE-7044: Manually unmount ceph and fuse.s3fs filesystems from master and worker nodes during power down
CASMTRIAGE-7051: Improved sat checks after booting compute and application nodes to reduce amount of output from nodes with desired settings
CASMTRIAGE-7036: Added checks for current etcd backups and alarms to power down of Kubernetes cluster
CASMTRIAGE-7039: Install psmisc rpm to have tools to find processes preventing filesystem unmounting
CASMTRIAGE-7046: Improve power up checks for Kubernetes: Uptime on all NCNs, Remount /etc/cray/upgrade/csm ceph filesystem, move spire-jwks remediation earlier since it is always needed, note cray-cps-cm-pm pods will be in error until CFS runs
CASMTRIAGE-7049: Enable hms-discovery before SAT cabinet-power stage due to SAT but, and confirm after SAT command that all Chassis are On
CASMTRIAGE-7034: Added sat status as first option to check power status and kept existing cray capmc option
CASMTRIAGE-7042: Unload DVS and Lnet kernel modules from worker nodes for shutdown
CASMTRIAGE-7038: For worker nodes: Stop UAIs, unmount Lustre, unmount DVS-mounted CPE and Analytics
CASMTRIAGE-7047: Added hints for when to work on off/on for external file system servers in parallel to other off/on activities and included checks that external file systems are ready before trying to use them
CASMTRIAGE-7048: Added workflow placeholder for site procedure to quiesce SpectrumScale GPFS on quorum nodes and unmount it on clients
CASMTRIAGE-7052: Added Slingshot 2.1.1 SSH permission fix, reinstallation of fmn-debug rpm, and troubleshooting procedure when some Slingshot switches are offline
CASMTRIAGE-6615: Check for potential expiration of Spire Intermedia CA certificate and Kubernetes and bare metal etcd certificates during system power down preparation
CASMTRIAGE-6614: Check for recent Nexus backup when Preparing for full system power down

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
