### PR TITLE
Update to HMS Restore docs (NO Jira ticket)

### DIFF
--- a/operations/Restore_HSM.md
+++ b/operations/Restore_HSM.md
@@ -11,7 +11,8 @@
         aws s3api list-objects --bucket $bucket --endpoint-url http://ncn-m001.nmn:8000
         ```
 
-    1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`). example:
+    1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`). For example:
+
 
         ```bash
         BACKUP_FILE=hms-backup_2023-06-28_11-12-24

--- a/operations/Restore_HSM.md
+++ b/operations/Restore_HSM.md
@@ -2,9 +2,9 @@
 
 ## Procedure
 
-1. If `tar` file was placed in s3 from [Backup](Backup_HMS.md) copy to the system to restore.
+1. If `tar` file was placed in `s3` from [Backup](Backup_HMS.md) copy to the system to restore.
 
-    1. List objects in s3
+    1. List objects in `s3`
 
         ```bash
         bucket=hms


### PR DESCRIPTION
# Description

Update to HMS Restore docs adding instructions for downloading file from S3 and disabling nodes

NO JIRA ticket was created for this update

NOTE: This change needs to be updated in release v1.6

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
