### PR TITLE
CASMTRIAGE-7199 : supply options -sv and/or -bpcd or -rv during IUF deliver-product stage to install SLURM or PBS

### DIFF
--- a/operations/iuf/stages/deliver_product.md
+++ b/operations/iuf/stages/deliver_product.md
@@ -20,6 +20,9 @@ The following arguments are most often used with the `deliver-product` stage. Se
 | Input    | `iuf` Argument | Description                                            |
 |----------|----------------|--------------------------------------------------------|
 | Activity | `-a ACTIVITY`  | Activity created for the install or upgrade operations |
+| Site variables                         | `-sv SITE_VARS`             | Path to YAML file containing site defaults and any overrides                 |
+| Recipe variables                       | `-rv RECIPE_VARS`           | Path to YAML file containing recipe variables provided by HPE                |
+| `sat bootprep` configuration directory | `-bpcd BOOTPREP_CONFIG_DIR` | Directory containing `sat bootprep` configuration files and recipe variables |
 
 ## Execution details
 
@@ -58,6 +61,14 @@ The following table describes upload behavior when the artifact being uploaded a
 
 (`ncn-m001#`) Execute the `deliver-product` stage for activity `admin-230127`.
 
+### Option 1: Install or upgrade without SLURM or PBS Products
+
 ```bash
 iuf -a admin-230127 run -r deliver-product
+```
+
+### Option 2: Install or upgrade along with SLURM or PBS Products
+
+```bash
+iuf -a admin-230127 run -sv /etc/cray/upgrade/csm/admin/site_vars.yaml -bpcd /etc/cray/upgrade/csm/admin -r deliver-product
 ```

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -54,12 +54,28 @@ Once this step has completed:
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `deliver-product` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
+### Option 1: Install or upgrade without SLURM or PBS Products
+
 1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-r` to execute the [`deliver-product`](../stages/deliver_product.md) stage. Perform the upgrade using product content found in `${MEDIA_DIR}`.
 
     (`ncn-m001#`) Execute the `deliver-product` stage.
 
     ```bash
     iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -r deliver-product
+    ```
+
+### Option 2: Install or upgrade along with SLURM or PBS Products
+
+**`NOTE`** This subsection is mandatory only while installing SLURM or PBS Products. Additional arguments are available to control the behavior of the `deliver-product` stage, for example `-rv`. See the [`deliver-product` stage
+documentation](../stages/deliver_product.md) for details and adjust the examples below if necessary.
+
+1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-r` to execute the [`deliver-product`](../stages/deliver_product.md) stage. Perform the upgrade using product content found in `${MEDIA_DIR}`.
+Use site variables from the `site_vars.yaml` file found in `${ADMIN_DIR}` and recipe variables from the `product_vars.yaml` file found in `${ADMIN_DIR}`.
+
+    (`ncn-m001#`) Execute the `deliver-product` stage.
+
+    ```bash
+    iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run --site-vars "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r deliver-product
     ```
 
 Once this step has completed:


### PR DESCRIPTION

# Description

CASMTRIAGE-7199 : supply options -sv and/or -bpcd or -rv during IUF deliver-product stage to install SLURM or PBS

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
