### PR TITLE
CASMINST-6906: Update RPMs on all NCNs in prerequisites.sh; allow vendor changes in test RPM updater

### DIFF
--- a/upgrade/Validate_CSM_Health_During_Upgrade.md
+++ b/upgrade/Validate_CSM_Health_During_Upgrade.md
@@ -24,15 +24,12 @@
     If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
     after a break, always be sure that a typescript is running before proceeding.
 
-1. Validate CSM health.
+1. (`ncn-m002#`) Validate CSM health.
 
-    Run the combined health check script, which runs a variety of health checks that should pass at this stage of the upgrade:
-
-    - Kubernetes health checks
-    - NCN health checks
+    Run the combined health check script, which runs a variety of health checks that should pass at this stage of the upgrade.
 
     ```bash
-    /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
+    /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
     ```
 
     Review the output and follow the instructions provided to resolve any test failures. With the exception of

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1409,8 +1409,9 @@ if [[ ${state_recorded} == "0" ]]; then
     systemctl enable goss-servers
     systemctl restart goss-servers
 
-    # Install above RPMs and restart goss-servers on ncn-w001
-    ssh ncn-w001 "rpm --force -Uvh ${url_list[*]}; systemctl enable goss-servers; systemctl restart goss-servers;"
+    # Install above RPMs and restart goss-servers on all other NCNs
+    ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | grep -Ev "^$(hostname -s)$" | tr -t '\n' ',')
+    pdsh -S -b -w ${ncns} "rpm --force -Uvh ${url_list[*]}; systemctl enable goss-servers; systemctl restart goss-servers;"
 
     # get all installed CSM version into a file
     kubectl get cm -n services cray-product-catalog -o json | jq -r '.data.csm' | yq r - -d '*' -j | jq -r 'keys[]' > /tmp/csm_versions

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -27,21 +27,23 @@
 # If --local is not specified, upgrade the test RPMs on all NCNs
 # If --local is specified, upgrade the test RPMs just on the system where the script is being executed
 
+RPM_LIST="hpe-csm-goss-package csm-testing goss-servers craycli cray-cmstools-crayctldeploy"
+
 set -euo pipefail
 if [[ $# -eq 0 ]]; then
 
   ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
 
-  echo "Installing updated versions of hpe-csm-goss-package csm-testing goss-servers craycli RPMs"
-  pdsh -S -b -w ${ncns} 'zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli'
+  echo "Installing updated versions of RPMs on all NCNs: ${RPM_LIST}"
+  pdsh -S -b -w ${ncns} "zypper install -y --allow-vendor-change ${RPM_LIST}"
 
   echo "Enabling and restarting goss-servers"
   pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl restart goss-servers'
 
 elif [[ $# -eq 1 && $1 == --local ]]; then
 
-  echo "Installing updated versions of hpe-csm-goss-package csm-testing goss-servers craycli RPMs"
-  zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli
+  echo "Installing updated versions of RPMs: ${RPM_LIST}"
+  zypper install -y --allow-vendor-change ${RPM_LIST}
 
   echo "Enabling and restarting goss-servers"
   systemctl enable goss-servers && systemctl restart goss-servers


### PR DESCRIPTION
This PR addresses a problem seen on fanta during its upgrade from CSM 1.4.4 to CSM 1.5.2.
The cmsdev test failed because the Cray CLI was not updated on the node where it ran. This update did not happen for two reasons:

1. The `prerequisites` script only updates the test RPMs on a couple of NCNs, instead of on all of them.
2. The update test RPM script fails to update some RPMs because their vendors changed from Cray to HPE.

This PR fixes #1 by updating the RPMs on all NCNs, and fixes #2 by calling zypper with a flag to allow the vendor change.

This PR also fixes an error on the "validate csm during upgrade" page where it referenced the old name of a script, that no longer exists.

Backports:
CSM 1.6: https://github.com/Cray-HPE/docs-csm/pull/5196
CSM 1,4  https://github.com/Cray-HPE/docs-csm/pull/5197 (just the allow vendor change bit)