### PR TITLE
CASM-4673: Documentation for Kyverno signature validation policy 

### DIFF
--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -409,7 +409,7 @@ warning messages in to the cluster report and as events)
 By default, the `check-image` policy is shipped as a `ClusterPolicy` and is configured to work in a sample (non-existent) namespace. To enable the policy, end users must customize it to the targeted namespaces.
 
 CSM runs in an air gapped environment, where the images stored in `artifactory` are mirrored to the local Nexus registry. Kyverno policy engine does not support
-this environment. To enable Kyverno policy for such environments, all `image specs` need to be replaced from `artifactory.algol60.net/csm-docker/stable/image:tag`
+this environment for image verification. To enable Kyverno policy for such environments, all `image specs` need to be replaced from `artifactory.algol60.net/csm-docker/stable/image:tag`
 to `registry.local/artifactory.algol60.net/csm-docker/stable/image:tag` (prepend `registry.local/` to the image spec). This will force Kyverno to check local Nexus
 registry for the images. Without `registry.local/`, Kyverno will try to contact remote registry (`artifactory`) every time, and this may trigger timeouts due to delays,
 and eventually lead to policy failure.


### PR DESCRIPTION

The sentence changed to convey that only image verification is not supported and rest are supported.

