### PR TITLE
CASM-4860 Add a Note to check latest version of docs-csm is installed or not, if Upgrading CSM manually

### DIFF
--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -39,7 +39,7 @@ This section defines environment variables and directory content that is used th
    [latest version of `docs-csm`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
     is installed for the target CSM version being installed or upgraded.
 
-    **`NOTE`** This subsection is optional and can be skipped if upgrading CSM through IUF.
+    **`NOTE`** When using IUF to upgrade CSM, please skip this subsection.
 
     For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install `docs-csm-1.5.1.noarch`
 

--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -39,6 +39,8 @@ This section defines environment variables and directory content that is used th
    [latest version of `docs-csm`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
     is installed for the target CSM version being installed or upgraded.
 
+    **`NOTE`** This subsection is optional and can be skipped if upgrading CSM through IUF.
+
     For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install `docs-csm-1.5.1.noarch`
 
 ## 2. Use of `iuf activity`

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -31,7 +31,7 @@ Refer to that table and any corresponding product documents before continuing to
     iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -e pre-install-check
     ```
 
-> **`IMPORTANT`*** Ensure that the `docs-csm-latest.noarch.rpm` and `libcsm-latest.noarch.rpm` are available at path `/root/<rpm>` before executing the above command.
+> **`IMPORTANT`*** If Upgrading CSM manually , Ensure that the `docs-csm-latest.noarch.rpm` and `libcsm-latest.noarch.rpm` are available at path `/root/<rpm>` before executing the above command.
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -31,7 +31,7 @@ Refer to that table and any corresponding product documents before continuing to
     iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -e pre-install-check
     ```
 
-> **`IMPORTANT`*** If Upgrading CSM manually , Ensure that the `docs-csm-latest.noarch.rpm` and `libcsm-latest.noarch.rpm` are available at path `/root/<rpm>` before executing the above command.
+> **`IMPORTANT`*** If upgrading CSM manually, ensure that the `docs-csm-latest.noarch.rpm` and `libcsm-latest.noarch.rpm` RPMs are available at path `/root/<rpm>` before executing the above command.
 
 Once this step has completed:
 


### PR DESCRIPTION
# Description

CSM Upgrade through IUF: Documentation

Add a Note to check latest version of docs-csm is installed or not .Only Upgrading CSM manually

Resolves  :

[CASM-4860](https://jira-pro.it.hpe.com:8443/browse/CASM-4860) Add a Note to check latest version of docs-csm is installed or not , if Upgrading CSM manually


# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
