### PR TITLE
CASMCMS-8970 parry peak console hang workaround

### DIFF
--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -7,10 +7,9 @@
 
 Parry Peak hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
 
+## Workaround
 
-## Workaround 
-
-1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting with Parry Peak hardware.
+1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting Parry Peak hardware.
 
     ```bash
     cray ims jobs create --public-key-id $PK_ID --job-type customize --artifact-id $IMAGE_ID --image-root-archive-name $NEW_IMAGE_NAME
@@ -54,7 +53,7 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
     ```
 
 1. (`ncn-mw#`) SSH into the customization pod.
-    
+
    ```bash
    ssh 066423ff-2704-4e3f-9df4-82eb210d776b.ims.cmn.vidar.hpc.amslabs.hpecorp.net
    ```
@@ -65,7 +64,7 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    cd /mnt/image/image-root/boot
    ```
 
-1. Edit the kernel-parameters file and change `console=ttyS0,115200` to `console=ttyS1,115200` 
+1. Edit the kernel-parameters file and change `console=ttyS0,115200` to `console=ttyS1,115200`
 
 1. Finish the customization session.
 
@@ -73,5 +72,5 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    touch /mnt/image/complete
    ```
 
-1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`. Once this is complete, Parry Peak hardware should 
-successfully boot with the given created BOS template.
+1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
+   Optionally, you can add a node_list within the template to specifcally target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete, Parry Peak hardware should successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -10,7 +10,7 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
 
 ## Workaround 
 
-1. (`ncn-mw#`) Customize the image to be used for booting with Parry Peak hardware.
+1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting with Parry Peak hardware.
 
     ```bash
     cray ims jobs create --public-key-id $PK_ID --job-type customize --artifact-id $IMAGE_ID --image-root-archive-name $NEW_IMAGE_NAME
@@ -70,8 +70,8 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
 1. Finish the customization session.
 
    ```bash
-   touch /tmp/complete
+   touch /mnt/image/complete
    ```
 
-1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS template that references the new image id and `etag`. Once this is complete, Parry Peak hardware should 
+1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`. Once this is complete, Parry Peak hardware should 
 successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -73,6 +73,6 @@
    ```
 
 1. Once the image has finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes, or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames. 
+   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes, or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames.
    Another option available would be to create a custom group for `HPE Cray EX255a` hardware using HSM and to reference that group using the `node_groups` feature within your BOS template.
    This will allow for specifying the hardware without referencing individual nodes each time in the session template. Once this is complete, `HPE Cray EX255a` hardware should successfully boot using the BOS template created previously.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -73,4 +73,6 @@
    ```
 
 1. Once the image has finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes, or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames. Another option available would be to create a custom group for `HPE Cray EX255a` hardware using HSM and to reference that group using the `node_groups` feature within your BOS template, this will allow for specifying the hardware without the need for referencing indivdual nodes each time in the session template. Once this is complete, `HPE Cray EX255a` hardware should successfully boot using the BOS template created previously.
+   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes, or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames. 
+   Another option available would be to create a custom group for `HPE Cray EX255a` hardware using HSM and to reference that group using the `node_groups` feature within your BOS template.
+   This will allow for specifying the hardware without referencing individual nodes each time in the session template. Once this is complete, `HPE Cray EX255a` hardware should successfully boot using the BOS template created previously.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Parry Peak hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port ttyS0 which is provided in the uss-compute image provided during installation of CSM 1.5.2.
+Parry Peak hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
 
 
 ## Workaround 
@@ -65,7 +65,7 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    cd /mnt/image/image-root/boot
    ```
 
-1. Edit the kernel-parameters file and change console=ttyS0,115200 to console=ttyS1,115200 
+1. Edit the kernel-parameters file and change `console=ttyS0,115200` to `console=ttyS1,115200` 
 
 1. Finish the customization session.
 
@@ -73,5 +73,5 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    touch /tmp/complete
    ```
 
