### PR TITLE
CASMMON-394: CSM1.5.1: "grok-exporter" pod status showing as "Contain…

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -36,7 +36,6 @@ The following administrative topics can be found in this guide:
       - [MetalLB in BGP-mode](#metallb-in-bgp-mode)
 - [Spire](#spire)
 - [Update firmware with FAS](#update-firmware-with-fas)
-- [User Access Service (UAS)](#user-access-service-uas)
 - [System Admin Toolkit (SAT)](#system-admin-toolkit-sat)
 - [Install and Upgrade Framework (IUF)](#install-and-upgrade-framework-iuf)
 - [Backup and recovery](#backup-and-recovery)
@@ -466,6 +465,7 @@ confident that a lack of issues indicates the system is operating normally.
 - [Grafterm](system_management_health/Grafterm.md)
 - [Remove Kiali](system_management_health/Remove_Kiali.md)
 - [`prometheus-kafka-adapter` errors during installation](system_management_health/Prometheus_Kafka_Error.md)
+- [`grok-exporter` errors during installation](system_management_health/Grok-Exporter_Error.md)
 - [Troubleshoot Prometheus Alerts](system_management_health/Troubleshoot_Prometheus_Alerts.md)
 - [Configure UAN Node Exporter](system_management_health/uan_node_exporter_configs.md)
 

--- a/operations/system_management_health/Grok-Exporter_Error.md
+++ b/operations/system_management_health/Grok-Exporter_Error.md
@@ -18,7 +18,7 @@ installed, then disregard them.
 The root file system on master is at more than 80% but keeps hitting the threshold to raise `NodeHasDiskPressure`(85%) which causes the
 node to then attempt to reclaim ephemeral-storage.
 
-Increase/clean root filesystem and delete the grok exporter pod as below:
+Increase/clean the root filesystem and delete the grok exporter pod as follows:
 
 ```bash
 kubectl delete pod -l app=grok-exporter -n sysmgmt-health

--- a/operations/system_management_health/Grok-Exporter_Error.md
+++ b/operations/system_management_health/Grok-Exporter_Error.md
@@ -1,0 +1,25 @@
+# `grok-exporter` pod status showing as `ContainerStatusUnknown` Error
+
+## Symptom
+
+On CSM upgrade, the grok-exporter pod log has errors similar to the following:
+
+```text
+The node was low on resource: ephemeral-storage. Container grok-exporter was using 127200Ki, which exceeds its request of 0.
+```
+
+## Solution
+
+This Kafka service does not exist, because the [System Monitoring Application (SMA)](../../glossary.md#system-monitoring-application-sma)
+has not been installed yet. This causes the above errors for retry to be logged. Prometheus can operate without SMA Kafka and it will
+periodically retry the connection to Kafka. These errors will be logged until SMA is installed. Therefore, if they are seen before SMA is
+installed, then disregard them.
+
+The root file system on master is at more than 80% but keeps hitting the threshold to raise `NodeHasDiskPressure`(85%) which causes the
+node to then attempt to reclaim ephemeral-storage.
+
+Increase/clean root filesystem and delete the grok exporter pod as below:
+
+```bash
+kubectl delete pod -l app=grok-exporter -n sysmgmt-health
+```


### PR DESCRIPTION
Description
CSM1.5.1: "grok-exporter" pod status showing as "ContainerStatusUnknown" and "Error"

[[CASMMON-260](https://jira-pro.it.hpe.com:8443/browse/CASMMON-260)]([https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-260](https://jira-pro.it.hpe.com:8443/browse/CASMMON-394)](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-260%5D(https://jira-pro.it.hpe.com:8443/browse/CASMMON-394))
