### PR TITLE
CASMPET-7209 add instructions to mount admin-tools bucket if desired

### DIFF
--- a/operations/utility_storage/Troubleshoot_S3FS_Mounts.md
+++ b/operations/utility_storage/Troubleshoot_S3FS_Mounts.md
@@ -8,9 +8,11 @@ Master nodes should host the following three mount points:
 
 ```bash
 /var/opt/cray/config-data (config-data S3 bucket)
-/var/lib/admin-tools (admin-tools S3 bucket)
 /var/opt/cray/sdu/collection-mount (sds S3 bucket)
 ```
+
+> NOTE: the mount `/var/lib/admin-tools (admin-tools S3 bucket)` is no longer mounted in CSM 1.4+.
+> If it is desired to have this bucket mounted, please see [Mount 'admin-tools' S3 bucket](#mount-admin-tools-s3-bucket).
 
 ## Worker Node Mount Points
 
@@ -31,7 +33,6 @@ Run the following command on master nodes to ensure the mounts are present:
 ```bash
 ncn-m: # mount | grep 's3fs on'
 s3fs on /var/opt/cray/config-data type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
-s3fs on /var/lib/admin-tools type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
 s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
 ```
 
@@ -57,7 +58,6 @@ Ensure the `/etc/fstab` contains the following content:
 ```bash
 ncn-m: # grep fuse.s3fs /etc/fstab
 sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
-admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr 0 0
 config-data /var/opt/cray/config-data fuse.s3fs _netdev,allow_other,passwd_file=/root/.config-data.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_xattr 0 0
 ```
 
@@ -84,3 +84,71 @@ ncn-mw: # mount -a
 
 If the above command fails, then the error likely indicates that there is an issue communicating with Ceph's `Radosgw` endpoint (`rgw-vip`).
 In this case the [Troubleshoot an Unresponsive S3 Endpoint](Troubleshoot_an_Unresponsive_S3_Endpoint.md) procedure should be followed to ensure the endpoint is healthy.
+
+## Mount 'admin-tools' S3 bucket
+
+In CSM 1.2 and CSM 1.3, `/var/lib/admin-tools (admin-tools S3 bucket)` was a mounted S3 bucket. Starting in CSM 1.4, the `admin-tools` S3 bucket is no longer mounted.
+It is not necessary for this bucket to be mounted for system operations.
+However, if it is desired to have the `admin-tools` S3 bucket mounted, please follow the steps below.
+
+  1. (`ncn-m#`) Mount the `admin-tools` S3 bucket. Run this on each master node where the bucket should be mounted.
+
+      ```bash
+      function mount_admin_tools() {
+        s3_bucket="admin-tools"
+        s3fs_mount_dir="/var/lib/admin-tools"
+        s3_user="admin-tools"
+        
+        s3fs_cache_dir=/var/lib/s3fs_cache
+        if [ -d ${s3fs_cache_dir} ]; then
+          s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist,use_xattr"
+        else
+          s3fs_opts="use_path_request_style,use_xattr"
+        fi
+
+        echo "Configuring for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
+
+        mkdir -p ${s3fs_mount_dir}
+
+        pwd_file=/root/.${s3_user}.s3fs
+        access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)
+        secret_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.secret_key' | base64 -d)
+        s3_endpoint=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.http_s3_endpoint' | base64 -d)
+
+        echo "${access_key}:${secret_key}" > ${pwd_file}
+        chmod 600 ${pwd_file}
+
+        echo "Mounting bucket: ${s3_bucket} at ${s3fs_mount_dir}"
+        s3fs ${s3_bucket} ${s3fs_mount_dir} -o passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts}
+
+        echo "Adding fstab entry for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
+        echo "${s3_bucket} ${s3fs_mount_dir} fuse.s3fs _netdev,allow_other,passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts} 0 0" >> /etc/fstab
+
+        echo "Set cache pruning for admin tools to 5G of the 200G volume (every 2nd hour)"
+        echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-admin-tools-cache
+      }
+      mount_admin_tools
+      ```
+
+  1. (`ncn-m#`) Check that the `admin-tools` bucket is mounted correctly.
+
+      1. Check `/etc/fstab` contains the following content:
+
+          ```bash
+          ncn-m: # grep fuse.s3fs /etc/fstab
+          sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
+          admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr 0 0
+          config-data /var/opt/cray/config-data fuse.s3fs _netdev,allow_other,passwd_file=/root/.config-data.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_xattr 0 0
+          ```
+
+      1. Check that `/var/lib/admin-tools` is mounted.
+
+          ```bash
+          ncn-m: # mount | grep 's3fs on'
+          s3fs on /var/opt/cray/config-data type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
+          s3fs on /var/lib/admin-tools type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
+          s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
+          ```
+
+> NOTE: This mount will not be recreated after a node upgrade or rebuild.
+> This procedure will need to be redone in the case of a node upgrade or rebuild.

--- a/operations/utility_storage/Troubleshoot_S3FS_Mounts.md
+++ b/operations/utility_storage/Troubleshoot_S3FS_Mounts.md
@@ -89,66 +89,13 @@ In this case the [Troubleshoot an Unresponsive S3 Endpoint](Troubleshoot_an_Unre
 
 In CSM 1.2 and CSM 1.3, `/var/lib/admin-tools (admin-tools S3 bucket)` was a mounted S3 bucket. Starting in CSM 1.4, the `admin-tools` S3 bucket is no longer mounted.
 It is not necessary for this bucket to be mounted for system operations.
-However, if it is desired to have the `admin-tools` S3 bucket mounted, please follow the steps below.
+However, if it is desired to have the `admin-tools` S3 bucket mounted, please run the following script on all master nodes where the `admin-tools` bucket should be mounted.
 
-  1. (`ncn-m#`) Mount the `admin-tools` S3 bucket. Run this on each master node where the bucket should be mounted.
+(`ncn-m#`) Mount the `admin-tools` S3 bucket.
 
-      ```bash
-      function mount_admin_tools() {
-        s3_bucket="admin-tools"
-        s3fs_mount_dir="/var/lib/admin-tools"
-        s3_user="admin-tools"
-        
-        s3fs_cache_dir=/var/lib/s3fs_cache
-        if [ -d ${s3fs_cache_dir} ]; then
-          s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist,use_xattr"
-        else
-          s3fs_opts="use_path_request_style,use_xattr"
-        fi
-
-        echo "Configuring for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
-
-        mkdir -p ${s3fs_mount_dir}
-
-        pwd_file=/root/.${s3_user}.s3fs
-        access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)
-        secret_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.secret_key' | base64 -d)
-        s3_endpoint=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.http_s3_endpoint' | base64 -d)
-
-        echo "${access_key}:${secret_key}" > ${pwd_file}
-        chmod 600 ${pwd_file}
-
-        echo "Mounting bucket: ${s3_bucket} at ${s3fs_mount_dir}"
-        s3fs ${s3_bucket} ${s3fs_mount_dir} -o passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts}
-
-        echo "Adding fstab entry for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
-        echo "${s3_bucket} ${s3fs_mount_dir} fuse.s3fs _netdev,allow_other,passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts} 0 0" >> /etc/fstab
-
-        echo "Set cache pruning for admin tools to 5G of the 200G volume (every 2nd hour)"
-        echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-admin-tools-cache
-      }
-      mount_admin_tools
-      ```
-
-  1. (`ncn-m#`) Check that the `admin-tools` bucket is mounted correctly.
-
-      1. Check `/etc/fstab` contains the following content:
-
-          ```bash
-          ncn-m: # grep fuse.s3fs /etc/fstab
-          sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
-          admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr 0 0
-          config-data /var/opt/cray/config-data fuse.s3fs _netdev,allow_other,passwd_file=/root/.config-data.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_xattr 0 0
-          ```
-
-      1. Check that `/var/lib/admin-tools` is mounted.
-
-          ```bash
-          ncn-m: # mount | grep 's3fs on'
-          s3fs on /var/opt/cray/config-data type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
-          s3fs on /var/lib/admin-tools type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
-          s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,relatime,user_id=0,group_id=0,allow_other)
-          ```
+  ```bash
+  /usr/share/doc/csm/scripts/mount-admin-tools-bucket.sh
+  ```
 
 > NOTE: This mount will not be recreated after a node upgrade or rebuild.
 > This procedure will need to be redone in the case of a node upgrade or rebuild.

--- a/scripts/mount-admin-tools-bucket.sh
+++ b/scripts/mount-admin-tools-bucket.sh
@@ -20,13 +20,12 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
+set -euo pipefail
 # Mount admin-tools S3 bucket
-s3_bucket="admin-tools"
-s3fs_mount_dir="/var/lib/admin-tools"
-s3_user="admin-tools"
-
-s3fs_cache_dir=/var/lib/s3fs_cache
+s3_bucket="${S3_BUCKET:-admin-tools}"
+s3fs_mount_dir="${S3FS_MOUNT_DIR:-/var/lib/admin-tools}"
+s3_user="${S3_USER:-admin-tools}"
+s3fs_cache_dir="${S3FS_CACHE_DIR:-/var/lib/s3fs_cache}"
 if [ -d ${s3fs_cache_dir} ]; then
   s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist,use_xattr"
 else
@@ -35,12 +34,28 @@ fi
 
 echo "Configuring for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
 
-mkdir -p ${s3fs_mount_dir}
+if [ ! -d "${s3fs_mount_dir}" ]; then
+  mkdir -pv "${s3fs_mount_dir}"
+fi
 
-pwd_file=/root/.${s3_user}.s3fs
-access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)
-secret_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.secret_key' | base64 -d)
-s3_endpoint=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.http_s3_endpoint' | base64 -d)
+pwd_file="/root/.${s3_user}.s3fs"
+secret_name="${s3_user}-s3-credentials"
+s3_user_credentials="$(
+  if ! kubectl get secret "$secret_name" -o json 2>/dev/null | jq -r '.data' 2>/dev/null; then
+    echo >&2 "Failed to obtain credential data for user: [$s3_user]"
+  fi
+)"
+if [ -z "$s3_user_credentials" ]; then
+  echo "Exiting."
+  exit 1
+fi
+access_key="$(jq -n -r --argjson s3_user_credentials "$s3_user_credentials" '$s3_user_credentials.access_key' | base64 -d)"
+secret_key="$(jq -n -r --argjson s3_user_credentials "$s3_user_credentials" '$s3_user_credentials.secret_key' | base64 -d)"
+s3_endpoint="$(jq -n -r --argjson s3_user_credentials "$s3_user_credentials" '$s3_user_credentials.http_s3_endpoint' | base64 -d)"
+if [ "$access_key" = 'null' ] || [ "$secret_key" = 'null' ] || [ "$s3_endpoint" = 'null' ]; then
+  echo >&2 "Failed to find access_key, secret_key, or http_s3_endpoint for [$s3_user]"
+  exit 1
+fi
 
 echo "${access_key}:${secret_key}" > ${pwd_file}
 chmod 600 ${pwd_file}
