### PR TITLE
CASMTRIAGE-7294 upgrade cert-manager in prerequisites.sh if cray-drydock is not on the correct version

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -760,15 +760,26 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     # This will only be the case in some CSM 1.6 to CSM 1.6 upgrades.
     # It only needs to be checked if cert-manager is not already being upgraded.
     if [ "${needs_upgrade}" -eq 0 ]; then
-      drydock_vers=$(helm get metadata -n loftsman cray-drydock -o json | jq -r '.version')
+      drydock_vers=$(helm get values -n loftsman cray-drydock | grep version: | sed 's/ *version: //')
       major=2
       minor=18
       patch=4
-      if [[ $(echo "$drydock_vers" | cut -d. -f1) -eq $major ]] && [[ $(echo "$drydock_vers" | cut -d. -f2) -eq $minor ]] && [[ $(echo "$drydock_vers" | cut -d. -f3) -lt $patch ]]; then
-        ((needs_upgrade += 1))
-        echo "Cray-drydock version: $drydock_vers is installed and needs to be upgraded. Cray-drydock will be upgraded and the cert-manager namespace will be redeployed."
+      drydock_major="${drydock_vers%%.*}"
+      drydock_minor_patch="${drydock_vers#*.}" # temp
+      drydock_patch="${drydock_minor_patch#*.}"
+      drydock_minor="${drydock_minor_patch%.*}"
+      if [ $drydock_major -lt $major ]; then
+        needs_upgrade=1
+      elif [ $drydock_major -eq $major ] && [ $drydock_minor -lt $minor ]; then
+        needs_upgrade=1
+      elif [ $drydock_major -eq $major ] && [ $drydock_minor -eq $minor ] && [ $drydock_patch -lt $patch ]; then
+        needs_upgrade=1
       elif [[ $drydock_vers == "" ]]; then
-        ((needs_upgrade += 1))
+        needs_upgrade=1
+      fi
+      if [ $needs_upgrade -ne 0 ]; then
+        echo "cray-drydock version [$drydock_vers] less than $major.$minor.$patch and needs to be upgraded."
+        echo "Cray-drydock will be upgraded and the cert-manager namespace will be redeployed."
       fi
     fi
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In CSM 1.6, the latest cray-drydock version is 2.18.4. In that version, cray-drydock creates the cert-manager namespace. If the system has already been upgraded to an early version on CSM 1.6, then cert-manager has likely been upgraded and cray-drydock has not. The cray-drydock chart fails to upgrade when cert-manager is installed. This PR adds logic in the case of a CSM 1.6 to CSM 1.6 upgrade. It allows cray-drydock to be upgraded by uninstalling cert-manager, then upgrading drydock, then reinstalling cert-manager. Again, this is only used on a CSM 1.6 to CSM 1.6 upgrade.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
