### PR TITLE
CASMTRIAGE-7122: ncn-upgrade-master-nodes.sh: Add retries of docs-csm RPM install

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -187,9 +187,23 @@ state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
   echo "====> ${state_name} ..."
   {
-    record_state "${state_name}" ${target_ncn}
     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
-    ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
+    # CASMTRIAGE-7122: This RPM install can fail if it happens while CFS is installing RPMs
+    # Therefore, we retry a limited number of times before giving up
+    attempt=0
+    while [[ true ]]; do
+      if [[ ${attempt} -gt 0 ]]; then
+        # Wait briefly before trying again
+        sleep 5
+      fi
+      if [[ ${attempt} -lt 12 ]]; then
+        let attempt+=1
+        ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm" && break || continue
+      fi
+      # Final attempt. The lack of the || continue means that this will cause the script to
+      # fail (since it runs with set -e) if the command fails
+      ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm" && break
+    done
   } >> ${LOG_FILE} 2>&1
   record_state "${state_name}" ${target_ncn}
 else


### PR DESCRIPTION
Mikhail reported a problem where this RPM install can fail because CFS is running at the same time, and the rpm lock file is present. By adding a few retries and sleeps, this PR should allow the RPM install to succeed eventually, if this is the problem.

(No similar change is needed on the CFS side, since it already has retry logic built in)

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/5209
1.4: https://github.com/Cray-HPE/docs-csm/pull/5210
1.3: https://github.com/Cray-HPE/docs-csm/pull/5211
1.2: https://github.com/Cray-HPE/docs-csm/pull/5212
1.0: https://github.com/Cray-HPE/docs-csm/pull/5213