@@ -49,23 +64,23 @@ echo "Mounting bucket: ${s3_bucket} at ${s3fs_mount_dir}"
 s3fs ${s3_bucket} ${s3fs_mount_dir} -o passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts}
 
 echo "Adding fstab entry for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
-if [[ -z $(cat /etc/fstab | grep "admin-tools" | grep "fuse.s3fs") ]]; then
+if grep "${s3_bucket}" /etc/fstab | grep -q "fuse.s3fs"; then
   echo "${s3_bucket} ${s3fs_mount_dir} fuse.s3fs _netdev,allow_other,passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts} 0 0" >> /etc/fstab
 else
   echo "An entry in /etc/fstab already exists for ${s3_bucket} ${s3fs_mount_dir} fuse.s3fs"
 fi
 
 echo "Set cache pruning for admin tools to 5G of the 200G volume (every 2nd hour)"
-echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-admin-tools-cache
+echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh ${s3_bucket} ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-${s3_bucket}-cache
 
-echo -e "Done mounting admin-tools S3 bucket\n"
+echo -e "Done mounting ${s3_bucket} S3 bucket\n"
 
 # Validate admin-tools S3 bucket has been mounted
 
 echo "/etc/fstab has the following content:"
 grep fuse.s3fs /etc/fstab
 exit_code=0
