### PR TITLE
CASMTRIAGE-6990 update the IUF manual configuration instructions UAS and Badger

### DIFF
--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -203,6 +203,12 @@ required for initial installation scenarios.
   - Configure SAT authentication via `sat auth`
   - Generate SAT S3 credentials
   - Configure system revision information via `sat setrev`
+- UAS
+  - Configure UAS network settings 
+    - The network settings for UAS must match the WLM to allow job submission from UAIs
+- Badger
+  - Update CSM Diags network attachment definition
+
 
 Once this step has completed:
 


### PR DESCRIPTION
Resolves CASMTRIAGE-6990

# Description

Update IUF documentation to show "manual configuration" steps for UAS and Badger

The WLM documentation has some manual steps which show how to update the UAS and Badger configurations to match the network settings for SLURM and/or PBS Pro. We should get the IUF "manual configuration" instructions updated to reference this documentation: 
https://cray-hpe.github.io/docs-csm/en-15/operations/iuf/workflows/configuration/#3-perform-manual-product-configuration-operations

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
