### PR TITLE
CASMTRIAGE-7099-1.6 port of CSM 1.4 full system power off/on procedures to CSM 1.6

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -647,6 +647,7 @@ prebuilt
 preempted
 preemptively
 provisioners
+PXEboot
 qemu-user-static
 rados-gateway
 re-architecting

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -15,7 +15,7 @@ The following services are backed up daily \(one week of backups retained\) as p
 
 - Boot Orchestration Service \(BOS\)
 - Boot Script Service \(BSS\)
-- Controller Diagnostics Orchestration (FOX) 
+- Controller Diagnostics Orchestration (FOX)
 - Firmware Action Service \(FAS\)
 - Heartbeat Tracking Daemon \(HBTD\)
 - HMS Notification Fanout Daemon \(HMNFD\)

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -15,6 +15,7 @@ The following services are backed up daily \(one week of backups retained\) as p
 
 - Boot Orchestration Service \(BOS\)
 - Boot Script Service \(BSS\)
+- Controller Diagnostics Orchestration (FOX) 
 - Firmware Action Service \(FAS\)
 - Heartbeat Tracking Daemon \(HBTD\)
 - HMS Notification Fanout Daemon \(HMNFD\)
@@ -34,7 +35,7 @@ See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_e
 
 This test will show PASS or FAIL for each of the etcd clusters as it verifies whether they had a backup in the last 24 hours.
 
