### PR TITLE
CASMPET-7152-release-1.3 add documentation for restoring kubernetes encryption after master rebuild

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -74,6 +74,11 @@ make sure that the following conditions are met:
 
 ### Master node
 
+> If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
+then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading.
+The directory needs to be restored after the node has been rebuilt and the `kube-apiserver` on the node should be restarted.
+See details on how to restart the `kube-apiserver` in the [Kubernetes `kube-apiserver` Failing document](../../../troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md).
+
 (`ncn-m#`) Run `ncn-rebuild-master-nodes.sh`:
 
 ```bash

--- a/troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md
+++ b/troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md
@@ -1,0 +1,131 @@
+# Kubernetes `kube-apiserver` Failing
+
+If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../operations/kubernetes/encryption/README.md) and the encryption files have not been restored after a master node rebuild or upgrade,
+then the `kube-apiserver` on that node will fail.
+This document only outlines the fix if the `kube-apiserver` if it is failing due to Kubernetes encryption not being restored.
+
+## Process
+
+1. (`ncn-m001`) Check if Kubernetes encryption is enabled.
+
+    1. Check if all master nodes have the same encryption files. It is possible that a master node that was upgraded or rebuilt does not have the encryption files that exist on the other nodes.
+
+        ```bash
+        pdsh -w ncn-m00[1-3] 'ls -lh /etc/cray/kubernetes/encryption'
+        ```
+
+        Expected output if encyrption is not enabled. The `current.yaml` file should be symbolically linked to the `default.yaml` file on all master nodes as seen below:
+
+        ```bash
+        ncn-m001:~ # pdsh -w ncn-m00[1-3] 'ls -lh /etc/cray/kubernetes/encryption'
+        ncn-m002: Warning: Permanently added 'ncn-m002,10.252.1.11' (ECDSA) to the list of known hosts.
+        ncn-m003: Warning: Permanently added 'ncn-m003,10.252.1.12' (ECDSA) to the list of known hosts.
+        ncn-m001: Warning: Permanently added 'ncn-m001' (ECDSA) to the list of known hosts.
+        ncn-m001: total 4.0K
+        ncn-m001: lrwxrwxrwx 1 root root  44 Jul  6 21:01 current.yaml -> /etc/cray/kubernetes/encryption/default.yaml
+        ncn-m001: -r-------- 1 root root 151 Jul  6 21:01 default.yaml
+        ncn-m002: total 4.0K
+        ncn-m002: lrwxrwxrwx 1 root root  44 Jul  6 19:33 current.yaml -> /etc/cray/kubernetes/encryption/default.yaml
+        ncn-m002: -r-------- 1 root root 151 Jul  6 19:33 default.yaml
+        ncn-m003: total 4.0K
+        ncn-m003: lrwxrwxrwx 1 root root  44 Jul  6 19:34 current.yaml -> /etc/cray/kubernetes/encryption/default.yaml
+        ncn-m003: -r-------- 1 root root 151 Jul  6 19:34 default.yaml
+        ```
+
+        Expected output if encryption is enabled but has not been restored on a single master node:
+
+        ```bash
+        ncn-m001:~ # pdsh -w ncn-m00[1-3] 'ls -lh /etc/cray/kubernetes/encryption'
+        ncn-m001: Warning: Permanently added 'ncn-m001,10.252.1.10' (ECDSA) to the list of known hosts.
+        ncn-m002: Warning: Permanently added 'ncn-m002' (ECDSA) to the list of known hosts.
+        ncn-m002: total 8.0K
+        ncn-m002: lrwxrwxrwx 1 root root  69 Jul 23 22:22 current.yaml -> d857284b70d5157900ee74db5c2ba802f05f7e0d066e91c83c8832d373dd271a.yaml
+        ncn-m002: -rw------- 1 root root 334 Jul 23 22:21 d857284b70d5157900ee74db5c2ba802f05f7e0d066e91c83c8832d373dd271a.yaml
+        ncn-m002: -r-------- 1 root root 151 Jul  6 19:33 default.yaml
+        ncn-m001: total 4.0K
+        ncn-m001: lrwxrwxrwx 1 root root  44 Jul  6 21:01 current.yaml -> /etc/cray/kubernetes/encryption/default.yaml
+        ncn-m001: -r-------- 1 root root 151 Jul  6 21:01 default.yaml
+        ncn-m003: total 8.0K
+        ncn-m003: lrwxrwxrwx 1 root root  69 Jul 23 22:20 current.yaml -> d857284b70d5157900ee74db5c2ba802f05f7e0d066e91c83c8832d373dd271a.yaml
+        ncn-m003: -rw------- 1 root root 334 Jul 23 22:19 d857284b70d5157900ee74db5c2ba802f05f7e0d066e91c83c8832d373dd271a.yaml
+        ncn-m003: -r-------- 1 root root 151 Jul  6 19:34 default.yaml
+        ```
+
+    2. Check the status of Kubernetes encryption.
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+        ```
+
+        Expected output if encyrption is not enabled:
+
+        ```bash
+        ncn-m001:~ # /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+        k8s encryption status
+        changed: 2024-07-06 20:07:35+0000
+        ncn-m001: identity
+        ncn-m002: identity
+        ncn-m003: dentity
+        current: identity
+        goal: identity
+        etcd: identity
+        ```
+
+        Expected output if encryption is enabled but has not been restored on a single master node:
+
+        ```bash
+        ncn-m001:~ # /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+        k8s encryption status
+        changed: 2024-07-06 20:07:35+0000
+        ncn-m001: identity
+        ncn-m002: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        ncn-m003: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        interim state detected, ensure all control plane nodes are in sync
+        ```
+
+        Expected output if encryption is enabled on all master nodes:
+
+        ```bash
+        ncn-m001:~ # /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+        k8s encryption status
+        changed: 2024-07-06 20:07:35+0000
+        ncn-m001: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        ncn-m002: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        ncn-m003: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        ```
+
+    If Kubernetes encryption is set up on the system and is enabled on all master nodes, then there is nothing more to do. Follow the next step if Kubernetes encryption is not correctly set up on a master node.
+
+1. (`ncn-m001`) Set up Kubernetes encryption on the master node that does not have it enabled.
+
+    1. Copy `/etc/cray/kubernetes/encryption` files to the master node without Kubernetes encryption enabled from another master node. Adjust the node names below based on which master node contains the correct files and which node is the target node.
+
+        ```bash
+        scp /etc/cray/kubernetes/encryption/* ncn-m001:/etc/cray/kubernetes/encryption/
+        ```
+
+    1. Restart `kube-apiserver` on the node where Kubernetes encryption is being enabled. This should be the same node that the `kube-apiserver` is failing on and why this troubleshooting document is being followed.
+
+        Set the `failing_api_serv_node` to the node where the `kube-apiserver` is failing.
+
+        ```bash
+        failing_api_serv_node=ncn-m001
+        ```
+
+        Delete the failing `kube-apiserver` pod.
+
+        ```bash
+        kubectl delete pod -n kube-system kube-apiserver-${failing_api_serv_node}
+        ```
+
+1. (`ncn-m001`) Check that encryption is enabled on all master nodes. This may take 10 minutes to for the output to reflect an encryption change. Please see  the [Kubernetes Encryption Documentation](../../operations/kubernetes/encryption/README.md) for details.
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+    ```

--- a/troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md
+++ b/troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md
@@ -4,6 +4,13 @@ If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documen
 then the `kube-apiserver` on that node will fail.
 This document only outlines the fix if the `kube-apiserver` if it is failing due to Kubernetes encryption not being restored.
 
+If a `kube-apiserver` is failing because of encryption, the error seen in the `kube-apiserver` pod logs can look like the error below.
+
+```bash
+E0724 19:46:36.855160       1 cacher.go:420] cacher (*core.Secret): unexpected ListAndWatch error: failed to list *core.Secret: unable to transform key "/registry/secrets/argo/argo-server-secret": no matching prefix found; reinitializing...
+E0724 19:46:37.872059       1 cacher.go:420] cacher (*core.Secret): unexpected ListAndWatch error: failed to list *core.Secret: unable to transform key "/registry/secrets/argo/argo-server-secret": no matching prefix found; reinitializing..
+```
+
 ## Process
 
 1. (`ncn-m001`) Check if Kubernetes encryption is enabled.
@@ -32,7 +39,7 @@ This document only outlines the fix if the `kube-apiserver` if it is failing due
         ncn-m003: -r-------- 1 root root 151 Jul  6 19:34 default.yaml
         ```
 
