### PR TITLE
Instructions to disable nodes after restore (CASMHMS-6210)

### DIFF
--- a/operations/Restore_HSM.md
+++ b/operations/Restore_HSM.md
@@ -4,7 +4,8 @@
 
 1. If `tar` file was placed in `s3` from [Backup](Backup_HMS.md) copy to the system to restore.
 
-    1. List objects in `s3`
+    1. (`ncn-mw#`) List objects in `s3`
+
 
         ```bash
         bucket=hms

--- a/operations/Restore_HSM.md
+++ b/operations/Restore_HSM.md
@@ -2,9 +2,32 @@
 
 ## Procedure
 
-1. Place `tar` file from [Backup](Backup_HMS.md) on the system to restore.
+1. If `tar` file was placed in `s3` from [Backup](Backup_HMS.md) copy to the system to restore.
 
-1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`).
+    1. List objects in `s3`
+
+        ```bash
+        bucket=hms
+        aws s3api list-objects --bucket $bucket --endpoint-url http://ncn-m001.nmn:8000
+        ```
+
+    1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`). For example:
+
+
+        ```bash
+        BACKUP_FILE=hms-backup_2023-06-28_11-12-24
+        ```
+
+    1. (`ncn-mw#`) To retrieve files from backup disk.
+
+        ```bash
+        file=$BACKUP_FILE.tar.gz
+        aws s3api get-object --bucket $bucket --key $file $file --endpoint-url http://ncn-m001.nmn:8000
+        file=sls_input_file.json
+        aws s3api get-object --bucket $bucket --key $file $file --endpoint-url http://ncn-m001.nmn:8000
+        ```
+
+1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`). example:
 
     ```bash
     BACKUP_FILE=hms-backup_2023-06-28_11-12-24
@@ -34,6 +57,7 @@
 
     ```bash
     kubectl replace -f cray-hms-base-config_$BACKUP_FILE.yaml
+    sleep 60
     $DOCS_DIR/operations/hardware_state_manager/updateroles.py cray-smd-components-dump_$BACKUP_FILE.json
     ```
 
@@ -103,4 +127,14 @@
 
     ```bash
     $DOCS_DIR/operations/boot_script_service/bss-restore-bootparameters.sh cray-bss-boot-parameters-dump_$BACKUP_FILE.json
+    ```
+
+1. (`ncn-mw#`) Disable nodes.
+
+    ```bash
+    COMPONENT_FILE=cray-smd-components-dump_$BACKUP_FILE.json
+    ENABLE_URL=https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled
+    xnames=`cat $COMPONENT_FILE | jq '.[] | .[] | select(.Enabled==false)' | jq .ID | paste -sd, -`
+    payload='{"ComponentIDs": ['$xnames'], "Enabled": false}'
+    if [ ${#xnames} -gt 0 ]; then curl -k -s -X PATCH -H "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" -d $payload $ENABLE_URL; echo $xnames; fi
     ```

--- a/operations/Restore_HSM.md
+++ b/operations/Restore_HSM.md
@@ -13,7 +13,6 @@
 
     1. (`ncn-mw#`) Set name of backup file (without `.tar.gz`). For example:
 
-
         ```bash
         BACKUP_FILE=hms-backup_2023-06-28_11-12-24
         ```


### PR DESCRIPTION
# Description
Update to Restore procedure to add disabling nodes (copied from release 1.5)

CASMHMS-6210

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
