### PR TITLE
CASMINST-6988: DR scripts: Extend timeouts

### DIFF
--- a/scripts/operations/configuration/copy_ims_data_from_minio.py
+++ b/scripts/operations/configuration/copy_ims_data_from_minio.py
@@ -190,7 +190,7 @@ class DestinationDirectory:
             include_args.extend(["--include", art.path])
         logging.info("Copying selected artifacts from minio to '%s'", self.path)
         run_aws_s3_cmd("sync", f"s3://cms/{folder_name}", self.path, "--exclude", "*",
-                       *include_args, num_retries=5, timeout=7200)
+                       *include_args, num_retries=5, timeout=14400)
         if self.is_main_dir:
             return
         logging.info("Creating symbolic links in main export directory to files under '%s'",

--- a/scripts/operations/configuration/python_lib/ims_import_export/s3_helper.py
+++ b/scripts/operations/configuration/python_lib/ims_import_export/s3_helper.py
@@ -64,7 +64,7 @@ class S3TransferResult(NamedTuple):
 
 def do_s3_upload(transfer_request: S3TransferRequest) -> JsonDict:
     logging.info("Starting S3 upload of %s", transfer_request.url)
-    return create_artifact(transfer_request.url, transfer_request.filepath, num_retries=3, timeout=1800)
+    return create_artifact(transfer_request.url, transfer_request.filepath, num_retries=5, timeout=1800)
 
 
 def do_s3_download(transfer_request: S3TransferRequest) -> None:

--- a/scripts/operations/configuration/python_lib/ims_import_export/s3_helper.py
+++ b/scripts/operations/configuration/python_lib/ims_import_export/s3_helper.py
@@ -64,12 +64,12 @@ class S3TransferResult(NamedTuple):
 
 def do_s3_upload(transfer_request: S3TransferRequest) -> JsonDict:
     logging.info("Starting S3 upload of %s", transfer_request.url)
-    return create_artifact(transfer_request.url, transfer_request.filepath, num_retries=3, timeout=1200)
+    return create_artifact(transfer_request.url, transfer_request.filepath, num_retries=3, timeout=1800)
 
 
 def do_s3_download(transfer_request: S3TransferRequest) -> None:
     logging.info("Starting S3 download of %s", transfer_request.url)
-    get_artifact(transfer_request.url, transfer_request.filepath, num_retries=3, timeout=1200)
+    get_artifact(transfer_request.url, transfer_request.filepath, num_retries=3, timeout=1800)
 
 
 def s3_transfer_worker(do_transfer: Callable,


### PR DESCRIPTION
Based on additional DR runs at UKMet, this extends the timeouts for some DR script operations.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/5328
1.6: https://github.com/Cray-HPE/docs-csm/pull/5329
