### PR TITLE
CRAYSAT-1711: Improve procedure to get BOS session templates

### DIFF
--- a/install/re-installation.md
+++ b/install/re-installation.md
@@ -21,7 +21,7 @@ the NCNs have been deployed (e.g. there is no more PIT node).
 The application and compute nodes must be shutdown prior to a reinstallation. If they are left on, then they will
 potentially end up in an undesirable state.
 
-See [Shut Down and Power Off Compute and User Access Nodes](../operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+See [Shut Down and Power Off Managed Nodes](../operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Disable DHCP service
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -149,7 +149,7 @@ Procedures required for a full power off of an HPE Cray EX system.
 Additional links to power off sub-procedures provided for reference. Refer to the main procedure linked above before using any of these sub-procedures:
 
 - [Prepare the System for Power Off](power_management/Prepare_the_System_for_Power_Off.md)
-- [Shut Down and Power Off Compute and User Access Nodes](power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md)
+- [Shut Down and Power Off Managed Nodes](power_management/Shut_Down_and_Power_Off_Managed_Nodes.md)
 - [Save Management Network Switch Configuration Settings](power_management/Save_Management_Network_Switch_Configurations.md)
 - Power Off Compute Cabinets
     - [Power Off Compute Cabinets](power_management/Power_Off_Compute_Cabinets.md) using CAPMC
@@ -170,7 +170,7 @@ Additional links to power on sub-procedures provided for reference. Refer to the
     - [Power On Compute Cabinets](power_management/Power_On_Compute_Cabinets.md) using CAPMC
     - [Power On Compute Cabinets](power_management/Power_Control_Service/Power_On_Compute_Cabinets.md) using PCS
 - [Power On the External Lustre File System](power_management/Power_On_the_External_Lustre_File_System.md)
-- [Power On and Boot Compute and User Access Nodes](power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md)
+- [Power On and Boot Managed Nodes](power_management/Power_On_and_Boot_Managed_Nodes.md)
 - Recover from a Liquid Cooled Cabinet EPO Event
     - [Recover from a Liquid Cooled Cabinet EPO Event](power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) using CAPMC
     - [Recover from a Liquid Cooled Cabinet EPO Event](power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) using PCS

--- a/operations/power_management/Power_Control_Service/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Control_Service/Power_Off_Compute_Cabinets.md
@@ -24,7 +24,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
   documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 * This procedure assumes all system software and user jobs were shut down. See
-  [Shut Down and Power Off Compute and User Access Nodes (UAN)](../Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+  [Shut Down and Power Off Managed Nodes)](../Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Procedure
 

--- a/operations/power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -177,4 +177,4 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
 
 8. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
-    See [Power On and Boot Compute and User Access Nodes](../Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md).
+    See [Power On and Boot Managed Nodes](../Power_On_and_Boot_Managed_Nodes.md).

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -24,7 +24,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
   documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 * This procedure assumes all system software and user jobs were shut down. See
-  [Shut Down and Power Off Compute and User Access Nodes (UAN)](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+  [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Procedure
 

--- a/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -107,4 +107,4 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
 
 8. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
-    See [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md).
+    See [Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md).

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -15,7 +15,7 @@ To make sure that the system is healthy before power off and all the information
 
 ## Shut Down Compute Nodes and UANs
 
-To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Compute and User Access Nodes](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Save Management Network Switch Settings
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -34,9 +34,10 @@ To power on the management cabinet and bring up the management Kubernetes cluste
 
 To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On Compute Cabinets](Power_On_Compute_Cabinets.md).
 
-## Power on and boot compute nodes and user access nodes \(UANs\)
+## Power on and boot managed nodes
 
-To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to users.
+To power on and boot managed nodes, e.g. compute nodes and User Access Nodes (UANs), refer to
+[Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md) and make nodes available to users.
 
 ## Run system health checks
 

--- a/operations/security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md
+++ b/operations/security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md
@@ -1,6 +1,9 @@
 # Change Cray EX Liquid-Cooled Cabinet Global Default Password
 
-This procedure changes the global default `root` credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.
+This procedure changes the global default `root` credential on HPE Cray EX liquid-cooled cabinet
+embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller
+(nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these
+procedures.
 
 ## Prerequisites
 
@@ -9,7 +12,7 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 
 ### Procedure
 
-1. If necessary, shut down compute nodes in each cabinet. Refer to [Shut Down and Power Off Compute and User Access Nodes](../power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+1. If necessary, shut down compute nodes in each cabinet. Refer to [Shut Down and Power Off Managed Nodes](../power_management/Shut_Down_and_Power_Off_Managed_Nodes.md).
 
    ```screen
    sat bootsys shutdown --stage bos-operations --bos-templates COS_SESSION_TEMPLATE
@@ -23,7 +26,7 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 
 3. Power off all compute slots in the cabinets the passwords are to be changed on.
 
-  > **`NOTE`**: If a chassis is not fully populated, specify each slot individually.
+   > **`NOTE`**: If a chassis is not fully populated, specify each slot individually.
 
    Example showing fully populated cabinets 1000-1003:
 
@@ -44,4 +47,3 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 5. Perform the procedures in [Updating the Liquid-Cooled EX Cabinet Default Credentials after a CEC Password Change](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md).
 
 6. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide (> 1.6.0)*.
-


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

As part of the system power off/on procedure, the admin must use BOS to shutdown the nodes and to boot the nodes. To do so, they must find the right BOS session templates to use.

Currently this procedure is duplicated in three places in the documentation. Consolidate and improve the documentation in one place, the "Prepare the System for Power Off" section, and refer to it from the other two documents which need to reference the procedure for finding the appropriate BOS session templates.

Also rename the procedures for booting and shutting down compute nodes and user access nodes to use the more general term "Managed Nodes" instead, which is consistent with the IUF's terminology. Update all locations to use the new titles and markdown file names.

Improve and streamline the procedures in the "Power On and Boot Managed Nodes" and "Shut Down and Power Off Managed Nodes" procedures.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
