### PR TITLE
CASMTRIAGE-7217 - DNS check failing in 5.setup_nexus.yaml stage

### DIFF
--- a/install/scripts/csm_services/steps/5.setup_nexus.yaml
+++ b/install/scripts/csm_services/steps/5.setup_nexus.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/install/scripts/csm_services/steps/5.setup_nexus.yaml
+++ b/install/scripts/csm_services/steps/5.setup_nexus.yaml
@@ -53,9 +53,10 @@ spec:
           counter_max=10
           sleep_time=30
           url=packages.local
+          dns_server=10.92.100.225
           while [[ $nexus_resources_ready -eq 0 ]] && [[ "$counter" -le "$counter_max" ]]; do
               nexus_check_configmap=$(kubectl -n services get cm cray-dns-unbound -o json 2>&1 | jq '.binaryData."records.json.gz"' -r 2>&1 | base64 -d 2>&1| gunzip - 2>&1|jq 2>&1|grep $url|wc -l)
-              nexus_check_dns=$(dig $url +short |wc -l)
+              nexus_check_dns=$(dig @$dns_server $url +short |wc -l)
               nexus_check_pod=$(kubectl get pods -n nexus| grep nexus | grep -v Completed |awk {' print $3 '})
 
               if [[ "$nexus_check_dns" -eq "1" ]] && [[ "$nexus_check_pod" == "Running" ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

SLES 15 SP6 changes the behaviour of the `dig` command and it now produces errors for DNS servers it can't get a response from.
```
fanta-pit:~ # dig packages.local +short
;; communications error to 127.0.0.1#53: connection refused
;; communications error to 127.0.0.1#53: connection refused
;; communications error to 127.0.0.1#53: connection refused
10.92.100.71
```
This causes the `5.setup_nexus.yaml` stage of the install to fail because `dnsmasq` is shutdown (as expected at this point) but the system hasn't pivoted fully over to `cray-dns-unbound` yet.

While it would be nice to rely on return code, `dig` also returns 0 in the event that the DNS server replies but the record doesn't exist so the best fix here is to query Unbound directly for the existence of the record.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Testing

## Assuming the following /etc/resolv.conf
```
search nmn mtl hmn
nameserver 127.0.0.1
nameserver 10.92.100.225
```

## Test 1 - Everything working as expected
```
fanta-pit:/usr/share/doc/csm/install/scripts/csm_services/steps # bash check.sh
packages.local is in dns.
Nexus pod Running.
Moving forward with Nexus setup.
```
## Test 2 - Query a non-existent record
```
fanta-pit:/usr/share/doc/csm/install/scripts/csm_services/steps # bash check.sh
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 1 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 2 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 3 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 4 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 5 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 6 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 7 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 8 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 9 out of 10.
fake.local is not in DNS yet.
fake.local is not loaded into unbound configmap yet.
Waiting for DNS and nexus pod to be ready. Retry in 30 seconds. Try 10 out of 10.
Max number of checks reached, exiting.
Please check the status of nexus, cray-dns-unbound and cray-sls.
```
## Test 3 - Query unresponsive DNS server
```
fanta-pit:/usr/share/doc/csm/install/scripts/csm_services/steps # bash check.sh
Max number of checks reached, exiting.
Please check the status of nexus, cray-dns-unbound and cray-sls.
```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