-if [[ -n $(cat /etc/fstab | grep "admin-tools" | grep "fuse.s3fs") ]]; then
+if grep "$s3_bucket" /etc/fstab | grep -q "fuse.s3fs"; then
   echo -e "admin-tools was successfully added to /etc/fstab\n"
 else
   echo -e "Error: admin-tools fuse.s3fs mount was not added to the /etc/fstab file\n"
@@ -73,14 +88,16 @@ else
 fi
 echo "The following s3fs mounts exist:"
 mount | grep 's3fs on'
-if [[ -n $(mount | grep 's3fs on /var/lib/admin-tools') ]]; then
-  echo -e "/var/lib/admin-tools is a s3fs mount\n"
+if mount | grep -q 's3fs on '"$s3fs_mount_dir"'; then
+  echo -e "$s3fs_mount_dir is an s3fs mount\n"
 else
-  echo -e "Error: /var/lib/admin-tools is not a s3fs mount.\n"
+  echo -e "Error: ${s3fs_mount_dir} is not an s3fs mount.\n"
   exit_code=1
 fi
 
-if [[ $exit_code == 0 ]]; then
-  echo "Successfully mounted admin-tools bucket"
+if [ "$exit_code" -eq 0 ]; then
+  echo "Successfully mounted ${s3_bucket} bucket"
+else
+  echo "Errors encountered. Please review script output."
 fi
 exit $exit_code

