### PR TITLE
CASMCMS-9141: Update multitenancy docs to use BOS CLI shortcuts

### DIFF
--- a/operations/multi-tenancy/Modify_a_Tenant.md
+++ b/operations/multi-tenancy/Modify_a_Tenant.md
@@ -202,13 +202,13 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
 1. (`ncn-mw#`) Clear the desired state.
 
-    - If only a single component is changing tenants, then use the following command:
+    - For a single component changing tenants, then use the following command:
 
         ```bash
         cray bos v2 components update --enabled true --clear-pending-state <xname> 
         ```
 
-    - If multiple components are changing tenants, then use the following command:
+    - For multiple components changing tenants, then use the following command:
 
         ```bash
         cray bos v2 components updatemany --enabled true --clear-pending-state --filter-ids <xname1>,<xname2>,...
@@ -218,13 +218,13 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
     Because the previous step cleared the desired state, the `stable` state indicates that the components are powered off.
 
-    - To check a single component, use the following command:
+    - For checking a single component, use the following command:
 
         ```bash
         cray bos v2 components describe <xname> --format json | jq .status.status
         ```
 
-    - To check multiple components, use the following command:
+    - For checking multiple components, use the following command:
 
         ```bash
         cray bos v2 components list --ids <xname1>,<xname2>,... --format json | jq '.[] | .status.status'

--- a/operations/multi-tenancy/Modify_a_Tenant.md
+++ b/operations/multi-tenancy/Modify_a_Tenant.md
@@ -202,13 +202,13 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
 1. (`ncn-mw#`) Clear the desired state.
 
-    - For a single component changing tenants, then use the following command:
+    - For a single component changing tenants, use the following command:
 
         ```bash
         cray bos v2 components update --enabled true --clear-pending-state <xname> 
         ```
 
-    - For multiple components changing tenants, then use the following command:
+    - For multiple components changing tenants, use the following command:
 
         ```bash
         cray bos v2 components updatemany --enabled true --clear-pending-state --filter-ids <xname1>,<xname2>,...

--- a/operations/multi-tenancy/Modify_a_Tenant.md
+++ b/operations/multi-tenancy/Modify_a_Tenant.md
@@ -202,19 +202,30 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
 1. (`ncn-mw#`) Clear the desired state.
 
-    > Repeat this step for each component that moving from one tenant to another.
+    - If only a single component is changing tenants, then use the following command:
 
-    ```bash
-    cray bos v2 components update <xname> --enabled true --staged-state-session "" --staged-state-configuration "" \
-        --staged-state-boot-artifacts-initrd "" --staged-state-boot-artifacts-kernel-parameters "" --staged-state-boot-artifacts-kernel "" \
-        --desired-state-bss-token "" --desired-state-configuration "" --desired-state-boot-artifacts-initrd "" \
-        --desired-state-boot-artifacts-kernel-parameters "" --desired-state-boot-artifacts-kernel ""
-    ```
+        ```bash
+        cray bos v2 components update --enabled true --clear-pending-state <xname> 
+        ```
 
-1. (`ncn-mw#`) Wait until the component reaches a `stable` state.
+    - If multiple components are changing tenants, then use the following command:
 
-    Because the previous step cleared the desired state, the `stable` state indicates that the component is powered off.
+        ```bash
+        cray bos v2 components updatemany --enabled true --clear-pending-state --filter-ids <xname1>,<xname2>,...
+        ```
 
-    ```bash
-    cray bos v2 components describe <xname> --format json | jq .status.status
-    ```
+1. (`ncn-mw#`) Wait until the components reach a `stable` state.
+
+    Because the previous step cleared the desired state, the `stable` state indicates that the components are powered off.
+
+    - To check a single component, use the following command:
+
+        ```bash
+        cray bos v2 components describe <xname> --format json | jq .status.status
+        ```
+
+    - To check multiple components, use the following command:
+
+        ```bash
+        cray bos v2 components list --ids <xname1>,<xname2>,... --format json | jq '.[] | .status.status'
+        ```


### PR DESCRIPTION
This shouldn't merge until the following PR merges:
https://github.com/Cray-HPE/csm/pull/3663

This updates the multitenancy docs to replace a lengthy BOS CLI command with one that uses a new BOS CLI shortcut. In addition, it updates the same document to provide easier ways to perform the operation on multiple components, rather than having to issue CLI commands for each component.

No backports -- the CLI shortcuts are new in CSM 1.6.