### PR TITLE
CASMCMS-8979 - add documentation for IMS remote build node status.

### DIFF
--- a/operations/conman/Console_Services_Troubleshooting_Guide.md
+++ b/operations/conman/Console_Services_Troubleshooting_Guide.md
@@ -159,7 +159,7 @@ Check on the current running state of the `cray-console-data-postgres` database.
 1. (`ncn-mw#`) Find the `cray-console-data-postgres` pods and note one that is in `Running` state.
 
     ```bash
-    kubectl -n services get pods | grep cray-console-data-postres
+    kubectl -n services get pods | grep cray-console-data-postgres
     ```
 
     Example output:

--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -688,3 +688,77 @@ Expected output will be something like:
     }
 ]
 ```
+
+### Checking the status of remote build nodes
+
+Before a job is set up to be launched on a remote build node, IMS checks that it is
+ready to run remote jobs. If a node is registered as a remote build node, but is not
+able to run remote jobs, that node will not have remote jobs scheduled on it. The
+status of the remote build nodes may be queried. The status object will have a field
+`ableToRunJobs` that contains a boolean indicating if the node is able to run jobs.
+If the node is not able to run jobs, the status object will document the issue with
+running jobs on that node.
+
+* NOTE: a value of '-1' for `numCurrentJobs` indicates that the actual number of
+   current jobs on the node was not able to be determined.
+
+(`ncn-mw#`) To check the status of a particular remote build node:
+
+```bash
+cray ims remote-build-nodes status describe "${IMS_REMOTE_NODE_XNAME}"
+```
+
+If the node is ready to run jobs, the output will look something like:
+
+```text
+{
+  "ableToRunJobs": true,
+  "nodeArch": "x86_64",
+  "numCurrentJobs": 0,
+  "podmanStatus": "Podman present at /usr/bin/podman",
+  "sshStatus": "SSH connection established.",
+  "xname": "x3000c0s3b0n0"
+}
+```
+
+If the node is not able to run jobs, the output will look something like:
+
+```text
+{
+  "ableToRunJobs": false,
+  "nodeArch": "Unknown",
+  "numCurrentJobs": -1,
+  "podmanStatus": "Unknown",
+  "sshStatus": "Unable to connect to node. Error: [Errno -2] Name does not resolve",
+  "xname": "x3000c0s3b0n1"
+}
+```
+
+(`ncn-m-w#`) To check the status of all defined remote build nodes:
+
+```bash
+cray ims remote-build-nodes status list
+```
+
+The output will look something like:
+
+```text
+[
+  {
+    "ableToRunJobs": true,
+    "nodeArch": "x86_64",
+    "numCurrentJobs": 2,
+    "podmanStatus": "Podman present at /usr/bin/podman",
+    "sshStatus": "SSH connection established.",
+    "xname": "x3000c0s3b0n0"
+  },
+  {
+    "ableToRunJobs": false,
+    "nodeArch": "Unknown",
+    "numCurrentJobs": -1,
+    "podmanStatus": "Unknown",
+    "sshStatus": "Unable to connect to node. Error: [Errno -2] Name does not resolve",
+    "xname": "x3000c0s3b0n1"
+  }
+]
+```

--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -701,7 +701,7 @@ on that node.
 
 In order to run jobs all of the following conditions must be met:
 
-* The IMS service can ssh to the node.
+* The IMS service can SSH to the node.
 * The node architecture must be determined and valid.
 * The `podman` executable must be installed.
 
@@ -724,7 +724,7 @@ If the node is ready to run jobs, the output will look something like:
 }
 ```
 
-If IMS is unable to ssh to a node the output may look something like:
+If IMS is unable to SSH to a node the output may look something like:
 
 ```text
 {

--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -691,16 +691,19 @@ Expected output will be something like:
 
 ### Checking the status of remote build nodes
 
-Before a job is set up to be launched on a remote build node, IMS checks that it is
-ready to run remote jobs. If a node is registered as a remote build node, but is not
-able to run remote jobs, that node will not have remote jobs scheduled on it. The
-status of the remote build nodes may be queried. The status object will have a field
-`ableToRunJobs` that contains a boolean indicating if the node is able to run jobs.
-If the node is not able to run jobs, the status object will document the issue with
-running jobs on that node.
+Before a job is set up to be launched on a remote build node, IMS checks that there is
+a remote node capable of running the job. If a node is registered as a remote build node
+but is not able to run remote jobs, that node will not have remote jobs scheduled on it.
+The status of the remote build nodes may be queried. The status object will have a field
+`ableToRunJobs` that contains a boolean indicating if the node is able to run jobs. If the
+node is not able to run jobs, the status object will document the issue with running jobs
+on that node.
 
-* NOTE: a value of '-1' for `numCurrentJobs` indicates that the actual number of
-   current jobs on the node was not able to be determined.
+In order to run jobs all of the following conditions must be met:
+
+* The IMS service can ssh to the node.
+* The node architecture must be determined and valid.
+* The `podman` executable must be installed.
 
 (`ncn-mw#`) To check the status of a particular remote build node:
 
@@ -714,14 +717,14 @@ If the node is ready to run jobs, the output will look something like:
 {
   "ableToRunJobs": true,
   "nodeArch": "x86_64",
-  "numCurrentJobs": 0,
+  "numCurrentJobs": 4,
   "podmanStatus": "Podman present at /usr/bin/podman",
   "sshStatus": "SSH connection established.",
   "xname": "x3000c0s3b0n0"
 }
 ```
 
-If the node is not able to run jobs, the output will look something like:
+If IMS is unable to ssh to a node the output may look something like:
 
 ```text
 {
@@ -730,6 +733,32 @@ If the node is not able to run jobs, the output will look something like:
   "numCurrentJobs": -1,
   "podmanStatus": "Unknown",
   "sshStatus": "Unable to connect to node. Error: [Errno -2] Name does not resolve",
+  "xname": "x3000c0s3b0n1"
+}
+```
+
+If IMS is unable to determine the architecture of the node the output may look something like:
+
+```text
+{
+  "ableToRunJobs": false,
+  "nodeArch": "Unable to determine architecture of node.",
+  "numCurrentJobs": -1,
+  "podmanStatus": "Unknown",
+  "sshStatus": "SSH connection established.",
+  "xname": "x3000c0s3b0n1"
+}
+```
+
+If `podman` is not correctly installed the output may look something like:
+
+```text
+{
+  "ableToRunJobs": false,
+  "nodeArch": "x86_64",
+  "numCurrentJobs": -1,
+  "podmanStatus": "Podman not installed on node.",
+  "sshStatus": "SSH connection established.",
   "xname": "x3000c0s3b0n1"
 }
 ```


### PR DESCRIPTION
# Description

Add documentation to the new IMS remote build node status API. This allows users to query the current state of the remote build nodes to verify they are capable of running jobs. This will help the user debug what is going on when jobs fail to start on remote nodes. 

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8979

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

