### PR TITLE
CASMTRIAGE-7337 Doc improvements for IUF Upgrade

### DIFF
--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -122,6 +122,10 @@ Once this step has completed:
 - `${ADMIN_DIR}` is populated with `product_vars.yaml`, `site_vars.yaml`, and `sat bootprep` input files
 - The aforementioned configuration files have been updated to reflect site preferences
 
+**`NOTE`** If performing an upgrade that includes upgrading only CSM, return to the
+  [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
+  workflow to continue the upgrade.
+
 ## 2. Execute the IUF `update-vcs-config` stage
 
 For each product that uploaded Ansible configuration content to a configuration management VCS repository, the `update-vcs-config` stage attempts to merge the pristine branch of the configuration management repository into a

--- a/upgrade/Upgrade_Only_CSM_with_iuf.md
+++ b/upgrade/Upgrade_Only_CSM_with_iuf.md
@@ -24,6 +24,10 @@ using IUF.
 
    Follow the IUF [Product delivery](../operations/iuf/workflows/product_delivery.md) instructions.
 
+1. Configuration
+
+   Follow the IUF [Configuration](../operations/iuf/workflows/configuration.md) instructions.
+
 1. Image preparation
 
    Follow the IUF [Image preparation](../operations/iuf/workflows/image_preparation.md) instructions.

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -155,7 +155,7 @@ Return here after verifying that SNMP is properly configured on the management n
    starts. After the upgrade is completed, another health check is performed, and it is important to know
    if any problems observed at that time existed prior to the upgrade.
 
-   **`IMPORTANT`**: See the `CSM Install Validation and Health Checks` procedures in the
+   **`IMPORTANT`**: See the [`CSM Install Validation and Health Checks`](../operations/validate_csm_health.md) procedures in the
    documentation for the **`CURRENT`** CSM version on the system. The validation procedures in the CSM
    documentation are only intended to work with that specific version of CSM.
 


### PR DESCRIPTION
# Description

CASMTRIAGE-7337

1)https://github.com/Cray-HPE/docs-csm/blob/release/1.6/upgrade/prepare_for_upgrade.md#7-health-validation (Step 7.1)
Provide the link to Validate CSM Health documentation

2)Upgrade only CSM documentation does not have the update-vcs-config stage which contains details on creating the bootprep files and vars files, there should be a pointer in the main doc to take care of those details, especially to update the product and site vars (also to comment out unnecessary layers as this is a csm only upgrade)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
