### PR TITLE
CASMTRIAGE-7055: Check for the latest docs-csm before starting the up…

### DIFF
--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -35,6 +35,12 @@ Once this step has completed:
 
 - Environment variables have been set and required IUF directories have been created
 
+2. Ensure that the 
+   [latest version of docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
+    is installed for the target CSM version being installed or upgraded.
+    
+    For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install docs-csm-1.5.1.noarch
+
 ## 2. Use of `iuf activity`
 
 **`NOTE`** This section is informational only. There are no operations to perform.

--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -36,10 +36,10 @@ This section defines environment variables and directory content that is used th
     - Environment variables have been set and required IUF directories have been created
 
 1. Ensure that the
-   [latest version of docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
+   [latest version of `docs-csm`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
     is installed for the target CSM version being installed or upgraded.
 
-    For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install docs-csm-1.5.1.noarch
+    For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install `docs-csm-1.5.1.noarch`
 
 ## 2. Use of `iuf activity`
 

--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -35,10 +35,10 @@ Once this step has completed:
 
 - Environment variables have been set and required IUF directories have been created
 
-2. Ensure that the 
+1. Ensure that the
    [latest version of docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
     is installed for the target CSM version being installed or upgraded.
-    
+
     For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install docs-csm-1.5.1.noarch
 
 ## 2. Use of `iuf activity`

--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -31,9 +31,9 @@ This section defines environment variables and directory content that is used th
     mkdir -p "${ACTIVITY_DIR}" "${MEDIA_DIR}" "${ADMIN_DIR}"
     ```
 
-Once this step has completed:
+    Once this step has completed:
 
-- Environment variables have been set and required IUF directories have been created
+    - Environment variables have been set and required IUF directories have been created
 
 1. Ensure that the
    [latest version of docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)


### PR DESCRIPTION
# Description
  Resolves CASMTRIAGE-7055
  
  To use the new scripts mentioned in the doc we need to upgrade docs-csm.

We have updated preparation.md to check for the latest docs-csm before starting the upgrade.
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions.
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

