### PR TITLE
CRAYSAT-1893: Doc update on timeout for bos-operations stage

### DIFF
--- a/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
@@ -113,7 +113,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
 1. (`ncn-m001#`) Use `sat bootsys boot` to power on and boot the managed nodes.
 
     **Important:** No default timeout is set for `sat bootsys boot --stage bos-operations`. It is infinite.
-    However, if a specific timeout is required, user can still set a custom value using the
+    However, if a specific timeout is required, a user can still set a custom value using the
     `--bos-boot-timeout BOS_BOOT_TIMEOUT` option. If a custom timeout is set, `sat` will no longer watch the BOS sessions
     once the timeout has been exceeded even if the sessions are still in progress.
 

--- a/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
@@ -112,10 +112,10 @@ This procedure boots all managed nodes in the context of a full system power-up.
 
 1. (`ncn-m001#`) Use `sat bootsys boot` to power on and boot the managed nodes.
 
-    **Important:** The default timeout for the `sat bootsys boot --stage bos-operations` command is 900 seconds.
-    If it is known that the nodes take longer than this amount of time to boot, then a different value
-    can be set using `--bos-boot-timeout BOS_BOOT_TIMEOUT` with a value larger than 900 for `BOS_BOOT_TIMEOUT`. Once
-    this timeout has been exceeded, `sat` will no longer watch the BOS sessions even if they are still in progress.
+    **Important:** No default timeout is set for `sat bootsys boot --stage bos-operations`. It is infinite.
+    However, if a specific timeout is required, user can still set a custom value using the
+    `--bos-boot-timeout BOS_BOOT_TIMEOUT` option. If a custom timeout is set, `sat` will no longer watch the BOS sessions
+    once the timeout has been exceeded even if the sessions are still in progress.
 
     After this step there are several commands that can be used in other windows from where the `sat bootsys boot --stage bos-operations`
     command has been run to monitor the status of the booting process as nodes move through the phases of powering on, booting Linux,

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -27,10 +27,10 @@ The BOS session templates to use for shutting down all managed nodes in the syst
 
    An optional `--loglevel debug` can be used to provide more information as the system shuts down. If used, it must be added after `sat` but before `bootsys`.
 
-   **Important:** The default timeout for the `sat bootsys boot --stage bos-operations` command is 600 seconds. If it is known that
-   the nodes take longer than this amount of time to shutdown, then a different value can be set using `--bos-shutdown-timeout BOS_SHUTDOWN_TIMEOUT`
-   with a value larger than 600 for `BOS_SHUTDOWN_TIMEOUT`. Once this timeout has been exceeded, `sat` will no longer watch the BOS sessions
-   even if they are still in progress.
+   **Important:** No default timeout is set for `sat bootsys shutdown --stage bos-operations`. It is infinite.
+   However, if a specific timeout is required, user can still set a custom value using the
+   `--bos-shutdown-timeout BOS_SHUTDOWN_TIMEOUT` option. If a custom timeout is set, `sat` will no longer watch the
+   BOS sessions once the timeout has been exceeded even if the sessions are still in progress.
 
    ```bash
    sat bootsys shutdown --stage bos-operations --bos-shutdown-timeout BOS_SHUTDOWN_TIMEOUT \

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -28,7 +28,7 @@ The BOS session templates to use for shutting down all managed nodes in the syst
    An optional `--loglevel debug` can be used to provide more information as the system shuts down. If used, it must be added after `sat` but before `bootsys`.
 
    **Important:** No default timeout is set for `sat bootsys shutdown --stage bos-operations`. It is infinite.
-   However, if a specific timeout is required, user can still set a custom value using the
+   However, if a specific timeout is required, a user can still set a custom value using the
    `--bos-shutdown-timeout BOS_SHUTDOWN_TIMEOUT` option. If a custom timeout is set, `sat` will no longer watch the
    BOS sessions once the timeout has been exceeded even if the sessions are still in progress.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.
--->
# Description
Changed `sat bootsys` to enable default timeouts to infinite for `--bos-operations` stage to boot, shutdown, and reboot.
It will continue waiting until the BOS session is completed.
Also allow to specify an alternate timeout for BOS operations, if desired.

Relates to:

- https://github.com/Cray-HPE/sat/pull/259

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
