### PR TITLE
CASMTRIAGE-7272 fix

### DIFF
--- a/workflows/templates/base/sat-general-iuf.template.argo.yaml
+++ b/workflows/templates/base/sat-general-iuf.template.argo.yaml
@@ -87,6 +87,10 @@ spec:
             # Set up the SAT config to use the token file
             sed -i -e 's|.*token_file.*|token_file = "/root/.config/sat/token.json"|' /root/.config/sat/sat.toml
 
+            vcs_pass=`kubectl get secret -n services vcs-user-credentials -o jsonpath='{.data.vcs_password}'| base64 -d`
+            rm -f /tmp/vcs_passwd
+            echo $vcs_pass  > /tmp/vcs_passwd
+
             # TODO: Fix sat bootprep code to load kube config from cluster
             # To workaround this issue for now, construct kubeconfig file in the pod
             secret=`kubectl -n argo get serviceaccount/default -o jsonpath='{.secrets[0].name}'`


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Resolves [CASMTRIAGE-7272](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7272)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
