### PR TITLE
CASMINST-6879: install-goss-tests.sh on PIT needs CSM_PATH OR CSM_RELEASE

### DIFF
--- a/install/scripts/install-goss-tests.sh
+++ b/install/scripts/install-goss-tests.sh
@@ -106,7 +106,7 @@ function err_exit {
 }
 
 function run_on_pit {
-  [[ -n ${CSM_RELEASE} ]] || err_exit 'Please set and export $CSM_RELEASE and try again'
+  [[ -n ${CSM_RELEASE} || -n ${CSM_PATH} ]] || err_exit 'Please set and export $CSM_PATH or $CSM_RELEASE and try again'
 
   local MTOKEN STOKEN WTOKEN PREPDIR STORAGE_NCNS K8S_NCNS PREP_RPM_DIR ncn
   local STORAGE_RPM_PATHS K8S_RPM_PATHS STORAGE_RPM_BASENAMES K8S_RPM_BASENAMES

--- a/scripts/operations/system_recovery/rapid_reinstall.sh
+++ b/scripts/operations/system_recovery/rapid_reinstall.sh
@@ -106,3 +106,6 @@ kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
   | jq 'del(.spec.template.metadata.labels."controller-uid")' \
   | kubectl replace --force -f -
 kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m
+
+# Update the test RPMs (and related RPMs) on all NCNs and PIT
+/usr/share/doc/csm/install/scripts/install-goss-tests.sh


### PR DESCRIPTION
This script is currently too picky. It should be happy if either of these variable is set. I have tested this on UKMet TDSY.

This PR also adds a call to this script at the end of the rapid reinstall script that we use during DR, to address an issue I saw during our latest iterations of DR work at UKMet.

Backports:
CSM 1.3: https://github.com/Cray-HPE/docs-csm/pull/5146
CSM 1.5: https://github.com/Cray-HPE/docs-csm/pull/5147
CSM 1.6: https://github.com/Cray-HPE/docs-csm/pull/5148
