### PR TITLE
CASMINST-7025: Ensure that BOS data is backed up on all upgrade paths

### DIFF
--- a/upgrade/scripts/common/k8s-common.sh
+++ b/upgrade/scripts/common/k8s-common.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -e -o pipefail
+
+function k8s_job_exists {
+  # usage: k8s_job_exists <namespace> <job name>
+  # Returns 0 if the job exists
+  # Returns 1 if the job does not exist
+  # Exits if Kubernetes errors prevent us from determining that
+  if [[ $# -ne 2 ]]; then
+    echo "ERROR: $0: Function requires exactly 2 arguments but received $#: $*" >&2
+    exit 1
+  elif [[ -z $1 ]]; then
+    echo "ERROR: $0: Namespace may not be blank" >&2
+    exit 1
+  elif [[ -z $2 ]]; then
+    echo "ERROR: $0: Job name may not be blank" >&2
+    exit 1
+  fi
+
+  local i wait_time job_name ns tempfile
+  i=1
+  max_checks=3
+  wait_time=15
+  ns="$1"
+  job_name="$2"
+  tempfile=$(mktemp)
+
+  # To prevent failure caused by some transient Kubernetes error, retry this check
+  while [[ ${i} -le ${max_checks} ]]; do
+    echo "Checking if Kubernetes job ${job_name} (namespace: ${ns}) exists (${i}/${max_checks})"
+    [[ ${i} -eq 1 ]] || sleep ${wait_time}
+    if kubectl get job -n "${ns}" "${job_name}" > /dev/null 2> "${tempfile}"; then
+      echo "${job_name} job exists"
+      return 0
+    elif grep -Eiq 'NotFound|not found' "${tempfile}"; then
+      echo "${job_name} job does not exist"
+      return 1
+    fi
+    echo "Error checking existence of ${job_name} Kubernetes job."
+    if [[ ${i} -lt ${max_checks} ]]; then
+      echo "Retrying after ${wait_time} seconds."
+      sleep ${wait_time}
+    fi
+  done
+  echo "ERROR: Unable to determine whether or not Kubernetes job ${job_name} (namespace ${ns}) exists" >&2
+  exit 1
+}
+
+function wait_for_k8s_job_to_exist {
+  # usage: wait_for_k8s_job_to_exist <namespace> <job name>
+  # Returns 0 if the job exists
+  # Returns 1 if the job does not exist by the time the retries are exhausted
+  # Exits 1 for other fatal errors
+  if [[ $# -ne 2 ]]; then
+    echo "ERROR: $0: Function requires exactly 2 arguments but received $#: $*" >&2
+    exit 1
+  elif [[ -z $1 ]]; then
+    echo "ERROR: $0: Namespace may not be blank" >&2
+    exit 1
+  elif [[ -z $2 ]]; then
+    echo "ERROR: $0: Job name may not be blank" >&2
+    exit 1
+  fi
+
+  local i max_checks wait_time job_name ns start_time
+  i=1
+  max_checks=40
+  wait_time=15
+  ns="$1"
+  job_name="$2"
+  start_time=${SECONDS}
+
+  while [[ ${i} -le ${max_checks} ]]; do
+    echo "Waiting for Kubernetes job ${job_name} (namespace: ${ns}) to exist (${i}/${max_checks})"
+    [[ ${i} -eq 1 ]] || sleep ${wait_time}
+    i=$((i + 1))
+    if k8s_job_exists "${ns}" "${job_name}"; then
+      echo "Kubernetes job ${job_name} exists"
+      return 0
+    fi
+    echo "Kubernetes job ${job_name} does not yet exist"
+    if [[ ${i} -lt ${max_checks} ]]; then
+      echo "Checking again after ${wait_time} seconds."
+      sleep ${wait_time}
+    fi
+  done
+  echo "ERROR: Kubernetes job ${job_name} (namespace: ${ns}) does not exist after $((SECONDS - start_time)) seconds" >&2
+  return 1
+}
+
+function wait_for_k8s_job_to_succeed {
+  # usage: wait_for_k8s_job_to_complete <namespace> <job name>
+  # Returns 0 if the job completes successfully
+  # Returns 1 if the job does not succeed by the time the retries are exhausted
+  # Exits 1 for other fatal errors
+  if [[ $# -ne 2 ]]; then
+    echo "ERROR: $0: Function requires exactly 2 arguments but received $#: $*" >&2
+    exit 1
+  elif [[ -z $1 ]]; then
+    echo "ERROR: $0: Namespace may not be blank" >&2
+    exit 1
+  elif [[ -z $2 ]]; then
+    echo "ERROR: $0: Job name may not be blank" >&2
+    exit 1
+  fi
+
+  local i max_checks wait_time job_name ns start_time
+  i=1
+  max_checks=40
+  wait_time=15
+  ns="$1"
+  job_name="$2"
+  start_time=${SECONDS}
+
+  while [[ ${i} -le ${max_checks} ]]; do
+    echo "Waiting for Kubernetes job ${job_name} (namespace: ${ns}) to succeed (${i}/${max_checks})"
+    [[ ${i} -eq 1 ]] || sleep ${wait_time}
+    i=$((i + 1))
+    if [[ $(kubectl get job -n services "${job_name}" -o jsonpath='{.status.succeeded}') == 1 ]]; then
+      echo "Kubernetes job ${job_name} succeeded"
+      return 0
+    fi
+    echo "Kubernetes job ${job_name} not yet succeeded"
+    if [[ ${i} -lt ${max_checks} ]]; then
+      echo "Checking again after ${wait_time} seconds."
+      sleep ${wait_time}
+    fi
+  done
+  echo "ERROR: Kubernetes job ${job_name} (namespace: ${ns}) did not succeed after $((SECONDS - start_time)) seconds" >&2
+  return 1
+}

--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -26,6 +26,7 @@
 set -e
 basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 . ${basedir}/../common/upgrade-state.sh
+. ${basedir}/../common/k8s-common.sh
 trap 'err_report' ERR
 
 . /etc/cray/upgrade/csm/myenv
@@ -155,6 +156,66 @@ fi
 
 # Restart CFS deployments to avoid CASMINST-6852
 "${basedir}/../common/restart-cfs.sh"
+
+# Back up BOS data post-sysmgmt upgrade, and record contents of the migration pod
+# This only needs to be done if the cray-bos-migration job exists
+job_name=cray-bos-migration
+ns=services
+state_name="POST_UPGRADE_BOS_SNAPSHOT"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
+  echo "====> ${state_name} ..."
+  {
+    # Make sure the BOS migration job is complete (succeeded or failed)
+    job_error=""
+    wait_for_k8s_job_to_succeed "${ns}" "${job_name}" || job_error="migration_job_not_successful."
+
+    DATESTRING=$(date +%Y-%m-%d_%H-%M-%S)
+    SNAPSHOT_DIR=$(mktemp -d --tmpdir=/root "csm_upgrade.post_bos_upgrade_snapshot.${job_error}${DATESTRING}.XXXXXX")
+    echo "Post-BOS-upgrade snapshot directory: ${SNAPSHOT_DIR}"
+
+    # Record BOS data, because the upgrade to CSM 1.6 deleted all BOS v1 data, and sanitized
+    # the BOS v2 data
+    echo "Backing up BOS data"
+    /usr/share/doc/csm/scripts/operations/configuration/export_bos_data.sh "${SNAPSHOT_DIR}"
+
+    # Record state of BOS Kubernetes pods.
+    K8S_PODS_SNAPSHOT=${SNAPSHOT_DIR}/k8s_bos_pods.txt
+    echo "Taking snapshot of current BOS Kubernetes pod states to ${K8S_PODS_SNAPSHOT}"
+    kubectl get pods -n services -l 'app.kubernetes.io/instance in (cray-bos, cray-bos-db)' \
+      -o wide --show-labels > "${K8S_PODS_SNAPSHOT}"
+
+    # Record pod logs
+    K8S_POD_LOGS=${SNAPSHOT_DIR}/k8s_bos_pod_logs.txt
+    kubectl logs -n services --ignore-errors --all-containers --timestamps --prefix --max-log-requests 500 \
+      --insecure-skip-tls-verify-backend --tail=-1 \
+      -l 'app.kubernetes.io/instance in (cray-bos, cray-bos-db)' > "${K8S_POD_LOGS}"
+
+    SNAPSHOT_DIR_BASENAME=$(basename "${SNAPSHOT_DIR}")
+    TARFILE_BASENAME="${SNAPSHOT_DIR_BASENAME}.tgz"
+    TARFILE_FULLPATH="/tmp/${TARFILE_FULLPATH}"
+    echo "Creating compressed tarfile of snapshot data: ${TARFILE_FULLPATH}"
+    tar -C /root -czf "${TARFILE_FULLPATH}" "${SNAPSHOT_DIR_BASENAME}"
+
+    backupBucket="config-data"
+    cray artifacts list "${backupBucket}" || backupBucket="vbis"
+
+    echo "Uploading tarfile to S3 (bucket $backupBucket)"
+    cray artifacts create "${backupBucket}" "${TARFILE_BASENAME}" "${TARFILE_FULLPATH}"
+
+    echo "Deleting tar file from local filesystem"
+    rm -v "${TARFILE_FULLPATH}"
+
+    if [[ -n ${job_error} ]]; then
+      echo "ERROR: Kubernetes job ${job_name} (namespace: ${ns}) did not succeed" >&2
+      exit 1
+    fi
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)"
+  echo
+else
+  echo "====> ${state_name} has been completed"
+fi
 
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -29,6 +29,7 @@ locOfScript=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 . "${locOfScript}/../common/ncn-common.sh" "$(hostname)"
 # upgrade-state.sh uses CSM_RELEASE defined by ncn-common.sh
 . "${locOfScript}/../common/upgrade-state.sh"
+. "${locOfScript}/../common/k8s-common.sh"
 trap 'err_report' ERR INT TERM HUP EXIT
 # array for paths to unmount after chrooting images
 # shellcheck disable=SC2034
@@ -245,6 +246,11 @@ function is_vshasta_node {
   return $?
 }
 
+function set_backupBucket_var {
+  backupBucket="config-data"
+  cray artifacts list "${backupBucket}" || backupBucket="vbis"
+}
+
 if is_vshasta_node; then
   vshasta="true"
 else
@@ -258,31 +264,26 @@ state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
-
     DATESTRING=$(date +%Y-%m-%d_%H-%M-%S)
     SNAPSHOT_DIR=$(mktemp -d --tmpdir=/root "csm_upgrade.pre_upgrade_snapshot.${DATESTRING}.XXXXXX")
     echo "Pre-upgrade snapshot directory: ${SNAPSHOT_DIR}"
 
-    # Record BOS data, because the upgrade to CSM 1.6 will delete all BOS v1 data, and will sanitize
-    # the BOS v2 data
-    echo "Backing up BOS data"
-    /usr/share/doc/csm/scripts/operations/configuration/export_bos_data.sh --include-v1 "${SNAPSHOT_DIR}"
+    /usr/share/doc/csm/upgrade/scripts/upgrade/util/pre-upgrade-status.sh -o "${SNAPSHOT_DIR}" --hsn-not-required --sdu-not-required
 
-    # Record CFS components and configurations, since these are modified during the upgrade process
-    CFS_CONFIG_SNAPSHOT=${SNAPSHOT_DIR}/cfs_configurations.json
-    echo "Backing up CFS configurations to ${CFS_CONFIG_SNAPSHOT}"
-    curl -k -H "Authorization: Bearer $(get_token)" https://api-gw-service-nmn.local/apis/cfs/v3/configurations > "${CFS_CONFIG_SNAPSHOT}"
+    SNAPSHOT_DIR_BASENAME=$(basename "${SNAPSHOT_DIR}")
+    TARFILE_BASENAME="${SNAPSHOT_DIR_BASENAME}.tgz"
+    TARFILE_FULLPATH="/tmp/${TARFILE_FULLPATH}"
+    echo "Creating compressed tarfile of backup data: ${TARFILE_FULLPATH}"
+    tar -C /root -czf "${TARFILE_FULLPATH}" "${SNAPSHOT_DIR_BASENAME}"
 
-    CFS_COMP_SNAPSHOT=${SNAPSHOT_DIR}/cfs_components.json
-    echo "Backing up CFS components to ${CFS_COMP_SNAPSHOT}"
-    curl -k -H "Authorization: Bearer $(get_token)" https://api-gw-service-nmn.local/apis/cfs/v3/components > "${CFS_COMP_SNAPSHOT}"
+    # This function sets the $backupBucket variable. It is defined earlier in this file.
+    set_backupBucket_var
 
-    # Record state of Kubernetes pods. If a pod is later seen in an unexpected state, this can provide a reference to
-    # determine whether or not the issue existed prior to the upgrade.
-    K8S_PODS_SNAPSHOT=${SNAPSHOT_DIR}/k8s_pods.txt
-    echo "Taking snapshot of current Kubernetes pod states to ${K8S_PODS_SNAPSHOT}"
-    kubectl get pods -A -o wide --show-labels > "${K8S_PODS_SNAPSHOT}"
+    echo "Uploading tarfile to S3 (bucket $backupBucket)"
+    cray artifacts create "${backupBucket}" "${TARFILE_BASENAME}" "${TARFILE_FULLPATH}"
 
+    echo "Deleting tar file from local filesystem"
+    rm -v "${TARFILE_FULLPATH}"
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
   echo
@@ -578,41 +579,12 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     job_name="csm-config-import-${CSM_RELEASE}"
-    i=1
-    max_checks=40
-    wait_time=15
+    ns=services
     # First, wait for the job to be created
-    created=no
-    while [[ ${i} -le ${max_checks} ]]; do
-      echo "Waiting for Kubernetes job ${job_name} to exist (${i}/${max_checks})"
-      sleep ${wait_time}
-      i=$((i + 1))
-      if kubectl get job -n services "${job_name}" 2> /dev/null; then
-        echo "Kubernetes job ${job_name} exists"
-        created=yes
-        break
-      fi
-    done
-    if [[ ${created} == no ]]; then
-      echo "ERROR: Kubernetes job ${job_name} does not exist after $((max_checks * wait_time)) seconds" >&2
-      exit 1
-    fi
+    wait_for_k8s_job_to_exist "${ns}" "${job_name}"
+
     # Now wait for the job to succeed
-    passed=no
-    while [[ ${i} -le ${max_checks} ]]; do
-      echo "Waiting for Kubernetes job ${job_name} to succeed (${i}/${max_checks})"
-      sleep ${wait_time}
-      i=$((i + 1))
-      if [[ $(kubectl get job -n services "${job_name}" -o jsonpath='{.status.succeeded}') == 1 ]]; then
-        echo "Kubernetes job ${job_name} succeeded"
-        passed=yes
-        break
-      fi
-    done
-    if [[ ${passed} == no ]]; then
-      echo "ERROR: Kubernetes job ${job_name} did not succeed after $((max_checks * wait_time)) seconds" >&2
-      exit 1
-    fi
+    wait_for_k8s_job_to_succeed "${ns}" "${job_name}"
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
https://jira-pro.it.hpe.com:8443/browse/CASMINST-7025

This PR ensures that regardless of which CSM upgrade path is used, certain BOS-related data is collected before and after the CSM services are upgraded. This is necessary because BOS data may be changed or deleted during the upgrade, and we want to make sure that none of it is completely lost.

For the pre-upgrade backup, I noticed that when using IUF, the `upgrade/scripts/upgrade/util/pre-upgrade-status.sh` script was used to take a snapshot. And when not using IUF, there was a section in `upgrade/scripts/upgrade/prerequisites.sh` which served a similar purpose. This PR modifies these scripts so that both paths end up using the `upgrade/scripts/upgrade/util/pre-upgrade-status.sh` script. This involved adding some flags to that script to be used when it is called from the non-IUF path. I also added code to that script to upload the resulting data to S3.

For the post-upgrade snapshot, those changes were made in the `upgrade/scripts/upgrade/csm-upgrade.sh` script itself, since both IUF and non-IUF upgrades use that script to do the services update.

I also created a new common functions file (`upgrade/scripts/common/k8s-common.sh`), to avoid duplicated code between some of the scripts.

Since this is in aid of stuff that is specific to CSM 1.6, no backports are needed.

I am going to make documentation changes using [CASMINST-6992](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6992) to describe the possible BOS data loss/changes. This PR is just for the script side of things, and doesn't need to wait on the doc PR before it merges.