### PR TITLE
CASMTRIAGE-7286 Add CSM DIAGS product to Update customizations.yaml list

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -43,8 +43,8 @@ Once this step has completed:
 
 **`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
-Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products and the UAN product. Refer to the
-"Install and Upgrade Framework" section of the Slurm, PBS, and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
+Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products , CSM Diags and the UAN product. Refer to the
+"Install and Upgrade Framework" section of the Slurm, PBS, CSM Diags and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -43,8 +43,8 @@ Once this step has completed:
 
 **`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
-Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products , CSM Diags and the UAN product. Refer to the
-"Install and Upgrade Framework" section of the Slurm, PBS, CSM Diags and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
+Some products require modifications to the `customizations.yaml` file before executing the `deliver-product` stage. Currently, this is limited to the Slurm and PBS Workload Manager (WLM) products, CSM Diags, and the UAN product. Refer to the
+"Install and Upgrade Framework" section of the Slurm, PBS, CSM Diags, and UAN product documents to determine the actions that need to be performed to update `customizations.yaml`.
 
 Once this step has completed:
 


### PR DESCRIPTION
Resolves CASMTRIAGE-7286

# Description

Update IUF documentation to show "manual configuration" steps for CSM DIAGS product

This documentation has some manual steps which show how to update the CSM DIAGS product configurations to match the  settings  We should get the IUF "manual configuration" instructions updated to reference this documentation: 
https://cray-hpe.github.io/docs-csm/en-15/operations/iuf/workflows/configuration/#3-perform-manual-product-configuration-operations

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
