### PR TITLE
CASMINST-6949: create k8s auditing volumes properly

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -45,7 +45,17 @@ cm_auditing_enabled=$?
 if [[ ${manifest_auditing_enabled} -eq 0 && ${cm_auditing_enabled} -ne 0 ]]; then
   echo "Updating kubeadm-config configmap with audit configuration"
   sed -i '/      runtime-config/a\        audit-log-maxbackup: "100"\n        audit-log-path: /var/log/audit/kl8s/apiserver/audit.log\n        audit-policy-file: /etc/kubernetes/audit/audit-policy.yaml' /tmp/kubeadm-config.yaml
-  sed -i '/    apiServer:/a\      extraVolumes:\n      - hostPath: /var/log/audit/kl8s/apiserver\n        mountPath: /var/log/audit/kl8s/apiserver\n        name: k8s-audit-log\n        pathType: DirectoryOrCreate\n        readOnly: false\n      - hostPath: /etc/kubernetes/audit\n        mountPath: /etc/kubernetes/audit\n        name: k8s-audit\n        pathType: DirectoryOrCreate\n        readOnly: true' /tmp/kubeadm-config.yaml
+  # a temporary replacement hack for the subsequent yq4 command to work
+  sed -i 's/ClusterConfiguration: |/ClusterConfiguration:/' /tmp/kubeadm-config.yaml
+  if [ "$(yq4 eval '.data.ClusterConfiguration.apiServer.extraVolumes' /tmp/kubeadm-config.yaml)" == null ]; then
+    # No existing volumes
+    sed -i '/    apiServer:/a\      extraVolumes:\n      - hostPath: /var/log/audit/kl8s/apiserver\n        mountPath: /var/log/audit/kl8s/apiserver\n        name: k8s-audit-log\n        pathType: DirectoryOrCreate\n        readOnly: false\n      - hostPath: /etc/kubernetes/audit\n        mountPath: /etc/kubernetes/audit\n        name: k8s-audit\n        pathType: DirectoryOrCreate\n        readOnly: true' /tmp/kubeadm-config.yaml
+  else
+    yq4 eval '.data.ClusterConfiguration.apiServer.extraVolumes += {"hostPath": "/var/log/audit/kl8s/apiserver", "mountPath": "/var/log/audit/kl8s/apiserver", "name":"k8s-audit-log", "pathType":"DirectoryOrCreate", "readOnly":false}' -i /tmp/kubeadm-config.yaml
+    yq4 eval '.data.ClusterConfiguration.apiServer.extraVolumes += {"hostPath": "/etc/kubernetes/audit", "mountPath": "/etc/kubernetes/audit", "name":"k8s-audit", "pathType":"DirectoryOrCreate", "readOnly":true}' -i /tmp/kubeadm-config.yaml
+  fi
+  # reverse the temporary replacement hack
+  sed -i 's/ClusterConfiguration:/ClusterConfiguration: |/' /tmp/kubeadm-config.yaml
 fi
 
 kubectl -n kube-system apply -f /tmp/kubeadm-config.yaml


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When k8s api server auditing is turned on, two volume mounts need to be added to the config. The original script didn't handle existing volume mounts which caused the k8s upgrade to fail. This PR provides the fix for the issue.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