--- a/scripts/mount-admin-tools-bucket.sh
+++ b/scripts/mount-admin-tools-bucket.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Mount admin-tools S3 bucket
+s3_bucket="admin-tools"
+s3fs_mount_dir="/var/lib/admin-tools"
+s3_user="admin-tools"
+
+s3fs_cache_dir=/var/lib/s3fs_cache
+if [ -d ${s3fs_cache_dir} ]; then
+  s3fs_opts="use_path_request_style,use_cache=${s3fs_cache_dir},check_cache_dir_exist,use_xattr"
+else
+  s3fs_opts="use_path_request_style,use_xattr"
+fi
+
+echo "Configuring for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
+
+mkdir -p ${s3fs_mount_dir}
+
+pwd_file=/root/.${s3_user}.s3fs
+access_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.access_key' | base64 -d)
+secret_key=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.secret_key' | base64 -d)
+s3_endpoint=$(kubectl get secret ${s3_user}-s3-credentials -o json | jq -r '.data.http_s3_endpoint' | base64 -d)
+
+echo "${access_key}:${secret_key}" > ${pwd_file}
+chmod 600 ${pwd_file}
+
+echo "Mounting bucket: ${s3_bucket} at ${s3fs_mount_dir}"
+s3fs ${s3_bucket} ${s3fs_mount_dir} -o passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts}
+
+echo "Adding fstab entry for ${s3_bucket} S3 bucket at ${s3fs_mount_dir} for ${s3_user} S3 user"
+if [[ -z $(cat /etc/fstab | grep "admin-tools" | grep "fuse.s3fs") ]]; then
+  echo "${s3_bucket} ${s3fs_mount_dir} fuse.s3fs _netdev,allow_other,passwd_file=${pwd_file},url=${s3_endpoint},${s3fs_opts} 0 0" >> /etc/fstab
+else
+  echo "An entry in /etc/fstab already exists for ${s3_bucket} ${s3fs_mount_dir} fuse.s3fs"
+fi
+
+echo "Set cache pruning for admin tools to 5G of the 200G volume (every 2nd hour)"
+echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh admin-tools ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-admin-tools-cache
+
+echo -e "Done mounting admin-tools S3 bucket\n"
+
+# Validate admin-tools S3 bucket has been mounted
+
+echo "/etc/fstab has the following content:"
+grep fuse.s3fs /etc/fstab
+exit_code=0
+if [[ -n $(cat /etc/fstab | grep "admin-tools" | grep "fuse.s3fs") ]]; then
+  echo -e "admin-tools was successfully added to /etc/fstab\n"
+else
+  echo -e "Error: admin-tools fuse.s3fs mount was not added to the /etc/fstab file\n"
+  exit_code=1
+fi
+echo "The following s3fs mounts exist:"
+mount | grep 's3fs on'
+if [[ -n $(mount | grep 's3fs on /var/lib/admin-tools') ]]; then
+  echo -e "/var/lib/admin-tools is a s3fs mount\n"
+else
+  echo -e "Error: /var/lib/admin-tools is not a s3fs mount.\n"
+  exit_code=1
+fi
+
+if [[ $exit_code == 0 ]]; then
+  echo "Successfully mounted admin-tools bucket"
+fi
+exit $exit_code

--- a/scripts/mount-admin-tools-bucket.sh
+++ b/scripts/mount-admin-tools-bucket.sh
@@ -70,20 +70,20 @@ else
   echo "An entry in /etc/fstab already exists for ${s3_bucket} ${s3fs_mount_dir} fuse.s3fs"
 fi
 
-echo "Set cache pruning for admin tools to 5G of the 200G volume (every 2nd hour)"
+echo "Set cache pruning for s3_bucket to 5G of the 200G volume (every 2nd hour)"
 echo "0 */2 * * * root /usr/bin/prune-s3fs-cache.sh ${s3_bucket} ${s3fs_cache_dir} 5368709120 -silent" > /etc/cron.d/prune-s3fs-${s3_bucket}-cache
 
 echo -e "Done mounting ${s3_bucket} S3 bucket\n"
 
