### PR TITLE
CASMTRIAGE-7016: Fix update_tags.sh by removing bad `echo`

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -75,7 +75,6 @@ function get_latest_tag_for_image() {
     THIS_PREFIX="${THIS_REGISTRY_NAME}/"
     THIS_IMAGE=$(echo "${THIS_IMAGE}" | sed "s#^${DEFAULT_REGISTRY_REGEX}/##")
   fi
-  echo $THIS_PODMAN_TLS $THIS_PREFIX$THIS_IMAGE
   podman search $THIS_PODMAN_TLS $THIS_PREFIX$THIS_IMAGE --list-tags --format=json | jq -r '
     def opt(f):
       . as $in | try f catch $in;


### PR DESCRIPTION

# Description
The `echo` command inside of `get_latest_tag_for_image` pollutes the output of this function, which is then fed into `update_tags_in_file`, which then results in the incorrect arguments being passed to a `sed` command which results in `sed` failing with a "No such file or directory" error.

Remove this `echo` command. It's not clear what its purpose is.

# Test Description
Removed this echo command from a copy of the script and executed the script and verified that it correctly updated image tags in Argo workflow templates.# Checklist

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
