### PR TITLE
CASMMON-416: cray-sysmgmt-health will not install with SNMP monitoring enabled

### DIFF
--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -89,7 +89,7 @@ under the `spec.kubernetes.services.cray-sysmgmt-health.snmpExporter` service de
 
 | Customization            | Default      | Description                                                                         |
 |--------------------------|--------------|-------------------------------------------------------------------------------------|
-| `snmpExporter.enabled` | `true`       | Enables `VMServiceScrape` for SNMP Exporter \(default chart value is `true`\)        |
+| `snmpExporter.enabled`   | `true`       | Enables `VMServiceScrape` for SNMP Exporter \(default chart value is `true`\)        |
 | `params.enabled`         | `true`       | Sets the SNMP Exporter `params` change to `true` \(default chart value is `false`\) |
 | `params.conf.module`     | `if_mib`     | SNMP Exporter to select which module \(default chart value is `if_mib`\)            |
 | `params.conf.target`     | `10.252.0.2` | Add list of switch targets to SNMP Exporter to monitor                              |

--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -58,8 +58,8 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
    [{'name': 'sw-spine-001', 'target': '10.254.0.2'},
     {'name': 'sw-spine-002', 'target': '10.254.0.3'},
     {'name': 'sw-leaf-bmc-001', 'target': '10.254.0.4'}]
-   Enabling prometheus-snmp-exporter serviceMonitor
-   Adding the targets to the SNMP serviceMonitor configuration
+   Enabling snmpExporter VMServiceScrape
+   Adding the targets to the SNMP VMServiceScrape configuration
    ```
 
    The HMN is used by default as ACLs in the switch configuration block SNMP over the NMN.
@@ -68,29 +68,28 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
 1. (`pit#`) Review the SNMP Exporter configuration.
 
     ```bash
-    yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter' "${PITDATA}/prep/site-init/customizations.yaml"
+    yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.snmpExporter' "customizations.yaml"
     ```
 
     The expected output looks similar to:
 
     ```yaml
-    serviceMonitor:
-      enabled: true
-      params:
-        - name: sw-spine-001
-          target: 10.254.0.2
-        - name: sw-spine-002
-          target: 10.254.0.3
-        - name: sw-leaf-bmc-001
-          target: 10.254.0.4
+    enabled: true
+    params:
+      - name: sw-spine-001
+        target: 10.254.0.2
+      - name: sw-spine-002
+        target: 10.254.0.3
+      - name: sw-leaf-bmc-001
+        target: 10.254.0.4
       ```
 
 The most common configuration parameters are specified in the following table. They must be set in the `customizations.yaml` file
-under the `spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter` service definition.
+under the `spec.kubernetes.services.cray-sysmgmt-health.snmpExporter` service definition.
 
 | Customization            | Default      | Description                                                                         |
 |--------------------------|--------------|-------------------------------------------------------------------------------------|
-| `serviceMonitor.enabled` | `true`       | Enables `serviceMonitor` for SNMP Exporter \(default chart value is `true`\)        |
+| `snmpExporter.enabled` | `true`       | Enables `VMServiceScrape` for SNMP Exporter \(default chart value is `true`\)        |
 | `params.enabled`         | `true`       | Sets the SNMP Exporter `params` change to `true` \(default chart value is `false`\) |
 | `params.conf.module`     | `if_mib`     | SNMP Exporter to select which module \(default chart value is `if_mib`\)            |
 | `params.conf.target`     | `10.252.0.2` | Add list of switch targets to SNMP Exporter to monitor                              |

--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -89,7 +89,7 @@ under the `spec.kubernetes.services.cray-sysmgmt-health.snmpExporter` service de
 
 | Customization            | Default      | Description                                                                         |
 |--------------------------|--------------|-------------------------------------------------------------------------------------|
-| `snmpExporter.enabled`   | `true`       | Enables `VMServiceScrape` for SNMP Exporter \(default chart value is `true`\)        |
+| `snmpExporter.enabled`   | `true`       | Enables `VMServiceScrape` for SNMP Exporter \(default chart value is `true`\)       |
 | `params.enabled`         | `true`       | Sets the SNMP Exporter `params` change to `true` \(default chart value is `false`\) |
 | `params.conf.module`     | `if_mib`     | SNMP Exporter to select which module \(default chart value is `if_mib`\)            |
 | `params.conf.target`     | `10.252.0.2` | Add list of switch targets to SNMP Exporter to monitor                              |

--- a/scripts/configure_snmp_monitor.py
+++ b/scripts/configure_snmp_monitor.py
@@ -80,16 +80,15 @@ try:
         customizations = yaml.safe_load(customizations_file)
 
         print("Enabling prometheus-snmp-exporter serviceMonitor")
-        if "prometheus-snmp-exporter" not in customizations:
+        if "snmpExporter" not in customizations:
             customizations['spec']['kubernetes']['services']['cray-sysmgmt-health'].update(
-                {"prometheus-snmp-exporter":{'serviceMonitor': {'enabled': True, 'params': []}}})
+                {"snmpExporter":{'enabled': True, 'params': []}})
         else:
-            customizations['spec']['kubernetes']['services']['cray-sysmgmt-health']['prometheus-snmp-exporter'][
-                'serviceMonitor'].update({'enabled': 'true'})
+            customizations['spec']['kubernetes']['services']['cray-sysmgmt-health']['snmpExporter'].update({'enabled': 'true'})
 
         print("Adding the targets to the SNMP serviceMonitor configuration")
