### PR TITLE
CRAYSAT-1909: Remove "verify Lustre access" step from power on procedure

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -170,10 +170,6 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
     screen -x 26745.SAT-console-ncn-m003-mgmt
     ```
 
-### Verify access to Lustre file system
-
-Verify that the Lustre file system is available from the management cluster.
-
 ### Start Kubernetes and other services
 
 1. (`ncn-m001#`) Start the Kubernetes cluster.


### PR DESCRIPTION
# Description
Remove the vague "verify Lustre access" step from the system power on procedure. The step is too vague to be useful as it is written, and it probably doesn't make sense to do this step at this stage in the system power on procedure as the Kubernetes cluster isn't up yet, and the Slingshot fabric will not be initialized yet.

(cherry picked from commit adb929f960a741f92f16fbac97204fb4237ef0e5)

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
