### PR TITLE
CASMINST-7006 Added note about 1.6 support for NVIDIA

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -36,6 +36,7 @@ StatefulSets
 1.3.x
 1.4.x
 1.5.x
+1.5.x.
 1.6.x
 100GBASE-CR2
 100GBASE-CR4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@
 
 ### New hardware support
 
+* CSM 1.6.0 does not support servers with NVIDIA CPUs and GPUs. Systems with these servers should not be upgraded to CSM 1.6.0.
+
 ### Automation improvements
 
 ### Base platform component upgrades
@@ -41,6 +43,7 @@ For a list of all features with an announced removal target, see [Removals](intr
 
 ## Known issues
 
+* CSM 1.6.0 does not support servers with NVIDIA CPUs and GPUs. Systems with these servers should not be upgraded to CSM 1.6.0.
 * After updating Paradise BMC firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
     * See [Updating Foxconn Paradise Nodes with FAS](operations/firmware/FAS_Paradise.md) for details on how to do this
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@
 
 ### New hardware support
 
-* CSM 1.6.0 does not support servers with NVIDIA CPUs and GPUs. Systems with these servers should not be upgraded to CSM 1.6.0.
+* CSM 1.6.0 **does not support servers with NVIDIA CPUs and GPUs**. Systems with these servers should not be upgraded to CSM 1.6.0. Please stay on the supported CSM release of 1.5.x.
 
 ### Automation improvements
 
@@ -43,7 +43,7 @@ For a list of all features with an announced removal target, see [Removals](intr
 
 ## Known issues
 
-* CSM 1.6.0 does not support servers with NVIDIA CPUs and GPUs. Systems with these servers should not be upgraded to CSM 1.6.0.
+* CSM 1.6.0 **does not support servers with NVIDIA CPUs and GPUs**. Systems with these servers should not be upgraded to CSM 1.6.0. Please stay on the supported CSM release of 1.5.x.
 * After updating Paradise BMC firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
     * See [Updating Foxconn Paradise Nodes with FAS](operations/firmware/FAS_Paradise.md) for details on how to do this
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@
 
 ### New hardware support
 
-* CSM 1.6.0 **does not support servers with NVIDIA CPUs and GPUs**. Systems with these servers should not be upgraded to CSM 1.6.0. Please stay on the supported CSM release of 1.5.x.
+* **IMPORTANT** Systems with NVIDIA CPUs and GPUs must see [Known issues](#known-issues)
 
 ### Automation improvements
 

--- a/install/README.md
+++ b/install/README.md
@@ -4,6 +4,10 @@ This page will guide an administrator through installing Cray System Management 
 HPE Cray EX system. Fresh-installations on bare-metal or re-installations of CSM must follow
 this guide in order.
 
+## Release Notes
+
+Before installing review the [Release Notes](../RELEASE_NOTES.md)
+
 ## Bifurcated CAN notice
 
 Introduced in CSM 1.2, a major feature of CSM is the [Bifurcated CAN (BICAN)](../glossary.md#bifurcated-can-bican).
@@ -11,6 +15,11 @@ The BICAN is designed to separate administrative network traffic from user netwo
 More information can be found on the [BICAN Technical Summary](../operations/network/management_network/bican_technical_summary.md).
 Review the BICAN summary before continuing with the CSM install.
 For detailed BICAN documentation, see [BICAN Technical Details](../operations/network/management_network/bican_technical_details.md).
+
+## NVIDIA CPU and GPU notice
+
+Servers with NVIDIA CPUs and GPUs are not supported by CSM 1.6.0. Systems with these servers should
+not be installed with CSM 1.6.0
 
 ## High-level overview of CSM install
 

--- a/install/README.md
+++ b/install/README.md
@@ -18,8 +18,8 @@ For detailed BICAN documentation, see [BICAN Technical Details](../operations/ne
 
 ## NVIDIA CPU and GPU notice
 
-Servers with NVIDIA CPUs and GPUs are not supported by CSM 1.6.0. Systems with these servers should
-not be installed with CSM 1.6.0
+Servers with NVIDIA CPUs and GPUs are **not** supported by CSM 1.6.0. Systems with these servers should
+**not** be installed with CSM 1.6.0. Please install CSM 1.5.x, which supports these servers.
 
 ## High-level overview of CSM install
 

--- a/install/README.md
+++ b/install/README.md
@@ -6,7 +6,7 @@ this guide in order.
 
 ## Release Notes
 
-Before installing review the [Release Notes](../RELEASE_NOTES.md)
+Before installing, review the [Release Notes](../RELEASE_NOTES.md).
 
 ## Bifurcated CAN notice
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -12,7 +12,7 @@ software. Choose the appropriate procedure from the sections below.
 
 ## Release Notes
 
-Before upgrading review the [Release Notes](../RELEASE_NOTES.md)
+Before upgrading, review the [Release Notes](../RELEASE_NOTES.md)
 
 ### NVIDIA CPU and GPU notice
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -3,11 +3,21 @@
 There are several alternative procedures to perform an upgrade of Cray Systems Management (CSM)
 software. Choose the appropriate procedure from the sections below.
 
+* [Release Notes](#release-notes)
 * [CSM major/minor version upgrade](#csm-majorminor-version-upgrade)
     * [Option 1: Upgrade CSM with additional HPE Cray EX software products](#option-1-upgrade-csm-with-additional-hpe-cray-ex-software-products)
     * [Option 2: Upgrade only additional HPE Cray EX software products](#option-2-upgrade-only-additional-hpe-cray-ex-software-products)
     * [Option 3: Upgrade only CSM](#option-3-upgrade-only-csm)
 * [CSM patch version upgrade](#csm-patch-version-upgrade)
+
+## Release Notes
+
+Before upgrading review the [Release Notes](../RELEASE_NOTES.md)
+
+### NVIDIA CPU and GPU notice
+
+Servers with NVIDIA CPUs and GPUs are not supported by CSM 1.6.0. Systems with these servers should
+not be upgraded to CSM 1.6.0
 
 ## CSM major/minor version upgrade
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -16,8 +16,8 @@ Before upgrading review the [Release Notes](../RELEASE_NOTES.md)
 
 ### NVIDIA CPU and GPU notice
 
-Servers with NVIDIA CPUs and GPUs are not supported by CSM 1.6.0. Systems with these servers should
-not be upgraded to CSM 1.6.0
+Servers with NVIDIA CPUs and GPUs are **not** supported by CSM 1.6.0. Systems with these servers should
+**not** be upgraded to CSM 1.6.0. Please upgrade to CSM 1.5.x, which supports these servers.
 
 ## CSM major/minor version upgrade
 


### PR DESCRIPTION

# Description
Added note that customers with NVIDIA servers should not upgrade to CSM 1.6.

Relates to:
- [CASMINST-7006](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7006)


# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
