### PR TITLE
CASMTRIAGE-6849 - Update to EPO Recovery Docs

### DIFF
--- a/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -26,22 +26,17 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
 
 3. Check the Chassis Controller Module \(CCM\) log for `Critical` messages and the EPO event.
 
-    A cabinet has eight chassis.
-
     ```bash
-    kubectl logs -n services -l app.kubernetes.io/name=cray-capmc \
-    -c cray-capmc --tail -1 | grep EPO -A 10
+    ssh x9000c1b0 egrep \"Critical\|= No\" /var/log/messages
     ```
 
     Example output:
 
     ```text
-    2019/10/24 02:37:30 capmcd.go:805: Message: Can not issue Enclosure Chassis.Reset 'On'|'Off' while in EPO state
-    2019/10/24 02:37:30 capmcd.go:808: ExtendedInfo.Message: Can not issue Enclosure Chassis.Reset 'On'|'Off' while in EPO state
-    2019/10/24 02:37:30 capmcd.go:809: ExtendedInfo.Resolution: Verify physical hardware, issue Enclosure Chassis.Reset --> 'ForceOff', and resubmit the request
-    2019/10/24 02:37:31 capmcd.go:136: Info: <-- Bad Request (400) POST https://x1000c7b0/redfish/v1/ Chassis/Enclosure/Actions/Chassis.Reset (1.045967005s)
-    2019/10/24 02:37:31 capmcd.go:799: POST https://x1000c7b0/redfish/v1/Chassis/Enclosure/Actions/Chassis.Reset
-    !HTTP Error!
+    Apr 8 03:47:55 x9000c1 user.info redfish-cmmd[4453]: do_cmm_enclosure_reset_forceoff: Handling Enclosure (Force)Off request: clearing EPO = No
+    Apr 8 03:47:55 x9000c1 user.info redfish-cmmd[4453]: rbe_set_chassis_status: Update Chassis 'Enclosure' Status: UnavailableOffline, Critical
+    Apr 11 04:00:06 x9000c1 user.info redfish-cmmd[4453]: do_cmm_enclosure_reset_forceoff: Handling Enclosure (Force)Off request: clearing EPO = No
+    Apr 11 04:00:06 x9000c1 user.info redfish-cmmd[4453]: rbe_set_chassis_status: Update Chassis 'Enclosure' Status: UnavailableOffline, Critical
     ```
 
 4. Disable the hms-discovery Kubernetes cron job.
@@ -100,7 +95,7 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
     err_msg = ""
     ```
 
-7. Bring up the Slingshot Fabric.
+7. Verify the Slingshot Fabric.
     Refer to the following documentation for more information on how to bring up the Slingshot Fabric:
     * The *Slingshot Administration Guide* PDF for HPE Cray EX systems.
     * The *Slingshot Troubleshooting Guide* PDF.


### PR DESCRIPTION
# Description
Update to Docs v1.4 for Recover from a Liquid Cooled Cabinet EPO Event
Docs for v1.5 / v1.6 have already been updated and CAPMC changed to PCS

Relates to:
- CASMTRIAGE -6849

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
