### PR TITLE
CRAYSAT-1882: Update power off/on procedures for `sat bootsys` improvements

### DIFF
--- a/install/re-installation.md
+++ b/install/re-installation.md
@@ -21,7 +21,7 @@ the NCNs have been deployed (e.g. there is no more PIT node).
 The application and compute nodes must be shutdown prior to a reinstallation. If they are left on, then they will
 potentially end up in an undesirable state.
 
-See [Shut Down and Power Off Compute and User Access Nodes](../operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+See [Shut Down and Power Off Managed Nodes](../operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Disable DHCP service
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -149,7 +149,7 @@ Procedures required for a full power off of an HPE Cray EX system.
 Additional links to power off sub-procedures provided for reference. Refer to the main procedure linked above before using any of these sub-procedures:
 
 - [Prepare the System for Power Off](power_management/Prepare_the_System_for_Power_Off.md)
-- [Shut Down and Power Off Compute and User Access Nodes](power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md)
+- [Shut Down and Power Off Managed Nodes](power_management/Shut_Down_and_Power_Off_Managed_Nodes.md)
 - [Save Management Network Switch Configuration Settings](power_management/Save_Management_Network_Switch_Configurations.md)
 - Power Off Compute Cabinets
     - [Power Off Compute Cabinets](power_management/Power_Off_Compute_Cabinets.md) using CAPMC
@@ -170,7 +170,7 @@ Additional links to power on sub-procedures provided for reference. Refer to the
     - [Power On Compute Cabinets](power_management/Power_On_Compute_Cabinets.md) using CAPMC
     - [Power On Compute Cabinets](power_management/Power_Control_Service/Power_On_Compute_Cabinets.md) using PCS
 - [Power On the External Lustre File System](power_management/Power_On_the_External_Lustre_File_System.md)
-- [Power On and Boot Compute and User Access Nodes](power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md)
+- [Power On and Boot Managed Nodes](power_management/Power_On_and_Boot_Managed_Nodes.md)
 - Recover from a Liquid Cooled Cabinet EPO Event
     - [Recover from a Liquid Cooled Cabinet EPO Event](power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) using CAPMC
     - [Recover from a Liquid Cooled Cabinet EPO Event](power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) using PCS

--- a/operations/power_management/Power_Control_Service/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Control_Service/Power_Off_Compute_Cabinets.md
@@ -24,7 +24,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
   documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 * This procedure assumes all system software and user jobs were shut down. See
-  [Shut Down and Power Off Compute and User Access Nodes (UAN)](../Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+  [Shut Down and Power Off Managed Nodes)](../Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Procedure
 

--- a/operations/power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Power_Control_Service/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -177,4 +177,4 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
 
 8. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
-    See [Power On and Boot Compute and User Access Nodes](../Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md).
+    See [Power On and Boot Managed Nodes](../Power_On_and_Boot_Managed_Nodes.md).

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -39,7 +39,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
     This example shows liquid-cooled cabinets 1000 - 1003.
 
     ```bash
-    cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
+    cray power status list --xnames x[1000-1003]c[0-7] --format json
     ```
 
 1. (`ncn-m#`) Check the power status for nodes in the standard racks before shutdown.
@@ -67,11 +67,11 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. (`ncn-m#`) Shut down cabinet power.
 
-    **Important:** The default timeout for the call to CAPMC is 120 seconds. If the `sat bootsys shutdown` command fails
-    to power off some cabinets and indicate that requests to CAPMC have timed out, the `sat` command may be run with an increased `--capmc-timeout` value.
+    **Important:** The default timeout for the call to PCS is 120 seconds. If the `sat bootsys shutdown` command fails
+    to power off some cabinets and indicate that requests to PCS have timed out, the `sat` command may be run with an increased `--pcs-timeout` value.
 
     ```bash
-    sat bootsys shutdown --stage cabinet-power --capmc-timeout 240
+    sat bootsys shutdown --stage cabinet-power --pcs-timeout 240
     ```
 
 1. (`ncn-m#`) Verify that the `hms-discovery` cron job has been suspended.
@@ -94,7 +94,7 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
     This example shows cabinets 1000 - 1003.
 
     ```bash
-    cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
+    cray power status list --xnames x[1000-1003]c[0-7] --format json
     ```
 
 1. Rectifiers \(PSUs\) in the liquid-cooled cabinets should indicate that DC power is `OFF` \(`AC OK` means the power is on\).

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -24,7 +24,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
   documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 * This procedure assumes all system software and user jobs were shut down. See
-  [Shut Down and Power Off Compute and User Access Nodes (UAN)](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+  [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Procedure
 

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -47,23 +47,29 @@ power-on command from Cray System Management \(CSM\) software.
    sat bootsys boot --stage cabinet-power
    ```
 
-   This command first resumes the `hms-discovery` Kubernetes cronjob and waits for it to be
-   scheduled. Then, the `hms-discovery` job initiates power-on of the liquid-cooled cabinets.
-   Finally, the `sat bootsys` command waits for the components in the liquid-cooled cabinets to be
-   powered on. The `sat bootsys` command controls power only to liquid-cooled cabinets.
+   This command resumes the `hms-discovery` Kubernetes cronjob and waits for it to be scheduled.
+   Once scheduled, the `hms-discovery` job initiates power-on of the liquid-cooled cabinets, and the
+   `sat bootsys` command waits for the components in the liquid-cooled cabinets to be powered on.
+   The `sat bootsys` command only powers on liquid-cooled cabinets.
 
-   If the `hms-discovery` cronjob fails to be scheduled after it is resumed, then SAT will delete
-   and re-create the cronjob, and will wait for it to run. After the cronjob has been scheduled
-   within the time expected based on its cron schedule, execute the `sat bootsys boot --stage
-   cabinet-power` command again.
+   If the `hms-discovery` cronjob fails to be scheduled after it is resumed, then `sat bootsys` will
+   delete and re-create the cronjob and wait again for it to be scheduled. If this command fails, it is safe to run it again until it succeeds.
 
-   If `sat bootsys` fails to power on the cabinets through `hms-discovery`, then use CAPMC to manually power on the cabinet chassis,
-   compute blade slots, and all populated switch blade slots \(1, 3, 5, and 7\). This example shows cabinets 1000-1003.
+   If `sat bootsys` fails to power on the cabinets through `hms-discovery`, then components can be
+   manually powered on directly with PCS. The example below will power on the cabinet chassis,
+   compute blade slots, and all populated switch blade slots (1, 3, 5, and 7) in cabinets 1000-1003.
+   Adjust the example as needed for the system.
 
    ```bash
-   cray capmc xname_on create --xnames x[1000-1003]c[0-7] --format json
-   cray capmc xname_on create --xnames x[1000-1003]c[0-7]s[0-7] --format json
-   cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[1,3,5,7] --format json
+   cray power transition on --xnames "x[1000-1003]c[0-7]" --format json
+   cray power transition on --xnames "x[1000-1003]c[0-7]s[0-7]" --format json
+   cray power transition on --xnames "x[1000-1003]c[0-7]r[1,3,5,7]" --format json
+   ```
+
+   Verify the status of each of the power operations.
+
+   ```bash
+   cray power transition describe TRANSITION_ID --format json
    ```
 
 ### Power On Standard Rack PDU Circuit Breakers

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -224,6 +224,12 @@ Verify that the Lustre file system is available from the management cluster.
     - ncn-w003
 
     Are the above NCN groupings correct? [yes,no] yes
+    Executing step: Ensure containerd is running and enabled on all Kubernetes NCNs.
+    Executing step: Ensure etcd is running and enabled on all Kubernetes manager NCNs.
+    Executing step: Start and enable kubelet on all Kubernetes NCNs.
+    Waiting up to 300 seconds for the Kubernetes API to become available
+    The Kubernetes API is currently unreachable.
+    Kubernetes API is available
     ```
 
     The `sat bootsys boot` command may fail with a message like the following:

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -134,13 +134,33 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
    Are the above NCN groupings and exclusions correct? [yes,no] yes
    INFO: Starting console logging on ncn-s003,ncn-s001,ncn-w002,ncn-m003,ncn-w004,ncn-m002,ncn-s002,ncn-w001,ncn-w003.
    Powering on NCNs and waiting up to 900 seconds for them to be reachable via SSH: ncn-m002, ncn-m003
-   INFO: Sending IPMI power on command to host ncn-m003
-   INFO: Sending IPMI power on command to host ncn-m002
+   INFO: Sending IPMI power on command to host ncn-s002
+   INFO: Sending IPMI power on command to host ncn-s001
+   INFO: Sending IPMI power on command to host ncn-s003
    Waiting for condition "Hosts accessible via SSH" timed out after 300 seconds
    ERROR: Unable to reach the following NCNs via SSH after powering them on: ncn-m003, ncn-s002.. Troubleshoot the issue and then try again.
    ```
 
    In the preceding example, the `ssh` command to the NCN nodes timed out and reported `ERROR` messages. Repeat the above step until you see `Succeeded with boot of other management NCNs.` Each iteration should get further in the process.
+
+   NOTE: During power on, if Ceph does not become healthy, it will time out, prompting to either proceed further or exit to fix Ceph health.
+   If 'yes' is given as the input, it would skip to check the ceph status and proceed further.
+
+   Example output:
+
+   ```text
+    INFO: Checking Ceph health
+    Waiting for condition "Ceph cluster in healthy state" timed out after 60 seconds
+    ERROR: Failed to unfreeze Ceph on storage NCNs: Ceph is not healthy. Please correct Ceph health and try again.
+    eph is not healthy. Do you want to continue anyway? [yes,no] yes
+    INFO: Continuing despite Ceph not being healthy as per user's input, make sure to verify it later.
+    INFO: Checking whether ceph filesystem is mounted on /etc/cray/upgrade/csm.
+    ```
+
+   If 'No' is given as the input, it would exit the execution. To fix the Ceph health, see [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting.
+   steps, which may include restarting Ceph services.
+
+   Once Ceph is healthy, repeat the `sat bootsys boot --stage ncn-power --ncn-boot-timeout 900` command.
 
 1. (`ncn-m001#`) Monitor the consoles for each NCN.
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -279,29 +279,6 @@ Verify that the Lustre file system is available from the management cluster.
 
     To resolve the space issue, see [Troubleshoot Ceph OSDs Reporting Full](../utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md).
 
-1. (`ncn-m001#`) Manually mount S3 filesystems on the master and worker nodes. These nodes try
-    to mount several S3 filesystems when they are booted. Since Ceph is not available during boot
-    time, this workaround is required. The `boot-images` S3 filesystem is required for CPS pods
-    to successfully start on worker nodes.
-
-    ```bash
-    pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g') "awk '{ if (\$3 == \"fuse.s3fs\") { print \$2; }}' /etc/fstab | xargs -I {} -n 1 sh -c \"mountpoint {} || mount {}\"" | dshbak -c
-    ```
-
-    Example output:
-
-    ```text
-    ----------------
-    ncn-m[001-003]
-    ----------------
-    /var/opt/cray/sdu/collection-mount is a mountpoint
-    /var/opt/cray/config-data is a mountpoint
-    ----------------
-    ncn-w[001-003]
-    ----------------
-    /var/lib/cps-local/boot-images is a mountpoint
-    ```
-
 1. (`ncn-m001#`) Monitor the status of the management cluster and which pods are restarting (as indicated by either a `Running` or `Completed` state).
 
     ```bash

--- a/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -107,4 +107,4 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
 
 8. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
-    See [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md).
+    See [Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md).

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -90,9 +90,9 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 1. (`ncn-m001#`) Set variables as comma-separated lists for the three types of management NCNs.
 
    ```bash
-   MASTERS="ncn-m002,ncn-m003"
-   STORAGE=$(ceph orch host ls | grep ncn-s | awk '{print $1}' | xargs | sed 's/ /,/g')
-   WORKERS=$(kubectl get nodes | grep ncn-w | awk '{print $1}' | sort -u | xargs | sed 's/ /,/g')
+   MASTERS="ncn-m002,ncn-m003"; echo MASTERS=$MASTERS
+   STORAGE=$(ceph orch host ls | grep ncn-s | awk '{print $1}' | xargs | sed 's/ /,/g'); echo STORAGE=$STORAGE
+   WORKERS=$(kubectl get nodes | grep ncn-w | awk '{print $1}' | sort -u | xargs | sed 's/ /,/g'); echo WORKERS=$WORKERS
    ```
 
 1. (`ncn-m001#`) Shut down platform services.
@@ -101,7 +101,9 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    sat bootsys shutdown --stage platform-services
    ```
 
-   Example output:
+   The following example output shows warnings that may occur while stopping containers on
+   Kubernetes nodes. When these warnings occur, the `sat bootsys` command will continue attempting
+   to stop containers until all containers are stopped.
 
    ```text
    Proceed with stopping platform services? [yes,no] yes
@@ -121,86 +123,24 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
    - ncn-w003
 
    Are the above NCN groupings correct? [yes,no] yes
-
    Executing step: Create etcd snapshot on all Kubernetes manager NCNs.
    Executing step: Stop etcd on all Kubernetes manager NCNs.
    Executing step: Stop and disable kubelet on all Kubernetes NCNs.
    Executing step: Stop containers running under containerd on all Kubernetes NCNs.
-   WARNING: One or more "crictl stop" commands timed out on ncn-w003
-   WARNING: One or more "crictl stop" commands timed out on ncn-w002
-   ERROR: Failed to stop 1 container(s) on ncn-w003. Execute "crictl ps -q" on the host to view running containers.
-   ERROR: Failed to stop 2 container(s) on ncn-w002. Execute "crictl ps -q" on the host to view running containers.
-   WARNING: One or more "crictl stop" commands timed out on ncn-w001
-   ERROR: Failed to stop 4 container(s) on ncn-w001. Execute "crictl ps -q" on the host to view running containers.
-   WARNING: Non-fatal error in step "Stop containers running under containerd on all Kubernetes NCNs." of platform services stop: Failed to stop containers on the following NCN(s): ncn-w001, ncn-w002, ncn-w003
-   Continue with platform services stop? [yes,no] no
-   Aborting.
-   ```
-
-   In the preceding example, the commands to stop containers timed out on all the worker nodes and reported `WARNING` and `ERROR` messages.
-   A summary of the issue displays and prompts the user to continue or stop. Respond `no` to stop the shutdown. Then review the containers running on the nodes.
-
-   ```bash
-   for ncn in $(echo $WORKERS | sed 's/,/ /g'); do echo "${ncn}"; ssh "${ncn}" "crictl ps"; echo; done
-   ```
-
-   Example output:
-
-   ```text
-   ncn-w001
-   CONTAINER         IMAGE             CREATED           STATE         NAME              ATTEMPT         POD ID
-   032d69162ad24     302d9780da639     54 minutes ago    Running       cray-dhcp-kea     0               e4d1c01818a5a
-   7ab8021279164     2ad3f16035f1f     3 hours ago       Running       log-forwarding    0               a5e89a366f5a3
-
-   ncn-w002
-   CONTAINER         IMAGE             CREATED           STATE         NAME              ATTEMPT         POD ID
-   1ca9d9fb81829     de444b360808f     4 hours ago       Running       cray-uas-mgr      0               902287a6d0393
-
-   ncn-w003
-   CONTAINER         IMAGE             CREATED           STATE         NAME              ATTEMPT         POD ID
-   ```
-
-   Run the `sat` command again and enter `yes` at the prompt about the `etcd` snapshot not being created:
-
-   ```bash
-   sat bootsys shutdown --stage platform-services
-   ```
-
-   Example output:
-
-   ```text
-   The following Non-compute Nodes (NCNs) will be included in this operation:
-   managers:
-   - ncn-m001
-   - ncn-m002
-   - ncn-m003
-   storage:
-   - ncn-s001
-   - ncn-s002
-   - ncn-s003
-   workers:
-   - ncn-w001
-   - ncn-w002
-   - ncn-w003
-
-   Are the above NCN groupings correct? [yes,no] yes
-
-   Executing step: Create etcd snapshot on all Kubernetes manager NCNs.
-   WARNING: Failed to create etcd snapshot on ncn-m001: The etcd service is not active on ncn-m001 so a snapshot cannot be created.
-   WARNING: Failed to create etcd snapshot on ncn-m002: The etcd service is not active on ncn-m002 so a snapshot cannot be created.
-   WARNING: Failed to create etcd snapshot on ncn-m003: The etcd service is not active on ncn-m003 so a snapshot cannot be created.
-   WARNING: Non-fatal error in step "Create etcd snapshot on all Kubernetes manager NCNs." of platform services stop: Failed to create etcd snapshot on hosts: ncn-m001, ncn-m002, ncn-m003
-   Continue with platform services stop? [yes,no] yes
-   Continuing.
-   Executing step: Stop etcd on all Kubernetes manager NCNs.
-   Executing step: Stop and disable kubelet on all Kubernetes NCNs.
-   Executing step: Stop containers running under containerd on all Kubernetes NCNs.
+   All containers stopped on ncn-m001.
+   All containers stopped on ncn-m003.
+   All containers stopped on ncn-w003.
+   All containers stopped on ncn-w002.
+   WARNING: Some containers are still running after stop attempt on ncn-m002: ['f8a4d0ffe74588fcd4a6ab644cac62cc271df7681cea74173f28d66b5391873a']
+   Retrying container stop procedure on ncn-m002
+   WARNING: Some containers are still running after stop attempt on ncn-w001: ['21570acf6af066532bf80b2ece10c6808506f9672a03d24fd4f7e5a7775512bf', '5aebf6f06341327bbec581543e9812a20faac977fe45d870dffabf4d6f81a6c8', 'd1970d162b2f2e8f460fdba554f4aa5193c7450aa1dd0230272e18d3f6360177']
+   Retrying container stop procedure on ncn-w001
+   All containers stopped on ncn-m002.
+   WARNING: Some containers are still running after stop attempt on ncn-w001: ['5aebf6f06341327bbec581543e9812a20faac977fe45d870dffabf4d6f81a6c8']
+   Retrying container stop procedure on ncn-w001
+   All containers stopped on ncn-w001.
    Executing step: Stop containerd on all Kubernetes NCNs.
-   Executing step: Check health of Ceph cluster and freeze state.
    ```
-
-   If the process continues to report errors due to `Failed to stop containers`, then iterate on the above step. Each iteration should reduce the number of containers running. If necessary,
-   containers can be manually stopped using `crictl stop CONTAINER`. If containers are stopped manually, then re-run the above procedure to complete any final steps in the process.
 
 1. (`ncn-m001#`) Shut down and power off all management NCNs except `ncn-m001`.
 

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -146,11 +146,11 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
     This command requires input for the IPMI username and password for the management nodes.
 
-    **Important:** The default timeout for the `sat bootsys shutdown --stage ncn-power` command is 300 seconds. If it is known that
-    the nodes take longer than this amount of time for a graceful shutdown, then a different value
-    can be set using `--ncn-shutdown-timeout NCN_SHUTDOWN_TIMEOUT` with a value other than 300
-    for `NCN_SHUTDOWN_TIMEOUT`. Once this timeout has been exceeded, the node will be forcefully
-    powered down.
+    **Important:** The default timeout for the `sat bootsys shutdown --stage ncn-power` command is
+    300 seconds. If it is known that the nodes take longer than this amount of time for a graceful
+    shutdown, then a different value can be set using `--ncn-shutdown-timeout NCN_SHUTDOWN_TIMEOUT`
+    with a value other than 300 for `NCN_SHUTDOWN_TIMEOUT`. Once this timeout has been exceeded, the
+    command will prompt whether the node should be forcefully powered off.
 
    1. Shutdown management NCNs.
 
@@ -158,7 +158,7 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
       sat bootsys shutdown --stage ncn-power --ncn-shutdown-timeout 900
       ```
 
-      Example output:
+      Example output when the command is successful:
 
       ```text
       Proceed with shutdown of other management NCNs? [yes,no] yes
@@ -185,13 +185,124 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
       workers: []
 
       Are the above NCN groupings and exclusions correct? [yes,no] yes
+      INFO: Successfully set next boot device to disk (Boot0014) for ncn-w001
+      INFO: Successfully set next boot device to disk (Boot0012) for ncn-w002
+      INFO: Successfully set next boot device to disk (Boot0014) for ncn-w003
+      INFO: Starting console logging on ncn-w001,ncn-w002,ncn-w003.
+      INFO: Shutting down worker NCNs: ncn-w001, ncn-w002, ncn-w003
+      INFO: Executing command on host "ncn-w001": `shutdown -h now`
+      INFO: Executing command on host "ncn-w002": `shutdown -h now`
+      INFO: Executing command on host "ncn-w003": `shutdown -h now`
+      INFO: Waiting up to 900 seconds for worker NCNs to shut down...
+      INFO: Stopping console logging on ncn-w001,ncn-w002,ncn-w003,ncn-w004.
+      INFO: Successfully set next boot device to disk (Boot0000) for ncn-m001
+      INFO: Successfully set next boot device to disk (Boot0014) for ncn-m002
+      INFO: Successfully set next boot device to disk (Boot000F) for ncn-m003
+      INFO: Starting console logging on ncn-m002,ncn-m003.
+      INFO: Shutting down manager NCNs: ncn-m002, ncn-m003
+      INFO: Executing command on host "ncn-m002": `shutdown -h now`
+      INFO: Executing command on host "ncn-m003": `shutdown -h now`
+      INFO: Waiting up to 900 seconds for manager NCNs to shut down...
+      INFO: Stopping console logging on ncn-m002,ncn-m003.
+      INFO: Finding mounted RBD devices on ncn-m001
+      INFO: Found no mounted RBD devices on ncn-m001
+      INFO: Finding mounted Ceph or s3fs filesystems on ncn-m001
+      INFO: Found 3 mounted Ceph or s3fs filesystems on ncn-m001
+      INFO: Checking whether mounts are in use on ncn-m001
+      INFO: Checking whether mount point /var/opt/cray/config-data is in use on ncn-m001
+      INFO: Mount point /var/opt/cray/config-data is not in use on ncn-m001
+      INFO: Checking whether mount point /etc/cray/upgrade/csm is in use on ncn-m001
+      INFO: Mount point /etc/cray/upgrade/csm is not in use on ncn-m001
+      INFO: Checking whether mount point /var/opt/cray/sdu/collection-mount is in use on ncn-m001
+      INFO: Mount point /var/opt/cray/sdu/collection-mount is not in use on ncn-m001
+      INFO: All mount points are not in use and ready to be unmounted
+      INFO: Disabling cron job that ensures Ceph and s3fs filesystems are mounted on ncn-m001
+      INFO: Successfully disabled cron job on ncn-m001
+      INFO: Unmounting 3 filesystems on ncn-m001
+      INFO: Unmounting /var/opt/cray/config-data on ncn-m001
+      INFO: Successfully unmounted /var/opt/cray/config-data on ncn-m001
+      INFO: Unmounting /etc/cray/upgrade/csm on ncn-m001
+      INFO: Successfully unmounted /etc/cray/upgrade/csm on ncn-m001
+      INFO: Unmounting /var/opt/cray/sdu/collection-mount on ncn-m001
+      INFO: Successfully unmounted /var/opt/cray/sdu/collection-mount on ncn-m001
+      INFO: Successfully unmounted 3 filesystems on ncn-m001
+      INFO: Unmapping all RBD devices on ncn-m001
+      INFO: Successfully unmapped all RBD devices on ncn-m001
+      INFO: Successfully set next boot device to disk (Boot000F) for ncn-s001
+      INFO: Successfully set next boot device to disk (Boot000F) for ncn-s002
+      INFO: Successfully set next boot device to disk (Boot000F) for ncn-s003
+      INFO: Freezing Ceph and shutting down storage NCNs: ncn-s001, ncn-s002, ncn-s003
+      INFO: Checking Ceph health
+      INFO: Freezing Ceph
+      INFO: Running command: ceph osd set noout
+      INFO: Command output: noout is set
+      INFO: Running command: ceph osd set norecover
+      INFO: Command output: norecover is set
+      INFO: Running command: ceph osd set nobackfill
+      INFO: Command output: nobackfill is set
+      INFO: Ceph freeze completed successfully on storage NCNs.
+      INFO: Starting console logging on ncn-s001,ncn-s002,ncn-s003.
+      INFO: Executing command on host "ncn-s001": `shutdown -h now`
+      INFO: Executing command on host "ncn-s002": `shutdown -h now`
+      INFO: Executing command on host "ncn-s003": `shutdown -h now`
+      INFO: Waiting up to 900 seconds for storage NCNs to shut down...
+      INFO: Shutdown and power off of storage NCNs: ncn-s001, ncn-s002, ncn-s003
+      INFO: Stopping console logging on ncn-s001,ncn-s002,ncn-s003.
+      INFO: Shutdown and power off of all management NCNs complete.
+      INFO: Succeeded with shutdown of other management NCNs.
       ```
+
+      Manual intervention may be required in the above command if a timeout occurs while waiting for
+      nodes to gracefully power down or if mount points provided by Ceph are in use. See the
+      following sub-steps for how to proceed in either of those cases.
+
+      1. If any nodes fail to reach a powered off state, log messages and a prompt like the
+         following will be displayed:
+
+         ```text
+         ERROR: Waiting for condition "IPMI power off" timed out after 900 seconds
+         WARNING: The following nodes did not complete a graceful shutdown within the timeout: ncn-w003
+         Do you want to forcibly power off the nodes that timedout? [yes,no]
+         ```
+
+         Enter 'yes' at the prompt if you wish to perform a hard power off of these nodes. See the
+         next main step of the procedure for instructions on viewing console logs to see why the
+         node is still shutting down. The following messages will be logged if the prompt is
+         answered with 'yes':
+
+         ```text
+         INFO: Proceeding with hard power off.
+         INFO: Sending IPMI power off command to host ncn-w004
+         ```
+
+      1. If any filesystems provided by Ceph are in use, the command will log a message like the
+         following:
+
+         ```text
+         INFO: Mount point /etc/cray/upgrade/csm is in use by the following processes on ncn-m001:
+         INFO: COMMAND    PID USER   FD   TYPE DEVICE SIZE/OFF     NODE NAME
+         INFO: bash    560967 root  cwd    DIR 252,16     4096 63569921 /etc/cray/upgrade/csm
+         Some filesystems to be unmounted remain in use. Please address this before continuing.
+         Proceed with unmount of filesystems? [yes,no]
+         ```
+
+         The output of the `lsof` command is logged to help identify processes using the
+         filesystem(s). Stop all usages of the identified filesystems, and then enter 'yes' to
+         proceed with the next step of shutting down management NCNs. If 'no' is entered at the
+         prompt, run the `sat bootsys` command again when the filesystems are no longer in use.
 
    1. (`ncn-m001#`) Monitor the consoles for each NCN.
 
-      Use `tail` to monitor the log files in `/var/log/cray/console_logs` for each NCN.
+      Use `tail` to monitor the log files in `/var/log/cray/console_logs` for each NCN. For example,
+      to watch the console log for `ncn-w003`, use the following `tail` command:
 
-      Alternately attach to the screen session \(screen sessions real time, but not saved\):
+      ```text
+      tail -f /var/log/cray/console_logs/console-ncn-w003-mgmt.log
+      ```
+
+      Alternatively, attach to the screen session in which the `ipmitool sol activate` command is running. This allows for input to be provided on the console if needed.
+
+      List the screen sessions:
 
       ```bash
       screen -ls
@@ -201,37 +312,28 @@ documentation (`S-8031`) for instructions on how to acquire a SAT authentication
 
       ```text
       There are screens on:
-      26745.SAT-console-ncn-m003-mgmt (Detached)
-      26706.SAT-console-ncn-m002-mgmt (Detached)
-      26666.SAT-console-ncn-s003-mgmt (Detached)
-      26627.SAT-console-ncn-s002-mgmt (Detached)
-      26589.SAT-console-ncn-s001-mgmt (Detached)
       26552.SAT-console-ncn-w003-mgmt (Detached)
       26514.SAT-console-ncn-w002-mgmt (Detached)
       26444.SAT-console-ncn-w001-mgmt (Detached)
       ```
 
+      Attach to a screen session as follows:
+
       ```bash
-      screen -x 26745.SAT-console-ncn-w003-mgmt
+      screen -x 26552.SAT-console-ncn-w003-mgmt
       ```
 
-   1. (`ncn-m001#`) Check the power off status of management NCNs.
+      Detach from the screen session using `Ctrl + A` followed by `D`. This will leave the screen
+      session running in detached mode. The `sat bootsys` command will automatically exit screen
+      sessions when nodes have finished shutting down.
 
-       > NOTE: `read -s` is used to read the password in order to prevent it from being
-       > echoed to the screen or preserved in the shell history.
+   1. Proceed with the next step to shut down `ncn-m001` only when the `sat bootsys shutdown --stage ncn-power`
+      command has succeeded with the final messages:
 
-       ```bash
-       USERNAME=root
-       read -r -s -p "NCN BMC ${USERNAME} password: " IPMI_PASSWORD
-       ```
-
-       ```bash
-       export IPMI_PASSWORD
-       for ncn in $(echo "$MASTERS,$STORAGE,$WORKERS" | sed 's/,/ /g'); do
-           echo -n "${ncn}: "
-           ipmitool -U "${USERNAME}" -H "${ncn}-mgmt" -E -I lanplus chassis power status
-       done
-       ```
+      ```text
+      INFO: Shutdown and power off of all management NCNs complete.
+      INFO: Succeeded with shutdown of other management NCNs.
+      ```
 
 1. (`external#`) From a remote system, activate the serial console for `ncn-m001`.
 

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -15,7 +15,7 @@ To make sure that the system is healthy before power off and all the information
 
 ## Shut Down Compute Nodes and UANs
 
-To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Compute and User Access Nodes](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 
 ## Save Management Network Switch Settings
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -34,9 +34,10 @@ To power on the management cabinet and bring up the management Kubernetes cluste
 
 To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On Compute Cabinets](Power_On_Compute_Cabinets.md).
 
-## Power on and boot compute nodes and user access nodes \(UANs\)
+## Power on and boot managed nodes
 
-To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to users.
+To power on and boot managed nodes, e.g. compute nodes and User Access Nodes (UANs), refer to
+[Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md) and make nodes available to users.
 
 ## Run system health checks
 

--- a/operations/security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md
+++ b/operations/security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md
@@ -1,6 +1,9 @@
 # Change Cray EX Liquid-Cooled Cabinet Global Default Password
 
-This procedure changes the global default `root` credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.
+This procedure changes the global default `root` credential on HPE Cray EX liquid-cooled cabinet
+embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller
+(nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these
+procedures.
 
 ## Prerequisites
 
@@ -9,7 +12,7 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 
 ### Procedure
 
-1. If necessary, shut down compute nodes in each cabinet. Refer to [Shut Down and Power Off Compute and User Access Nodes](../power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
+1. If necessary, shut down compute nodes in each cabinet. Refer to [Shut Down and Power Off Managed Nodes](../power_management/Shut_Down_and_Power_Off_Managed_Nodes.md).
 
    ```screen
    sat bootsys shutdown --stage bos-operations --bos-templates COS_SESSION_TEMPLATE
@@ -23,7 +26,7 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 
 3. Power off all compute slots in the cabinets the passwords are to be changed on.
 
-  > **`NOTE`**: If a chassis is not fully populated, specify each slot individually.
+   > **`NOTE`**: If a chassis is not fully populated, specify each slot individually.
 
    Example showing fully populated cabinets 1000-1003:
 
@@ -44,4 +47,3 @@ This procedure changes the global default `root` credential on HPE Cray EX liqui
 5. Perform the procedures in [Updating the Liquid-Cooled EX Cabinet Default Credentials after a CEC Password Change](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md).
 
 6. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide (> 1.6.0)*.
-


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Changes were made to the `sat bootsys` command to improve the full-system power off/on procedures in docs-csm. This pull request updates the documentation to match the current behavior of `sat bootsys`.

## Details from commit messages

* CRAYSAT-1882: Improve "Power On Compute Cabinets"

  Improve the procedure to power on compute cabinets as follows:
  
  * Minor wording adjustments
  * Note that it is safe to re-run `sat bootsys boot --stage
    cabinet-power` as needed until it's successful.
  * Change CAPMC references and commands to PCS. Note that these
    instructions were taken from the document on the same name in the
    `Power_Control_Service` directory, and that copy of the procedure will
    be removed in CRAYSAT-1891.

* CRAYSAT-1882: Improve steps for shutting down K8s cluster

  Improve the steps in the "Shut Down and Power Off the Management
  Kubernetes Cluster" section of the "System Power Off Procedures". This
  includes the following changes:
  
  * Include more complete example output from the `ncn-power` stage of
    `sat bootsys shutdown`, so that the admin knows what to expect.
  * Add sub-steps describing what to do in known exceptional circumstances
    that can occur during the `ncn-power` stage of shutdown.
  * Improve console monitoring instructions, similarly to how they were
    improved for the boot process.
  * Remove unnecessary `ipmitool` commands that query for power status of
    NCNs using `ipmitool`. This is already done by the `sat bootsys
    shutdown --stage ncn-power` command.

* CRAYSAT-1882: Improve steps for starting Kubernetes cluster

  Improve the steps in the "Power On and Start the Management Kubernetes
  Cluster" section of the "System Power On Procedures". This includes the
  following changes:
  
  * Show the successful output of the `ncn-power` stage first. Then show
    exceptional conditions in sub-steps. Improve the wording.
  * Ensure all log messages in example output are appropriately prefixed
    with the log level as they will be with the latest version of `sat`.
  * Improve documentation around monitoring node console logs to include a
    `tail` command and describe using `screen` in more detail.
  * Remove the Ceph troubleshooting from the `platform-services` stage
    since it has been moved to the `ncn-power` stage.
  * Add a general reminder to re-run the `platform-services` stage if any
    unexpected errors occur.

* CRAYSAT-1877: Improvement on platform services stage


* CRAYSAT-1882: sat bootsys shutdown and boot improvements doc changes (#5262)

  * As part of sat bootsys shutdown and boot, improvements have been done.
  
  Changing the order off booting the ncn's.
  Adding prompt to bypass ceph health wait
  updating SAT command to shutdown cabinets using PCS
  PCS command inplace of CAPMC cmd
  Move the ceph troubleshoot under ncn-power stage
  
* CRAYSAT-1711: Improve procedure to get BOS session templates (#5260)

  As part of the system power off/on procedure, the admin must use BOS to
  shutdown the nodes and to boot the nodes. To do so, they must find the
  right BOS session templates to use.
  
  Currently this procedure is duplicated in three places in the
  documentation. Consolidate and improve the documentation in one place,
  the "Prepare the System for Power Off" section, and refer to it from the
  other two documents which need to reference the procedure for finding
  the appropriate BOS session templates.
  
  Also rename the procedures for booting and shutting down compute nodes
  and user access nodes to use the more general term "Managed Nodes" instead, which is consistent
  with the IUF's terminology. Update all locations to use the new titles
  and markdown file names.
  
  Improve and streamline the procedures in the "Power On and Boot Managed
  Nodes" and "Shut Down and Power Off Managed Nodes" procedures.
* CRAYSAT-1715 Removing the manual process there to mount as it is automated. (#5143)

  Removing the manual process there to mount as it is automated.
  
  IM:CRAYSAT-1715
  Reviewer:Ryan
  
  Currently the user mounts the s3fs filesystem manually. This has been automated.
  
  CRAYSAT-1852 automates by mounting the file systems on m001 before booting the
  other master(m002,m003) and worker nodes. Thus after the boot mount points would
  be readily available on the nodes. Hence removing the mnaul process documented.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
