### PR TITLE
CASMTIAGE-7232 Metal-iPXE Hotfix Notice

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -411,10 +411,10 @@ These variables will need to be set for many procedures within the CSM installat
    tar -zxvf  "${PITDATA}/csm-${CSM_RELEASE}.tar.gz" -C ${PITDATA}
    ```
 
-1. (`pit#`) ***CSM 1.5.0 Only*** At this time, the metal-ipxe 1.5.0 pre-install hotfix is required. Please review the current field notices for the hotfix.
-   This hotfix will insert a new metal-ipxe RPM into the extracted tarball.
+1. (`pit#`) ***HOTFIX: 1.5.0 through 1.5.2*** At this time, a newer metal-ipxe RPM is required. Please review the current field notices for the hotfix(es).
+   The hotfix will insert a new metal-ipxe RPM into the extracted tarball.
 
-    > ***NOTE*** CSM 1.5.1 and later do NOT need to run this. The metal-ipxe RPM is already included in their tarballs.
+    > ***NOTE*** Anything newer than 1.5.2 may continue without needing any additional step.
 
 1. (`pit#`) Install/update the RPMs necessary for the CSM installation.
 


### PR DESCRIPTION
The notice should now include 1.5.1 and 1.5.2 to cover CASMTRIAGE-7232.
