### PR TITLE
Fix short-circuit

### DIFF
--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -624,7 +624,7 @@ fi
 set_timezone
 if [[ $CSM_RELEASE =~ ^1\.4\.4 ]]; then
   csm_144_patch
-elif [[ $CSM_RELEASE =~ ^1\.4\.([5-9]|[1-9]0+|[1-9]{2,}) ]]; then
+elif [[ $CSM_RELEASE =~ ^^1\.4\.([5-9]|[1-9]0+|[1-9]{2,}) ]]; then
   csm_144_patch
   csm_145_patch
 fi


### PR DESCRIPTION
This is a nit.

The pattern that exists here would successfull match any 1.4.5+ release, however the pattern was a little sloppy in the sense that it wasn't finding an exact match with some numbers.

- 1.4.50-1.4.99 were incomplete matches, albeit successful.
- Every first 10 digits of each hundred were also incomplete (1.4.202 would match as 1.4.20)
- Every 10th number starting with 50 in every hundred were also incomplete (e.g., 1.4.500, 1.4.600)

This regex is just more complete, and less greedy. The problem was that the regex group short-circuits, since `[5-9]` was first in the group then the match was declared before checking the rest of the group.


I tested that it still validated all the same numbers by doing this:

```bash
for i in $(seq 1 600); do echo 1.4.$i >> ~/Downloads/t.txt; done
for line in $(cat ~/Downloads/t.txt); do if [[ $line =~ ^1\.4\.([1-9][0-9]+|[0-9]{2,}|[5-9]) ]]; then echo "$line yes" >> ~/Downloads/t.test.txt; else echo "$line no" >> ~/Downloads/t.test.txt; fi; done
```

I tested that the groups matched every digit by copying the content of `t.txt` and dumping it into https://regexr.com/, setting my regex as `/^1\.4\.([5-9]|[1-9]0+|[1-9]{2,})/gm`.