### PR TITLE
CRAYSAT-1892: Update "sat bootsys boot --stage ncn-power" with new output

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -159,16 +159,14 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
    INFO: Mounting fuse.s3fs filesystem on /var/opt/cray/config-data.
    INFO: Successfully mounted fuse.s3fs filesystem on /var/opt/cray/config-data.
    INFO: Successfully restarted 'cray-sdu-rda' service on ncn-m001
-   INFO: Powering on NCNs and waiting up to 900 seconds for them to be reachable via SSH: ncn-m002, ncn-m003
-   INFO: Sending IPMI power on command to host ncn-m002
-   INFO: Sending IPMI power on command to host ncn-m003
-   INFO: Powered on NCNs: ncn-m002, ncn-m003
-   INFO: Powering on NCNs and waiting up to 900 seconds for them to be reachable via SSH: ncn-w001, ncn-w002, ncn-w003
-   INFO: Sending IPMI power on command to host ncn-w003
+   INFO: Powering on NCNs and waiting up to 900 seconds for them to be reachable via SSH: ncn-m002, ncn-m003,ncn-w001, ncn-w002, ncn-w003
    INFO: Sending IPMI power on command to host ncn-w001
+   INFO: Sending IPMI power on command to host ncn-m002
+   INFO: Sending IPMI power on command to host ncn-w003
    INFO: Sending IPMI power on command to host ncn-w002
-   INFO: Powered on NCNs: ncn-w001, ncn-w002, ncn-w003
-   INFO: Stopping console logging on ncn-s003,ncn-m002,ncn-w001,ncn-m003,ncn-w003,ncn-s002,ncn-s001,ncn-w002.
+   INFO: Sending IPMI power on command to host ncn-m003
+   INFO: Powered on NCNs: ncn-m002, ncn-m003, ncn-w001, ncn-w002, ncn-w003
+   INFO: Stopping console logging on ncn-s001,ncn-w001,ncn-m002,ncn-w003,ncn-s003,ncn-s002,ncn-w002,ncn-m003.
    INFO: Succeeded with boot of other management NCNs.
    ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Review and Modify `sat bootsys boot --stage ncn-power` output to boot the master nodes (other than ncn-m001) and the worker nodes at the same time.

Resolves [CRAYSAT-1892](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1892)

Relates to:
- https://github.com/Cray-HPE/sat/pull/251
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
