### PR TITLE
Revert "CASMINST-6968 `upgrade_control_plane.sh` refactor"

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -22,8 +22,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-set -euo pipefail
-
 workdir="$(mktemp -d)"
 [ -z "${DEBUG:-}" ] && trap 'rm -fr '"${workdir}"'' ERR INT EXIT RETURN || echo "DEBUG was set in environment, $workdir will not be cleaned up."
 

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -110,6 +110,6 @@ for master in $masters; do
     exit 1
   fi
   echo ""
-  echo "Successfully upgraded apiserver-etcd-client certificate for $master."
+  echo "Successfully upgraded  apiserver-etcd-client certificate for $master."
   echo ""
 done


### PR DESCRIPTION
Reverts Cray-HPE/docs-csm#5296

Unterminated `}` causes failure: https://github.com/Cray-HPE/docs-csm/blame/release/1.6/upgrade/scripts/k8s/upgrade_control_plane.sh#L36