### PR TITLE
CASMTRIAGE-7250 add troubleshooting if ceph is looping waiting for health to be okay

### DIFF
--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -4,11 +4,11 @@
 [Relevant troubleshooting links for upgrade-related issues](Upgrade_Management_Nodes_and_CSM_Services.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
 - [Stage 2 - Ceph image upgrade](#stage-2---ceph-image-upgrade)
-  - [Start typescript](#start-typescript)
-  - [Argo workflows](#argo-workflows)
-  - [Storage node image upgrade and Ceph upgrade](#storage-node-image-upgrade-and-ceph-upgrade)
-  - [Stop typescript](#stop-typescript)
-  - [Stage completed](#stage-completed)
+    - [Start typescript](#start-typescript)
+    - [Argo workflows](#argo-workflows)
+    - [Storage node image upgrade and Ceph upgrade](#storage-node-image-upgrade-and-ceph-upgrade)
+    - [Stop typescript](#stop-typescript)
+    - [Stage completed](#stage-completed)
 
 ## Start typescript
 
@@ -49,6 +49,9 @@ It is possible to upgrade a single storage node at a time using the following co
 
 >**Storage node image upgrade troubleshooting**
 >
+> - If the storage node upgrade is looping on the `wait-for-ncn-s00X-health` stage and Ceph is in a `HEALTH_WARN` state, this is likely **not** a problem.
+Ceph needs time to recover after a node upgrade. Run `ceph -s` and observe that the percentage by `Degraded data redundancy` is decreasing.
+If the percentage is not decreasing, then continue to the following troubleshooting statements.
 > - The best troubleshooting tool for this stage is the Argo UI. Information about accessing this UI and about using Argo Workflows is above.
 > - If the upgrade is 'waiting for Ceph `HEALTH_OK`', the output from commands `ceph -s` and `ceph health detail` should provide information.
 > - If a crash has occurred, [dumping the Ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This PR adds a comment to the storage node upgrade troubleshooting that it is okay if Ceph has to wait for health to be okay. It is expected for there to be degraded data redundancy after a storage node rebuild.

Note, this comment was added to the CSM only upgrade. I did not add a comment to the docs used for upgrading storage nodes through IUF. There is no specific troubleshooting information in that section of the documentation and customers have not had quesitions about this before. People internally tend to have questions about this.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