-# Validate admin-tools S3 bucket has been mounted
+# Validate S3 bucket has been mounted
 
 echo "/etc/fstab has the following content:"
 grep fuse.s3fs /etc/fstab
 exit_code=0
 if grep "$s3_bucket" /etc/fstab | grep -q "fuse.s3fs"; then
-  echo -e "admin-tools was successfully added to /etc/fstab\n"
+  echo -e "${s3_bucket} was successfully added to /etc/fstab\n"
 else
-  echo -e "Error: admin-tools fuse.s3fs mount was not added to the /etc/fstab file\n"
+  echo -e "Error: ${s3_bucket} fuse.s3fs mount was not added to the /etc/fstab file\n"
   exit_code=1
 fi
 echo "The following s3fs mounts exist:"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In CSM 1.2 and CSM 1.3, the admin-tools s3 bucket was mounted. In CSM 1.4+, this bucket is no longer mounted. This PR updates documentation so that the admin-tools bucket can be manually mounted if desired.
 
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Tested 3 different test cases.
1. Admin-tools bucket was not mounted and no entry was in /etc/fstab.

    ```shell
    Configuring for admin-tools S3 bucket at /var/lib/admin-tools for admin-tools S3 user
    Mounting bucket: admin-tools at /var/lib/admin-tools
    Adding fstab entry for admin-tools S3 bucket at /var/lib/admin-tools for admin-tools S3 user
    Set cache pruning for admin-tools to 5G of the 200G volume (every 2nd hour)
    Done mounting admin-tools S3 bucket
    
    /etc/fstab has the following content:
    sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
    config-data /var/opt/cray/config-data fuse.s3fs _netdev,allow_other,passwd_file=/root/.config-data.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_xattr 0 0
    admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr 0 0
    admin-tools was successfully added to /etc/fstab
    
    The following s3fs mounts exist:
    s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
    s3fs on /var/opt/cray/config-data type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
    s3fs on /var/lib/admin-tools type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
    /var/lib/admin-tools is an s3fs mount
    
    Successfully mounted admin-tools bucket
    ``` 

2. Admin-tools bucket was already mounted

    ```shell
    ncn-m001:~/leliasen # ./mount-admin-tools-bucket.sh
    Configuring for admin-tools S3 bucket at /var/lib/admin-tools for admin-tools S3 user
    Mounting bucket: admin-tools at /var/lib/admin-tools
    s3fs: MOUNTPOINT directory /var/lib/admin-tools is not empty. if you are sure this is safe, can use the 'nonempty' mount option.
    Error: Check that admin-tools is not already mounted and /var/lib/admin-tools is empty.
    ncn-m001:~/leliasen # echo $?
    1
    ```

3. Admin-tools bucket was not mounted but and entry already existed in /etc/fstab

    ```shell
    ncn-m001:~/leliasen # ./mount-admin-tools-bucket.sh
    Configuring for admin-tools S3 bucket at /var/lib/admin-tools for admin-tools S3 user
    Mounting bucket: admin-tools at /var/lib/admin-tools
    Adding fstab entry for admin-tools S3 bucket at /var/lib/admin-tools for admin-tools S3 user
    An entry in /etc/fstab already exists for admin-tools /var/lib/admin-tools fuse.s3fs
    Set cache pruning for admin-tools to 5G of the 200G volume (every 2nd hour)
    Done mounting admin-tools S3 bucket
    
    /etc/fstab has the following content:
    sds /var/opt/cray/sdu/collection-mount fuse.s3fs _netdev,allow_other,passwd_file=/root/.sds.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr,uid=2370,gid=2370,umask=0007,allow_other 0 0
    config-data /var/opt/cray/config-data fuse.s3fs _netdev,allow_other,passwd_file=/root/.config-data.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_xattr 0 0
    admin-tools /var/lib/admin-tools fuse.s3fs _netdev,allow_other,passwd_file=/root/.admin-tools.s3fs,url=http://rgw-vip.nmn,use_path_request_style,use_cache=/var/lib/s3fs_cache,check_cache_dir_exist,use_xattr 0 0
    admin-tools was successfully added to /etc/fstab
    
    The following s3fs mounts exist:
    s3fs on /var/opt/cray/sdu/collection-mount type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
    s3fs on /var/opt/cray/config-data type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
    s3fs on /var/lib/admin-tools type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)
    /var/lib/admin-tools is an s3fs mount
    
    Successfully mounted admin-tools bucket
    ```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