-(`ncn-mw#`) To view all available etcd backups across all clusters
+(`ncn-mw#`) To view all available etcd backups across all clusters:
 
 ```bash
 /opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_backups_check

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -5,6 +5,9 @@ Services that are not backed up automatically will need to be manually rediscove
 
 - [Clusters with automated backups](#clusters-with-automated-backups)
 - [Clusters without automated backups](#clusters-without-automated-backups)
+- [Test for recent etcd cluster backups](#test-for-recent-etcd-cluster-backups)
+- [Check backup status for a specific etcd cluster](#check-backup-status-for-a-specific-etcd-cluster)
+- [Check status of etcd cluster backups](#check-status-of-etcd-cluster-backups)
 
 ## Clusters with automated backups
 
@@ -13,7 +16,71 @@ The following services are backed up daily \(one week of backups retained\) as p
 - Boot Orchestration Service \(BOS\)
 - Boot Script Service \(BSS\)
 - Firmware Action Service \(FAS\)
+- Heartbeat Tracking Daemon \(HBTD\)
+- HMS Notification Fanout Daemon \(HMNFD\)
+- Power Control Service \(PCS\)
 - User Access Service \(UAS\)
+
+## Clusters without automated backups
+
+The following projects are not backed up as part of the automated solution:
+
+- Content Projection Service \(CPS\)
+
+If these clusters become unhealthy, the process for rediscovering their data should be followed.
+See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
+
+## Test for recent etcd cluster backups
+
+This test will show PASS or FAIL for each of the etcd clusters as it verifies whether they had a backup in the last 24 hours.
+
+(`ncn-mw#`) To view all available etcd backups across all clusters
+
+```bash
+/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_backups_check
+```
+
+Example output:
+
+```text
+**************************************************************************
+
+=== Verify etcd clusters have a backup in the last 24 hours. ===
+=== The complete list of backups can be listed as follows:
+=== % /opt/cray/platform-utils/etcd/etcd-util.sh list_backups -
+Tue 08 Oct 2024 05:37:02 PM UTC
+
+-- cray-bos -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-bss -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-fas -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-fox -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-hbtd -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-hmnfd -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-power-control -- backups
+PASS: backup found less than 24 hours old.
+
+-- cray-uas-mgr -- backups
+PASS: backup found less than 24 hours old.
+ --- PASSED --- 
+```
+
+If a particular service is not included, it is an indication
+that the service was not backed up automatically or was not backed up with success. Create a manual backup for that service by following the
+[Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
+
+## Check backup status for a specific etcd cluster
 
 (`ncn-mw#`) Run the following command on any Kubernetes master or worker node in order to list the backups for a specific project.
 In the example below, the backups for BSS are listed.
@@ -25,10 +92,23 @@ In the example below, the backups for BSS are listed.
 Example output:
 
 ```text
-cray-bss/db-2023-03-08_23-00
-cray-bss/db-2023-03-09_00-00
-cray-bss/db-2023-03-09_01-00
+cray-bss/db-2024-09-30_23-01
+cray-bss/db-2024-10-01_23-00
+cray-bss/db-2024-10-02_23-00
+cray-bss/db-2024-10-03_23-00
+cray-bss/db-2024-10-04_23-00
+cray-bss/db-2024-10-05_23-00
+cray-bss/db-2024-10-06_23-00
+cray-bss/db-2024-10-07_00-01
+cray-bss/db-2024-10-07_01-00
+cray-bss/db-2024-10-07_02-00
+cray-bss/db-2024-10-07_03-00
+cray-bss/db-2024-10-07_04-01
+
+[...]
 ```
+
+## Check status of etcd cluster backups
 
 (`ncn-mw#`) To view all available backups across all projects:
 
@@ -39,14 +119,19 @@ cray-bss/db-2023-03-09_01-00
 Example output:
 
 ```text
-cray-bss/etcd.backup_v4508_2023-03-08-01:00:03
-cray-crus/etcd.backup_v1_2023-03-08-01:00:03
-cray-fas/etcd.backup_v2963_2023-03-08-01:00:04
-cray-bss/etcd.backup_v8828_2023-03-09-01:00:03
-cray-crus/etcd.backup_v1_2023-03-09-01:00:04
-cray-bos/db-2023-03-09_18-00
-bare-metal/etcd-backup-2023-03-09-18-10-02.tar.gz
-bare-metal/etcd-backup-2023-03-09-18-20-02.tar.gz
+cray-bos/db-2024-09-30_23-00
+cray-bss/db-2024-09-30_23-01
+cray-fas/db-2024-09-30_23-01
+cray-fox/db-2024-09-30_23-00
+cray-hbtd/db-2024-09-30_23-00
+cray-hmnfd/db-2024-09-30_23-01
+cray-power-control/db-2024-09-30_23-00
+cray-uas-mgr/db-2024-09-30_23-00
+cray-bos/db-2024-10-01_23-00
+cray-bss/db-2024-10-01_23-00
+cray-fas/db-2024-10-01_23-00
+cray-fox/db-2024-10-01_23-00
+cray-hbtd/db-2024-10-01_23-01
 
 [...]
 ```
@@ -55,13 +140,3 @@ The returned output includes the date and time of the latest backup for each ser
 that the service is not backed up automatically. Create a manual backup for that service by following the
 [Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
 
-## Clusters without automated backups
-
-The following projects are not backed up as part of the automated solution:
-
-- Content Projection Service \(CPS\)
-- Heartbeat Tracking Daemon \(HBTD\)
-- HMS Notification Fanout Daemon \(HMNFD\)
-
-If these clusters become unhealthy, the process for rediscovering their data should be followed.
-See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -139,4 +139,3 @@ cray-hbtd/db-2024-10-01_23-01
 The returned output includes the date and time of the latest backup for each service. If a recent backup for any service is not included, it is an indication
 that the service is not backed up automatically. Create a manual backup for that service by following the
 [Create a Manual Backup of a Healthy etcd Cluster](Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md) procedure.
-

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -210,11 +210,11 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. (`ncn-m#`) Shut down cabinet power.
 
-    **Important:** The default timeout for the call to CAPMC is 120 seconds. If the `sat bootsys shutdown` command fails
-    to power off some cabinets and indicate that requests to CAPMC have timed out, the `sat` command may be run with an increased `--capmc-timeout` value.
+    **Important:** The default timeout for the call to PCS is 120 seconds. If the `sat bootsys shutdown` command fails
+    to power off some cabinets and indicate that requests to PCS have timed out, the `sat` command may be run with an increased `--pcs-timeout` value.
 
     ```bash
-    sat bootsys shutdown --stage cabinet-power --capmc-timeout 240
+    sat bootsys shutdown --stage cabinet-power --pcs-timeout 240
     ```
 
 1. (`ncn-m#`) Verify that the `hms-discovery` cron job has been suspended.

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -34,9 +34,9 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 
    If coolant levels are on the verge of being too low, there may be a fault upon power up due to not enough coolant.
 
-1. (`ncn-m#`) Check the power status in liquid-cooled cabinets before shutdown.
+1. (`ncn-m#`) Check the power status for liquid-cooled cabinets before shutdown.
 
-    Either use `sat status` or `cray power` to check. The `State` should be `Off` for every Chassis.
+    Either use `sat status` or `cray power` to check. The `State` should be `On` for every Chassis.
 
     1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
 
@@ -50,14 +50,14 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
        +---------+---------+-------+------+---------+------+----------+----------+
        | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
        +---------+---------+-------+------+---------+------+----------+----------+
-       | x1020c0 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c1 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c2 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c3 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c4 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c5 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c6 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
-       | x1020c7 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c0 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c1 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c2 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c3 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c4 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c5 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c6 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c7 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
        ...
        +---------+---------+-------+------+---------+------+----------+----------+
        ```
@@ -138,6 +138,7 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
        ```
 
     1. (`ncn-m001#`) Check the power status with PCS.
+
        This example shows nodes in cabinets 3001 - 3003.
 
        The `cray power status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
@@ -234,11 +235,39 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. (`ncn-m#`) Check the power status for liquid-cooled cabinets after shutdown.
 
-    This example shows cabinets 1000 - 1003.
+    Either use `sat status` or `cray power` to check. The `State` should be `Off` for every Chassis.
 
-    ```bash
-    cray power status list --xnames x[1000-1003]c[0-7] --format json
-    ```
+    1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
+
+       ```bash
+       sat status --types Chassis
+       ```
+
+       Example output:
+
+       ```text
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | x1020c0 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c1 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c2 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c3 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c4 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c5 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c6 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c7 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       ...
+       +---------+---------+-------+------+---------+------+----------+----------+
+       ```
+
+    1. (`ncn-m001#`) Check the power status with PCS.
+
+       This example shows cabinets 1000 - 1003.
+
+       ```bash
+       cray power status list --xnames x[1000-1003]c[0-7] --format json
+       ```
 
 1. Rectifiers \(PSUs\) in the liquid-cooled cabinets should indicate that DC power is `OFF` \(`AC OK` means the power is on\).
 

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -34,31 +34,174 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 
    If coolant levels are on the verge of being too low, there may be a fault upon power up due to not enough coolant.
 
-1. (Optional) (`ncn-m#`) Check the power status in liquid-cooled cabinets before shutdown.
+1. (`ncn-m#`) Check the power status in liquid-cooled cabinets before shutdown.
 
-    This example shows liquid-cooled cabinets 1000 - 1003.
+    Either use `sat status` or `cray power` to check. The `State` should be `Off` for every Chassis.
 
-    ```bash
-    cray power status list --xnames x[1000-1003]c[0-7] --format json
-    ```
+    1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
 
-1. (Optional) (`ncn-m#`) Check the power status for nodes in the standard racks before shutdown.
+       ```bash
+       sat status --types Chassis
+       ```
 
-    This example shows nodes in cabinets 3001 - 3003.
+       Example output:
 
-    ```bash
-    cray power status list --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
-    ```
+       ```text
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
+       +---------+---------+-------+------+---------+------+----------+----------+
+       | x1020c0 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c1 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c2 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c3 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c4 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c5 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c6 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       | x1020c7 | Chassis | Off   | OK   | True    | X86  | Mountain | Sling    |
+       ...
+       +---------+---------+-------+------+---------+------+----------+----------+
+       ```
 
-    The `power status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
+    1. (`ncn-m001#`) Check the power status with PCS.
 
-    The command does not filter nonexistent component names \(xnames\) and
-    displays an error when invalid component names are specified. Use `power status list`
-    with no `--xnames` option to show everything.
+        This example shows liquid-cooled cabinets 1000 - 1003.
 
-    ```bash
-    cray power status list --format json
-    ```
+        ```bash
+        cray power status list --xnames x[1000-1003]c[0-7] --format json
+        ```
+
+        Example output:
+
+        ```json
+        {
+          "status": [
+            {
+              "xname": "x1000c0",
+              "powerState": "on",
+              "managementState": "available",
+              "error": "",
+              "supportedPowerTransitions": [
+                "Force-Off",
+                "Soft-Off",
+                "Off",
+                "On",
+                "Init",
+                "Hard-Restart",
+                "Soft-Restart"
+              ],
+              "lastUpdated": "2024-09-28T12:35:05.267949294Z"
+            },
+            {
+              "xname": "x1000c1",
+              "powerState": "on",
+              "managementState": "available",
+              "error": "",
+              "supportedPowerTransitions": [
+                "Soft-Off",
+                "Off",
+                "On",
+                "Force-Off",
+                "Init",
+                "Hard-Restart",
+                "Soft-Restart"
+              ],
+              "lastUpdated": "2024-09-28T12:35:05.187416764Z"
+            },
+       [...]
+       ```
+
+1. (`ncn-m#`) Check the power status for nodes in the standard racks before shutdown.
+
+    Either use `sat status` or `cray power` to check. The `State` should be `Off` for every node.
+
+    1. (`ncn-m001#`) Check the power status for every `River` node which is not a management node.
+
+       ```bash
+       sat status --filter class=river --filter role!=management --filter enabled=true --hsm-fields
+       ```
+
+       Example output:
+
+       ```text
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
+       | xname          | Type | NID      | State   | Flag  | Enabled | Arch | Class | Role        | SubRole    | Net Type |
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
+       | x3000c0s14b0n0 | Node | 49168832 | Off     | OK    | True    | X86  | River | Application | UAN        | Sling    |
+       | x3000c0s16b0n0 | Node | 49168896 | Off     | OK    | True    | X86  | River | Application | LNETRouter | Sling    |
+       | x3000c0s18b0n0 | Node | 49168960 | Off     | OK    | True    | X86  | River | Application | LNETRouter | Sling    |
+       | x3000c0s20b1n0 | Node | 1        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b2n0 | Node | 2        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b3n0 | Node | 3        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       | x3000c0s20b4n0 | Node | 4        | Off     | OK    | True    | X86  | River | Compute     | None       | Sling    |
+       ...
+       +----------------+------+----------+---------+-------+---------+------+-------+-------------+------------+----------+
+       ```
+
+    1. (`ncn-m001#`) Check the power status with PCS.
+       This example shows nodes in cabinets 3001 - 3003.
+
+       The `cray power status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
+
+       ```bash
+       cray power status list --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
+       ```
+
+       Example output:
+
+       ```json
+       {
+         "status": [
+           {
+             "xname": "x3001c0s1b0n0",
+             "powerState": "undefined",
+             "managementState": "unavailable",
+             "error": "",
+             "supportedPowerTransitions": [
+               "Soft-Off",
+               "Off",
+               "On",
+               "Force-Off",
+               "Soft-Restart",
+               "Init",
+               "Hard-Restart"
+             ],
+             "lastUpdated": "2024-09-19T07:55:01.518324667Z"
+           },
+           {
+             "xname": "x3001c0s3b0n0",
+             "powerState": "on",
+             "managementState": "available",
+             "error": "",
+             "supportedPowerTransitions": [
+               "On",
+               "Force-Off",
+               "Soft-Off",
+               "Off",
+               "Soft-Restart",
+               "Init",
+               "Hard-Restart"
+             ],
+             "lastUpdated": "2024-10-02T05:02:38.945889134Z"
+           },
+           {
+             "xname": "x3000c0s5b0n0",
+             "powerState": "",
+             "managementState": "",
+             "error": "Component not found in component map.",
+             "supportedPowerTransitions": null,
+             "lastUpdated": ""
+           },
+
+       [...]
+       ```
+
+       The command does not filter nonexistent component names \(xnames\) and
+       displays an error for each invalid component names specified. Use `cray power status list`
+       with no `--xnames` option to show everything.
+
+       ```bash
+       cray power status list --format json
+       ```
 
 ### Shut down cabinet power
 
@@ -67,11 +210,11 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. (`ncn-m#`) Shut down cabinet power.
 
-    **Important:** The default timeout for the call to PCS is 120 seconds. If the `sat bootsys shutdown` command fails
-    to power off some cabinets and indicate that requests to PCS have timed out, the `sat` command may be run with an increased `--pcs-timeout` value.
+    **Important:** The default timeout for the call to CAPMC is 120 seconds. If the `sat bootsys shutdown` command fails
+    to power off some cabinets and indicate that requests to CAPMC have timed out, the `sat` command may be run with an increased `--capmc-timeout` value.
 
     ```bash
-    sat bootsys shutdown --stage cabinet-power --pcs-timeout 240
+    sat bootsys shutdown --stage cabinet-power --capmc-timeout 240
     ```
 
 1. (`ncn-m#`) Verify that the `hms-discovery` cron job has been suspended.
@@ -89,7 +232,7 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
     hms-discovery   */3 * * * *   True      0        117s            15d
     ```
 
-1. (Optional) (`ncn-m#`) Check the power status for liquid-cooled cabinets after shutdown.
+1. (`ncn-m#`) Check the power status for liquid-cooled cabinets after shutdown.
 
     This example shows cabinets 1000 - 1003.
 
@@ -99,7 +242,7 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
 
 1. Rectifiers \(PSUs\) in the liquid-cooled cabinets should indicate that DC power is `OFF` \(`AC OK` means the power is on\).
 
-1. (Optional) (`ncn-m#`) Check the power status for nodes in the standard racks after shutdown.
+1. (`ncn-m#`) Check the power status for nodes in the standard racks after shutdown.
 
     ```bash
     cray power status list --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
@@ -125,6 +268,10 @@ liquid-cooled cabinet chassis, compute modules, and router modules, then powers 
     ![CDU Circuit Breakers](../../img/operations/CDU_Circuit_Breakers.png)
 
 ### Power off standard rack PDU circuit breakers
+
+**CAUTION:** If any of the external Lustre or Spectrum Scale (GPFS) file systems are in air-cooled cabinets shared with air-cooled
+compute nodes or management nodes, then the power off of the PDU circuits in these cabinets should be delayed until the external
+file systems have been confirmed to be cleanly shut down. See the procedures in [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 
 1. Set each cabinet PDU circuit breaker to `OFF`.
 

--- a/operations/power_management/Power_Off_Storage_Cabinets.md
+++ b/operations/power_management/Power_Off_Storage_Cabinets.md
@@ -5,7 +5,7 @@ Power off storage nodes and management switches in standard racks.
 ## Power off standard rack PDU circuit breakers
 
 **CAUTION:** The Lustre or Spectrum Scale (GPFS) file systems on nodes and switches in storage cabinets should only
-be powered off when it has been confirmed that the filesystems have been cleanly shut down. See the procedures in
+be powered off when it has been confirmed that the file systems have been cleanly shut down. See the procedures in
 [Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
 
 1. Set each cabinet PDU circuit breaker to `OFF`.

--- a/operations/power_management/Power_Off_Storage_Cabinets.md
+++ b/operations/power_management/Power_Off_Storage_Cabinets.md
@@ -1,0 +1,21 @@
+# Power Off Storage Cabinets
+
+Power off storage nodes and management switches in standard racks.
+
+## Power off standard rack PDU circuit breakers
+
+**CAUTION:** The Lustre or Spectrum Scale (GPFS) file systems on nodes and switches in storage cabinets should only
+be powered off when it has been confirmed that the filesystems have been cleanly shut down. See the procedures in
+[Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems).
+
+1. Set each cabinet PDU circuit breaker to `OFF`.
+
+    A slotted screwdriver may be required to open PDU circuit breakers.
+
+1. To power off Motivair liquid-cooled chilled doors and CDUs, locate the power off switch on the CDU control panel and set it to `OFF`.
+
+    Refer to vendor documentation for the chilled-door cooling system for power control procedures when chilled doors are installed on standard racks.
+
+## Next step
+
+Return to [System Power Off Procedures](System_Power_Off_Procedures.md) and continue with next step.

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -72,6 +72,32 @@ power-on command from Cray System Management \(CSM\) software.
    cray power transition describe TRANSITION_ID --format json
    ```
 
+1. (`ncn-m001#`) Check the power status for every liquid-cooled cabinet Chassis.
+
+   The `State` should be `On` for every Chassis.
+
+   ```bash
+   sat status --types Chassis
+   ```
+
+   Example output.
+
+   ```text
+   +---------+---------+-------+------+---------+------+----------+----------+
+   | xname   | Type    | State | Flag | Enabled | Arch | Class    | Net Type |
+   +---------+---------+-------+------+---------+------+----------+----------+
+   | x1020c0 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c1 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c2 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c3 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c4 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c5 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c6 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   | x1020c7 | Chassis | On    | OK   | True    | X86  | Mountain | Sling    |
+   ...
+   +---------+---------+-------+------+---------+------+----------+----------+
+   ```
+
 ### Power On Standard Rack PDU Circuit Breakers
 
 1. Switch the standard rack compute cabinet PDU circuit breakers to ON.

--- a/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
@@ -68,7 +68,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
         kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible
         ```
 
-1. (Only for Slingshot 2.1.1 and 2.1.2) Set permissions on the SSH keys in the `slingshot-fabric-manager` pod.
+1. (Only for HPE Slingshot 2.1.1 and 2.1.2) Set permissions on the SSH keys in the `slingshot-fabric-manager` pod.
 
     1. (`ncn-m001#`) Enter the `slingshot-fabric-manager` pod.
 
@@ -85,7 +85,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
        exit
        ```
 
-1. (`ncn-m001#`) If the Slingshot `fmn-debug` rpm is used inside the `slingshot-fabric-manager` pod, ensure it is available after the pod has been restarted by the power up procedure.
+1. (`ncn-m001#`) If the HPE Slingshot `fmn-debug` rpm is used inside the `slingshot-fabric-manager` pod, ensure it is available after the pod has been restarted by the power up procedure.
 
    > This step assumes the `fmn-debug` rpm was previously copied to the PVC which is mounted as `/opt/slingshot`. The version of the rpm might be different.
 
@@ -94,7 +94,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
             -c slingshot-fabric-manager -- sudo rpm -ivh /opt/slingshot/data/fmn-debug-2.1.1-22.noarch.rpm  --nodeps
     ```
 
-1. (`ncn-m001#`) Check that the slingshot switches are all online.
+1. (`ncn-m001#`) Check that the HPE Slingshot switches are all online.
 
     If BOS will be used to boot computes and if DVS is configured to use HSN, then check the fabric manager switches to ensure the switches are all online
     before attempting to boot computes.
@@ -127,7 +127,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
     Offline Switches:
     ```
 
-1. If any of the slingshot switches are offline, troubleshoot them.
+1. If any of the HPE Slingshot switches are offline, troubleshoot them.
 
    1. (`ncn-m001#`) Enter the `slingshot-fabric-manager` pod
 
@@ -211,7 +211,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
             kubectl -n services rollout status deployment slingshot-fabric-manager
             ```
 
-         1. (`ncn-m001#`) Check that the Slingshot switches are all online.
+         1. (`ncn-m001#`) Check that the HPE Slingshot switches are all online.
 
             ```bash
             kubectl exec -it -n services \
@@ -395,7 +395,7 @@ the UANs and compute nodes.
       or are disabled in HSM (`Enabled=False`) or have `State` not equal to `Ready`.
 
       ```bash
-      sat status --filter role!=management --filter enabled=true --filter state!=ready --hsm-fields 
+      sat status --filter role!=management --filter enabled=true --filter state!=ready --hsm-fields
       ```
 
       Example output:

--- a/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
@@ -1,13 +1,14 @@
 # Power On and Boot Managed Nodes
 
-Use the Boot Orchestration Service (BOS) and choose the appropriate session template to power on and
-boot managed nodes, e.g. compute nodes and User Access Nodes (UANs).
+Use the Boot Orchestration Service \(BOS\) and choose the appropriate session templates to power on and
+boot the managed compute nodes and application nodes, including the User Access Nodes (UANs).
 
 This procedure boots all managed nodes in the context of a full system power-up.
 
 ## Prerequisites
 
 * All compute cabinet PDUs, servers, and switches must be powered on.
+* All external file systems, such as Lustre or Spectrum Scale (GPFS), should be available to be mounted by clients
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section
   of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 
@@ -67,6 +68,32 @@ This procedure boots all managed nodes in the context of a full system power-up.
         kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible
         ```
 
+1. (Only for Slingshot 2.1.1 and 2.1.2) Set permissions on the SSH keys in the `slingshot-fabric-manager` pod.
+
+    1. (`ncn-m001#`) Enter the `slingshot-fabric-manager` pod.
+
+       ```bash
+       kubectl exec -it -n services "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" -c slingshot-fabric-manager -- bash
+       ```
+
+    1. (`slingshot-fabric-manager>`) Correct SSH file permissions.
+
+       ```bash
+       chmod 600 ~/.ssh/id_rsa
+       chmod 644 ~/.ssh/id_rsa.pub
+       chmod 600 ~/.ssh/config
+       exit
+       ```
+
+1. (`ncn-m001#`) If the Slingshot `fmn-debug` rpm is used inside the `slingshot-fabric-manager` pod, ensure it is available after the pod has been restarted by the power up procedure.
+
+   > This step assumes the `fmn-debug` rpm was previously copied to the PVC which is mounted as `/opt/slingshot`. The version of the rpm might be different.
+
+    ```bash
+    kubectl exec -it -n services "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" \
+            -c slingshot-fabric-manager -- sudo rpm -ivh /opt/slingshot/data/fmn-debug-2.1.1-22.noarch.rpm  --nodeps
+    ```
+
 1. (`ncn-m001#`) Check that the slingshot switches are all online.
 
     If BOS will be used to boot computes and if DVS is configured to use HSN, then check the fabric manager switches to ensure the switches are all online
@@ -74,7 +101,7 @@ This procedure boots all managed nodes in the context of a full system power-up.
 
     ```bash
     kubectl exec -it -n services "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" \
-            -c slingshot-fabric-manager -- fmn_status -q
+            -c slingshot-fabric-manager -- fmn-show-status -q
     ```
 
     Example output:
@@ -99,6 +126,125 @@ This procedure boots all managed nodes in the context of a full system power-up.
     ============================
     Offline Switches:
     ```
+
+1. If any of the slingshot switches are offline, troubleshoot them.
+
+   1. (`ncn-m001#`) Enter the `slingshot-fabric-manager` pod
+
+      ```bash
+      kubectl exec -it -n services "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" -c slingshot-fabric-manager -- bash
+      ```
+
+   1. (`slingshot-fabric-manager>`) Set a variable with the switches which are offline. The list should be separated by space characters.
+
+      ```bash
+      SWITCHES="x1000c0r7b0 x1001c1r3b0 x1004c0r3b0"
+      ```
+
+   1. (`slingshot-fabric-manager>`) Reboot the switches and reset their ASICs.
+
+      ```bash
+      date; fmn-reset-switch -k -i $SWITCHES; sleep 3m; date; fmn-reset-switch -r -i $SWITCHES; sleep 3m; date
+      ```
+
+   1. (`slingshot-fabric-manager>`) Check whether the switches are online now.
+
+      ```bash
+      fmn-show-status -q
+      ```
+
+   1. (`slingshot-fabric-manager>`) If the switches are all online, then exit the `slingshot-fabric-manager` pod and continue to the next step not related to Slingshot.
+
+      ```bash
+      exit
+      ```
+
+   1. (`slingshot-fabric-manager>`) If some switches are still offline, then repeat the step to reboot the Slingshot switches and reset the ASICs.
+
+      ```bash
+      date; fmn-reset-switch -k -i $SWITCHES ; sleep 3m; date;  fmn-reset-switch -r -i $SWITCHES; sleep 3m; date
+      ```
+
+   1. (`slingshot-fabric-manager>`) Check whether the switches are online now.
+
+      ```bash
+      fmn-show-status -q
+      ```
+
+   1. (`slingshot-fabric-manager>`) If the switches are all online after the second attempt, then exit the `slingshot-fabric-manager` pod and continue to the next step not related to Slingshot.
+
+      ```bash
+      exit
+      ```
+
+   1. (`slingshot-fabric-manager>`) If that doesn't work, then check the `FabricHost` log in the `slingshot-fabric-manager` pod for messages to see whether sweeps are happening on a regular basis (10 seconds) and have the correct quantity of Slingshot switches.
+
+      ```bash
+      tail -f /opt/slingshot/data/slingshot/fabric-manager/8000/FabricHost.8000.0.log
+      ```
+
+      Example output excerpts:
+
+      ```bash
+      [48365][I][2024-06-04T21:17:17.006Z][219][8000/fabric/available-agents][lambda$handlePeriodicMaintenance$4][Switch Availability: 180/180 switches available]
+      [48366][I][2024-06-04T21:17:28.062Z][56][8000/fabric/available-agents][lambda$handlePeriodicMaintenance$4][Switch Availability: 180/180 switches available]
+      [48367][I][2024-06-04T21:17:39.072Z][56][8000/fabric/available-agents][lambda$handlePeriodicMaintenance$4][Switch Availability: 180/180 switches available]
+      ```
+
+      1. (`slingshot-fabric-manager>`) If no sweeps are visible, then the `slingshot-fabric-manager` pod will need to be restarted.
+
+         1. Exit from the `slingshot-fabric-manager` pod.
+
+            ```bash
+            exit
+            ```
+
+         1. (`ncn-m001#`) Restart the `slingshot-fabric-manager`.
+
+            ```bash
+            kubectl -n services rollout restart deployment slingshot-fabric-manager
+            ```
+
+         1. (`ncn-m001#`) Wait for the `slingshot-fabric-manager` to restart.
+
+            ```bash
+            kubectl -n services rollout status deployment slingshot-fabric-manager
+            ```
+
+         1. (`ncn-m001#`) Check that the Slingshot switches are all online.
+
+            ```bash
+            kubectl exec -it -n services \
+              "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager -n services --no-headers | head -1 | awk '{print $1}')" \
+              -c slingshot-fabric-manager -- fmn-show-status -q
+            ```
+
+            If the switches are not online repeat the steps above to reboot the Slingshot switches and reset the ASICs.
+
+1. If any workload manager queues were disabled during the power off procedure, enable them.
+   Follow the vendor workload manager documentation to enable queues for running jobs on compute nodes.
+   After compute nodes boot and configure, they will become available in the workload manager.
+
+    1. For Slurm, see the `scontrol` man page.
+
+       If any queues were disabled during the power off procedure, enable them.
+
+    1. For PBS Professional, see the `qstat` and `qmgr` man pages.
+
+       Below is an example to list the available queues, enable a specific queue named `workq`, and check
+       that the queue has been enabled:
+
+       ```bash
+       qstat -q
+       qmgr -c 'set queue workq enabled = True'
+       qmgr -c 'list queue workq enabled'
+       ```
+
+       Each system might have many different queue names. There is no default queue name.
+
+1. If the servers providing external Lustre or Spectrum Scale (GPFS) file systems have been powering up in parallel
+to the CSM system, ensure that they are ready to be mounted by clients before continuing to the next step which boots
+the UANs and compute nodes.
 
 1. (`ncn-m001#`) Set a variable to contain a comma-separated list of the BOS session templates to
    use to boot managed nodes. For example:
@@ -167,9 +313,9 @@ This procedure boots all managed nodes in the context of a full system power-up.
 
 1. If desired, monitor status of the booting process for each BOS session.
 
-   1. (`ncn-m001#`) Use the BOS session ID to monitor the progress of each boot session.
+   1. (`ncn-m001#`) Use the BOS session ID to monitor the progress of the compute node boot session.
 
-      For example, to monitor the compute node boot session from the previous example use the
+      For example, to monitor the compute node BOS session from the previous example use the
       session ID `76d4d98e-814d-4235-b756-4bdfaf3a2cb3`.
 
       ```bash
@@ -198,6 +344,15 @@ This procedure boots all managed nodes in the context of a full system power-up.
           "start_time": "2024-01-30T00:24:49"
         }
       }
+      ```
+
+   1. (`ncn-m001#`) In another shell window, use a similar command to monitor the UAN boot session.
+
+      For example, to monitor the UAN BOS session from the previous example use the
+      session ID `dacad888-e077-41f3-9ab0-65a5a45c64e5`.
+
+      ```bash
+      cray bos sessions status list --format json dacad888-e077-41f3-9ab0-65a5a45c64e5
       ```
 
       In the following example, 33% of the 6 nodes had an issue and stayed in the powering_off phase
@@ -230,14 +385,17 @@ This procedure boots all managed nodes in the context of a full system power-up.
       }
       ```
 
-   1. (`ncn-m001#`) Check the HSM state from `sat status` of the non-management nodes.
+   1. (`ncn-m001#`) Check the HSM state from `sat status` of the compute and application nodes, but not the management nodes.
 
       A node will progress through HSM states in this order: `Off`, `On`, `Ready`. If a node fails to leave `Off` state or
       moves from `On` to `Off` state, it needs to be investigated. If nodes are in `Standby`, that means they had been in `Ready`,
       but stopped sending a heartbeat to HSM so transitioned to `Standby` and may need to be investigated.
 
+      Check which nodes are not in the `Ready` state. This sample command excludes nodes which have `Role` equal to `Management`
+      or are disabled in HSM (`Enabled=False`) or have `State` not equal to `Ready`.
+
       ```bash
-      sat status --filter role!=management --hsm-fields
+      sat status --filter role!=management --filter enabled=true --filter state!=ready --hsm-fields 
       ```
 
       Example output:
@@ -246,29 +404,18 @@ This procedure boots all managed nodes in the context of a full system power-up.
       +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
       | xname          | Type | NID      | State | Flag | Enabled | Arch | Class | Role        | SubRole   | Net Type |
       +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
-      | x3209c0s13b0n0 | Node | 52593056 | Ready | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s15b0n0 | Node | 52593120 | Ready | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s17b0n0 | Node | 52593184 | Ready | OK   | True    | X86  | River | Application | UAN       | Sling    |
       | x3209c0s22b0n0 | Node | 52593344 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
       | x3209c0s23b0n0 | Node | 52593376 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
-      | x9002c1s0b0n0  | Node | 1000     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b0n1  | Node | 1001     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n0  | Node | 1002     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n1  | Node | 1003     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n0  | Node | 1004     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n1  | Node | 1005     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n0  | Node | 1006     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n1  | Node | 1007     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n0  | Node | 1008     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n1  | Node | 1009     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n0  | Node | 1010     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n1  | Node | 1011     | Ready | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
+      | x9002c1s1b0n1  | Node | 1005     | On    | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
+      | x9002c1s2b1n1  | Node | 1011     | On    | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
       +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
       ```
 
-      In this example, two of the application Gateway nodes have a `State` of `Off` which means that they did not power on.
+      In this example, two of the application Gateway nodes have a `State` of `Off` which means that they did not power on
+      and two of the compute nodes have a `State` of `On` which means they powered on but failed to boot to multi-user Linux.
 
-   1. (`ncn-m001#`) Check the BOS fields from `sat status`, but exclude the management nodes which are never booted with BOS.
+   1. (`ncn-m001#`) Check the BOS fields from `sat status`, but exclude the nodes which have `Most Recent BOS Session`
+       set to `Missing`. This will exclude the management nodes because they are never booted with BOS.
 
       ```bash
       sat status --bos-fields --filter '"Most Recent BOS Session"!=MISSING'
@@ -337,6 +484,23 @@ This procedure boots all managed nodes in the context of a full system power-up.
       ```
 
       In this example, two of the application nodes have an older `Desired Config` version than the other UANs and have a last reported `Configuration Status` of pending, meaning they have not begun their CFS configuration.
+
+      To highlight which nodes still have configuration `pending` also exclude nodes which do not have `Configuration Status` set to `configured`.
+
+      ```bash
+      sat status --cfs-fields --filter '"Desired Config"!=*management*' --filter '"Configuration Status"!=configured'
+      ```
+
+      Example output:
+
+      ```text
+      +----------------+----------------------+----------------------+-------------+
+      | xname          | Desired Config       | Configuration Status | Error Count |
+      +----------------+----------------------+----------------------+-------------+
+      | x3209c0s22b0n0 | uan-22.11.0          | pending              | 0           |
+      | x3209c0s23b0n0 | uan-22.11.0          | pending              | 0           |
+      +----------------+----------------------+----------------------+-------------+
+      ```
 
    1. (`ncn-m001#`) For any managed nodes which booted but failed the CFS configuration, check the CFS Ansible log for errors.
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -246,6 +246,19 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
     session running in detached mode. The `sat bootsys` command will automatically exit screen
     sessions when nodes have finished booting.
 
+1. (`ncn-m001#`) Confirm all NCNs have booted.
+
+    ```bash
+     pdsh -w $(grep "nmn ncn-" /etc/hosts | awk '{print $3}' | xargs | sed 's/ /,/g') uptime
+    ```
+
+### Verify Access to External File Systems
+
+If the worker nodes host User Access Instance (UAI) pods or normally mount the external Lustre or Spectrum Scale (GPFS) file systems,
+then verify that the external file system is ready to be mounted by the worker nodes.
+
+Some systems are configured with lazy mounts that do not have this requirement for the worker nodes.
+
 ### Start Kubernetes and other services
 
 1. (`ncn-m001#`) Start the Kubernetes cluster.
@@ -317,6 +330,41 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
     To resolve the space issue, see [Troubleshoot Ceph OSDs Reporting Full](../utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md).
 
+1. (`ncn-m001#`) Check that `spire` pods have started.
+
+    Monitor the status of the `spire-jwks` pods to ensure they restart and enter the `Running` state.
+
+    ```bash
+    kubectl get pods -n spire -o wide | grep spire-jwks
+    ```
+
+    Example output:
+
+    ```text
+    spire-jwks-6b97457548-gc7td    2/3  CrashLoopBackOff   9    23h   10.44.0.117  ncn-w002 <none>   <none>
+    spire-jwks-6b97457548-jd7bd    2/3  CrashLoopBackOff   9    23h   10.36.0.123  ncn-w003 <none>   <none>
+    spire-jwks-6b97457548-lvqmf    2/3  CrashLoopBackOff   9    23h   10.39.0.79   ncn-w001 <none>   <none>
+    ```
+
+   1. (`ncn-m001#`) If the `spire-jwks` pods indicate `CrashLoopBackOff`, then restart the Spire deployment.
+
+       ```bash
+       kubectl rollout restart -n spire deployment spire-jwks
+       ```
+
+   1. (`ncn-m001#`) Rejoin Spire on the worker and master NCNs, to avoid issues with Spire tokens.
+
+       ```bash
+       kubectl rollout restart -n spire daemonset request-ncn-join-token
+       kubectl rollout status -n spire daemonset request-ncn-join-token
+       ```
+
+   1. (`ncn-m001#`) Rejoin Spire on the storage NCNs, to avoid issues with Spire tokens.
+
+       ```bash
+       /opt/cray/platform-utils/spire/fix-spire-on-storage.sh
+       ```
+
 1. (`ncn-m001#`) Monitor the status of the management cluster and which pods are restarting (as indicated by either a `Running` or `Completed` state).
 
     ```bash
@@ -355,39 +403,6 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
     * `/var/lib/cni/networks/macvlan-slurmctld-nmn-conf`
     * `/var/lib/cni/networks/macvlan-slurmdbd-nmn-conf`
-
-1. (`ncn-m001#`) Check that `spire` pods have started.
-
-    ```bash
-    kubectl get pods -n spire -o wide | grep spire-jwks
-    ```
-
-    Example output:
-
-    ```text
-    spire-jwks-6b97457548-gc7td    2/3  CrashLoopBackOff   9    23h   10.44.0.117  ncn-w002 <none>   <none>
-    spire-jwks-6b97457548-jd7bd    2/3  CrashLoopBackOff   9    23h   10.36.0.123  ncn-w003 <none>   <none>
-    spire-jwks-6b97457548-lvqmf    2/3  CrashLoopBackOff   9    23h   10.39.0.79   ncn-w001 <none>   <none>
-    ```
-
-   1. (`ncn-m001#`) If Spire pods indicate `CrashLoopBackOff`, then restart the Spire deployment.
-
-       ```bash
-       kubectl rollout restart -n spire deployment spire-jwks
-       ```
-
-   1. (`ncn-m001#`) Rejoin Spire on the worker and master NCNs, to avoid issues with Spire tokens.
-
-       ```bash
-       kubectl rollout restart -n spire daemonset request-ncn-join-token
-       kubectl rollout status -n spire daemonset request-ncn-join-token
-       ```
-
-   1. (`ncn-m001#`) Rejoin Spire on the storage NCNs, to avoid issues with Spire tokens.
-
-       ```bash
-       /opt/cray/platform-utils/spire/fix-spire-on-storage.sh
-       ```
 
 1. (`ncn-m001#`) Check if any pods are in `CrashLoopBackOff` state because of errors connecting to Vault.
 
@@ -461,7 +476,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 1. (`ncn-m001#`) Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
 
-    **Note:** The `systemctl` command run on each node may have `exit code 3` reported, this does not indicate a problem with `cfs-state-reporter` on that node..
+    **Note:** The `systemctl` command run on each node may have `exit code 3` reported. This does not indicate a problem with `cfs-state-reporter` on that node..
 
     ```bash
     pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g') systemctl status cfs-state-reporter | grep "Active: activating"

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -476,7 +476,7 @@ Some systems are configured with lazy mounts that do not have this requirement f
 
 1. (`ncn-m001#`) Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
 
-    **Note:** The `systemctl` command run on each node may have `exit code 3` reported. This does not indicate a problem with `cfs-state-reporter` on that node..
+    **Note:** The `systemctl` command run on each node may have `exit code 3` reported. This does not indicate a problem with `cfs-state-reporter` on that node.
 
     ```bash
     pdsh -w $(kubectl get nodes | grep -v NAME | awk '{print $1}' | xargs | sed 's/ /,/g') systemctl status cfs-state-reporter | grep "Active: activating"

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -79,6 +79,91 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
    To prevent this issue from happening, remove stale `ssh` host keys from `/root/.ssh/known_hosts` before running the `sat` command.
 
+1. Check certificate expiration deadlines to ensure that a certificate won't expire while the system is powered off.
+
+   1. (`ncn-mw#`) Check the expiration date of the Spire Intermediate CA Certificate.
+
+      ```bash
+      kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+      ```
+
+      Example output:
+
+      ```bash
+      notAfter=Dec 17 00:00:24 2024 GMT
+      ```
+
+      If the certificate will expire while the system is powered off, replace it before powering off the system.
+      See [Replace the Spire Intermediate CA Certificate](../spire/Update_Spire_Intermediate_CA_Certificate.md#replace-the-spire-intermediate-ca-certificate).
+
+   1. (`ncn-m#`) Check the Kubernetes and Bare Metal etcd certificates from a master node.
+
+      Check certificate expiration deadlines for Kubernetes and its bare-metal etcd cluster.
+
+      ```bash
+      kubeadm certs check-expiration --config /etc/kubernetes/kubeadmcfg.yaml
+      ```
+
+      Example output:
+
+      ```text
+      WARNING: kubeadm cannot validate component configs for API groups [kubelet.config.k8s.io kubeproxy.config.k8s.io]
+
+      CERTIFICATE                EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
+      admin.conf                 Sep 24, 2021 15:21 UTC   14d             ca                      no
+      apiserver                  Sep 24, 2021 15:21 UTC   14d             ca                      no
+      apiserver-etcd-client      Sep 24, 2021 15:20 UTC   14d             etcd-ca                 no
+      apiserver-kubelet-client   Sep 24, 2021 15:21 UTC   14d             ca                      no
+      controller-manager.conf    Sep 24, 2021 15:21 UTC   14d             ca                      no
+      etcd-healthcheck-client    Sep 24, 2021 15:19 UTC   14d             etcd-ca                 no
+      etcd-peer                  Sep 24, 2021 15:19 UTC   14d             etcd-ca                 no
+      etcd-server                Sep 24, 2021 15:19 UTC   14d             etcd-ca                 no
+      front-proxy-client         Sep 24, 2021 15:21 UTC   14d             front-proxy-ca          no
+      scheduler.conf             Sep 24, 2021 15:21 UTC   14d             ca                      no
+
+      CERTIFICATE AUTHORITY   EXPIRES                  RESIDUAL TIME   EXTERNALLY MANAGED
+      ca                      Sep 02, 2030 15:21 UTC   8y              no
+      etcd-ca                 Sep 02, 2030 15:19 UTC   8y              no
+      front-proxy-ca          Sep 02, 2030 15:21 UTC   8y              no
+      ```
+
+      Depending on which certificates will expire, one of these procedures could be used for the renewal. The first procedure
+      will renew all certificates, but that may be more than needs to be renewed.
+
+      * See [Renew All Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-all-certificates)
+      * See [Renew Etcd Certificate](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
+      * See [Update Client Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
+
+1. (`ncn-mw#`) Check for a recent backup of Nexus data.
+
+   **Note:** Doing the Nexus backup may take multiple hours with Nexus being unavailable for the entire time.
+
+   Check whether an export PVC called `nexus-bak` exists and is recent.
+
+   ```bash
+   kubectl get pvc -n nexus
+   ```
+
+   Example output:
+
+   ```text
+   NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
+   nexus-bak    Bound    pvc-09b6efe6-18e3-4681-8103-53590ad49d04   1000Gi     RWO            k8s-block-replicated   293d
+   nexus-data   Bound    pvc-bce9db69-d1a6-491d-89fc-d458c92f2895   1000Gi     RWX            ceph-cephfs-external   518d
+   ```
+
+   This output shows that the `nexus-bak` PVC was created 293 days ago.
+
+   * If there is no `nexus-bak` PVC, then use this Nexus export procedure to create one. This procedure does check that
+   there is enough space available for the copy of the `nexus-data` PVC and provides guidance on how to clean up space if
+   necessary or reduce the size of the existing `nexus-data` PVC.
+   See [Nexus Export](../package_repository_management/Nexus_Export_and_Restore.md#Export).
+
+   * If there is an existing `nexus-bak` PVC, but it is too old or the age is not recent enough to include the most recent
+   software update or otherwise not considered valid, then use the Nexus cleanup procedure before the export procedure.
+   See [Nexus Cleanup](../package_repository_management/Nexus_Export_and_Restore.md#Cleanup), then see
+   [Nexus Export](../package_repository_management/Nexus_Export_and_Restore.md#Export).
+
 ### Identify BOS session templates for managed nodes
 
 (`ncn-mw#`) Determine the appropriate Boot Orchestration Service (BOS) templates to use to shut down
@@ -271,24 +356,14 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
     1. Check HSN status.
 
-        Determine the name of the `slingshot-fabric-manager` pod:
+       Run `fmn-show-status` in the `slingshot-fabric-manager` pod and save the output to a file.
 
         ```bash
-        kubectl get pods -l app.kubernetes.io/name=slingshot-fabric-manager -n services
-        ```
-
-        Example output:
-
-        ```text
-        NAME                                        READY   STATUS    RESTARTS   AGE
-        slingshot-fabric-manager-5dc448779c-d8n6q   2/2     Running   0          4d21h
-        ```
-
-        Run `fmn_status` in the `slingshot-fabric-manager` pod and save the output to a file:
-
-        ```bash
-        kubectl exec -it -n services slingshot-fabric-manager-5dc448779c-d8n6q \
-                     -c slingshot-fabric-manager -- fmn_status --details | tee -a fabric.status
+        kubectl exec -it -n services \
+            "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager
+            -n services --no-headers | head -1 | awk '{print $1}')" \
+             -c slingshot-fabric-manager -- fmn-show-status --details \
+           | tee -a fmn-show-status-details.txt
         ```
 
     1. Check management switches to verify they are reachable.
@@ -420,6 +495,10 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
     There is no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
 
+1. Notify users and operations staff about the upcoming full system power off.
+
+   The notification method will vary by system, but might be email, messaging applications, `/etc/motd` on UANs, `wall` commands on UANs, etc.
+
 1. Follow the vendor workload manager documentation to drain processes running on compute nodes.
 
     1. For Slurm, see the `scontrol` man page.
@@ -434,7 +513,18 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
        scontrol update NodeName=ALL State=DRAIN Reason="Shutdown"
        ```
 
-    1. For PBS Professional, see the `pbsnodes` man page.
+    1. For PBS Professional, see the `qstat` and `qmgr` man pages.
+
+       Below is an example to list the available queues, disable a specific queue named `workq`, and check
+       that the queue has been disabled:
+
+       ```bash
+       qstat -q
+       qmgr -c 'set queue workq enabled = False
+       qmgr -c 'list queue workq enabled'
+       ```
+
+       Each system might have many different queue names. There is no default queue name.
 
 ## Next step
 

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -79,7 +79,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
    To prevent this issue from happening, remove stale `ssh` host keys from `/root/.ssh/known_hosts` before running the `sat` command.
 
-1. Check certificate expiration deadlines to ensure that a certificate won't expire while the system is powered off.
+1. Check certificate expiration deadlines to ensure that a certificate will not expire while the system is powered off.
 
    1. (`ncn-mw#`) Check the expiration date of the Spire Intermediate CA Certificate.
 
@@ -497,13 +497,13 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
 1. Notify users and operations staff about the upcoming full system power off.
 
-   The notification method will vary by system, but might be email, messaging applications, `/etc/motd` on UANs, `wall` commands on UANs, etc.
+   The notification method will vary by system, but might be email, messaging applications, `/etc/motd` on UANs, `wall` commands on UANs, and so on.
 
 1. Follow the vendor workload manager documentation to drain processes running on compute nodes.
 
     1. For Slurm, see the `scontrol` man page.
 
-       Below are examples of how to drain nodes using `slurm`. The list of nodes can be copy/pasted from the `sinfo` command for nodes in an `idle` state:
+       The following are examples of how to drain nodes using `slurm`. The list of nodes can be copy/pasted from the `sinfo` command for nodes in an `idle` state:
 
        ```bash
        scontrol update NodeName=nid[001001-001003,001005] State=DRAIN Reason="Shutdown"
@@ -515,7 +515,7 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
     1. For PBS Professional, see the `qstat` and `qmgr` man pages.
 
-       Below is an example to list the available queues, disable a specific queue named `workq`, and check
+       The following is an example to list the available queues, disable a specific queue named `workq`, and check
        that the queue has been disabled:
 
        ```bash

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -13,6 +13,11 @@ The BOS session templates to use for shutting down all managed nodes in the syst
 
 ## Procedure
 
+1. If this system mounts an external Spectrum Scale (GPFS) file system on the compute nodes and UANs, then follow the site procedures
+to ensure that the file system and its quorum nodes are quiesced before shutting down the nodes which have it mounted.
+
+   The quorum nodes might be on worker nodes or on application nodes.
+
 1. (`ncn-m001#`) Set a variable to contain a comma-separated list of the BOS session templates to
    use to shut down managed nodes. For example:
 
@@ -109,40 +114,91 @@ The BOS session templates to use for shutting down all managed nodes in the syst
       }
       ```
 
-   1. (`ncn-m001#`) Check the HSM state from `sat status` of the non-management nodes.
+   1. (`ncn-m001#`) Check the HSM state from `sat status`of the compute and application nodes, but not the management nodes.
+      All the nodes should be in the `Off` state after the previous `sat bootsys shutdown` step, unless they are disabled in HSM,
+      shown as `False` in the `Enabled` column of output from this SAT command.
 
       A node will progress through HSM states in this order: `Ready`, `Standby`, `Off`.
 
       ```bash
-      sat status --filter role!=management --hsm-fields
+      sat status --filter role!=management --hsm-fields --filter state!=off
       ```
 
       Example output:
 
       ```text
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
-      | xname          | Type | NID      | State | Flag | Enabled | Arch | Class | Role        | SubRole   | Net Type |
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
-      | x3209c0s13b0n0 | Node | 52593056 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s15b0n0 | Node | 52593120 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s17b0n0 | Node | 52593184 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s19b0n0 | Node | 52593248 | Off   | OK   | True    | X86  | River | Application | UAN       | Sling    |
-      | x3209c0s22b0n0 | Node | 52593344 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
-      | x3209c0s23b0n0 | Node | 52593376 | Off   | OK   | True    | X86  | River | Application | Gateway   | Sling    |
-      | x9002c1s0b0n0  | Node | 1000     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b0n1  | Node | 1001     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n0  | Node | 1002     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s0b1n1  | Node | 1003     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n0  | Node | 1004     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b0n1  | Node | 1005     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n0  | Node | 1006     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s1b1n1  | Node | 1007     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n0  | Node | 1008     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b0n1  | Node | 1009     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n0  | Node | 1010     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      | x9002c1s2b1n1  | Node | 1011     | Off   | OK   | True    | X86  | Hill  | Compute     | Compute   | Sling    |
-      +----------------+------+----------+-------+------+---------+------+-------+-------------+-----------+----------+
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
+      | xname          | Type | NID      | State  | Flag | Enabled | Arch | Class     | Role        | SubRole   | Net Type |
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
+      | x3000c0s13b0n0 | Node | 52593056 | Ready  | OK   | True    | X86  | River     | Application | UAN       | Sling    |
+      | x3000c0s15b0n0 | Node | 52593120 | Standby| OK   | True    | X86  | River     | Application | UAN       | Sling    |
+      | x3001c0s22b0n0 | Node | 52593344 | Ready  | OK   | True    | X86  | River     | Application | Gateway   | Sling    |
+      | x1002c1s0b0n0  | Node | 1000     | Standby| OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1002c3s2b0n0  | Node | 1008     | On     | OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1004c1s2b0n1  | Node | 1009     | Ready  | OK   | True    | X86  | Mountain  | Compute     | Compute   | Sling    |
+      | x1005c7s2b1n0  | Node | 1010     | Standby| OK   | False   | X86  | Mountain  | Compute     | Compute   | Sling    |
+      +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
       ```
+
+1. Check for User Access Instance (UAI) pods and remove them.
+
+   > Not all systems have been configured to use the containerized user environment (UAI) on worker nodes, but if they are in use, they should be stopped now.
+
+   1. (`ncn-m#`) Check for any UAI pods. This will show the username for each pod.
+
+   ```bash
+   cray uas uais list
+   ```
+
+   1. (`ncn-m#`) Remove any UAI pods using the usernames found in the previous step.
+
+   ```bash
+   cray uas uais delete --username USERNAME
+   ```
+
+1. If any external filesystems are mounted on the worker nodes, unmount them.
+
+   Lustre, Spectrum Scale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the `group_vars`
+   directory structure, such as `group_vars/all/filesystems.yml` or `group_vars/Management_Worker/filesystems.yml`. These steps
+   will run the `cos-config-management` Ansible playbook `configure_fs_unload.yml` using the variables set in `filesystems.yml`.
+
+   1. (`ncn-m#`) Copy the `dvs_reload_ncn script` from `ncn-w001` to a master node.
+
+   ```bash
+   scp ncn-w001:/opt/cray/dvs/default/sbin/dvs_reload_ncn /tmp
+   ```
+
+   1. (`ncn-m#`) Get list of worker nodes.
+
+   ```bash
+   WORKERS=$(cray hsm state components list --subrole Worker --type Node --format json | jq -r .Components[].ID | xargs)
+   echo $WORKERS
+   ```
+
+   1. (`ncn-m#`) Determine CFS configuration assigned to worker nodes. This is expected to be the same for all worker nodes.
+
+   ```bash
+   for node in $WORKERS; do cray cfs components describe $node --format json | jq -r ' .id+" "+.desiredConfig'; done
+   ```
+
+   1. (`ncn-m#`) Set variable for the configuration assigned to worker nodes found in the previous step.
+
+   ```bash
+   CONFIGURATION=
+   echo $CONFIGURATION
+   ```
+
+   1. (`ncn-m#`) Run CFS `configure_fs_unload` Ansible playbook on worker nodes.
+
+   ```bash
+   /tmp/dvs_reload_ncn -c $CONFIGURATION -p configure_fs_unload.yml $WORKERS
+   ```
+
+   1. (`ncn-m#`) Wait for the resulting Kubernetes CFS job (`CFSSESSION`) from the previous step to complete before continuing.
+
+   ```bash
+   kubectl logs -f -n services -c ansible CFSSESSION
+   ```
 
 ## Next Steps
 

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -168,7 +168,7 @@ to ensure that the file system and its quorum nodes are quiesced before shutting
    scp ncn-w001:/opt/cray/dvs/default/sbin/dvs_reload_ncn /tmp
    ```
 
-   1. (`ncn-m#`) Get list of worker nodes.
+   1. (`ncn-m#`) Get a list of worker nodes.
 
    ```bash
    WORKERS=$(cray hsm state components list --subrole Worker --type Node --format json | jq -r .Components[].ID | xargs)

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -17,21 +17,29 @@ To make sure that the system is healthy before power off and all the information
 
 To shut down compute nodes and User Access Nodes \(UANs\), refer to [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 
+## Power Off the External File Systems
+
+To power off the external Lustre file system (ClusterStor), refer to [Power Off the External Lustre File System](Power_Off_the_External_Lustre_File_System.md).
+
+To power off the external Spectrum Scale (GPFS) file system, refer to site procedures.
+
 ## Save Management Network Switch Settings
 
 To save management switch configuration settings, refer to [Save Management Network Switch Configuration Settings](Save_Management_Network_Switch_Configurations.md).
 
 ## Power Off System Cabinets
 
+If any of the external file systems are in air-cooled cabinets shared with air-cooled compute nodes or management nodes, then
+the power off of the PDU circuits in these cabinets should be delayed until the external Lustre or Spectrum Scale (GPFS) file
+systems have been cleanly shut down.
+
 To power off standard rack and liquid-cooled cabinet PDUs, refer to [Power Off Compute Cabinets](Power_Off_Compute_Cabinets.md).
+
+To power off standard racks which have only storage nodes and switches, refer to [Power Off Storage Cabinets](Power_Off_Storage_Cabinets.md).
 
 ## Shut Down the Management Kubernetes Cluster
 
 To shut down the management Kubernetes cluster, refer to [Shut Down and Power Off the Management Kubernetes Cluster](Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md).
-
-## Power Off the External Lustre File System
-
-To power off the external Lustre file system (ClusterStor), refer to [Power Off the External Lustre File System](Power_Off_the_External_Lustre_File_System.md).
 
 ## `Lockout Tagout` Facility Power
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -22,9 +22,15 @@ cabinets are powered on, wait at least 10 minutes for systems to initialize.
 
 After all the system cabinets are powered on, be sure that all management network and Slingshot network switches are powered on, and that there are no error LEDS or hardware failures.
 
-## Power on the external Lustre file system
+## Power On the External File Systems
 
 To power on an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
+
+To power on the external Spectrum Scale (GPFS) file system, refer to site procedures.
+
+**Note:** If the external file systems are not mounted on worker nodes, then continue to power them in parallel with
+the power on and boot of the Kubernetes management cluster and the power on of the compute cabinets. This must be completed
+before beginning to power on and boot the compute nodes and User Access Nodes (UANs).
 
 ## Power on and boot the Kubernetes management cluster
 
@@ -36,8 +42,10 @@ To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On 
 
 ## Power on and boot managed nodes
 
-To power on and boot managed nodes, e.g. compute nodes and User Access Nodes (UANs), refer to
-[Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md) and make nodes available to users.
++**Note:** Ensure that the external Lustre and Spectrum Scale (GPFS) filesystems are available before starting to boot the compute nodes and UANs.
+
+To power on and boot managed compute nodes and application nodes, such as the User Access Nodes (UANs), refer to
+[Power On and Boot Managed Nodes](Power_On_and_Boot_Managed_Nodes.md).
 
 ## Run system health checks
 


### PR DESCRIPTION
CASMTRIAGE-7099-1.6 port of CSM 1.4 full system power off/on procedures to CSM 1.6

# Description

Several smaller changes are included in the branch from [CASMTRIAGE-7027]:

[CASMTRIAGE-7028](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7028): Correct SDU collection directory mountpoint
[CASMTRIAGE-7029](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7029):Adjust preparation step to check HSN status to be single command line
[CASMTRIAGE-7033](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7033): filter sat status command to remove nodes in Off state
[CASMTRIAGE-7032](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7032): Added power down steps to disable PBS queues. Added reminder to enable Slurm and PBS queues during power up
[CASMTRIAGE-7031](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7031): Added Preparation step to warn users and operations staff of impending system power down
[CASMTRIAGE-7037](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7037): Update env variables to allow better copy/pasting of variables to 2nd window, adjust ncn-shutdown-timeout to 1200
[CASMTRIAGE-7051](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7051): Improved sat checks after booting compute and application nodes to reduce amount of output from nodes with desired settings
[CASMTRIAGE-7036](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7036): Added checks for current etcd backups and alarms to power down of Kubernetes cluster
[CASMTRIAGE-7039](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7039): Install psmisc rpm to have tools to find processes preventing filesystem unmounting
[CASMTRIAGE-7046](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7046): Improve power up checks for Kubernetes: Uptime on all NCNs, move spire-jwks remediation earlier since it is always needed, note cray-cps-cm-pm pods will be in error until CFS runs
[CASMTRIAGE-7049](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7049): confirm after SAT command that all Chassis are On
[CASMTRIAGE-7034](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7034): Added sat status as first option to check power status and kept existing cray power option
[CASMTRIAGE-7042](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7042): Unload DVS and Lnet kernel modules from worker nodes for shutdown
[CASMTRIAGE-7038](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7038): For worker nodes: Stop UAIs, unmount Lustre, unmount DVS-mounted CPE
[CASMTRIAGE-7047](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7047): Added hints for when to work on off/on for external file system servers in parallel to other off/on activities and included checks that external file systems are ready before trying to use them
[CASMTRIAGE-7048](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7048): Added workflow placeholder for site procedure to quiesce SpectrumScale GPFS on quorum nodes and unmount it on clients
[CASMTRIAGE-7052](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7052): Added Slingshot 2.1.1 SSH permission fix, reinstallation of fmn-debug rpm, and troubleshooting procedure when some Slingshot switches are offline
[CASMTRIAGE-6615](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6615): Check for potential expiration of Spire Intermedia CA certificate and Kubernetes and bare metal etcd certificates during system power down preparation
[CASMTRIAGE-6614](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6614): Check for recent Nexus backup when Preparing for full system power down

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
