### PR TITLE
CASMTRIAGE-7228 - DCLDAP changes

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -153,7 +153,7 @@ with system-specific customizations.
 
 1. (`pit#`) Set environment variables for the LDAP server and its port.
 
-   In the example below, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port 636.
+   In the example below, the LDAP server has the hostname `dcldap2.hpc.amslabs.hpecorp.net` and is using the port 636.
 
    ```bash
    LDAP=dcldap2.hpc.amslabs.hpecorp.net

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -153,7 +153,7 @@ with system-specific customizations.
 
 1. (`pit#`) Set environment variables for the LDAP server and its port.
 
-   In the example below, the LDAP server has the hostname `dcldap2.hpc.amslabs.hpecorp.net` and is using the port 636.
+   In the following example, the LDAP server has the hostname `dcldap2.hpc.amslabs.hpecorp.net` and is using the port 636.
 
    ```bash
    LDAP=dcldap2.hpc.amslabs.hpecorp.net

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -156,7 +156,7 @@ with system-specific customizations.
    In the example below, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port 636.
 
    ```bash
-   LDAP=dcldap2.us.cray.com
+   LDAP=dcldap2.hpc.amslabs.hpecorp.net
    PORT=636
    ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The `dcldap2.us.cray.com` LDAP server was decommissioned when the certificate was up for renewal.

While it's poor practice to include in house systems in customer facing documentation, this PR is a stop gap measure to allow system installers to continue to do fresh installs until this documentation can be reworked with a generic example and the in house documentation relocated to a Confluence page.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
