### PR TITLE
CASMTRIAGE-7260: skip checking cray-dvs-mqtt-ss rollout status

### DIFF
--- a/upgrade/scripts/upgrade/rollout-restart.sh
+++ b/upgrade/scripts/upgrade/rollout-restart.sh
@@ -182,6 +182,11 @@ restart_and_check_status() {
     resource_type=$(echo "$resource" | cut -d'/' -f1)
     resource_name=$(echo "$resource" | cut -d'/' -f2)
 
+    if [ "$resource_name" = "cray-dvs-mqtt-ss" ]; then
+      # CASMTRIAGE-7260: skip it as its second replicaSet will stay in the "1/2 Running" state (instead of "2/2 Running")
+      continue
+    fi
+
     resolved_resource=$(resolve_deployment "$resource_type" "$resource_name")
     if [[ $? -eq 0 ]]; then
       echo "Checking rollout status for $resolved_resource in namespace: $namespace"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
After restarting all deployments during CSM 1.6 upgrade, we should skip checking rollout status of cray-dvs-mqtt-ss StatefulSet, as its second replicaSet will stay in the 1/2 Running state instead of the 2/2 Running state. This PR adds the logic to handle this special case.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