-1. Once the image is finished customization and has been bundled and uploaded to s3, create or copy a bos template that references the new image id and etag. Once this is complete, Parry Peak hardware should 
-successfully boot with the given created bos template.
+1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS template that references the new image id and `etag`. Once this is complete, Parry Peak hardware should 
+successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -1,4 +1,4 @@
-# HPE Cray EX255a Boot Issue with Console Parameter
+# HPE Cray `EX255a` Boot Issue with Console Parameter
 
 - [Description](#description)
 - [Workaround](#workaround)

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -73,4 +73,5 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    ```
 
 1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a node_list within the template to specifcally target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete, Parry Peak hardware should successfully boot with the given created BOS template.
+   Optionally, you can add a `node_list` within the template to specifically target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete, 
+   Parry Peak hardware should successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -1,15 +1,15 @@
-# Parry Peak Boot Issue with Console Parameter
+#  HPE Cray EX255a Boot Issue with Console Parameter
 
 - [Description](#description)
 - [Workaround](#workaround)
 
 ## Description
 
-Parry Peak hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
+ HPE Cray EX255a hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
 
 ## Workaround
 
-1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting Parry Peak hardware.
+1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting  HPE Cray EX255a hardware.
 
     ```bash
     cray ims jobs create --public-key-id $PK_ID --job-type customize --artifact-id $IMAGE_ID --image-root-archive-name $NEW_IMAGE_NAME
@@ -73,5 +73,5 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    ```
 
 1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete,
-   Parry Peak hardware should successfully boot with the given created BOS template.
+   Optionally, you can add a `node_list` within the template to specifically target  HPE Cray EX255a nodes or you can use the BOS limit option when creating a session to specify only  HPE Cray EX255a xnames . Once this is complete,
+   HPE Cray EX255a hardware should successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -17,7 +17,7 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
 
     Example output:
 
-    ```text
+    ```toml
     artifact_id = "fdc16942-ba1d-49b5-a4a2-0c7bbce8bb68"
     job_type = "customize"
     image_root_archive_name = "uss-compute-jsmit-test"

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -58,13 +58,13 @@
    ssh 066423ff-2704-4e3f-9df4-82eb210d776b.ims.cmn.vidar.hpc.amslabs.hpecorp.net
    ```
 
-1. Navigate to the boot directory of the image to be customized
+1. Navigate to the boot directory of the image to be customized.
 
    ```bash
    cd /mnt/image/image-root/boot
    ```
 
-1. Edit the kernel-parameters file and change `console=ttyS0,115200` to `console=ttyS1,115200`
+1. Edit the kernel-parameters file and change `console=ttyS0,115200` to `console=ttyS1,115200`.
 
 1. Finish the customization session.
 

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -73,5 +73,5 @@ Parry Peak hardware has an issue in it's firmware configuration that causes boot
    ```
 
 1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete, 
+   Optionally, you can add a `node_list` within the template to specifically target Parry Peak nodes or you can use the BOS limit option when creating a session to specify only Parry Peak xnames . Once this is complete,
    Parry Peak hardware should successfully boot with the given created BOS template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -1,0 +1,77 @@
+# Parry Peak Boot Issue with Console Parameter
+
+- [Description](#description)
+- [Workaround](#workaround)
+
+## Description
+
+Parry Peak hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port ttyS0 which is provided in the uss-compute image provided during installation of CSM 1.5.2.
+
+
+## Workaround 
+
+1. (`ncn-mw#`) Customize the image to be used for booting with Parry Peak hardware.
+
+    ```bash
+    cray ims jobs create --public-key-id $PK_ID --job-type customize --artifact-id $IMAGE_ID --image-root-archive-name $NEW_IMAGE_NAME
+    ```
+
+    Example output:
+
+    ```text
+    artifact_id = "fdc16942-ba1d-49b5-a4a2-0c7bbce8bb68"
+    job_type = "customize"
+    image_root_archive_name = "uss-compute-jsmit-test"
+    status = "creating"
+    require_dkms = false
+    job_mem_size = 8
+    public_key_id = "b815341b-d096-47fa-aa92-11a673b9bb69"
+    remote_build_node = ""
+    arch = "x86_64"
+    enable_debug = false
+    initrd_file_name = "initrd"
+    build_env_size = 30
+    created = "2024-07-30T18:01:24.961857+00:00"
+    kubernetes_service = "cray-ims-066423ff-2704-4e3f-9df4-82eb210d776b-service"
+    kubernetes_job = "cray-ims-066423ff-2704-4e3f-9df4-82eb210d776b-customize"
+    kubernetes_namespace = "ims"
+    kernel_parameters_file_name = "kernel-parameters"
+    kernel_file_name = "vmlinuz"
+    id = "066423ff-2704-4e3f-9df4-82eb210d776b"
+    kubernetes_configmap = "cray-ims-066423ff-2704-4e3f-9df4-82eb210d776b-configmap"
+    kubernetes_pvc = "cray-ims-066423ff-2704-4e3f-9df4-82eb210d776b-job-claim"
+    [[ssh_containers]]
+    status = "pending"
+    name = "customize"
+    jail = false
+
+    [ssh_containers.connection_info.customer_access]
+    port = 22
+    host = "066423ff-2704-4e3f-9df4-82eb210d776b.ims.cmn.vidar.hpc.amslabs.hpecorp.net"
+    [ssh_containers.connection_info."cluster.local"]
+    port = 22
+    host = "cray-ims-066423ff-2704-4e3f-9df4-82eb210d776b-service.ims.svc.cluster.local"
+    ```
+
+1. (`ncn-mw#`) SSH into the customization pod.
+    
+   ```bash
+   ssh 066423ff-2704-4e3f-9df4-82eb210d776b.ims.cmn.vidar.hpc.amslabs.hpecorp.net
+   ```
+
+1. Navigate to the boot directory of the image to be customized
+
+   ```bash
+   cd /mnt/image/image-root/boot
+   ```
+
+1. Edit the kernel-parameters file and change console=ttyS0,115200 to console=ttyS1,115200 
+
+1. Finish the customization session.
+
+   ```bash
+   touch /tmp/complete
+   ```
+
+1. Once the image is finished customization and has been bundled and uploaded to s3, create or copy a bos template that references the new image id and etag. Once this is complete, Parry Peak hardware should 
+successfully boot with the given created bos template.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-  `HPE Cray EX255a` hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
+  `HPE Cray EX255a` hardware has an issue in BIOS versions 1.1.0 and earlier that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
 
 ## Workaround
 
@@ -24,7 +24,7 @@
     status = "creating"
     require_dkms = false
     job_mem_size = 8
-    public_key_id = "b815341b-d096-47fa-aa92-11a673b9bb69"
+    public_key_id = "<public_key_id>"
     remote_build_node = ""
     arch = "x86_64"
     enable_debug = false
@@ -72,6 +72,5 @@
    touch /mnt/image/complete
    ```
 
-1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames . Once this is complete,
-   `HPE Cray EX255a` hardware should successfully boot with the given created BOS template.
+1. Once the image has finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
+   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes, or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames. Another option available would be to create a custom group for `HPE Cray EX255a` hardware using HSM and to reference that group using the `node_groups` feature within your BOS template, this will allow for specifying the hardware without the need for referencing indivdual nodes each time in the session template. Once this is complete, `HPE Cray EX255a` hardware should successfully boot using the BOS template created previously.

--- a/troubleshooting/known_issues/parry_peak_console_boot_errors.md
+++ b/troubleshooting/known_issues/parry_peak_console_boot_errors.md
@@ -1,15 +1,15 @@
-#  HPE Cray EX255a Boot Issue with Console Parameter
+# HPE Cray EX255a Boot Issue with Console Parameter
 
 - [Description](#description)
 - [Workaround](#workaround)
 
 ## Description
 
- HPE Cray EX255a hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
+  `HPE Cray EX255a` hardware has an issue in it's firmware configuration that causes boots to stall when configured to use the default kernel serial port `ttyS0` which is provided in the compute image created during installation of CSM 1.5.2.
 
 ## Workaround
 
-1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting  HPE Cray EX255a hardware.
+1. (`ncn-mw#`) Follow the steps for [customizing](../../operations/image_management/Customize_an_Image_Root_Using_IMS.md) an image to be used for booting `HPE Cray EX255a` hardware.
 
     ```bash
     cray ims jobs create --public-key-id $PK_ID --job-type customize --artifact-id $IMAGE_ID --image-root-archive-name $NEW_IMAGE_NAME
@@ -73,5 +73,5 @@
    ```
 
 1. Once the image is finished customization and has been bundled and uploaded to `s3`, create or copy a BOS [template](../../operations/boot_orchestration/Session_Templates.md) that references the new image id and `etag`.
-   Optionally, you can add a `node_list` within the template to specifically target  HPE Cray EX255a nodes or you can use the BOS limit option when creating a session to specify only  HPE Cray EX255a xnames . Once this is complete,
-   HPE Cray EX255a hardware should successfully boot with the given created BOS template.
+   Optionally, you can add a `node_list` within the template to specifically target `HPE Cray EX255a` nodes or you can use the BOS limit option when creating a session to specify only `HPE Cray EX255a` xnames . Once this is complete,
+   `HPE Cray EX255a` hardware should successfully boot with the given created BOS template.


### PR DESCRIPTION
# Description
Documents and provides a workaround for an issue where Parry Peak hardware would hang on boot when using a certain console serial port. 
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8970
# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
