### PR TITLE
CASMCMS-9148: Document BOS automatically tagging SBPS images

### DIFF
--- a/operations/boot_orchestration/BOS_Workflows.md
+++ b/operations/boot_orchestration/BOS_Workflows.md
@@ -106,7 +106,9 @@ The following workflows are included in this section:
 
 1. **Power-on operator**
 
-    The power-on operator will detect nodes with a `power-on-pending` status. The power-on operator first sets the desired boot artifacts in BSS.
+    The power-on operator will detect nodes with a `power-on-pending` status. If root file system provider is the Scalable Boot Provisioning Service (`SBPS`), then the power-on operator
+    will notify SBPS that the root file system needs to be projected. It will do this by tagging the image with `sbps-project: true` using the Image Management Service (IMS).
+     Then, the power-on operator sets the desired boot artifacts in BSS.
     If configuration is enabled for the node, the power-on operator will also call CFS to set the desired configuration and disable the node with CFS.
     The node must be disabled within CFS so that CFS does not try to configure node until it has booted.
     The power-on operator then calls PCS to power-on the node.
@@ -127,7 +129,7 @@ The following workflows are included in this section:
 
 1. **Status operator (configuring)**
 
-    The status operator monitors a node's power state until HSM reports that the power state is on.  
+    The status operator monitors a node's power state until HSM reports that the power state is on.
     When the power state for a node is on, the status operator will either set the phase to `configuring` if CFS configuration is required or it will clear the current phase
     if the node is in its final state.
 
@@ -236,7 +238,9 @@ The following workflows are included in this section:
 
 1. **Power-on operator**
 
-    The power-on operator will detect nodes with a `power-on-pending` status. The power-on operator first sets the desired boot artifacts in BSS.
+    The power-on operator will detect nodes with a `power-on-pending` status. If root file system provider is the Scalable Boot Provisioning Service (`SBPS`), then the power-on operator
+    will notify SBPS that the root file system needs to be projected. It will do this by tagging the image with `sbps-project: true` using the Image Management Service (IMS).
+     Then, the power-on operator sets the desired boot artifacts in BSS.
     If configuration is enabled for the node, the power-on operator will also call CFS to set the desired configuration and disable the node with CFS.
     The node must be disabled within CFS so that CFS does not try to configure node until it has booted.
     The power-on operator then calls PCS to power-on the node.


### PR DESCRIPTION
Describe how BOS automatically tags an image with `sbps-project: true` if the Scalable Boot Provisioning Service (SBPS) provides the root file system.


    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