-        Expected output if encryption is enabled but has not been restored on a single master node:
+        Expected output if encryption is enabled but has not been restored on a single master node. The `current.yaml` file is symbolically linked to the `default.yaml` file on only one master node:
 
         ```bash
         ncn-m001:~ # pdsh -w ncn-m00[1-3] 'ls -lh /etc/cray/kubernetes/encryption'
@@ -80,9 +87,9 @@ This document only outlines the fix if the `kube-apiserver` if it is failing due
         ncn-m001: identity
         ncn-m002: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
         ncn-m003: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
+        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
+        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
         interim state detected, ensure all control plane nodes are in sync
         ```
 
@@ -95,37 +102,66 @@ This document only outlines the fix if the `kube-apiserver` if it is failing due
         ncn-m001: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
         ncn-m002: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
         ncn-m003: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
-        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656 identity
+        current: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
+        goal: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
+        etcd: aescbc-625e61a4ebe4d3ddf8b5eec3b546663945b837d53ca966d72e49b42cdae4e656
         ```
 
     If Kubernetes encryption is set up on the system and is enabled on all master nodes, then there is nothing more to do. Follow the next step if Kubernetes encryption is not correctly set up on a master node.
 
-1. (`ncn-m001`) Set up Kubernetes encryption on the master node that does not have it enabled.
+1. Set up Kubernetes encryption on the master node that does not have it enabled. All of the steps below should be performed from the node where encryption needs to be enabled.
 
-    1. Copy `/etc/cray/kubernetes/encryption` files to the master node without Kubernetes encryption enabled from another master node. Adjust the node names below based on which master node contains the correct files and which node is the target node.
+    1. `ssh` the node name where encryption needs to be enabled.
+
+    1. From the node where encryption needs to be enabled, set the environment variable `SRC_NODE` to be another master node which contains the correct configuration files.
 
         ```bash