-        customizations['spec']['kubernetes']['services']['cray-sysmgmt-health']['prometheus-snmp-exporter'][
-            'serviceMonitor']['params'] = switches_to_monitor
+        customizations['spec']['kubernetes']['services']['cray-sysmgmt-health']['snmpExporter'][
+            'params'] = switches_to_monitor
 
         customizations_file.seek(0)
         yaml.dump(customizations, customizations_file, sort_keys=False)

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -128,7 +128,10 @@ if [[ -z "$(yq r "$c" "spec.network.netstaticips.nmn_ncn_storage_mons")" ]]; the
   yq w -i --style=single "$c" spec.kubernetes.services.cray-sysmgmt-health.cephExporter.endpoints '{{ network.netstaticips.nmn_ncn_storage_mons }}'
 fi
 
-# Kube-prometheus-stack
+# Disable prometheus-snmp-exporter servicemonitor
+yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.enabled = false' -i $c
+
+# victoria-metrics-k8s-stack
 if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack' $c)" != null ]; then
   if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack' $c)" != null ]; then
     yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack = (.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack * .spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)' -i $c


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

https://jira-pro.it.hpe.com:8443/browse/CASM-4810

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams

# Logs

```
ncn-m001:/mnt/developer/ram # python script.py -c "customizations.yaml" -s "sls_input_file.json"
Switches to monitor for subnet HMN
[{'name': 'sw-spine-001', 'target': '10.254.0.2'},
 {'name': 'sw-spine-002', 'target': '10.254.0.3'},
 {'name': 'sw-leaf-bmc-001', 'target': '10.254.0.4'}]
Enabling snmpExporter VMServiceScrape
Adding the targets to the SNMP VMServiceScrape configuration


--------------------------


ncn-m001:/mnt/developer/ram # loftsman ship --charts-path . --manifest-path shs-cust.yaml                        2024-07-22T09:34:02Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default),ext (current-context) command=ship
2024-07-22T09:34:02Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2024-07-22T09:34:02Z INF Ensuring that the loftsman namespace exists command=ship
2024-07-22T09:34:02Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2024-07-22T09:34:02Z INF Running a release for the provided manifest at shs-cust.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-sysmgmt-health v0.30.1-20240702064137+e0b0c27
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2024-07-22T09:34:02Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.5
  - 10.252.1.6
  - 10.252.1.7
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.4
  - 10.252.1.5
  - 10.252.1.6
  - 10.252.1.7
imageHost: registry.local
snmpExporter:
  enabled: true
  params:
  - name: sw-spine-001
    target: 10.254.0.2
  - name: sw-spine-002
    target: 10.254.0.3
  - name: sw-leaf-bmc-001
    target: 10.254.0.4
victoria-metrics-k8s-stack:
  alertmanager:
    externalAuthority: alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net
    externalUrl: https://alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net/
  grafana:
    externalAuthority: grafana.cmn.fanta.hpc.amslabs.hpecorp.net
    plugins: ""
  kubeEtcd:
    endpoints:
    - 10.252.1.8
    - 10.252.1.9
    - 10.252.1.10
  vmselect:
    vmselectSpec:
      externalAuthority: vmselect.cmn.mug.hpc.amslabs.hpecorp.net
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.30.1-20240702064137+e0b0c27
2024-07-22T09:34:02Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-ealth-0.30.1-20240702064137+e0b0c27.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cra-health --set global.chart.version=0.30.1-20240702064137+e0b0c27 -f /tmp/loftsman-1721640842/cray-sysmgmt-health-ml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.30.1-20240702064137+e0b0c27
2024-07-22T09:34:28Z INF Release "cray-sysmgmt-health" does not exist. Installing it now.
coalesce.go:223: warning: destination for cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.testFramework.imtable. Ignoring non-table value (bats/bats)
coalesce.go:223: warning: destination for cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.testFramework.imtable. Ignoring non-table value (bats/bats)
coalesce.go:223: warning: destination for cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.testFramework.imtable. Ignoring non-table value (bats/bats)
coalesce.go:223: warning: destination for cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.testFramework.imtable. Ignoring non-table value (bats/bats)
coalesce.go:223: warning: destination for cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.testFramework.imtable. Ignoring non-table value (bats/bats)
W0722 09:34:13.057150 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:13.061003 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:13.064766 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:13.068404 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:14.730024 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:14.730062 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:14.730393 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:14.730437 3442298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailab25+
W0722 09:34:15.252772 3442298 warnings.go:70] spec.template.spec.containers[2].env[6].name: duplicate name "GF_PANS"
NAME: cray-sysmgmt-health
LAST DEPLOYED: Mon Jul 22 09:34:03 2024
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 1
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.30.1-20240702064137+e0b0c27
2024-07-22T09:34:28Z INF Ship status: success. Recording status, manifest to configmap loftsman-cray-sysmgmt-healespace loftsman command=ship
2024-07-22T09:34:28Z INF Recording log data to configmap loftsman-cray-sysmgmt-health-ship-log in namespace loftsnd=ship

```

![image](https://github.com/user-attachments/assets/af9623d5-cd8c-4124-bc55-b6cf0a56e0cd)

