### PR TITLE
CASMHMS-6225 Changed the remove node procedure to allow for already removed nodes

### DIFF
--- a/scripts/operations/node_management/remove_standard_rack_node.sh
+++ b/scripts/operations/node_management/remove_standard_rack_node.sh
@@ -64,7 +64,17 @@ echo
 echo "=================================================="
 echo "Removing BMC Event subscriptions"
 echo "=================================================="
-/usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py "${BMC_XNAME}"
+EXIT_CODE=0
+/usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py "${BMC_XNAME}" || EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+  if [[ -z ${TOKEN+x} ]]; then
+    # delete_bmc_subscriptions.py failed because the TOKEN was not set
+    exit $EXIT_CODE
+  fi
+  echo "The redfish subscriptions were not removed from ${BMC_XNAME}. Check the messages above for the specific errors."
+  echo "This could be because the node has already been physically removed."
+  echo "The subscriptions will need to be cleaned up when the node is added back, if it is added in a new xname location, and is on a system running CSM 1.4 or older."
+fi
 
 echo
 echo "=================================================="


### PR DESCRIPTION
# Description

Changed to not fatally fail the remove node script when it fails to remove the redfish subscriptions.

The rationales for this are:
1. Users often physically remove the node before doing the process to remove it from CSM.
2. Removing the subscriptions isn't crucial in newer versions of CSM.

I tested these changes on starlord

Relates to:
- [CASMHMS-6225](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6225)


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
