### PR TITLE
CASMPET-7224: remove unnecessary checking of some kubelet certs

### DIFF
--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -53,7 +53,7 @@ Services (master nodes):
 Client (master and worker nodes):
 
 ```text
-/var/lib/kubelet/pki/kubelet-client-2021-09-07-17-06-36.pem
+/var/lib/kubelet/pki/kubelet-client-<date-time>.pem
 /var/lib/kubelet/pki/kubelet-client-current.pem
 /var/lib/kubelet/pki/kubelet.crt
 /var/lib/kubelet/pki/kubelet.key
@@ -250,7 +250,7 @@ Run the following steps on each master node.
    ***This task is for each master node and below example checks each certificate in [File Locations](#file-locations).***
 
    ```bash
-   for i in $(ls /etc/kubernetes/pki/*.crt;ls /etc/kubernetes/pki/etcd/*.crt;ls /var/lib/kubelet/pki/*.crt;ls /var/lib/kubelet/pki/*.pem);do echo ${i}; openssl x509 -enddate -noout -in ${i};done
+   for i in $(ls /etc/kubernetes/pki/*.crt;ls /etc/kubernetes/pki/etcd/*.crt;ls /var/lib/kubelet/pki/kubelet-client-current.pem);do echo ${i}; openssl x509 -enddate -noout -in ${i};done
    ```
 
    Example output:
@@ -276,10 +276,6 @@ Run the following steps on each master node.
    notAfter=Sep 22 17:13:29 2022 GMT
    /etc/kubernetes/pki/etcd/server.crt
    notAfter=Sep 22 17:13:29 2022 GMT
-   /var/lib/kubelet/pki/kubelet.crt
-   notAfter=Sep 21 19:50:16 2022 GMT
-   /var/lib/kubelet/pki/kubelet-client-2021-09-07-17-06-36.pem
-   notAfter=Sep  4 17:01:38 2022 GMT
    /var/lib/kubelet/pki/kubelet-client-current.pem
    notAfter=Sep  4 17:01:38 2022 GMT
    ```
@@ -428,9 +424,10 @@ Repeat the above step on every master node.
         kubeadm init phase kubelet-finalize all --cert-dir /var/lib/kubelet/pki/ && echo OK
    ```
 
-5. Check the expiration of the `kubectl` certificate files. See [File Locations](#file-locations) for the list of files.
+5. Check the expiration of the `kubelet` certificate files. See [File Locations](#file-locations) for the list of files.
 
    **This task is for each master and worker node. The example checks each `kubelet` certificate in [File Locations](#file-locations).**
+   **`NOTE`** As long as the `kubelet-client-current.pem` certificate is current, expiration dates for other `kubelet` certificates can be ignored.
 
    ```bash
    for i in $(ls /var/lib/kubelet/pki/*.crt;ls /var/lib/kubelet/pki/*.pem);do echo ${i}; openssl x509 -enddate -noout -in ${i};done


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When checking expiration dates of kubelet certs, not all kubelet certs need to be current. Once kubelet certificate is rotated, /var/lib/kubelet/pki/kubelet.crt is no longer used; instead the symbolic link /var/lib/kubelet/pki/kubelet-client-current.pem is used and points to the latest rotated certificate. Only cert in kubelet-client-current.pem file needs to be current. This PR fixes the doc issue.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
