### PR TITLE
CASMTRIAGE-7131: Correct BOS CLI commands

### DIFF
--- a/operations/boot_orchestration/BOS_Workflows.md
+++ b/operations/boot_orchestration/BOS_Workflows.md
@@ -6,9 +6,9 @@ They also help provide a quicker and deeper understanding of how the system func
 
 * [Terminology](#terminology)
 * [Workflows]
-  * [Boot nodes](#boot-nodes)
-  * [Reboot nodes](#reboot-nodes)
-  * [Power off nodes](#power-off-nodes)
+    * [Boot nodes](#boot-nodes)
+    * [Reboot nodes](#reboot-nodes)
+    * [Power off nodes](#power-off-nodes)
 
 ## Terminology
 
@@ -16,11 +16,11 @@ The following are mentioned in the workflows:
 
 * Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes.
   The Boot Orchestration Service has the following components:
-  * A BOS session template is a collection of one or more boot sets. A boot set defines a collection of nodes and the information about the boot artifacts and parameters.
-    Session templates also include information on which [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) configuration should
-    be applied.
-  * BOS sessions provide a way to apply a template across a group of nodes and monitor the progress of those nodes as they move toward their desired state.
-  * BOS operators interact with other services to perform actions on nodes, moving them toward their desired state.
+    * A BOS session template is a collection of one or more boot sets. A boot set defines a collection of nodes and the information about the boot artifacts and parameters.
+      Session templates also include information on which [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) configuration should
+      be applied.
+    * BOS sessions provide a way to apply a template across a group of nodes and monitor the progress of those nodes as they move toward their desired state.
+    * BOS operators interact with other services to perform actions on nodes, moving them toward their desired state.
 * [Cray Advanced Platform Monitoring and Control (CAPMC)](../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc) service provides system-level power control
   for nodes in the system. CAPMC interfaces directly with the Redfish APIs to the controller infrastructure to effect power and environmental changes on the system.
 * [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm) tracks the state of each node and its group and role associations.

--- a/operations/boot_orchestration/BOS_Workflows.md
+++ b/operations/boot_orchestration/BOS_Workflows.md
@@ -1,7 +1,8 @@
 # BOS Workflows
 
 The following workflows present a high-level overview of common Boot Orchestration Service \(BOS\) operations.
-These workflows depict how services interact with each other when booting, configuring, or shutting down nodes. They also help provide a quicker and deeper understanding of how the system functions.
+These workflows depict how services interact with each other when booting, configuring, or shutting down nodes.
+They also help provide a quicker and deeper understanding of how the system functions.
 
 * [Terminology](#terminology)
 * [Workflows]
@@ -13,13 +14,15 @@ These workflows depict how services interact with each other when booting, confi
 
 The following are mentioned in the workflows:
 
-* Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes. The Boot Orchestration Service has the following components:
+* Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes.
+  The Boot Orchestration Service has the following components:
   * A BOS session template is a collection of one or more boot sets. A boot set defines a collection of nodes and the information about the boot artifacts and parameters.
-    Session templates also include information on which [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) configuration should be applied.
+    Session templates also include information on which [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) configuration should
+    be applied.
   * BOS sessions provide a way to apply a template across a group of nodes and monitor the progress of those nodes as they move toward their desired state.
   * BOS operators interact with other services to perform actions on nodes, moving them toward their desired state.
-* [Cray Advanced Platform Monitoring and Control (CAPMC)](../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc) service provides system-level power control for nodes in the system.
-  CAPMC interfaces directly with the Redfish APIs to the controller infrastructure to effect power and environmental changes on the system.
+* [Cray Advanced Platform Monitoring and Control (CAPMC)](../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc) service provides system-level power control
+  for nodes in the system. CAPMC interfaces directly with the Redfish APIs to the controller infrastructure to effect power and environmental changes on the system.
 * [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm) tracks the state of each node and its group and role associations.
 * [Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) stores per-node information about the iPXE boot script.
   When booting or rebooting, nodes consult BSS for boot artifacts \(kernel, `initrd`, image root\) and boot parameters.
@@ -71,28 +74,32 @@ The following workflows are included in this section:
 
 1. **Administrator creates a BOS session template**
 
-    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and  configuration that should be applied to them. A session template can be created from a JSON structure. It returns a Session Template ID if successful.
+    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and configuration that should be applied to them.
+    A session template can be created from a JSON structure. It returns a session template ID if successful.
 
-    See [Manage a Session Template](Manage_a_Session_Template.md) for more information.
+    See [Manage a session template](Manage_a_Session_Template.md) for more information.
 
 1. **Administrator creates a session**
 
-    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case, Administrator creates a session with operation as Boot and specifies the session template ID.
+    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case,
+    the administrator creates a session with operation as `boot` and specifies the session template ID.
 
     (`ncn-mw#`)
 
     ```bash
-    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation Boot
+    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation boot
     ```
 
 1. **Session setup operator**
 
     The creation of a session causes the session-setup operator to set a desired state on all components listed in the session template.
-    This includes pulling files from S3 to determine boot artifacts like kernel, `initrd`, and root file system. The session setup operator also enables the relevant components at this time.
+    This includes pulling files from S3 to determine boot artifacts like kernel, `initrd`, and root file system. The session setup operator also enables the relevant
+    components at this time.
 
 1. **Status operator (powering-on)**
 
-    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating with HSM to determine the current power status of the node.
+    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating with HSM
+    to determine the current power status of the node.
 
     In this example of booting nodes, the first phase is `powering-on`. If queried at this point, the nodes will have a status of `power-on-pending`.
     For more on component phase and status, see [Component Status](Component_Status.md)
@@ -103,7 +110,8 @@ The following workflows are included in this section:
     If configuration is enabled for the node, the power-on operator will also call CFS to set the desired configuration and disable the node with CFS.
     The node must be disabled within CFS so that CFS does not try to configure node until it has booted.
     The power-on operator then calls CAPMC to power-on the node.
-    Lastly, the power-on operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-on-called`.
+    Lastly, the power-on operator will update the state of the node in BOS, including setting the last action. If queried at this point,
+    the nodes will have a status of `power-on-called`.
 
 1. **CAPMC boots nodes**
 
@@ -120,7 +128,8 @@ The following workflows are included in this section:
 1. **Status operator (configuring)**
 
     The status operator monitors a node's power state until HSM reports that the power state is on.  
-    When the power state for a node is on, the status operator will either set the phase to `configuring` if CFS configuration is required or it will clear the current phase if the node is in its final state.
+    When the power state for a node is on, the status operator will either set the phase to `configuring` if CFS configuration is required or it will clear the current phase
+    if the node is in its final state.
 
 1. **CFS applies configuration**
 
@@ -173,28 +182,32 @@ The following workflows are included in this section:
 
 1. **Administrator creates a BOS session template**
 
-    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and  configuration that should be applied to them. A session template can be created from a JSON structure. It returns a Session Template ID if successful.
+    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and configuration that should be applied to them.
+    A session template can be created from a JSON structure. It returns a session template ID if successful.
 
-    See [Manage a Session Template](Manage_a_Session_Template.md) for more information.
+    See [Manage a session template](Manage_a_Session_Template.md) for more information.
 
 1. **Administrator creates a session**
 
-    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case, the administrator creates a session with operation as Boot and specifies the session template ID.
+    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case,
+    the administrator creates a session with operation as `reboot` and specifies the session template ID.
 
     (`ncn-mw#`)
 
     ```bash
-    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation Reboot
+    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation reboot
     ```
 
 1. **Session setup operator**
 
     The creation of a session causes the session-setup operator to set a desired state on all components listed in the session template.
-    This includes pulling files from S3 to determine boot artifacts like kernel, `initrd`, and root file system. The session setup operator also enables the relevant components at this time.
+    This includes pulling files from S3 to determine boot artifacts like kernel, `initrd`, and root file system. The session setup operator also enables the relevant
+    components at this time.
 
 1. **Status operator (powering-off)**
 
-    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating with HSM to determine the current power status of the node.
+    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating with
+    HSM to determine the current power status of the node.
 
     In this example of rebooting nodes, the first phase is `powering-off`. If queried at this point, the nodes will have a status of `power-off-pending`.
     For more on component phase and status, see [Component Status](Component_Status.md)
@@ -202,12 +215,14 @@ The following workflows are included in this section:
 1. **Graceful-power-off operator**
 
     The power-off operator will detect nodes with a `power-off-pending` status, calls CAPMC to power-off the node.
-    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-off-gracefully-called`.
+    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of
+    `power-off-gracefully-called`.
 
 1. **Forceful-power-off operator**
 
     If powering-off is taking too long, the forceful-power-off will take over. It also calls CAPMC to power-off the node, but with the addition of the forceful flag.
-    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-off-forcefully-called`.
+    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of
+    `power-off-forcefully-called`.
 
 1. **CAPMC powers off nodes**
 
@@ -216,7 +231,8 @@ The following workflows are included in this section:
 1. **Status operator (powering-on)**
 
     The status operator monitors a node's power state until HSM reports that the power state is off.
-    When the power state for a node is off, the status operator will set the phase to `powering-on`. If queried at this point, the nodes will have a status of `power-on-pending`.
+    When the power state for a node is off, the status operator will set the phase to `powering-on`. If queried at this point, the nodes will have a status of
+    `power-on-pending`.
 
 1. **Power-on operator**
 
@@ -224,7 +240,8 @@ The following workflows are included in this section:
     If configuration is enabled for the node, the power-on operator will also call CFS to set the desired configuration and disable the node with CFS.
     The node must be disabled within CFS so that CFS does not try to configure node until it has booted.
     The power-on operator then calls CAPMC to power-on the node.
-    Lastly, the power-on operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-on-called`.
+    Lastly, the power-on operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of
+    `power-on-called`.
 
 1. **CAPMC boots nodes**
 
@@ -241,7 +258,8 @@ The following workflows are included in this section:
 1. **Status operator (configuring)**
 
     The status operator monitors a node's power state until HSM reports that the power state is on.
-    When the power state for a node is on, the status operator will either set the phase to `configuring` if CFS configuration is required or it will clear the current phase if the node is in its final state.
+    When the power state for a node is on, the status operator will either set the phase to `configuring` if CFS configuration is required or it will clear the current
+    phase if the node is in its final state.
 
 1. **CFS applies configuration**
 
@@ -268,18 +286,20 @@ The following workflows are included in this section:
 
 1. **Administrator creates a BOS session template**
 
-    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and configuration that should be applied to them. A session template can be created from a JSON structure. It returns a Session Template ID if successful.
+    A session template is a collection of data specifying a group of nodes, as well as the boot artifacts and configuration that should be applied to them. A session
+    template can be created from a JSON structure. It returns a session template ID if successful.
 
-    See [Manage a Session Template](Manage_a_Session_Template.md) for more information.
+    See [Manage a session template](Manage_a_Session_Template.md) for more information.
 
 1. **Administrator creates a session**
 
-    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case, the administrator creates a session with operation as Boot and specifies the session template ID.
+    Create a session to perform the operation specified in the operation request parameter on the boot set defined in the session template. For this use case,
+    the administrator creates a session with operation as `shutdown` and specifies the session template ID.
 
     (`ncn-mw#`)
 
     ```bash
-    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation Reboot
+    cray bos v2 sessions create --template-name SESSIONTEMPLATE_NAME --operation shutdown
     ```
 
 1. **Session setup operator**
@@ -290,7 +310,8 @@ The following workflows are included in this section:
 
 1. **Status operator (powering-off)**
 
-    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating with HSM to determine the current power status of the node.
+    The status operator will detect the enabled components and assign them a phase. This involves checking the current state of the node, including communicating
+    with HSM to determine the current power status of the node.
 
     In this example of booting nodes, the first phase is `powering-off`. If queried at this point, the nodes will have a status of `power-off-pending`.
     For more on component phase and status, see [Component Status](Component_Status.md)
@@ -298,12 +319,14 @@ The following workflows are included in this section:
 1. **Graceful-power-off operator**
 
     The power-off operator will detect nodes with a `power-off-pending` status, calls CAPMC to power-off the node.
-    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-off-gracefully-called`.
+    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of
+    `power-off-gracefully-called`.
 
 1. **Forceful-power-off operator**
 
     If powering-off is taking too long, the forceful-power-off will take over. It also calls CAPMC to power-off the node, but with the addition of the forceful flag.
-    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of `power-off-forcefully-called`.
+    Then, the power-off operator will update the state of the node in BOS, including setting the last action. If queried at this point, the nodes will have a status of
+    `power-off-forcefully-called`.
 
 1. **CAPMC powers off nodes**
 

--- a/operations/boot_orchestration/Cheatsheet.md
+++ b/operations/boot_orchestration/Cheatsheet.md
@@ -9,25 +9,25 @@ To find the API versions of any commands listed, add `-vvv` to the end of the CL
 * (`ncn-mw#`) Boot all nodes in a template:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Boot
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation boot
     ```
 
 * (`ncn-mw#`) Reboot all nodes in a template:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Reboot
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation reboot
     ```
 
 * (`ncn-mw#`) Shutdown all nodes in a template:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Shutdown
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation shutdown
     ```
 
 * (`ncn-mw#`) Stage a reboot for all nodes in a template:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Reboot --staged True
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation reboot --staged True
     ```
 
 ## Single node commands
@@ -35,25 +35,25 @@ To find the API versions of any commands listed, add `-vvv` to the end of the CL
 * (`ncn-mw#`) Boot a single node:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Boot --limit <node's xname>
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation boot --limit <node's xname>
     ```
 
 * (`ncn-mw#`) Reboot a single node:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Reboot --limit <node's xname>
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation reboot --limit <node's xname>
     ```
 
 * (`ncn-mw#`) Shutdown a single node:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Shutdown --limit <node's xname>
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation shutdown --limit <node's xname>
     ```
 
 * (`ncn-mw#`) Stage a reboot for a single node:
 
     ```bash
-    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation Reboot --staged True --limit <node's xname>
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE_NAME --operation reboot --staged True --limit <node's xname>
     ```
 
 * (`ncn-mw#`) Monitor the overall boot progress of a single node:

--- a/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_CPS.md
+++ b/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_CPS.md
@@ -125,7 +125,7 @@ Refer to [Manage a Session Template](Manage_a_Session_Template.md) for more info
 (`ncn-mw#`) The new CPS-based session template can be used when creating a BOS session. The following is an example of creating a reboot session using the CLI:
 
 ```bash
-cray bos v2 sessions create --template-name cps_rootfs_template --operation Reboot
+cray bos v2 sessions create --template-name cps_rootfs_template --operation reboot
 ```
 
 ## Appendix: `root=` kernel parameter

--- a/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_SBPS.md
+++ b/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_SBPS.md
@@ -165,7 +165,7 @@ Refer to [Manage a Session Template](Manage_a_Session_Template.md) for more info
 (`ncn-mw#`) The new CPS-based session template can be used when creating a BOS session. The following is an example of creating a reboot session using the CLI:
 
 ```bash
-cray bos v2 sessions create --template-name cps_rootfs_template --operation Reboot
+cray bos v2 sessions create --template-name cps_rootfs_template --operation reboot
 ```
 
 ## Appendix: `root=` kernel parameter

--- a/operations/boot_orchestration/Manage_a_BOS_Session.md
+++ b/operations/boot_orchestration/Manage_a_BOS_Session.md
@@ -19,7 +19,7 @@ Creating a new BOS session requires the following command-line options:
 (`ncn-mw#`): The following is a boot operation:
 
 ```bash
-cray bos v2 sessions create --template-name <TEMPLATE_NAME> --operation Boot --format json
+cray bos v2 sessions create --template-name <TEMPLATE_NAME> --operation boot --format json
 ```
 
 Example output:


### PR DESCRIPTION
Some BOS CLI commands in the docs use capitalized operation names, but evidently BOS dislikes this, so this PR corrects the commands to respect BOS's wishes in this matter.

Also fixes some incorrect CLI command descriptions, and one case where a CLI command was specifying the wrong operation.

Backports forthcoming.