-        scp /etc/cray/kubernetes/encryption/* ncn-m001:/etc/cray/kubernetes/encryption/
+        SRC_NODE=ncn-m002
+        ```
+
+    1. Copy `/etc/cray/kubernetes/encryption` files from the `SRC_NODE` to the node where encryption needs to be enaled.
+
+        ```bash
+        scp ${SRC_NODE}:/etc/cray/kubernetes/encryption/* /etc/cray/kubernetes/encryption/
+        ```
+
+    1. Symbolically link the `current.yaml` file to the correct encryption file.
+
+        ```bash
+        function link_file() {
+            linked_file=$(ssh ${SRC_NODE} 'readlink /etc/cray/kubernetes/encryption/current.yaml')
+            cd /etc/cray/kubernetes/encryption
+            rm current.yaml
+            ln -s ${linked_file} current.yaml
+            ls -lh
+        }
+        link_file
         ```
 
     1. Restart `kube-apiserver` on the node where Kubernetes encryption is being enabled. This should be the same node that the `kube-apiserver` is failing on and why this troubleshooting document is being followed.
 
-        Set the `failing_api_serv_node` to the node where the `kube-apiserver` is failing.
-
         ```bash
-        failing_api_serv_node=ncn-m001
+        function restart_kubeapiserver() {
+            crictl ps | grep kube-apiserver
+            container_id=$(crictl ps | grep kube-apiserver | awk '{ print $1 }')
+            crictl stop $container_id
+            while [[ -z $(crictl ps | grep kube-apiserver) ]]; do
+              echo "waiting for kube-apiserver to start"
+              sleep 5
+            done
+            crictl ps | grep kube-apiserver
+        }
+        restart_kubeapiserver
         ```
 
-        Delete the failing `kube-apiserver` pod.
-
-        ```bash
-        kubectl delete pod -n kube-system kube-apiserver-${failing_api_serv_node}
-        ```
-
-1. (`ncn-m001`) Check that encryption is enabled on all master nodes. This may take 10 minutes to for the output to reflect an encryption change. Please see  the [Kubernetes Encryption Documentation](../../operations/kubernetes/encryption/README.md) for details.
+1. (`ncn-m001#`) Check that encryption is enabled on all master nodes. This may take 10 minutes to for the output to reflect an encryption change. Please see  the [Kubernetes Encryption Documentation](../../operations/kubernetes/encryption/README.md) for details.
 
     ```bash
     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+    ```
+
+1. (`ncn-m001#`) Check that all `kube-apiserver` pods are running.
+
+    ```bash
+    kubectl get pods -n kube-system -l component=kube-apiserver
     ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Kubernetes encryption needs to be restored after master nodes are rebuilt or upgraded. If this is not done, the kube-apiserver on that node will not work. This will be added to the upgrade and rebuild automation by [CASMPET-7087](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7087).

This PR adds documentation that tells the user to restore these files. This documentation is temporary until the automation gets in! It is important we have a note about this in the documentation so that this problem is not seen again before the automation is put in place.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
