### PR TITLE
CASMINST-6959: Create tarfile with --sparse option during m001 redeploy

### DIFF
--- a/install/scripts/backup-pit-data.sh
+++ b/install/scripts/backup-pit-data.sh
@@ -116,7 +116,7 @@ done
 echo "Creating PIT backup tarfile"
 
 pushd "${TEMPDIR}"
-run_cmd tar -czvf "${PITDATA}/prep/logs/pit-backup-$(date +%Y-%m-%d_%H-%M-%S).tgz" --remove-files *
+run_cmd tar --sparse -czvf "${PITDATA}/prep/logs/pit-backup-$(date +%Y-%m-%d_%H-%M-%S).tgz" --remove-files *
 popd
 run_cmd rmdir -v "${TEMPDIR}"
 


### PR DESCRIPTION
This significantly increases the speed of the tarfile creation, owing to some large sparse files it includes in its backup.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/5286
1.4: https://github.com/Cray-HPE/docs-csm/pull/5287