### PR TITLE
CASMTRIAGE-7199 : supply options -sv and/or -bpcd or -rv during IUF deliver-product stage to install SLURM or PBS

### DIFF
--- a/operations/iuf/stages/deliver_product.md
+++ b/operations/iuf/stages/deliver_product.md
@@ -17,9 +17,12 @@ The `deliver-product` stage does not change the running state of the system as t
 
 The following arguments are most often used with the `deliver-product` stage. See `iuf -h` and `iuf run -h` for additional arguments.
 
-| Input    | `iuf` Argument | Description                                            |
-|----------|----------------|--------------------------------------------------------|
-| Activity | `-a ACTIVITY`  | Activity created for the install or upgrade operations |
+| Input                                  | `iuf` Argument              | Description                                                                  |
+|----------------------------------------|-----------------------------|------------------------------------------------------------------------------|
+| Activity                               | `-a ACTIVITY`               | Activity created for the install or upgrade operations                       |
+| Site variables                         | `-sv SITE_VARS`             | Path to YAML file containing site defaults and any overrides                 |
+| Recipe variables                       | `-rv RECIPE_VARS`           | Path to YAML file containing recipe variables provided by HPE                |
+| `sat bootprep` configuration directory | `-bpcd BOOTPREP_CONFIG_DIR` | Directory containing `sat bootprep` configuration files and recipe variables |
 
 ## Execution details
 
@@ -56,8 +59,8 @@ The following table describes upload behavior when the artifact being uploaded a
 
 ## Example
 
-(`ncn-m001#`) Execute the `deliver-product` stage for activity `admin-230127`.
+(`ncn-m001#`) Execute the `deliver-product` stage for activity `admin-230127` using the `/etc/cray/upgrade/csm/admin/site_vars.yaml` file and the `product_vars.yaml` file found in the `/etc/cray/upgrade/csm/admin` directory.
 
 ```bash
-iuf -a admin-230127 run -r deliver-product
+iuf -a admin-230127 run -sv /etc/cray/upgrade/csm/admin/site_vars.yaml -bpcd /etc/cray/upgrade/csm/admin -r deliver-product
 ```

--- a/operations/iuf/stages/deploy_product.md
+++ b/operations/iuf/stages/deploy_product.md
@@ -17,18 +17,22 @@ The `deploy-product` stage changes the running state of the system.
 
 The following arguments are most often used with the `deploy-product` stage. See `iuf -h` and `iuf run -h` for additional arguments.
 
-| Input    | `iuf` Argument | Description                                            |
-|----------|----------------|--------------------------------------------------------|
-| Activity | `-a ACTIVITY`  | Activity created for the install or upgrade operations |
+| Input                                  | `iuf` Argument              | Description                                                                  |
+|----------------------------------------|-----------------------------|------------------------------------------------------------------------------|
+| Activity                               | `-a ACTIVITY`               | Activity created for the install or upgrade operations                       |
+| Site variables                         | `-sv SITE_VARS`             | Path to YAML file containing site defaults and any overrides                 |
+| Recipe variables                       | `-rv RECIPE_VARS`           | Path to YAML file containing recipe variables provided by HPE                |
+| `sat bootprep` configuration directory | `-bpcd BOOTPREP_CONFIG_DIR` | Directory containing `sat bootprep` configuration files and recipe variables |
 
 ## Execution details
 
-The code executed by this stage exists within IUF. See the `deploy-product` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files in `/usr/share/doc/csm/workflows/iuf/operations/` for details on the commands executed.
+The code executed by this stage exists within IUF. See the `deploy-product` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml`
+and the corresponding files in `/usr/share/doc/csm/workflows/iuf/operations/` for details on the commands executed.
 
 ## Example
 
-(`ncn-m001#`) Execute the `deploy-product` stage for activity `admin-230127`.
+(`ncn-m001#`) Execute the `deploy-product` stage for activity `admin-230127` using the `/etc/cray/upgrade/csm/admin/site_vars.yaml` file and the `product_vars.yaml` file found in the `/etc/cray/upgrade/csm/admin` directory.
 
 ```bash
-iuf -a admin-230127 run -r deploy-product
+iuf -a admin-230127 run -sv /etc/cray/upgrade/csm/admin/site_vars.yaml -bpcd /etc/cray/upgrade/csm/admin -r deploy-product
 ```

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -10,13 +10,16 @@
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `deploy-product` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Invoke `iuf run` with `-r` to execute the [`deploy-product`](../stages/deploy_product.md) stage.
+1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-r` to execute the [`deploy-product`](../stages/deploy_product.md) stage. Perform the upgrade using product content found in `${MEDIA_DIR}`.
+   Additional arguments are available to control the behavior of the `deploy-product` stage (for example, `-rv`).
+   See the [`deploy-product` stage documentation](../stages/deploy_product.md) for details and adjust the example below if necessary.
 
-    (`ncn-m001#`) Execute the `deploy-product` stage.
+      (`ncn-m001#`) Execute the `deploy-product` stage. Use site variables from the `site_vars.yaml` file found in `${ADMIN_DIR}` and recipe variables from the `product_vars.yaml` file found in `${ADMIN_DIR}`.
 
-    ```bash
-    iuf -a "${ACTIVITY_NAME}" run -r deploy-product
-    ```
+   ```bash
+   iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run --site-vars \
+   "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r deploy-product
+   ```
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -55,12 +55,18 @@ section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide
 Refer to that table and any corresponding product documents before continuing to the next step.
 
 1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-r` to execute the [`deliver-product`](../stages/deliver_product.md) stage. Perform the upgrade using product content found in `${MEDIA_DIR}`.
+   Additional arguments are available to control the behavior of the `deliver-product` stage (for example, `-rv`). See the [`deliver-product` stage documentation](../stages/deliver_product.md)
+   for details and adjust the example below if necessary.
 
-    (`ncn-m001#`) Execute the `deliver-product` stage.
+     **`NOTE`** When installing USS 1.1 or higher, select either SLURM or PBS Pro Products to use on the system before running this stage. For more information, see the `deliver-product` stage
+     details in the "Install and Upgrade Framework" section of the _HPE Cray Supercomputing User Services Software Administration Guide: CSM on HPE Cray Supercomputing EX Systems (S-8063)_.
 
-    ```bash
-    iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -r deliver-product
-    ```
+      (`ncn-m001#`) Execute the `deliver-product` stage. Use site variables from the `site_vars.yaml` file found in `${ADMIN_DIR}` and recipe variables from the `product_vars.yaml` file found in `${ADMIN_DIR}`.
+
+      ```bash
+      iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run --site-vars \
+      "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r deliver-product
+      ```
 
 Once this step has completed:
 


### PR DESCRIPTION
# Description

CASMTRIAGE-7199 : supply options -sv and/or -bpcd or -rv during IUF deliver-product stage to install SLURM or PBS

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
