### PR TITLE
CASM-4855 Make image signature validation rules customizable

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -489,7 +489,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     # NOTE:  There are currently no sealed secrets being added so we are skipping the sealed secrets steps
 
     cp "${CUSTOMIZATIONS_YAML}" "${CUSTOMIZATIONS_YAML}.bak"
-    . "${locOfScript}/util/update-customizations.sh" -i "${CUSTOMIZATIONS_YAML}"
+    . "${locOfScript}/util/update-customizations.sh" -i "${CUSTOMIZATIONS_YAML}" "${CSM_ARTI_DIR}/shasta-cfg/customizations.yaml"
 
     # rename customizations file so k8s secret name stays the same
     cp "${CUSTOMIZATIONS_YAML}" customizations.yaml


### PR DESCRIPTION
# Description
Currently, [`customizations.yaml`](https://github.com/Cray-HPE/shasta-cfg/blob/release/1.6/customizations.yaml) file used during fresh install is completely ignored during upgrades. Instead, customizations are inherited from `site-init` secret on live system, and massaged with [`update-customizations.sh`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/upgrade/scripts/upgrade/util/update-customizations.sh) script. This change adds `customization.yaml` from upgrade tarball as 2nd parameter to `update-customizations.sh` script - so that this script can import parts of new customizations selectively.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
