### PR TITLE
CASMHMS-6241 capmc and pcs transaction size limitation

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -66,6 +66,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [wait for unbound hang](known_issues/wait_for_unbound_hang.md)
 * [Product Catalog Upgrade Error](known_issues/product_catalog_upgrade_error.md)
 * [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
+* [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/pcs_and_capmc_transaction_size_limitation.md
+++ b/troubleshooting/known_issues/pcs_and_capmc_transaction_size_limitation.md
@@ -1,6 +1,6 @@
 # Transaction Size Limitation for PCS and CAPMC
 
-PCS (Power Control Service) and CAPMC (Cray Advanced Platform Monitoring and Control) cannot handle large requests. The maximum number of nodes in a single request is approximately 2500 nodes.
+The Power Control Service (PCS) and Cray Advanced Platform Monitoring and Control (CAPMC) cannot handle large requests. The maximum number of nodes in a single request is approximately 2500 nodes.
 
 ## Identifying the issue
 

--- a/troubleshooting/known_issues/pcs_and_capmc_transaction_size_limitation.md
+++ b/troubleshooting/known_issues/pcs_and_capmc_transaction_size_limitation.md
@@ -1,0 +1,21 @@
+# Transaction Size Limitation for PCS and CAPMC
+
+PCS (Power Control Service) and CAPMC (Cray Advanced Platform Monitoring and Control) cannot handle large requests. The maximum number of nodes in a single request is approximately 2500 nodes.
+
+## Identifying the issue
+
+When the request is too large `cray power` will return the following message.
+
+```text
+Error: Internal Server Error:  etcdserver: request is too large
+```
+
+The logs for the `cray-power-control` pods will contain text like the following.
+
+```text
+level=error msg="etcdserver: request too large" func="github.com/Cray-HPE/hps-power-control/internal/storage.("ETCDStorage).TASTransiation" file="/go/src/github.com/Cray-HPE/hps-power-control/internal/storage etcd impl.go:520"
+```
+
+## Solution
+
+Reduce the number of nodes in each request by running multiple `cray power` or `cray capmc` commands.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Added doc for the known issue that limits CAPMC and PCS requests to maximum of approximately 2500 nodes.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
