### PR TITLE
CASM-4555

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -167,6 +167,7 @@ Cutoff
 DB-9
 DCS-7060CX-32S
 DHCP
+Diags
 DNS
 DSAv2
 DUTs
@@ -404,6 +405,8 @@ TrustedCerts
 U.S.
 UAN-specific
 UANs
+UAI
+UAIs
 UIs
 URIs
 Un-rack

--- a/operations/iuf/workflows/backup.md
+++ b/operations/iuf/workflows/backup.md
@@ -19,5 +19,10 @@ Once this step has completed:
 
 ## 2. Next steps
 
-- Return to the [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -11,8 +11,8 @@ the HPC CSM Software Recipe with the existing content in `${ADMIN_DIR}`.
 
 - [1. Populate admin directory with files defining site preferences](#1-populate-admin-directory-with-files-defining-site-preferences)
 - [2. Execute the IUF `update-vcs-config` stage](#2-execute-the-iuf-update-vcs-config-stage)
-  - [2.1 Prerequisites](#21-prerequisites)
-  - [2.2 Procedure](#22-procedure)
+    - [2.1 Prerequisites](#21-prerequisites)
+    - [2.2 Procedure](#22-procedure)
 - [3. Perform manual product configuration operations](#3-perform-manual-product-configuration-operations)
 - [4. Next steps](#4-next-steps)
 
@@ -185,37 +185,36 @@ The following highlights some of the areas that require manual configuration cha
 required for initial installation scenarios.
 
 - USS
-  - Configure DVS and LNet with appropriate Slingshot settings
-  - Configure DVS and LNet for use on application nodes
-  - Enable site-specific file system mounts
-  - Set the USS root password in HashiCorp Vault
+    - Configure DVS and LNet with appropriate Slingshot settings
+    - Configure DVS and LNet for use on application nodes
+    - Enable site-specific file system mounts
+    - Set the USS root password in HashiCorp Vault
 - UAN
-  - Enable CAN, LDAP, and set MOTD
-  - Move DVS and LNet settings to USS branch
-  - Set the UAN root password in HashiCorp Vault
+    - Enable CAN, LDAP, and set MOTD
+    - Move DVS and LNet settings to USS branch
+    - Set the UAN root password in HashiCorp Vault
 - SHS
-  - Update release information in `group_vars` (done for each product release)
+    - Update release information in `group_vars` (done for each product release)
 - CPE
-  - Enable previous CPE versions or alternate 3rd party products (optional, done for each product release)
+    - Enable previous CPE versions or alternate 3rd party products (optional, done for each product release)
 - SDU
-  - Configure SDU via `sdu setup`
+    - Configure SDU via `sdu setup`
 - SAT
-  - Configure SAT authentication via `sat auth`
-  - Generate SAT S3 credentials
-  - Configure system revision information via `sat setrev`
+    - Configure SAT authentication via `sat auth`
+    - Generate SAT S3 credentials
+    - Configure system revision information via `sat setrev`
 - SLURM
-  - UAS
-    - Configure UAS network settings 
-      - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
-  - CSM Diags
-    - Update CSM Diags network attachment definition
+    - UAS
+        - Configure UAS network settings
+            - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
+    - CSM Diags
+        - Update CSM Diags network attachment definition
 - PBS Pro
-  - UAS
-    - Configure UAS network settings 
-      - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
-  - CSM Diags
-    - Update CSM Diags network attachment definition
-
+    - UAS
+        - Configure UAS network settings
+            - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
+    - CSM Diags
+        - Update CSM Diags network attachment definition
 
 Once this step has completed:
 
@@ -227,6 +226,10 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -25,6 +25,8 @@ Once this step has completed:
 
 ## 2. Upgrade Kubernetes
 
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+
 Follow the steps documented in [Stage 3.6 - Complete Kubernetes upgrade](../../../upgrade/Stage_3.md#stage-36---complete-kubernetes-upgrade).
 
 ## 3. Next steps
@@ -33,6 +35,14 @@ Follow the steps documented in [Stage 3.6 - Complete Kubernetes upgrade](../../.
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/image_preparation.md
+++ b/operations/iuf/workflows/image_preparation.md
@@ -7,7 +7,7 @@ and images are created with the correct content and configuration values.
 
 - [1. Execute the IUF `update-cfs-config` and `prepare-images` stages](#1-execute-the-iuf-update-cfs-config-and-prepare-images-stages)
 - [2. Manually prepare additional images](#2-manually-prepare-additional-images)
-  - [2.1 ARM images](#22-arm-images)
+    - [2.1 ARM images](#21-arm-images)
 - [3. Next steps](#3-next-steps)
 
 ## 1. Execute the IUF `update-cfs-config` and `prepare-images` stages
@@ -51,6 +51,14 @@ If it is necessary to build `aarch64` images, then see [ARM images](../IUF.md#ar
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/managed_rollout.md
+++ b/operations/iuf/workflows/managed_rollout.md
@@ -198,6 +198,10 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -13,6 +13,8 @@ This section updates the software running on management NCNs.
 
 ## 1. Perform Slingshot switch firmware updates
 
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+
 Instructions to perform Slingshot switch firmware updates are provided in the "Upgrade HPE Slingshot switch firmware in a CSM environment" section of the _HPE Slingshot Installation Guide for CSM_.
 
 Once this step has completed:
@@ -20,6 +22,8 @@ Once this step has completed:
 - Slingshot switch firmware has been updated
 
 ## 2. Update management host firmware (FAS)
+
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
 Refer to [Update Non-Compute Node (NCN) BIOS and BMC Firmware](../../firmware/FAS_Use_Cases.md#update-non-compute-node-ncn-bios-and-bmc-firmware) for details on how to upgrade the firmware on management nodes.
 
@@ -150,65 +154,104 @@ Refer to that table and any corresponding product documents before continuing to
 
 1. Upgrade `ncn-m001`.
 
-    1. Follow the steps documented in [Stage 3.3 - `ncn-m001` upgrade](../../../upgrade/Stage_3.md#stage-33---ncn-m001-upgrade).
-    **Stop** before performing the specific [upgrade `ncn-m001`](../../../upgrade/Stage_3.md#upgrade-ncn-m001) step and return to this document.
+    1. Option 1 - Perform the NCN master node upgrade on `ncn-m001` without IUF
 
-    1. Get the image ID and CFS configuration created for NCN master nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the
-    [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name` value matching `Management_Master`.
-    These values will be needed for upgrading `ncn-m001` in the following steps.
+        1. Follow the steps documented in [Stage 3.3 - `ncn-m001` upgrade](../../../upgrade/Stage_3.md#stage-33---ncn-m001-upgrade).
+           >**`Stop`** before performing the specific [upgrade `ncn-m001`](../../../upgrade/Stage_3.md#upgrade-ncn-m001) step and return to this document.
 
-    1. Set the CFS configuration on `ncn-m001`.
+            1. Get the image ID and CFS configuration created for NCN master nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the
+                [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name` value matching `Management_Master`.
+                These values will be needed for upgrading `ncn-m001` in the following steps.
 
-        1. (`ncn-m#`) Set `CFS_CONFIG_NAME` to be the value for `configuration` found for `Management_Master` nodes in the the second step.
+            1. Set the CFS configuration on `ncn-m001`.
 
-            ```bash
-            CFS_CONFIG_NAME=<appropriate configuration value>
-            ```
+                1. (`ncn-m#`) Set `CFS_CONFIG_NAME` to be the value for `configuration` found for `Management_Master` nodes in the the second step.
 
-        1. (`ncn-m#`) Get the xname of `ncn-m001`.
+                    ```bash
+                    CFS_CONFIG_NAME=<appropriate configuration value>
+                    ```
 
-            ```bash
-            XNAME=$(ssh ncn-m001 'cat /etc/cray/xname')
-            echo "${XNAME}"
-            ```
+                1. (`ncn-m#`) Get the xname of `ncn-m001`.
 
-        1. (`ncn-m#`) Set the CFS configuration on `ncn-m001`.
+                    ```bash
+                    XNAME=$(ssh ncn-m001 'cat /etc/cray/xname')
+                    echo "${XNAME}"
+                    ```
 
-            ```bash
-            /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-            --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames "${XNAME}" --no-enable --no-clear-err
-            ```
+                1. (`ncn-m#`) Set the CFS configuration on `ncn-m001`.
 
-            The expected output is:
+                    ```bash
+                    /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+                    --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames "${XNAME}" --no-enable --no-clear-err
+                    ```
 
-              ```bash
-              All components updated successfully.
-              ```
+                    The expected output is:
 
-    1. Set the image in BSS for `ncn-m001` by following the [Set NCN boot image for `ncn-m001`](../stages/management_nodes_rollout.md#set-ncn-boot-image-for-ncn-m001)
-    section of the [Management nodes rollout stage documentation](../stages/management_nodes_rollout.md).
-    Set the `IMS_RESULTANT_IMAGE_ID` variable to the `final_image_id` for `Management_Master` found in the second step.
+                    ```bash
+                    All components updated successfully.
+                    ```
 
-    1. (`ncn-m002#`) Upgrade `ncn-m001`. This **must** be executed on **`ncn-m002`**.
+            1. Set the image in BSS for `ncn-m001` by following the [Set NCN boot image for `ncn-m001`](../stages/management_nodes_rollout.md#set-ncn-boot-image-for-ncn-m001)
+            section of the [Management nodes rollout stage documentation](../stages/management_nodes_rollout.md).
+            Set the `IMS_RESULTANT_IMAGE_ID` variable to the `final_image_id` for `Management_Master` found in the second step.
 
-        > **`NOTE`** If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
-        then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading and restore the directory after the node has been upgraded.
+            1. (`ncn-m002#`) Upgrade `ncn-m001`. This **must** be executed on **`ncn-m002`**.
 
-        ```bash
-        /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
-        ```
+                > **`NOTE`** If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
+                then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading and restore the directory after the node has been upgraded.
 
-        > **`NOTE`** The `/etc/cray/kubernetes/encryption` directory should be restored if it was backed up. Once it is restored, the `kube-apiserver` on the rebuilt node should be restarted.
-        See [Kubernetes `kube-apiserver` Failing](../../../troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md) for details on how to restart the `kube-apiserver`.
+                ```bash
+                /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
+                ```
 
-1. Follow the steps documented in [Stage 3.4 - Upgrade `weave` and `multus`](../../../upgrade/Stage_3.md#stage-34---upgrade-weave-and-multus)
+                > **`NOTE`** The `/etc/cray/kubernetes/encryption` directory should be restored if it was backed up. Once it is restored, the `kube-apiserver` on the rebuilt node should     be restarted.
+                See [Kubernetes `kube-apiserver` Failing](../../../troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md) for details on how to restart the `kube-apiserver`.
 
-1. Follow the steps documented in [Stage 3.5 - `coredns` anti-affinity](../../../upgrade/Stage_3.md#stage-35---coredns-anti-affinity)
+            1. Follow the steps documented in [Stage 3.4 - Upgrade `weave` and `multus`](../../../upgrade/Stage_3.md#stage-34---upgrade-weave-and-multus)
 
-Once this step has completed:
+            1. Follow the steps documented in [Stage 3.5 - `coredns` anti-affinity](../../../upgrade/Stage_3.md#stage-35---coredns-anti-affinity)
 
-- All management NCNs have been upgraded to the image and CFS configuration created in the previous steps of this workflow
-- Per-stage product hooks have executed for the `management-nodes-rollout` stage
+    1. Option 2 - Perform the NCN master node upgrade on `ncn-m001` with IUF
+
+       **`NOTE`** This subsection is mandatory only for Upgrade CSM and additional products with IUF.
+
+       > **`NOTE`** If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
+       then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading and restore the directory after the node has been upgraded.
+
+       1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m001`. This will rebuild `ncn-m001` with the    new CFS configuration and image built in
+       previous steps of the workflow.
+
+           (`ncn-m002#`) Upgrade `ncn-m001`. This **must** be executed on **`ncn-m002`**.
+
+           1. Run `upload-rebuild-templates.sh` to update all the workflows that will be used by IUF and to ensure the correct CSM product versions will be used by IUF.
+
+               (`ncn-m002#`) Execute the `upload-rebuild-templates.sh` script.
+
+               ```bash
+               /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+               ```
+
+           (`ncn-m002#`) Execute the `management-nodes-rollout` stage with `ncn-m001`.
+
+           ```bash
+           iuf -a "${ACTIVITY_NAME}" --media-host ncn-m002 run -r management-nodes-rollout --limit-management-rollout ncn-m001
+           ```
+
+           > **`NOTE`** The `/etc/cray/kubernetes/encryption` directory should be restored if it was backed up. Once it is restored, the `kube-apiserver` on the rebuilt node should    be restarted.
+           See [Kubernetes `kube-apiserver` Failing](../../../troubleshooting/kubernetes/Kubernetes_Kube_apiserver_failing.md) for details on how to restart the `kube-apiserver`.
+
+       1. Verify that `ncn-m001` booted successfully with the desired image and CFS configuration.
+
+           ```bash
+           XNAME=$(ssh ncn-m001 'cat /etc/cray/xname')
+           echo "${XNAME}"
+           cray cfs components describe "${XNAME}"
+           ```
+
+    Once this step has completed:
+
+     - All management NCNs have been upgraded to the image and CFS configuration created in the previous steps of this workflow
+     - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
 Continue to the next section [4. Update management host Slingshot NIC firmware](#4-update-management-host-slingshot-nic-firmware).
 
@@ -447,6 +490,8 @@ Return to the procedure that was being followed for `management-nodes-rollout` t
 
 ## 4. Update management host Slingshot NIC firmware
 
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+
 If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of the _HPE Slingshot Installation Guide for CSM_ for details on how to update NIC firmware on management nodes.
 
 After updating management host Slingshot NIC firmware, all nodes where the firmware was updated must be power cycled.
@@ -464,6 +509,14 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -74,6 +74,14 @@ HSN status, Ceph status, and SDU and RDA configurations. This information will b
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -41,6 +41,8 @@ Once this step has completed:
 
 ## 2. Update `customizations.yaml`
 
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+
 Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products and the UAN product. Refer to the
 "Install and Upgrade Framework" section of the Slurm, PBS, and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
 
@@ -70,6 +72,8 @@ Once this step has completed:
 
 ## 4. Perform manual product delivery operations
 
+**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+
 **`NOTE`** This subsection is optional and can be skipped if third-party GPU and/or programming environment software is not needed.
 
 Some products provide instructions for delivering third-party content to the system outside of IUF. If this content is desired, refer to the following documentation for instructions and execute the procedures before continuing
@@ -94,6 +98,14 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -13,81 +13,13 @@ on the new images provided by the CSM product and customized by the additional H
 products, including the [User Services Software (USS)](../../../glossary.md#user-services-software-uss)
 and [Slingshot Host Software (SHS)](../../../glossary.md#slingshot-host-software-shs).
 
-The steps in this procedure alternate between CSM upgrade instructions that do not utilize the IUF
+There are two options to upgrade CSM and additional HPE Cray EX software products:
+
+1. This option alternates between CSM upgrade instructions that do not utilize IUF
 and instructions for upgrading additional HPE Cray EX software products whose installation is
-managed by the IUF.
+managed by the IUF. See
+[Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md) for that procedure.
 
-All stages of `iuf` are executed in this procedure. All of the new product software provided in the
-recipe release is deployed and all [management NCNs](../../../glossary.md#management-nodes) and managed
-[compute nodes](../../../glossary.md#compute-node-cn) and [application nodes](../../../glossary.md#application-node-an) are
-rebooted to new images and [Configuration Framework Service (CFS)](../../../glossary.md#configuration-framework-service-cfs)
-configurations. Manual operations are documented for procedures that are not currently managed by IUF.
-
-The upgrade workflow comprises the following procedures. The diagram shows the workflow and
-the steps below it provide detailed instructions which must be executed in the order shown.
-
-![Upgrade CSM and additional products with IUF](../../../img/operations/diagram_csm_stack_upgrade_111723.png)
-
-1. CSM preparation, Stage 0.1, and Stage 0.2
-
-   Read the _Important Notes_ section of the
-   [CSM 1.5.0 or later to 1.6.0 Upgrade Process](../../../upgrade/Upgrade_Management_Nodes_and_CSM_Services.md)
-   documentation and then follow only these CSM instructions in order:
-
-   1. [Prepare for Upgrade](../../../upgrade/prepare_for_upgrade.md)
-   1. [Stage 0.1 - Prepare assets](../../../upgrade/Stage_0_Prerequisites.md#stage-01---prepare-assets)
-   1. [Stage 0.2 - Prerequisites](../../../upgrade/Stage_0_Prerequisites.md#stage-02---prerequisites)
-
-1. Prepare for the upgrade procedure and download product media
-
-   1. Follow the IUF [Prepare for the install or upgrade](preparation.md) instructions to set
-      environment variables used during the upgrade process.
-
-   1. Download the desired HPE product media defined by the HPC CSM Software Recipe to `${MEDIA_DIR}`, which was defined in the previous step.
-
-1. Product delivery
-
-   Follow the IUF [Product delivery](product_delivery.md) instructions.
-
-1. Configuration
-
-   Follow the IUF [Configuration](configuration.md) instructions.
-
-1. Image preparation
-
-   Follow the IUF [Image preparation](image_preparation.md) instructions.
-
-1. CSM Stage 0.4
-
-   Follow the CSM
-   [Stage 0.4 - Backup workload manager data](../../../upgrade/Stage_0_Prerequisites.md#stage-04---backup-workload-manager-data)
-   instructions.
-
-1. Backup
-
-   Follow the IUF [Backup](backup.md) instructions.
-
-1. Management rollout
-
-   Follow the IUF [Management rollout](management_rollout.md) instructions.
-
-1. CSM Stage 3 and CSM health validation
-
-   Follow these CSM instructions in order:
-
-   1. [Stage 3 - CSM Service Upgrades](../../../upgrade/Stage_3.md)
-   1. [Validate CSM Health During Upgrade](../../../upgrade/Validate_CSM_Health_During_Upgrade.md)
-
-1. Deploy product
-
-   Follow these IUF instructions in order:
-
-   1. [Deploy product](deploy_product.md)
-   1. [Validate deployment](validate_deployment.md)
-
-1. Managed rollout
-
-   Follow the IUF [Managed rollout](managed_rollout.md) instructions.
-
-The IUF upgrade workflow is now complete. Exit any typescript sessions created during the upgrade
-procedure and remove any installation artifacts, if desired.
+1. This option is for upgrading CSM and additional HPE Cray EX software products using IUF. See
+[Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+for that procedure.

--- a/operations/iuf/workflows/upgrade_csm_iuf_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_iuf_additional_products_with_iuf.md
@@ -1,0 +1,63 @@
+# Upgrade CSM and additional products with IUF
+
+**Note: From CSM 1.6 , CSM supports upgrade through IUF.   All CSM specific steps mentioned in [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md) are now part of CSM Upgrade with IUF.**
+
+All stages of `iuf` are executed in this option. All of the new product software provided in the
+recipe release is deployed and all [management NCNs](../../../glossary.md#management-nodes) and managed
+[compute nodes](../../../glossary.md#compute-node-cn) and [application nodes](../../../glossary.md#application-node-an) are
+rebooted to new images and [Configuration Framework Service (CFS)](../../../glossary.md#configuration-framework-service-cfs)
+configurations. Manual operations are documented for procedures that are not currently managed by IUF.
+
+The upgrade workflow comprises the following procedures. The diagram shows the workflow and
+the steps below it provide detailed instructions which must be executed in the order shown.
+
+![Upgrade CSM and additional products with IUF](../../../img/operations/diagram_csm_stack_upgrade_111723.png)
+
+1. CSM preparation
+
+   Read the _Important Notes_ section of the
+   [CSM 1.5.0 or later to 1.6.0 Upgrade Process](../../../upgrade/Upgrade_Management_Nodes_and_CSM_Services.md)
+   documentation and then follow only these CSM instructions in order:
+
+   1. [Prepare for Upgrade](../../../upgrade/prepare_for_upgrade.md)
+
+1. Prepare for the upgrade procedure and download product media
+
+   1. Follow the IUF [Prepare for the install or upgrade](preparation.md) instructions to set
+      environment variables used during the upgrade process.
+
+   1. Download the desired HPE product media defined by the HPC CSM Software Recipe to `${MEDIA_DIR}`, which was defined in the previous step.
+
+1. Product delivery
+
+   Follow the IUF [Product delivery](product_delivery.md) instructions.
+
+1. Configuration
+
+   Follow the IUF [Configuration](configuration.md) instructions.
+
+1. Image preparation
+
+   Follow the IUF [Image preparation](image_preparation.md) instructions.
+
+1. Backup
+
+   Follow the IUF [Backup](backup.md) instructions.
+
+1. Management rollout
+
+   Follow the IUF [Management rollout](management_rollout.md) instructions.
+
+1. Deploy product
+
+   Follow these IUF instructions in order:
+
+   1. [Deploy product](deploy_product.md)
+   1. [Validate deployment](validate_deployment.md)
+
+1. Managed rollout
+
+   Follow the IUF [Managed rollout](managed_rollout.md) instructions.
+
+The IUF upgrade workflow is now complete. Exit any typescript sessions created during the upgrade
+procedure and remove any installation artifacts, if desired.

--- a/operations/iuf/workflows/upgrade_csm_manual_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_manual_and_additional_products_with_iuf.md
@@ -1,0 +1,70 @@
+# Upgrade CSM manually and additional products with IUF
+
+All stages of `iuf` are executed in this procedure. All of the new product software provided in the
+recipe release is deployed and all [management NCNs](../../../glossary.md#management-nodes) and managed
+[compute nodes](../../../glossary.md#compute-node-cn) and [application nodes](../../../glossary.md#application-node-an) are
+rebooted to new images and [Configuration Framework Service (CFS)](../../../glossary.md#configuration-framework-service-cfs)
+configurations. Manual operations are documented for procedures that are not currently managed by IUF.
+
+The upgrade workflow comprises the following procedures. The diagram shows the workflow and
+the steps below it provide detailed instructions which must be executed in the order shown.
+
+![Upgrade CSM and additional products with IUF](../../../img/operations/diagram_csm_stack_upgrade_111723.png)
+
+1. CSM preparation, Stage 0.1, and Stage 0.2
+
+   Read the _Important Notes_ section of the
+   [CSM 1.5.0 or later to 1.6.0 Upgrade Process](../../../upgrade/Upgrade_Management_Nodes_and_CSM_Services.md)
+   documentation and then follow only these CSM instructions in order:
+
+   1. [Prepare for Upgrade](../../../upgrade/prepare_for_upgrade.md)
+   1. [Stage 0.1 - Prepare assets](../../../upgrade/Stage_0_Prerequisites.md#stage-01---prepare-assets)
+   1. [Stage 0.2 - Prerequisites](../../../upgrade/Stage_0_Prerequisites.md#stage-02---prerequisites)
+
+1. Prepare for the upgrade procedure and download product media
+
+   1. Follow the IUF [Prepare for the install or upgrade](preparation.md) instructions to set
+      environment variables used during the upgrade process.
+
+   1. Download the desired HPE product media defined by the HPC CSM Software Recipe to `${MEDIA_DIR}`, which was defined in the previous step.
+
+1. Product delivery
+
+   Follow the IUF [Product delivery](product_delivery.md) instructions.
+
+1. Configuration
+
+   Follow the IUF [Configuration](configuration.md) instructions.
+
+1. Image preparation
+
+   Follow the IUF [Image preparation](image_preparation.md) instructions.
+
+1. Backup
+
+   Follow the IUF [Backup](backup.md) instructions.
+
+1. Management rollout
+
+   Follow the IUF [Management rollout](management_rollout.md) instructions.
+
+1. CSM Stage 3 and CSM health validation
+
+   Follow these CSM instructions in order:
+
+   1. [Stage 3 - CSM Service Upgrades](../../../upgrade/Stage_3.md)
+   1. [Validate CSM Health During Upgrade](../../../upgrade/Validate_CSM_Health_During_Upgrade.md)
+
+1. Deploy product
+
+   Follow these IUF instructions in order:
+
+   1. [Deploy product](deploy_product.md)
+   1. [Validate deployment](validate_deployment.md)
+
+1. Managed rollout
+
+   Follow the IUF [Managed rollout](managed_rollout.md) instructions.
+
+The IUF upgrade workflow is now complete. Exit any typescript sessions created during the upgrade
+procedure and remove any installation artifacts, if desired.

--- a/operations/iuf/workflows/validate_deployment.md
+++ b/operations/iuf/workflows/validate_deployment.md
@@ -28,6 +28,14 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM, return to the
-  [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
+- If performing an upgrade that includes upgrading CSM manually and additional products with IUF,
+  return to the [Upgrade CSM manually and additional products with IUF](upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+  return to the [Upgrade CSM and additional products with IUF](upgrade_csm_iuf_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+
+- If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -37,11 +37,17 @@ procedure.
 
 ### Option 3: Upgrade only CSM
 
-To perform an upgrade of only CSM, see the [Upgrade Only CSM](Upgrade_Only_CSM.md) procedure.
+There are two options to perform an upgrade of only CSM:
+
+1. [Upgrade Only CSM without IUF](Upgrade_Only_CSM_without_iuf.md) procedure.
+
+1. [Upgrade Only CSM with IUF](Upgrade_Only_CSM_with_iuf.md) procedure.
 
 This option applies to CSM-only systems and systems which have additional HPE Cray EX software
 products installed, as long as those additional products are not also being upgraded. This is an
 uncommon upgrade scenario.
+
+**Note: Beyond CSM 1.6 IUF will be the only option to upgrade CSM with or without additional HPE Cray EX software products.**
 
 ## CSM patch version upgrade
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -15,9 +15,8 @@ Stage 0 has several critical procedures which prepare the environment and verify
         - [Manual copy](#manual-copy)
     - [Stage 0.2 - Prerequisites](#stage-02---prerequisites)
     - [Stage 0.3 - Update management node CFS configuration and customize worker node image](#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image)
-        - [Option 1: Upgrade of CSM and additional products](#option-1-upgrade-of-csm-and-additional-products)
+        - [Option 1: Upgrade of CSM manually and additional products](#option-1-upgrade-of-csm-manually-and-additional-products)
         - [Option 2: Upgrade of CSM on CSM-only system](#option-2-upgrade-of-csm-on-csm-only-system)
-    - [Stage 0.4 - Backup workload manager data](#stage-04---backup-workload-manager-data)
     - [Stop typescript](#stop-typescript)
     - [Stage completed](#stage-completed)
 
@@ -194,9 +193,7 @@ The http proxy variables must be `unset` after the desired artifacts are downloa
    git push
    ```
 
-1. If performing an upgrade of CSM and additional HPE Cray EX software products using the IUF,
-   return to the [Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
-   procedure. Otherwise, if performing an upgrade of only CSM, proceed to Stage 0.3.
+1. Proceed to [Stage 0.3](#stage-03---update-management-node-cfs-configuration-and-customize-worker-node-image).
 
 ## Stage 0.3 - Update management node CFS configuration and customize worker node image
 
@@ -212,10 +209,10 @@ after it has booted.
 There are several options for this stage. Use the option which applies to the current upgrade
 scenario.
 
-- [Option 1: Upgrade of CSM and additional products](#option-1-upgrade-of-csm-and-additional-products)
+- [Option 1: Upgrade of CSM manually and additional products](#option-1-upgrade-of-csm-manually-and-additional-products)
 - [Option 2: Upgrade of CSM on CSM-only system](#option-2-upgrade-of-csm-on-csm-only-system)
 
-### Option 1: Upgrade of CSM and additional products
+### Option 1: Upgrade of CSM manually and additional products
 
 If performing an upgrade of CSM and additional HPE Cray EX software products, this stage
 should not be performed. Instead, the [Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
@@ -270,21 +267,8 @@ software products installed. This upgrade scenario is extremely uncommon in prod
    All components updated successfully.
    ```
 
-Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data).
-
-## Stage 0.4 - Backup workload manager data
-
-To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures for the workload manager in use,
-using the backup procedures for the currently installed version of the workload manager (not the target version of the upgrade, if the WLM is also being upgraded).
-The resulting backup data should be stored in a safe location off of the system. See the following links for the backup procedures:
-
-- For PBS, see `8.1 Backup PBS home directory` in
-  [HPE Portable Batch System Installation Guide: CSM on HPE Cray EX Systems (`S-8055`)](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=dp00004161en_us).
-- For Slurm, see `8.1 Backup Slurm accounting database` and `8.3 Backup Slurm spool directory` in
-  [HPE Slurm Installation Guide: CSM on HPE Cray EX Systems (`S-8058`)](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=dp00004162en_us).
-
-If performing an upgrade of CSM and additional HPE Cray EX software products using the IUF,
-return to the [Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+If performing an upgrade of CSM manually and additional HPE Cray EX software products using the IUF,
+return to the [Upgrade CSM manually and additional products with IUF](../operations/iuf/workflows/upgrade_csm_manual_and_additional_products_with_iuf.md)
 procedure. Otherwise, if performing an upgrade of only CSM, proceed to the next step.
 
 ## Stop typescript

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -76,4 +76,8 @@ For any typescripts that were started during this stage, stop them with the `exi
 This stage is completed. There are two different upgrade paths moving forward:
 
 - Path 1: If performing a CSM only upgrade without IUF, continue to [Stage 2](Stage_2.md).
-- Path 2: If performing an upgrade with IUF that includes upgrading CSM, return to [upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md) workflow to continue the upgrade.
+- Path 2: If performing an upgrade with IUF that includes upgrading CSM manually and additional products with IUF,
+ return to [Upgrade CSM manually and additional products with IUF](../operations/iuf/workflows/upgrade_csm_manual_and_additional_products_with_iuf.md)
+  workflow to continue the upgrade.
+- Path 3: If performing an upgrade with IUF that includes upgrading CSM and additional products with IUF, return to
+[Upgrade CSM and additional products with IUF](../operations/iuf/workflows/upgrade_csm_iuf_additional_products_with_iuf.md) workflow to continue the upgrade.

--- a/upgrade/Upgrade_Only_CSM_with_iuf.md
+++ b/upgrade/Upgrade_Only_CSM_with_iuf.md
@@ -1,0 +1,43 @@
+# Upgrade only CSM through IUF
+
+This option describes how to upgrade Cray Systems Management (CSM) software on a CSM-only system
+using IUF.
+
+![Upgrade CSM and additional products with IUF](../img/operations/diagram_csm_stack_upgrade_111723.png)
+
+1. CSM preparation
+
+   Read the _Important Notes_ section of the
+   [CSM 1.5.0 or later to 1.6.0 Upgrade Process](Upgrade_Management_Nodes_and_CSM_Services.md)
+   documentation and then follow only these CSM instructions in order:
+
+   1. [Prepare for Upgrade](prepare_for_upgrade.md)
+
+1. Prepare for the upgrade procedure and download product media
+
+   1. Follow the IUF [Prepare for the install or upgrade](../operations/iuf/workflows/preparation.md) instructions to set
+      environment variables used during the upgrade process.
+
+   1. Download the desired HPE product media defined by the HPC CSM Software Recipe to `${MEDIA_DIR}`, which was defined in the previous step.
+
+1. Product delivery
+
+   Follow the IUF [Product delivery](../operations/iuf/workflows/product_delivery.md) instructions.
+
+1. Image preparation
+
+   Follow the IUF [Image preparation](../operations/iuf/workflows/image_preparation.md) instructions.
+
+1. Management rollout
+
+   Follow the IUF [Management rollout](../operations/iuf/workflows/management_rollout.md) instructions.
+
+1. Deploy product
+
+   Follow these IUF instructions in order:
+
+   1. [Deploy product](../operations/iuf/workflows/deploy_product.md)
+   1. [Validate deployment](../operations/iuf/workflows/validate_deployment.md)
+
+The IUF upgrade workflow is now complete. Exit any typescript sessions created during the upgrade
+procedure and remove any installation artifacts, if desired.

--- a/upgrade/Upgrade_Only_CSM_without_iuf.md
+++ b/upgrade/Upgrade_Only_CSM_without_iuf.md
@@ -1,6 +1,6 @@
 # Upgrade only CSM
 
-This procedure describes how to upgrade Cray Systems Management (CSM) software on a CSM-only system
+This option describes how to upgrade Cray Systems Management (CSM) software on a CSM-only system
 without additional HPE Cray EX software products installed.
 
 After the upgrade of CSM software, the CSM health checks will validate the system before doing any


### PR DESCRIPTION
# Description

CSM Upgrade through IUF: Documentation

Note: Diagram has to be updated for 1.6 in seperate Jira

Remove reference to CSM WLM backup from upgrade documentation 

Resolves  :

[CASM-4555](https://jira-pro.it.hpe.com:8443/browse/CASM-4555) CSM Upgrade through IUF: Documentation

[CASM-4822](https://jira-pro.it.hpe.com:8443/browse/CASM-4822) Remove reference to CSM WLM backup from upgrade documentation 
 
# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
