### PR TITLE
CASMTRIAGE-7349 remove kubeconfig from IUF SAT template

### DIFF
--- a/workflows/templates/base/sat-general-iuf.template.argo.yaml
+++ b/workflows/templates/base/sat-general-iuf.template.argo.yaml
@@ -87,38 +87,6 @@ spec:
             # Set up the SAT config to use the token file
             sed -i -e 's|.*token_file.*|token_file = "/root/.config/sat/token.json"|' /root/.config/sat/sat.toml
 
-            vcs_pass=`kubectl get secret -n services vcs-user-credentials -o jsonpath='{.data.vcs_password}'| base64 -d`
-            rm -f /tmp/vcs_passwd
-            echo $vcs_pass  > /tmp/vcs_passwd
-
-            # TODO: Fix sat bootprep code to load kube config from cluster
-            # To workaround this issue for now, construct kubeconfig file in the pod
-            secret=`kubectl -n argo get serviceaccount/default -o jsonpath='{.secrets[0].name}'`
-            token=`kubectl -n argo get secret $secret -o jsonpath='{.data.token}'| base64 -d`
-            mkdir -p mykubeconfig
-            cat << EOF > mykubeconfig/admin.conf
-            apiVersion: v1
-            kind: Config
-            current-context: default
-            contexts:
-              - context:
-                  cluster: kubernetes
-                  user: default
-                  namespace: default
-                name: default
-            clusters:
-              - cluster:
-                  server: https://kubeapi-vip.local:6442
-                  insecure-skip-tls-verify: true
-                name: kubernetes
-            users:
-            - name: default
-              user:
-                token: ${token}
-          EOF
-            export KUBECONFIG=mykubeconfig/admin.conf
-            chmod 600 mykubeconfig/admin.conf
-
             # TODO: This is required to build images in IMS with sat bootprep. Find a way to pass
             # an IMS public key id into the argo workflow. Perhaps from the IUF CLI.
             ssh-keygen -f ~/.ssh/id_rsa -N ''


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

SAT is printing information that is unexpected by IUF. Because of this, IUF management-nodes-rollout is failing because it is not able to parse the output.

To fix this we should allow SAT to load the kubeconfig from the system and get the VCS password itself. Doing this, will cause SAT not to output the VCS password that is being passed in.


**More detailed description**

SAT being able to load the kubeconfig from the system is new in CSM 1.5 which is why this was not implemented in the first place. In CSM 1.6, a bad kubeconfig was being passed to SAT (because of a k8s 1.24 change) which prevented SAT from getting the necessary VCS password. A workaround solution was recently put in place to provide the VCS password to SAT. However, because SAT is able to load the kubeconfig from the system, there is no need to pass in the vcs password or provide a bad kubeconfig. This PR removes the vcs password and kubeconfig that are provided to SAT. As a result of this, SAT is able to output the expected information.

# Testing

This output is from the current, problematic SAT template. It is creating bad output by printing the vcs password

```bash
/tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= /tmp/vcs_passwd g4cQLgD-GJaEVsfQFbYwFka-eL1dX5AO6ZpAL662QFo= { "configurations": [ { "name": "compute-1.0.0-8443" }, { "name": "lnet-1.0.0-8443" }, { "name": "uan-1.0.0-8443" } ] }
```

The output below is the output from the updated template in this PR.

```bash
{ "configurations": [ { "name": "compute-1.0.0-8443" }, { "name": "lnet-1.0.0-8443" }, { "name": "uan-1.0.0-8443" } ] }
```


<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
