### PR TITLE
CASMTRIAGE-7308: Add Troubleshooting Steps

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -67,6 +67,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Product Catalog Upgrade Error](known_issues/product_catalog_upgrade_error.md)
 * [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
 * [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
+* [Istio-Proxy failing with too many open files](known_issues/Istio-Proxy_failing_with_too_many_open_files.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/Istio-Proxy_failing_with_too_many_open_files.md
+++ b/troubleshooting/known_issues/Istio-Proxy_failing_with_too_many_open_files.md
@@ -1,0 +1,46 @@
+# Istio-Proxy failing with too many open files
+
+## Issue Description
+
+After the CSM upgrade, some nodes with `Istio` might not have come up with the new `Istio-proxy` image due to too many open files so they need increased `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches` values.
+When pods with `istio-proxy` restart (such as after a power outage or node reboot), they may fail due to insufficient `inotify` resources, as the limits on the system are too low.
+
+### Related Issue
+
+- [Istio Issue #35829](https://github.com/istio/istio/issues/35829)
+
+## Error Identification
+
+When the issue occurs the following errors are emitted in the `istio-proxy` logs.
+
+```sh
+2024-07-22T17:00:37.322350Z info Workload SDS socket not found. Starting Istio SDS Server
+2024-07-22T17:00:37.322393Z info CA Endpoint istiod.istio-system.svc:15012, provider Citadel
+2024-07-22T17:00:37.322395Z info Opening status port 15020
+2024-07-22T17:00:37.322436Z info Using CA istiod.istio-system.svc:15012 cert with certs: var/run/secrets/istio/root-cert.pem
+2024-07-22T17:00:37.323487Z error failed to start SDS server: failed to start workload secret manager too many open files
+Error: failed to start SDS server: failed to start workload secret manager too many open files
+```
+
+## Error Conditions
+
+This issue manifests when:
+
+- Pods are unable to create enough `inotify` instances to monitor required files.
+- The system hits the maximum number of file watches, causing crashes or failures in services dependent on file system event monitoring.
+
+This problem can be triggered by events like:
+
+- A node dying and rebooting mid-upgrade.
+- Power outages where pods restart on nodes with old kernel settings.
+
+## Fix Description
+
+Manually increase the `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches` values to provide sufficient resources for Istio and other Kubernetes components.
+
+```bash
+pdsh -w ncn-m00[1-3],ncn-w00[1-5] 'sysctl -w fs.inotify.max_user_instances=1024'
+pdsh -w ncn-m00[1-3],ncn-w00[1-5] 'sysctl -w user.max_inotify_instances=1024'
+pdsh -w ncn-m00[1-3],ncn-w00[1-5] 'sysctl -w fs.inotify.max_user_watches=1048576'
+pdsh -w ncn-m00[1-3],ncn-w00[1-5] 'sysctl -w user.max_inotify_watches=1048576'
+```


### PR DESCRIPTION
# Istio Pods Crashing post upgrade due to `fs.inotify` Limits

# Description
[CASMTRIAGE-7308](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7308)
After the Istio upgrade, the nodes have not yet been rebooted into a new image where these limits (fs.inotify.max_user_instances and fs.inotify.max_user_watches) have been increased. As a result, when the pods are restarted, they might be trying to monitor more files or create more inotify instances than allowed by the system. This can cause the pods to crash or fail because they are unable to watch the files or directories they need, which may be critical for service mesh operations like traffic management, logging, or configuration changes.
In addition, power outage or node reboot mid-upgrade would hit the same problem because the pods would restart without the required kernel parameters being updated on the nodes.

Relates to:
- [cray-istio PR](https://github.com/Cray-HPE/cray-istio/pull/46)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
