### PR TITLE
CASMTRIAGE-7106 adding procedure for building NCN images in CSM 1.5.2 patch

### DIFF
--- a/upgrade/1.5.2/CSM-Only.md
+++ b/upgrade/1.5.2/CSM-Only.md
@@ -10,7 +10,7 @@ choose option 1.**
 
 ## Requirements
 
-* `CSM_RELEASE` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
+* `CSM_RELEASE_VERSION` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
 
 * Set `CSM_RELEASE` in the shell environment to the same value as `CSM_RELEASE_VERSION`.
 

--- a/upgrade/1.5.2/CSM-Only.md
+++ b/upgrade/1.5.2/CSM-Only.md
@@ -12,6 +12,13 @@ choose option 1.**
 
 * `CSM_RELEASE` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
 
+* Set `CSM_RELEASE` in the shell environment to the same value as `CSM_RELEASE_VERSION`.
+
+    ```text
+   export CSM_RELEASE="${CSM_RELEASE_VERSION}"
+   echo "${CSM_RELEASE}"
+   ```
+
 ## Steps
 
 1. (`ncn-m001#`) Generate a new [CFS](../../glossary.md#configuration-framework-service-cfs) configuration for the management nodes.

--- a/upgrade/1.5.2/CSM-Only.md
+++ b/upgrade/1.5.2/CSM-Only.md
@@ -14,7 +14,7 @@ choose option 1.**
 
 * Set `CSM_RELEASE` in the shell environment to the same value as `CSM_RELEASE_VERSION`.
 
-    ```text
+    ```bash
    export CSM_RELEASE="${CSM_RELEASE_VERSION}"
    echo "${CSM_RELEASE}"
    ```

--- a/upgrade/1.5.2/CSM-Only.md
+++ b/upgrade/1.5.2/CSM-Only.md
@@ -139,4 +139,4 @@ choose option 1.**
            -p "$NEW_STORAGE_IMAGE_ID"
        ```
 
-1. Return to [WLM backup](./README.md#update-test-suite-packages)
+1. Return to [Update test suite packages](./README.md#update-test-suite-packages)

--- a/upgrade/1.5.2/CSM-Only.md
+++ b/upgrade/1.5.2/CSM-Only.md
@@ -1,5 +1,9 @@
 # CSM Only Upgrade
 
+* [CSM Only Upgrade](#csm-only-upgrade)
+    * [Requirements](#requirements)
+    * [Steps](#steps)
+
 This page provides guidance for systems with exclusively CSM installed that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
 
 The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -1,5 +1,12 @@
 # CSM Only Upgrade on a System with Other Products
 
+* [CSM Only Upgrade on a System with Other Products](#csm-only-upgrade-on-a-system-with-other-products)
+    * [Requirements](#requirements)
+    * [Overview](#overview)
+    * [Steps](#steps)
+        * [Using `sat bootprep` with IUF generated input files](#using-sat-bootprep-with-iuf-generated-input-files)
+    * [Return to CSM `1.5.2` patch](#return-to-csm-152-patch)
+
 This page provides guidance for systems with products installed that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
 
 The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -29,8 +29,7 @@ Later in the CSM `v1.5.2` patch process, nodes will be rebooted into these image
 
 ### Using `sat bootprep` with IUF generated input files
 
-In order to follow this procedure, you will need to know the name of the IUF activity used to
-perform the initial installation of the HPE Cray EX software products. See the
+The name of the IUF activity used to install the HPE Cray EX software products must be known before proceeding. See the
 [Activities](../../operations/iuf/IUF.md#activities) section of the IUF documentation for more
 information on IUF activities. See [`list-activities`](../../operations/iuf/IUF.md#list-activities)
 for information about listing the IUF activities on the system. The first step provides an
@@ -276,4 +275,4 @@ example showing how to find the IUF activity.
 
 ## Return to CSM `1.5.2` patch
 
-Return to [Update test suite packages](./README.md#update-test-suite-packages)
+Return to [Update test suite packages](./README.md#update-test-suite-packages).

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -110,7 +110,7 @@ example showing how to find the IUF activity.
    `working_branch` specified for CSM:
 
    ```bash
-   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
+   yq4 eval '.csm.working_branch' "${BOOTPREP_DIR}/session_vars.yaml"
    ```
 
    If this produces no output, a `working_branch` is not in use for the CSM product, and this step

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -10,7 +10,14 @@ choose option 1.**
 
 ## Requirements
 
-* `CSM_RELEASE` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
+* `CSM_RELEASE_VERSION` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
+
+* Set `CSM_RELEASE` in the shell environment to the same value as `CSM_RELEASE_VERSION`.
+
+    ```text
+   export CSM_RELEASE="${CSM_RELEASE_VERSION}"
+   echo "${CSM_RELEASE}"
+   ```
 
 ## Overview
 

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -61,7 +61,7 @@ example showing how to find the IUF activity.
 1. (`ncn-m001#`) Record the media directory used for this activity in an environment variable.
 
    ```bash
-   export MEDIA_DIR="$(yq r "${ACTIVITY_DIR}/state/stage_hist.yaml" 'summary.media_dir')"
+   export MEDIA_DIR="$(yq4 eval '.summary.media_dir' "${ACTIVITY_DIR}/state/stage_hist.yaml")"
    echo "${MEDIA_DIR}"
    ```
 
@@ -101,7 +101,7 @@ example showing how to find the IUF activity.
 1. (`ncn-m001#`) Modify the CSM version in the copied `session_vars.yaml`:
 
    ```bash
-   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.version' "${CSM_RELEASE}"
+   yq4 eval -i '.csm.version = "'"$CSM_RELEASE"'"' "${BOOTPREP_DIR}/session_vars.yaml"
    ```
 
 1. (`ncn-m001#`) Update the `working_branch` if one is used for the CSM product.
@@ -124,8 +124,8 @@ example showing how to find the IUF activity.
    new working branch. Then check it again. For example:
 
    ```bash
-   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch' "integration-${CSM_RELEASE}"
-   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
+   yq4 eval -i '.csm.working_branch = "integration-'"${CSM_RELEASE}"'"' "${BOOTPREP_DIR}/session_vars.yaml"
+   yq4 eval '.csm.working_branch' "${BOOTPREP_DIR}/session_vars.yaml"
    ```
 
    This should output the name of the new CSM working branch.
@@ -137,7 +137,7 @@ example showing how to find the IUF activity.
    with different names from the ones created in the IUF activity.
 
    ```bash
-   yq w -i -- "${BOOTPREP_DIR}/session_vars.yaml" 'default.suffix' "-csm-${CSM_RELEASE}"
+   yq4 eval -i '.default.suffix = "-csm-'"${CSM_RELEASE}"'"' "${BOOTPREP_DIR}/session_vars.yaml"
    ```
 
 1. (`ncn-m001#`) Change directory to the `BOOTPREP_DIR` and run `sat bootprep`.
@@ -230,10 +230,10 @@ example showing how to find the IUF activity.
    1. Get the xnames of the master and worker management nodes.
 
       ```bash
-      WORKER_XNAMES=$(cray hsm state components list --role Management --subrole Worker --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")')
-      MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")')
+      WORKER_XNAMES="$(cray hsm state components list --role Management --subrole Worker --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')"
+      MASTER_XNAMES="$(cray hsm state components list --role Management --subrole Master --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')"
       echo "${MASTER_XNAMES},${WORKER_XNAMES}"
       ```
 
@@ -254,9 +254,9 @@ example showing how to find the IUF activity.
    1. Get the xnames of the storage management nodes.
 
       ```bash
-      STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json |
-          jq -r '.Components | map(.ID) | join(",")')
-      echo $STORAGE_XNAMES
+      STORAGE_XNAMES="$(cray hsm state components list --role Management --subrole Storage --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')"
+      echo "$STORAGE_XNAMES"
       ```
 
    1. Apply the CFS configuration to storage nodes using the xnames and CFS configuration name found in the previous steps.
@@ -264,7 +264,7 @@ example showing how to find the IUF activity.
       ```bash
       /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
           --no-config-change --config-name "${STORAGE_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
-          --xnames ${STORAGE_XNAMES}
+          --xnames "${STORAGE_XNAMES}"
       ```
 
       Successful output will end with the following:

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -14,7 +14,7 @@ choose option 1.**
 
 * Set `CSM_RELEASE` in the shell environment to the same value as `CSM_RELEASE_VERSION`.
 
-    ```text
+    ```bash
    export CSM_RELEASE="${CSM_RELEASE_VERSION}"
    echo "${CSM_RELEASE}"
    ```

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -6,7 +6,7 @@ The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page
 during [Update NCN images](../1.5.2/README.md#update-ncn-images).
 
 **If exclusively CSM is installed on the system, return to [Update NCN images](../1.5.2/README.md#update-ncn-images) and
-choose option 1.**
+choose option 2.**
 
 ## Requirements
 

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -16,7 +16,7 @@ choose option 1.**
 
 This process creates new NCN node images and CFS configurations in order to acquire any changes from CSM config.
 These images and CFS configurations will be assigned to the NCNs during this process.
-Later in the CSM `v1.5.2` patch process nodes will be rebooted into these images and the CFS configuration will be applied to the nodes.
+Later in the CSM `v1.5.2` patch process, nodes will be rebooted into these images and the CFS configuration will be applied to the nodes.
 
 ## Steps
 

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -1,0 +1,269 @@
+# CSM Only Upgrade on a System with Other Products
+
+This page provides guidance for systems with products installed that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
+
+The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page
+during [Update NCN images](../1.5.2/README.md#update-ncn-images).
+
+**If exclusively CSM is installed on the system, return to [Update NCN images](../1.5.2/README.md#update-ncn-images) and
+choose option 1.**
+
+## Requirements
+
+* `CSM_RELEASE` is set in the shell environment on `ncn-m001`. See [Preparation](README.md#preparation) for details on how it should be set.
+
+## Overview
+
+This process creates new NCN node images and CFS configurations in order to acquire any changes from CSM config.
+These images and CFS configurations will be assigned to the NCNs during this process.
+Later in the CSM `v1.5.2` patch process nodes will be rebooted into these images and the CFS configuration will be applied to the nodes.
+
+## Steps
+
+### Using `sat bootprep` with IUF generated input files
+
+In order to follow this procedure, you will need to know the name of the IUF activity used to
+perform the initial installation of the HPE Cray EX software products. See the
+[Activities](../operations/iuf/IUF.md#activities) section of the IUF documentation for more
+information on IUF activities. See [`list-activities`](../operations/iuf/IUF.md#list-activities)
+for information about listing the IUF activities on the system. The first step provides an
+example showing how to find the IUF activity.
+
+1. (`ncn-m001#`) Find the IUF activity used for the most recent install of the system.
+
+   ```bash
+   iuf list-activities
+   ```
+
+   This will output a list of IUF activity names. For example, if only a single install has been
+   performed on this system of the 24.01 recipe, the output may show a single line like this:
+
+   ```text
+   24.01-recipe-install
+   ```
+
+1. (`ncn-m001#`) Record the most recent IUF activity name and directory in environment variables.
+
+   ```bash
+   export ACTIVITY_NAME=
+   ```
+
+   ```bash
+   export ACTIVITY_DIR="/etc/cray/upgrade/csm/iuf/${ACTIVITY_NAME}"
+   ```
+
+1. (`ncn-m001#`) Record the media directory used for this activity in an environment variable.
+
+   ```bash
+   export MEDIA_DIR="$(yq r "${ACTIVITY_DIR}/state/stage_hist.yaml" 'summary.media_dir')"
+   echo "${MEDIA_DIR}"
+   ```
+
+   This should display a path to a media directory. For example:
+
+   ```text
+   /etc/cray/upgrade/csm/media/24.01-recipe-install
+   ```
+
+1. (`ncn-m001#`) Create a directory for the `sat bootprep` input files and the `session_vars.yaml` file.
+
+   This example uses a directory under the RBD mount used by the IUF:
+
+   ```bash
+   export BOOTPREP_DIR="/etc/cray/upgrade/csm/admin/bootprep-csm-${CSM_RELEASE}"
+   mkdir -pv "${BOOTPREP_DIR}"
+   ```
+
+1. (`ncn-m001#`) Copy the `sat bootprep` input file for management nodes into the directory.
+
+   It is possible that the file name will differ from `management-bootprep.yaml` if a different
+   file was used during the IUF activity.
+
+   ```bash
+   cp -pv "${MEDIA_DIR}/.bootprep-${ACTIVITY_NAME}/management-bootprep.yaml" "${BOOTPREP_DIR}"
+   ```
+
+1. (`ncn-m001#`) Copy the `session_vars.yaml` file into the directory.
+
+   ```bash
+   cp -pv "${ACTIVITY_DIR}/state/session_vars.yaml" "${BOOTPREP_DIR}"
+   ```
+
+1. (`ncn-m001#`) Modify the CSM version in the copied `session_vars.yaml`:
+
+   ```bash
+   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.version' "${CSM_RELEASE}"
+   ```
+
+1. (`ncn-m001#`) Update the `working_branch` if one is used for the CSM product.
+
+   By default, a `working_branch` is not used for the CSM product. Check if there is a
+   `working_branch` specified for CSM:
+
+   ```bash
+   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
+   ```
+
+   If this produces no output, a `working_branch` is not in use for the CSM product, and this step
+   can be skipped. Otherwise, it shows the name of the working branch. For example:
+
+   ```text
+   integration-1.4.0
+   ```
+
+   In this case, be sure to manually update the version string in the working branch to match the
+   new working branch. Then check it again. For example:
+
+   ```bash
+   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch' "integration-${CSM_RELEASE}"
+   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
+   ```
+
+   This should output the name of the new CSM working branch.
+
+1. (`ncn-m001#`) Modify the `default.suffix` value in the copied `session_vars.yaml`:
+
+   As long as the `sat bootprep` input file uses `{{default.suffix}}` in the names of the CFS
+   configurations and IMS images, this will ensure new CFS configurations and IMS images are created
+   with different names from the ones created in the IUF activity.
+
+   ```bash
+   yq w -i -- "${BOOTPREP_DIR}/session_vars.yaml" 'default.suffix' "-csm-${CSM_RELEASE}"
+   ```
+
+1. (`ncn-m001#`) Change directory to the `BOOTPREP_DIR` and run `sat bootprep`.
+
+   This will create a CFS configuration for management nodes, and it will use that CFS configuration
+   to customize the images for the master, worker, and storage management nodes.
+
+   ```bash
+   cd "${BOOTPREP_DIR}"
+   sat bootprep run --vars-file session_vars.yaml management-bootprep.yaml
+   ```
+
+1. (`ncn-m001#`) Gather the CFS configuration name, and the IMS image names from the output of `sat bootprep`.
+
+   `sat bootprep` will print a report summarizing the CFS configuration and IMS images it created.
+   For example:
+
+   ```text
+   ################################################################################
+   CFS configurations
+   ################################################################################
+   +-----------------------------+
+   | name                        |
+   +-----------------------------+
+   | management-22.4.0-csm-x.y.z |
+   +-----------------------------+
+   ################################################################################
+   IMS images
+   ################################################################################
+   +-----------------------------+--------------------------------------+--------------------------------------+-----------------------------+----------------------------+
+   | name                        | preconfigured_image_id               | final_image_id                       | configuration               | configuration_group_names  |
+   +-----------------------------+--------------------------------------+--------------------------------------+-----------------------------+----------------------------+
+   | master-secure-kubernetes    | c1bcaf00-109d-470f-b665-e7b37dedb62f | a22fb912-22be-449b-a51b-081af2d7aff6 | management-22.4.0-csm-x.y.z | Management_Master          |
+   | worker-secure-kubernetes    | 8b1343c4-1c39-4389-96cb-ccb2b7fb4305 | 241822c3-c7dd-44f8-98ca-0e7c7c6426d5 | management-22.4.0-csm-x.y.z | Management_Worker          |
+   | storage-secure-storage-ceph | f3dd7492-c4e5-4bb2-9f6f-8cfc9f60526c | 79ab3d85-274d-4d01-9e2b-7c25f7e108ca | storage-22.4.0-csm-x.y.z    | Management_Storage         |
+   +-----------------------------+--------------------------------------+--------------------------------------+-----------------------------+----------------------------+
+   ```
+
+   1. Save the names of the CFS configurations from the `configuration` column:
+
+      > Note that the storage node configuration might be titled `minimal-management-` or `storage-` depending on the value
+      > set in the sat `bootprep` file.
+      >
+      > The following uses the values from the example output above. Be sure to modify them
+      > to match the actual values.
+
+      ```bash
+      export KUBERNETES_CFS_CONFIG_NAME="management-22.4.0-csm-x.y.z"
+      export STORAGE_CFS_CONFIG_NAME="storage-22.4.0-csm-x.y.z"
+      ```
+
+   1. Save the name of the IMS images from the `final_image_id` column:
+
+      > The following uses the values from the example output above. Be sure to modify them
+      > to match the actual values.
+
+      ```bash
+      export MASTER_IMAGE_ID="a22fb912-22be-449b-a51b-081af2d7aff6"
+      export WORKER_IMAGE_ID="241822c3-c7dd-44f8-98ca-0e7c7c6426d5"
+      export STORAGE_IMAGE_ID="79ab3d85-274d-4d01-9e2b-7c25f7e108ca"
+      ```
+
+1. (`ncn-m001#`) Assign the images to the management nodes in BSS.
+
+   - Master management nodes:
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -m -p "$MASTER_IMAGE_ID"
+      ```
+
+   - Storage management nodes:
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -s -p "$STORAGE_IMAGE_ID"
+      ```
+
+   - Worker management nodes:
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -w -p "$WORKER_IMAGE_ID"
+      ```
+
+1. (`ncn-m001#`) Assign the CFS configuration to the management nodes.
+
+   This deliberately only sets the desired configuration of the components in CFS. It
+   disables the components and does not clear their configuration states or error counts. When the
+   nodes are rebooted to their new images later in the CSM upgrade, they will automatically be
+   enabled in CFS, and node personalization will occur.
+  
+   1. Get the xnames of the master and worker management nodes.
+
+      ```bash
+      WORKER_XNAMES=$(cray hsm state components list --role Management --subrole Worker --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')
+      MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')
+      echo "${MASTER_XNAMES},${WORKER_XNAMES}"
+      ```
+
+   1. Apply the CFS configuration to master nodes and worker nodes using the xnames and CFS configuration name found in the previous steps.
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+          --no-config-change --config-name "${KUBERNETES_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
+          --xnames ${MASTER_XNAMES},${WORKER_XNAMES}
+      ```
+
+      Successful output will end with the following:
+
+      ```text
+      All components updated successfully.
+      ```
+
+   1. Get the xnames of the storage management nodes.
+
+      ```bash
+      STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json |
+          jq -r '.Components | map(.ID) | join(",")')
+      echo $STORAGE_XNAMES
+      ```
+
+   1. Apply the CFS configuration to storage nodes using the xnames and CFS configuration name found in the previous steps.
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+          --no-config-change --config-name "${STORAGE_CFS_CONFIG_NAME}" --no-enable --no-clear-err \
+          --xnames ${STORAGE_XNAMES}
+      ```
+
+      Successful output will end with the following:
+
+      ```text
+      All components updated successfully.
+      ```
+
+## Return to CSM `1.5.2` patch
+
+Return to [Update test suite packages](./README.md#update-test-suite-packages)

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -24,8 +24,8 @@ Later in the CSM `v1.5.2` patch process, nodes will be rebooted into these image
 
 In order to follow this procedure, you will need to know the name of the IUF activity used to
 perform the initial installation of the HPE Cray EX software products. See the
-[Activities](../operations/iuf/IUF.md#activities) section of the IUF documentation for more
-information on IUF activities. See [`list-activities`](../operations/iuf/IUF.md#list-activities)
+[Activities](../../operations/iuf/IUF.md#activities) section of the IUF documentation for more
+information on IUF activities. See [`list-activities`](../../operations/iuf/IUF.md#list-activities)
 for information about listing the IUF activities on the system. The first step provides an
 example showing how to find the IUF activity.
 
@@ -193,19 +193,19 @@ example showing how to find the IUF activity.
 
 1. (`ncn-m001#`) Assign the images to the management nodes in BSS.
 
-   - Master management nodes:
+   * Master management nodes:
 
       ```bash
       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -m -p "$MASTER_IMAGE_ID"
       ```
 
-   - Storage management nodes:
+   * Storage management nodes:
 
       ```bash
       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -s -p "$STORAGE_IMAGE_ID"
       ```
 
-   - Worker management nodes:
+   * Worker management nodes:
 
       ```bash
       /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh -w -p "$WORKER_IMAGE_ID"

--- a/upgrade/1.5.2/CSM-With-Other-Products.md
+++ b/upgrade/1.5.2/CSM-With-Other-Products.md
@@ -96,6 +96,9 @@ example showing how to find the IUF activity.
    cp -pv "${ACTIVITY_DIR}/state/session_vars.yaml" "${BOOTPREP_DIR}"
    ```
 
+   > Update the `session_vars.yaml` file as needed based on the product
+   > versions that are installed on the system.
+
 1. (`ncn-m001#`) Modify the CSM version in the copied `session_vars.yaml`:
 
    ```bash

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -282,8 +282,8 @@ This step does not rebuild NCNs. These new images are built and stored in S3 to 
 1. Choose one of the following options based on the output from the previous step.
 
     * Option 1: [Upgrade of CSM on system with additional products](./CSM-With-Other-Products.md)
-    * Option 2: [Upgrade of CSM on CSM-only system](./CSM-Only.md#steps) ***(Do not use this procedure if more than CSM is
-      installed on the system.\)***
+    * Option 2: [Upgrade of CSM on CSM-only system](./CSM-Only.md#steps) _(Do not use this procedure if more than CSM is
+      installed on the system.\)_
 
 ### Update test suite packages
 

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -354,11 +354,18 @@ SUCCESS
 These clusters are automatically backed up every 24 hours, but taking a manual backup at this stage in the upgrade
 enables restoring from backup later in this process if needed.
 
-### NCN reboot
+### NCN Upgrade
 
-This is an optional step but is strongly recommended. As each patch release includes updated container images that may
-contain CVE fixes, it is recommended to reboot each NCN to refresh cached container images. For detailed instructions on
-how to gracefully reboot each NCN, refer to [Reboot NCNs](../../operations/node_management/Reboot_NCNs.md).
+This step is neccessary so that nodes are using the correct images. If NCN are
+not upgraded into these images, then `cloudinit` would fail on the nodes the next
+time the nodes are rebuilt. The images that the nodes are being upgraded to were
+set in BSS during [Update NCN images](../1.5.2/README.md#update-ncn-images).
+If the NCN nodes are not upgraded now, then any node reboot will cause the node to be
+booted into this new image which is not following the proper upgrade procedure which could cause problems.
+
+Additionally, each patch release includes updated container images that may
+contain CVE fixes, rebuilding each NCN will refresh cached container images.
+For instructions on how to upgrade NCNs for this patch release, refer to [Upgrade NCN during CSM `1.5.2` patch](./Upgrade_NCN_images.md).
 
 ### Configure E1000 node and Redfish Exporter for SMART data
 

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -281,7 +281,7 @@ This step does not rebuild NCNs. These new images are built and stored in S3 to 
 
 1. Choose one of the following options based on the output from the previous step.
 
-    * Option 1: [Upgrade of CSM on system with additional products](../Stage_0_Prerequisites.md#option-1-upgrade-of-csm-and-additional-products)
+    * Option 1: [Upgrade of CSM on system with additional products](./CSM-With-Other-Products.md)
     * Option 2: [Upgrade of CSM on CSM-only system](./CSM-Only.md#steps) ***(Do not use this procedure if more than CSM is
       installed on the system.\)***
 

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -282,8 +282,8 @@ This step does not rebuild NCNs. These new images are built and stored in S3 to 
 1. Choose one of the following options based on the output from the previous step.
 
     * Option 1: [Upgrade of CSM on system with additional products](./CSM-With-Other-Products.md)
-    * Option 2: [Upgrade of CSM on CSM-only system](./CSM-Only.md#steps) _(Do not use this procedure if more than CSM is
-      installed on the system.\)_
+    * Option 2: [Upgrade of CSM on CSM-only system](./CSM-Only.md#steps)
+      _(Do not use this procedure if more than CSM is installed on the system.\)_
 
 ### Update test suite packages
 

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -356,16 +356,9 @@ enables restoring from backup later in this process if needed.
 
 ### NCN upgrade
 
-This step is necessary so that nodes are using the correct images. If NCN are
-not upgraded into these images, then `cloudinit` would fail on the nodes the next
-time the nodes are rebuilt. The images that the nodes are being upgraded to were
-set in BSS during [Update NCN images](../1.5.2/README.md#update-ncn-images).
-If the NCN nodes are not upgraded now, then any node reboot will cause the node to be
-booted into this new image which is not following the proper upgrade procedure which could cause problems.
+This step is necessary so that nodes are using the correct images after running [Update NCN images](../1.5.2/README.md#update-ncn-images).
 
-Additionally, each patch release includes updated container images that may
-contain CVE fixes, rebuilding each NCN will refresh cached container images.
-For instructions on how to upgrade NCNs for this patch release, refer to [Upgrade NCN during CSM `1.5.2` patch](./Upgrade_NCN_images.md).
+The rebuild will also ensure that the NCN has the latest cached container images that often accompany a CSM patch release.
 
 ### Configure E1000 node and Redfish Exporter for SMART data
 

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -62,7 +62,7 @@ list of patch versions.
 1. [Update test suite packages](#update-test-suite-packages)
 1. [Verification](#verification)
 1. [Take Etcd manual backup](#take-etcd-manual-backup)
-1. [NCN reboot](#ncn-reboot)
+1. [NCN upgrade](#ncn-upgrade)
 1. [Configure E1000 node and Redfish Exporter for SMART data](#configure-e1000-node-and-redfish-exporter-for-smart-data)
 1. [Complete upgrade](#complete-upgrade)
 
@@ -354,9 +354,9 @@ SUCCESS
 These clusters are automatically backed up every 24 hours, but taking a manual backup at this stage in the upgrade
 enables restoring from backup later in this process if needed.
 
-### NCN Upgrade
+### NCN upgrade
 
-This step is neccessary so that nodes are using the correct images. If NCN are
+This step is necessary so that nodes are using the correct images. If NCN are
 not upgraded into these images, then `cloudinit` would fail on the nodes the next
 time the nodes are rebuilt. The images that the nodes are being upgraded to were
 set in BSS during [Update NCN images](../1.5.2/README.md#update-ncn-images).

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -360,6 +360,8 @@ This step is necessary so that nodes are using the correct images after running 
 
 The rebuild will also ensure that the NCN has the latest cached container images that often accompany a CSM patch release.
 
+Follow the [Upgrade NCNs during CSM `1.5.2` Patch](./Upgrade_NCN_images.md) instructions to perform the NCN node image upgrades.
+
 ### Configure E1000 node and Redfish Exporter for SMART data
 
 > **NOTE:** Please follow this step if SMART disk data is needed for E1000 node.

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -75,7 +75,7 @@ upgrade procedure which could cause problems.
             ```
 
         1. Set the following release variables to the same values they were set to on `ncn-m001`.
-           
+
             - `CSM_DISTDIR`
             - `CSM_RELEASE_VERSION`
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -37,7 +37,7 @@ upgrade procedure which could cause problems.
         1. Get a comma sperated list of storage nodes to be upgraded.
 
             ```bash
-            STORAGE_NODES="$(ceph orch host ls | grep ncn-s | grep -v "$STORAGE_CANARY" | awk '{print $1}' | tr '\n' ',' | head -c -1)"
+            STORAGE_NODES="$(ceph orch host ls | grep ncn-s | grep -v "$CANARY_NODE" | awk '{print $1}' | tr '\n' ',' | head -c -1)"
             echo "$STORAGE_NODES"
             ```
 
@@ -49,11 +49,11 @@ upgrade procedure which could cause problems.
 
     For troubleshooting the storage node upgrades, please see the notes in the [CSM storage node upgrade procedure](../Stage_2.md#storage-node-image-upgrade-and-ceph-upgrade).
 
-1. (`ncn-m001#`) Export `CSM_ARTI_DIR` environment variable. (`CSM_RELEASE` is expected to already be set).
+1. (`ncn-m001#`) Export `CSM_ARTI_DIR` environment variable. (`CSM_RELEASE_VERSION` and `CSM_DISTDIR` is expected to already be set).
 
     ```bash
-    CSM_REL_NAME="csm-${CSM_RELEASE}"
-    export CSM_ARTI_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}"
+    CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
+    export CSM_ARTI_DIR="${CSM_DISTDIR}"
     echo "${CSM_ARTI_DIR}"
     ```
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -58,7 +58,7 @@ upgrade procedure which could cause problems.
     echo "${CSM_ARTI_DIR}"
     ```
 
-1. Upgrade master nodes and worker nodes using the steps below, these will walk through the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) steps.
+1. Upgrade master nodes and worker nodes using the following steps, these will walk through the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) steps.
 
     1. (`ncn-m001#`) Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -81,8 +81,8 @@ upgrade procedure which could cause problems.
 
         1. Set the following release variables to the same values they were set to on `ncn-m001`.
 
-            - `CSM_DISTDIR`
-            - `CSM_RELEASE_VERSION`
+            * `CSM_DISTDIR`
+            * `CSM_RELEASE_VERSION`
 
            See the [`CSM-1.5.2` patch preparation](./README.md#preparation) for details on setting these variables.
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -61,8 +61,16 @@ upgrade procedure which could cause problems.
 
     Follow steps `3.1`, `3.2`, and `3.3` in the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) to upgrade master nodes and worker nodes.
 
-    Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade). Then perform the worker node upgrades.
-    Stop after completing [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
+    1. Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
+    1. Perform [Stage 3.2 - Master node image upgrade](../Stage_3.md#stage-32---worker-node-image-upgrade).
+    1. Perform [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
+    **Note:** before ugrading `ncn-m001`, export `CSM_REL_NAME` and `CSM_ARTI_DIR` variables on `ncn-m002`.
+
+        ```bash
+        CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
+        export CSM_ARTI_DIR="${CSM_DISTDIR}"
+        echo "${CSM_ARTI_DIR}"
+        ```
 
 ## Return to CSM `1.5.2` patch
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -1,0 +1,69 @@
+# Upgrade NCNs during CSM `1.5.2` Patch
+
+This page provides guidance for systems that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
+
+The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page
+during [Update NCN images](../1.5.2/README.md#update-ncn-images).
+
+## Overview
+
+This steps upgrade NCNs into the node images created during the [Update NCN images](../1.5.2/README.md#update-ncn-images)
+step of the patch procedure. The node upgrades will not change the state of the node.
+
+It is important to do this step so that nodes
+are using the correct images. If NCN are not upgraded into these images, then `cloudinit` would fail on the nodes the next
+time the nodes are rebuilt. These images were set in BSS during [Update NCN images](../1.5.2/README.md#update-ncn-images)
+and if the NCN nodes are not upgraded, then on any node reboot will cause the node to be booted into this new image which is not following the proper
+upgrade procedure which could cause problems.
+
+## Steps
+
+1. (`ncn-m001#`) Upgrade storage nodes.
+
+    1. Pick one storage node to test the first storage node upgrade on. This will be refered to as the `CANARY_NODE`.
+
+        ```bash
+        CANARY_NODE="ncn-s001"
+        ```
+
+    1. Perform the storage node upgrade on the `CANARY_NODE`.
+
+        ```bash
+        /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ${CANARY_NODE} --upgrade
+        ```
+
+    1. If the `CANARY_NODE` upgrade succeeded, upgrade the remaining storage nodes.
+
+        1. Get a comma sperated list of storage nodes to be upgraded.
+
+            ```bash
+            STORAGE_NODES="$(ceph orch host ls | grep ncn-s | grep -v "$STORAGE_CANARY" | awk '{print $1}' | tr '\n' ',' | head -c -1)"
+            echo "$STORAGE_NODES"
+            ```
+
+        1. Upgrade remaining storage nodes.
+
+            ```bash
+            /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ${STORAGE_NODES} --upgrade
+            ```
+
+    For troubleshooting the storage node upgrades, please see the notes in the [CSM storage node upgrade procedure](../Stage_2.md#storage-node-image-upgrade-and-ceph-upgrade).
+
+1. (`ncn-m001#`) Export `CSM_ARTI_DIR` environment variable. (`CSM_RELEASE` is expected to already be set).
+
+    ```bash
+    CSM_REL_NAME="csm-${CSM_RELEASE}"
+    export CSM_ARTI_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}"
+    echo "${CSM_ARTI_DIR}"
+    ```
+
+1. (`ncn-m001#`) Upgrade master nodes and worker nodes.
+
+    Follow steps `3.1`, `3.2`, and `3.3` in the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) to upgrade master nodes and worker nodes.
+
+    Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade). Then perform the worker node upgrades.
+    Stop after completing [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
+
+## Return to CSM `1.5.2` patch
+
+Return to the next step of the CSM `1.5.2` patch procedure [Configure E1000 node and Redfish Exporter for SMART data](./index.md#configure-e1000-node-and-redfish-exporter-for-smart-data).

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -32,19 +32,20 @@ upgrade procedure which could cause problems.
         /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ${CANARY_NODE} --upgrade
         ```
 
-    1. If the `CANARY_NODE` upgrade succeeded, upgrade the remaining storage nodes.
+    1. After successfully upgrading the `CANARY_NODE`, continue upgrading the remaining storage nodes.
 
         1. Get a comma sperated list of storage nodes to be upgraded.
 
             ```bash
-            STORAGE_NODES="$(ceph orch host ls | grep ncn-s | grep -v "$CANARY_NODE" | awk '{print $1}' | tr '\n' ',' | head -c -1)"
+            STORAGE_NODES="$(ceph orch host ls | awk '/^ncn\-s/{if ($1 != "'"$CANARY_NODE"'") print $1}')"
+            STORAGE_NODES="${STORAGE_NODES//$'\n'/,}"
             echo "$STORAGE_NODES"
             ```
 
         1. Upgrade remaining storage nodes.
 
             ```bash
-            /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ${STORAGE_NODES} --upgrade
+            /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh "${STORAGE_NODES}" --upgrade
             ```
 
     For troubleshooting the storage node upgrades, see the notes in the [CSM storage node upgrade procedure](../Stage_2.md#storage-node-image-upgrade-and-ceph-upgrade).
@@ -57,36 +58,48 @@ upgrade procedure which could cause problems.
     echo "${CSM_ARTI_DIR}"
     ```
 
-1. Upgrade master nodes and worker nodes.
-
-    Follow steps `3.1`, `3.2`, and `3.3` in the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) to upgrade master nodes and worker nodes.
+1. Upgrade master nodes and worker nodes using the steps below, these will walk through the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) steps.
 
     1. (`ncn-m001#`) Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
 
     1. (`ncn-m001#`) Perform [Stage 3.2 - Master node image upgrade](../Stage_3.md#stage-32---worker-node-image-upgrade).
 
-    1. (`ncn-m002#`) Upgrade `ncn-m001`.
+    1. (`ncn-m002#`) From `ncn-m002`, commence the upgrade for `ncn-m001`.
 
-        1. Move old `myenv` file and create a new file.
+    1. (`ncn-m002#`) From `ncn-m002`, commence the upgrade for `ncn-m001`.
+
+        1. Backup the previous `myenv` file.
 
             ```bash
             mv /etc/cray/upgrade/csm/myenv /etc/cray/upgrade/csm/myenv.old
-            touch /etc/cray/upgrade/csm/myenv
             ```
 
-        1. Set `CSM_RELEASE_VERSION` and `CSM_DISTDIR` release variables to the same values they were set to on `ncn-m001`.
-        See the [`CSM-1.5.2` patch preparation](./README.md#preparation) for deatils on how these variables were set
+        1. Set the following release variables to the same values they were set to on `ncn-m001`.
+           
+            - `CSM_DISTDIR`
+            - `CSM_RELEASE_VERSION`
 
-        1. Write release variables to the new `/etc/cray/upgrade/csm/myenv` so that they can be used with the upgrade of `ncn-m001`.
+           See the [`CSM-1.5.2` patch preparation](./README.md#preparation) for details on setting these variables.
 
-            ```bash
-            CSM_ARTI_DIR="${CSM_DISTDIR}"
-            CSM_RELEASE="${CSM_RELEASE_VERSION}"
-            CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
-            echo "export CSM_ARTI_DIR=${CSM_ARTI_DIR}" >> /etc/cray/upgrade/csm/myenv
-            echo "export CSM_RELEASE=${CSM_RELEASE}" >> /etc/cray/upgrade/csm/myenv
-            echo "export CSM_REL_NAME=${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
-            ```
+        1. Write release variables to a new `/etc/cray/upgrade/csm/myenv` for the upgrade of `ncn-m001`.
+
+            1. Set the new variables.
+
+               ```bash
+               export CSM_ARTI_DIR="${CSM_DISTDIR}"
+               export CSM_RELEASE="${CSM_RELEASE_VERSION}"
+               export CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
+               ```
+
+            1. Create the new `myenv` file.
+
+               ```bash
+               cat << EOF > /etc/cray/upgrade/csm/myenv
+               export CSM_ARTI_DIR=${CSM_ARTI_DIR}
+               export CSM_RELEASE=${CSM_RELEASE}
+               export CSM_REL_NAME=${CSM_REL_NAME}
+               EOF
+               ```
 
         1. Perform [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -3,7 +3,7 @@
 This page provides guidance for systems that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
 
 The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page
-during [Update NCN images](../1.5.2/README.md#update-ncn-images).
+during [NCN Upgrade](../1.5.2/README.md#ncn-upgrade).
 
 ## Overview
 
@@ -20,7 +20,7 @@ upgrade procedure which could cause problems.
 
 1. (`ncn-m001#`) Upgrade storage nodes.
 
-    1. Pick one storage node to test the first storage node upgrade on. This will be refered to as the `CANARY_NODE`.
+    1. Pick one storage node to test the first storage node upgrade on. This will be referred to as the `CANARY_NODE`.
 
         ```bash
         CANARY_NODE="ncn-s001"

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -39,7 +39,7 @@ upgrade procedure which could cause problems.
 
     1. After successfully upgrading the `CANARY_NODE`, continue upgrading the remaining storage nodes.
 
-        1. Get a comma sperated list of storage nodes to be upgraded.
+        1. Get a comma seperated list of storage nodes to be upgraded.
 
             ```bash
             STORAGE_NODES="$(ceph orch host ls | awk '/^ncn\-s/{if ($1 != "'"$CANARY_NODE"'") print $1}')"

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -64,7 +64,7 @@ upgrade procedure which could cause problems.
     1. Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
     1. Perform [Stage 3.2 - Master node image upgrade](../Stage_3.md#stage-32---worker-node-image-upgrade).
     1. Perform [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
-    **Note:** before ugrading `ncn-m001`, export `CSM_REL_NAME` and `CSM_ARTI_DIR` variables on `ncn-m002`.
+    **Note:** before upgrading `ncn-m001`, export `CSM_REL_NAME` and `CSM_ARTI_DIR` variables on `ncn-m002`.
 
         ```bash
         CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -7,11 +7,11 @@ during [NCN Upgrade](../1.5.2/README.md#ncn-upgrade).
 
 ## Overview
 
-This steps upgrade NCNs into the node images created during the [Update NCN images](../1.5.2/README.md#update-ncn-images)
+The following steps upgrade NCNs into the node images created during the [Update NCN images](../1.5.2/README.md#update-ncn-images)
 step of the patch procedure. The node upgrades will not change the state of the node.
 
 It is important to do this step so that nodes
-are using the correct images. If NCN are not upgraded into these images, then `cloudinit` would fail on the nodes the next
+are using the correct images. If NCNs are not upgraded into these images, then `cloudinit` will fail on the nodes the next
 time the nodes are rebuilt. These images were set in BSS during [Update NCN images](../1.5.2/README.md#update-ncn-images)
 and if the NCN nodes are not upgraded, then on any node reboot will cause the node to be booted into this new image which is not following the proper
 upgrade procedure which could cause problems.
@@ -47,7 +47,7 @@ upgrade procedure which could cause problems.
             /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ${STORAGE_NODES} --upgrade
             ```
 
-    For troubleshooting the storage node upgrades, please see the notes in the [CSM storage node upgrade procedure](../Stage_2.md#storage-node-image-upgrade-and-ceph-upgrade).
+    For troubleshooting the storage node upgrades, see the notes in the [CSM storage node upgrade procedure](../Stage_2.md#storage-node-image-upgrade-and-ceph-upgrade).
 
 1. (`ncn-m001#`) Export `CSM_ARTI_DIR` environment variable. (`CSM_RELEASE_VERSION` and `CSM_DISTDIR` is expected to already be set).
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -57,20 +57,38 @@ upgrade procedure which could cause problems.
     echo "${CSM_ARTI_DIR}"
     ```
 
-1. (`ncn-m001#`) Upgrade master nodes and worker nodes.
+1. Upgrade master nodes and worker nodes.
 
     Follow steps `3.1`, `3.2`, and `3.3` in the [CSM Stage 3 Upgrade Kubernetes documentation](../Stage_3.md) to upgrade master nodes and worker nodes.
 
-    1. Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
-    1. Perform [Stage 3.2 - Master node image upgrade](../Stage_3.md#stage-32---worker-node-image-upgrade).
-    1. Perform [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
-    **Note:** before upgrading `ncn-m001`, export `CSM_REL_NAME` and `CSM_ARTI_DIR` variables on `ncn-m002`.
+    1. (`ncn-m001#`) Start with step [Stage 3.1 - Master node image upgrade](../Stage_3.md#stage-31---master-node-image-upgrade).
 
-        ```bash
-        CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
-        export CSM_ARTI_DIR="${CSM_DISTDIR}"
-        echo "${CSM_ARTI_DIR}"
-        ```
+    1. (`ncn-m001#`) Perform [Stage 3.2 - Master node image upgrade](../Stage_3.md#stage-32---worker-node-image-upgrade).
+
+    1. (`ncn-m002#`) Upgrade `ncn-m001`.
+
+        1. Move old `myenv` file and create a new file.
+
+            ```bash
+            mv /etc/cray/upgrade/csm/myenv /etc/cray/upgrade/csm/myenv.old
+            touch /etc/cray/upgrade/csm/myenv
+            ```
+
+        1. Set `CSM_RELEASE_VERSION` and `CSM_DISTDIR` release variables to the same values they were set to on `ncn-m001`.
+        See the [`CSM-1.5.2` patch preparation](./README.md#preparation) for deatils on how these variables were set
+
+        1. Write release variables to the new `/etc/cray/upgrade/csm/myenv` so that they can be used with the upgrade of `ncn-m001`.
+
+            ```bash
+            CSM_ARTI_DIR="${CSM_DISTDIR}"
+            CSM_RELEASE="${CSM_RELEASE_VERSION}"
+            CSM_REL_NAME="csm-${CSM_RELEASE_VERSION}"
+            echo "export CSM_ARTI_DIR=${CSM_ARTI_DIR}" >> /etc/cray/upgrade/csm/myenv
+            echo "export CSM_RELEASE=${CSM_RELEASE}" >> /etc/cray/upgrade/csm/myenv
+            echo "export CSM_REL_NAME=${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
+            ```
+
+        1. Perform [Stage 3.3 - `ncn-m001` upgrade](../Stage_3.md#stage-33---ncn-m001-upgrade) and return to this document.
 
 ## Return to CSM `1.5.2` patch
 

--- a/upgrade/1.5.2/Upgrade_NCN_images.md
+++ b/upgrade/1.5.2/Upgrade_NCN_images.md
@@ -1,5 +1,10 @@
 # Upgrade NCNs during CSM `1.5.2` Patch
 
+* [Upgrade NCNs during CSM `1.5.2` Patch](#upgrade-ncns-during-csm-152-patch)
+    * [Overview](#overview)
+    * [Steps](#steps)
+    * [Return to CSM `1.5.2` patch](#return-to-csm-152-patch)
+
 This page provides guidance for systems that are performing an upgrade from a CSM `v1.5.X` release to the CSM `v1.5.2` release.
 
 The [`v1.5.2` upgrade page](../1.5.2/README.md) will refer to this page


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

During CSM 1.5.2 patch upgrade, this new step has been added: https://github.com/Cray-HPE/docs-csm/tree/release/1.5/upgrade/1.5.2#update-ncn-images

In case of with products - it links to this documentation: https://github.com/Cray-HPE/docs-csm/blob/release/1.5/upgrade/Stage_0_Prerequisites.md#option-1-upgrade-of-csm-and-additional-products , which then leads to a full IUF Upgrade run.

It should instead point to: https://github.com/Cray-HPE/docs-csm/blob/release/1.4/upgrade/Stage_0_Prerequisites.md#option-2-upgrade-of-csm-on-system-with-additional-products 
This procedure was removed in 1.5.

This PR adds this documentation back to the CSM 1.5.2 patch. I have added documentation for building new NCN images with that include the products. This documentation exists only in CSM 1.5.2 patch. It is not in `prerequisites` because this is not a procedure that would be needed outside of this patch process.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
