### PR TITLE
CASMTRIAGE-7059: Console and Parray Peak additions

### DIFF
--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -22,6 +22,7 @@ list of patch versions.
 ## Bug fixes and improvements
 
 * Added support for Paradise hardware
+    * A BMC firmware bug will prevent power capping on Paradise hardware from functioning. A future BMC fw update will resolve the issue
 * Added support for Parry Peak hardware
 * Console: Fixed issue in `conman` in order to support Paradise hardware
 * HSM: Fixed issue in `run_hms_ct_tests.sh` which caused false positives for CDU switches

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -22,7 +22,8 @@ list of patch versions.
 ## Bug fixes and improvements
 
 * Added support for Paradise hardware
-* HSM: Fixed issue in `conman` in order to support Paradise hardware
+* Added support for Parry Peak hardware
+* Console: Fixed issue in `conman` in order to support Paradise hardware
 * HSM: Fixed issue in `run_hms_ct_tests.sh` which caused false positives for CDU switches
 * HSM: Enhanced `hmcollector` logging
 * HSM: FAS now waits for the time limit to expire when verifying update. `FASUpdate.py` script also updated to accept a `--timeLimit` parameter to change the preset time limit

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -22,7 +22,7 @@ list of patch versions.
 ## Bug fixes and improvements
 
 * Added support for Paradise hardware
-    * A BMC firmware bug will prevent power capping on Paradise hardware from functioning. A future BMC fw update will resolve the issue
+    * A BMC firmware bug will prevent power capping on Paradise hardware from functioning. A future BMC firmware update will resolve the issue
 * Added support for Parry Peak hardware
 * Console: Fixed issue in `conman` in order to support Paradise hardware
 * HSM: Fixed issue in `run_hms_ct_tests.sh` which caused false positives for CDU switches


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Changes from Rod:
* Replaced "HSM" with "Console" for the `conman` line
* Added that it adds support for Parry Peak
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
