### PR TITLE
CRAYSAT-1882: sat bootsys shutdown and boot improvements doc changes

### DIFF
--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -39,7 +39,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
     This example shows liquid-cooled cabinets 1000 - 1003.
 
     ```bash
-    cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
+    cray power status list --xnames x[1000-1003]c[0-7] --format json
     ```
 
 1. (`ncn-m#`) Check the power status for nodes in the standard racks before shutdown.
@@ -67,11 +67,11 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. (`ncn-m#`) Shut down cabinet power.
 
-    **Important:** The default timeout for the call to CAPMC is 120 seconds. If the `sat bootsys shutdown` command fails
-    to power off some cabinets and indicate that requests to CAPMC have timed out, the `sat` command may be run with an increased `--capmc-timeout` value.
+    **Important:** The default timeout for the call to PCS is 120 seconds. If the `sat bootsys shutdown` command fails
+    to power off some cabinets and indicate that requests to PCS have timed out, the `sat` command may be run with an increased `--pcs-timeout` value.
 
     ```bash
-    sat bootsys shutdown --stage cabinet-power --capmc-timeout 240
+    sat bootsys shutdown --stage cabinet-power --pcs-timeout 240
     ```
 
 1. (`ncn-m#`) Verify that the `hms-discovery` cron job has been suspended.
@@ -94,7 +94,7 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
     This example shows cabinets 1000 - 1003.
 
     ```bash
-    cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
+    cray power status list --xnames x[1000-1003]c[0-7] --format json
     ```
 
 1. Rectifiers \(PSUs\) in the liquid-cooled cabinets should indicate that DC power is `OFF` \(`AC OK` means the power is on\).

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -143,7 +143,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
    In the preceding example, the `ssh` command to the NCN nodes timed out and reported `ERROR` messages. Repeat the above step until you see `Succeeded with boot of other management NCNs.` Each iteration should get further in the process.
 
-   NOTE: During the Power on if the ceph does not become healthy it would timeout after which, You would have a prompt as shown below to proceed further or exit to fix the ceph health.
+   NOTE: During power on, if Ceph does not become healthy, it will time out, prompting to either proceed further or exit to fix Ceph health.
    If 'yes' is given as the input, it would skip to check the ceph status and proceed further.
 
    Example output:
@@ -157,7 +157,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
     INFO: Checking whether ceph filesystem is mounted on /etc/cray/upgrade/csm.
     ```
 
-   If 'No' is given as the input, it would exit the execution, you can fix the ceph health, See [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting
+   If 'No' is given as the input, it would exit the execution. To fix the Ceph health, see [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting.
    steps, which may include restarting Ceph services.
 
    Once Ceph is healthy, repeat the `sat bootsys boot --stage ncn-power --ncn-boot-timeout 900` command.

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -134,13 +134,33 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
    Are the above NCN groupings and exclusions correct? [yes,no] yes
    INFO: Starting console logging on ncn-s003,ncn-s001,ncn-w002,ncn-m003,ncn-w004,ncn-m002,ncn-s002,ncn-w001,ncn-w003.
    Powering on NCNs and waiting up to 900 seconds for them to be reachable via SSH: ncn-m002, ncn-m003
-   INFO: Sending IPMI power on command to host ncn-m003
-   INFO: Sending IPMI power on command to host ncn-m002
+   INFO: Sending IPMI power on command to host ncn-s002
+   INFO: Sending IPMI power on command to host ncn-s001
+   INFO: Sending IPMI power on command to host ncn-s003
    Waiting for condition "Hosts accessible via SSH" timed out after 300 seconds
    ERROR: Unable to reach the following NCNs via SSH after powering them on: ncn-m003, ncn-s002.. Troubleshoot the issue and then try again.
    ```
 
    In the preceding example, the `ssh` command to the NCN nodes timed out and reported `ERROR` messages. Repeat the above step until you see `Succeeded with boot of other management NCNs.` Each iteration should get further in the process.
+
+   NOTE: During the Power on if the ceph does not become healthy it would timeout after which, You would have a prompt as shown below to proceed further or exit to fix the ceph health.
+   If 'yes' is given as the input, it would skip to check the ceph status and proceed further.
+
+   Example output:
+
+   ```text
+    INFO: Checking Ceph health
+    Waiting for condition "Ceph cluster in healthy state" timed out after 60 seconds
+    ERROR: Failed to unfreeze Ceph on storage NCNs: Ceph is not healthy. Please correct Ceph health and try again.
+    eph is not healthy. Do you want to continue anyway? [yes,no] yes
+    INFO: Continuing despite Ceph not being healthy as per user's input, make sure to verify it later.
+    INFO: Checking whether ceph filesystem is mounted on /etc/cray/upgrade/csm.
+    ```
+
+   If 'No' is given as the input, it would exit the execution, you can fix the ceph health, See [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting
+   steps, which may include restarting Ceph services.
+
+   Once Ceph is healthy, repeat the `sat bootsys boot --stage ncn-power --ncn-boot-timeout 900` command.
 
 1. (`ncn-m001#`) Monitor the consoles for each NCN.
 


### PR DESCRIPTION
As part of sat bootsys shutdown and boot, improvements have been done.

- Changing the order off booting the ncn's.
- Adding prompt to bypass ceph health wait
- updating SAT command to shutdown cabinets using PCS PCS command inplace of CAPMC cmd
- Move the ceph troubleshoot under ncn-power stage
Hence these are beng addressed and updated in the documentation

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
