### PR TITLE
Option 1 not Option 2

### DIFF
--- a/upgrade/1.4.4/CSM-Only.md
+++ b/upgrade/1.4.4/CSM-Only.md
@@ -6,7 +6,7 @@ The [v1.4.4 upgrade page](../1.4.4/README.md) will refer to this page
 during [Update NCN images](../1.4.4/README.md#update-ncn-images).
 
 **If other products are installed on the system, return to [Update NCN images](../1.4.4/README.md#update-ncn-images) and
-choose option 2.**
+choose option 1.**
 
 ## Requirements
 


### PR DESCRIPTION
If someone lands at the readme, they should choose option 1 instead. If they have other products installed, they should choose the option for that case.

This likely was neglected during one of the many 1.4.4 follow-up PRs when we changed the options around.
