### PR TITLE
CASMTRIAGE-7175: Handling sat image path update during 1.5 to 1.6 upgrade

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -87,7 +87,14 @@ function get_latest_tag_for_image() {
 }
 
 function get_filenames_referring_to_image() {
-  grep -RHl -e "${THIS_IMAGE}:" .
+  local fallback_image="artifactory.algol60.net/csm-docker/stable/cray-sat"
+  # Search for filenames referring to the image in the passed THIS_IMAGE value
+  filenames=$(grep -RHl -e "${THIS_IMAGE}:" .)
+  # If no files are found, search for the image in the fallback location
+  if [[ -z $filenames && ${THIS_IMAGE} =~ cray-sat ]]; then
+    filenames=$(grep -RHl -e "${fallback_image}:" .)
+  fi
+  echo "$filenames"
 }
 
 function update_tags_in_file() {
@@ -98,8 +105,22 @@ function update_tags_in_file() {
   sed -i -e "s|${THIS_IMAGE}:.*|${THIS_IMAGE}:${LATEST_TAG}|g" $THIS_FILE
 }
 
+function update_cray_sat_image() {
+  THIS_IMAGE=$1
+  # Capture the output of the podman search for img & update the img if it doesnt exist
+  SEARCH_OUTPUT=$(podman search ${DEFAULT_REGISTRY_NAME}/${THIS_IMAGE} 2>&1)
+  if [[ -z ${SEARCH_OUTPUT} ]]; then
+    THIS_IMAGE="artifactory.algol60.net/sat-docker/stable/cray-sat"
+  fi
+  echo "$THIS_IMAGE"
+}
+
 # Look up the latest tag for each image found and update the references in every file.
 for THIS_IMAGE in $(get_list_of_images_to_update); do
+  if [[ ${THIS_IMAGE} =~ cray-sat ]]; then
+    # CASMTRIAGE-7175 handle cray-sat image
+    THIS_IMAGE=$(update_cray_sat_image $THIS_IMAGE)
+  fi
   LATEST_TAG=$(get_latest_tag_for_image $THIS_IMAGE)
   # CASMTRIAGE-6188 retry for up to 60 seconds if LATEST_TAG is empty
   i=1


### PR DESCRIPTION
IM:CASMTRIAGE-7175

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->During the csm upgrade from 1.5 to 1.6, when the docs-csm rpm is installed before the 1.6 assets getting loaded. Due to which the sat tag pull up fails, since the new path(artifactory.algol60.net/csm-docker/stable/cray-sat) is not available on the system yet. Hence to handle the scenario, if the image doesnot exist for the default path. A function is created to verify and provide the alternative image path(artifactory.algol60.net/sat-docker/stable/cray-sat)

# Test Description
The scenario was recreated on starlord system. The script was executed to verify the update of the tag. It was able to update the tag with picking up the alternative path for SAT.

ncn-m001:/usr/share/doc/csm/workflows # ./update_tags.sh
Outside loop: 
3.32.0
Updating tag of artifactory.algol60.net/sat-docker/stable/cray-sat in /usr/share/doc/csm/workflows/./templates/base/sat-general-iuf.template.argo.yaml to 3.32.0.
ncn-m001:/usr/share/doc/csm/workflows #

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
