### PR TITLE
CASMCMS-9128: Updates to reflect recent BOS changes

### DIFF
--- a/operations/boot_orchestration/Session_Templates.md
+++ b/operations/boot_orchestration/Session_Templates.md
@@ -162,9 +162,13 @@ root=<Protocol>:<Root FS location>:<Etag>:<RootFS-provider-passthrough parameter
 ```
 
 BOS fills in the protocol based on the value provided in `rootfs_provider`. If BOS does not know the `rootfs_provider`, then it omits the protocol field.
-Currently, BOS only recognizes the `rootfs_provider` `cpss3`.
-BOS finds the `rootfs_provider` and `Etag` values in the manifest file in the session template in the boot set.
+BOS finds the `rootfs_provider` and `etag` values in the manifest file in the session template in the boot set.
 The `rootfs_provider_passthrough` parameters are appended to the `root` parameter without modification. They are "passed through", as the name implies.
+
+Currently, the only `rootfs` providers that BOS recognizes are `cpss3` and `sbps`.
+
+* For more information on `cpss3`, see [Create a Session Template to Boot Compute Nodes with CPS](Create_a_Session_Template_to_Boot_Compute_Nodes_with_CPS.md).
+* For more information on `sbps`, see [Create a Session Template to Boot Compute Nodes with SBPS](Create_a_Session_Template_to_Boot_Compute_Nodes_with_SBPS.md).
 
 #### `root` kernel parameter example
 

--- a/operations/boot_orchestration/Session_Templates.md
+++ b/operations/boot_orchestration/Session_Templates.md
@@ -182,7 +182,7 @@ The following table explains the different pieces in the preceding example.
 |------------------------------------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | Protocol                                 | `craycps-s3`                                                   | The protocol used to mount the root file system, using CPS in this example.                                             |
 | `rootfs_provider` location               | `s3://boot-images/b9caaf66-c0b4-4231-aba7-a45f6282b21d/rootfs` | The `rootfs_provider` location is a SquashFS image stored in S3.                                                        |
-| `Etag`                                   | `f040d70bd6fabaf91838fe4e484563cf-211`                         | The `Etag` (entity tag) is the identifier of the SquashFS image in S3.                                                  |
+| `etag`                                   | `f040d70bd6fabaf91838fe4e484563cf-211`                         | The `Etag` (entity tag) is the identifier of the SquashFS image in S3.                                                  |
 | `rootfs_provider` passthrough parameters | `dvs:api-gw-service-nmn.local:300:nmn0`                        | These are additional parameters passed through to CPS in this example, which it uses to properly mount the file system. |
 
 The `rootfs_provider_passthrough` parameters are explained in the following table.

--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -350,8 +350,6 @@ image that is installed with CSM. This image may be used to boot multiple remote
                     "etag": "<REMOTE_IMS_NODE_IMAGE_ETAG>",
                     "arch": "<REMOTE_NODE_ARCH>",
                     "path": "s3://boot-images/<REMOTE_IMS_NODE_IMAGE_ID>/manifest.json",
-                    "rootfs_provider": "",
-                    "rootfs_provider_passthrough": "",
                     "type": "s3"
                 }
             }
@@ -380,8 +378,6 @@ image that is installed with CSM. This image may be used to boot multiple remote
                         "Compute"
                     ],
                     "path": "s3://boot-images/f6d9cfc7-9291-4c46-8350-c252b919d396/manifest.json",
-                    "rootfs_provider": "",
-                    "rootfs_provider_passthrough": "",
                     "type": "s3"
                 }
             },
@@ -731,12 +727,12 @@ In order to run jobs all of the following conditions must be met:
 (`ncn-mw#`) To check the status of a particular remote build node:
 
 ```bash
-cray ims remote-build-nodes status describe "${IMS_REMOTE_NODE_XNAME}"
+cray ims remote-build-nodes status describe "${IMS_REMOTE_NODE_XNAME}" --format json
 ```
 
 If the node is ready to run jobs, the output will look something like:
 
-```text
+```json
 {
   "ableToRunJobs": true,
   "nodeArch": "x86_64",
@@ -749,7 +745,7 @@ If the node is ready to run jobs, the output will look something like:
 
 If IMS is unable to SSH to a node the output may look something like:
 
-```text
+```json
 {
   "ableToRunJobs": false,
   "nodeArch": "Unknown",
@@ -762,7 +758,7 @@ If IMS is unable to SSH to a node the output may look something like:
 
 If IMS is unable to determine the architecture of the node the output may look something like:
 
-```text
+```json
 {
   "ableToRunJobs": false,
   "nodeArch": "Unable to determine architecture of node.",
@@ -775,7 +771,7 @@ If IMS is unable to determine the architecture of the node the output may look s
 
 If `podman` is not correctly installed the output may look something like:
 
-```text
+```json
 {
   "ableToRunJobs": false,
   "nodeArch": "x86_64",
@@ -786,15 +782,15 @@ If `podman` is not correctly installed the output may look something like:
 }
 ```
 
-(`ncn-m-w#`) To check the status of all defined remote build nodes:
+(`ncn-mw#`) To check the status of all defined remote build nodes:
 
 ```bash
-cray ims remote-build-nodes status list
+cray ims remote-build-nodes status list --format json
 ```
 
 The output will look something like:
 
-```text
+```json
 [
   {
     "ableToRunJobs": true,

--- a/operations/power_management/Set_the_Turbo_Boost_Limit.md
+++ b/operations/power_management/Set_the_Turbo_Boost_Limit.md
@@ -39,8 +39,8 @@ Modify the Boot Orchestration Service \(BOS\) template for the nodes. This examp
       "node_roles_groups": [
         "compute"
       ],
-      "rootfs_provider": "",
-      "rootfs_provider_passthrough": ""
+      "rootfs_provider": "cpss3",
+      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0"
     },
   },
   "cfs": {


### PR DESCRIPTION
* This corrects a procedure that no longer works due to BOS changes in CSM 1.6.
* It also updates an old BOS example to reflect the same change.
* It updates the BOS session template page to account for the added support for `sbbs` as a `rootfs` provider.
* And obviously I always throw in some linting

Some of these changes will be backported. The changes made in the first two examples work equally well for prior BOS versions, so it'll be simpler to keep the docs consistent.

Backports:
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/5348
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/5349
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/5350
* 1.2: https://github.com/Cray-HPE/docs-csm/pull/5351
* 1.0: https://github.com/Cray-HPE/docs-csm/pull/5352