### PR TITLE
CASMCMS-9160: Remove BOS v1 references; linting

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -115,6 +115,7 @@ Use the Boot Orchestration Service \(BOS\) to boot, reboot, and shut down collec
       - [Stage Changes with BOS](boot_orchestration/Stage_Changes_with_BOS.md)
       - [Kernel Boot Parameters](boot_orchestration/Kernel_Boot_Parameters.md)
       - [Troubleshoot UAN Boot Issues](boot_orchestration/Troubleshoot_UAN_Boot_Issues.md)
+      - [Determine Which BOS Session Booted A Node](boot_orchestration/Determine_Which_BOS_Session_Booted_A_Node.md)
 - [BOS Options](boot_orchestration/Options.md)
 - [Exporting and Importing BOS Data](boot_orchestration/Exporting_and_Importing_BOS_Data.md)
 - [Exporting and Importing BSS Data](boot_orchestration/Exporting_and_Importing_BSS_Data.md)

--- a/operations/boot_orchestration/Determine_Which_BOS_Session_Booted_A_Node.md
+++ b/operations/boot_orchestration/Determine_Which_BOS_Session_Booted_A_Node.md
@@ -1,111 +1,56 @@
 # Determine Which BOS Session Booted a Node
 
-This guide is split into two sections, BOS Version 1 (V1) and BOS
-Version 2 (V2), because the procedures are different for the two different versions.
+## Overview
 
-## BOS Version 1 (V1)
-
-To determine which BOS Session booted or rebooted a node, query the node's
-kernel boot parameters. They contain a `bos_session_id` parameter which identifies
-which BOS session booted or rebooted the node. Then, use this BOS Session ID
-to describe the BOS Session, which identifies the BOS Session template used.
-
-### Query the Node
-
-(`ncn-mw#`) Set an environment variable to the xname of the node in question. For example:
-
-```bash
-export NODE_XNAME="x3000c0s19b4n0"
-```
-
-(`ncn-mw#`) Query the node in question via SSH.
-
-```bash
-BOS_SESSION_ID=$(ssh $NODE_XNAME "cat /proc/cmdline" | awk -v RS=" " -F "=" '{if ($1 == "bos_session_id") { print $2; }}')
-echo $BOS_SESSION_ID
-```
-
-The output will be the BOS session ID. For example:
-
-```text
-4b6744ee-837f-4f60-9051-897aed6c7623
-```
-
-### Query BOS
-
-(`ncn-mw#`)  Describe this session using the Cray CLI.
-
-```bash
-cray bos v1 session describe ${BOS_SESSION_ID} --format json
-```
-
-This will output information about the BOS session. For example:
-
-```json
-{
-  "complete": false,
-  "error_count": 0,
-  "in_progress": false,
-  "job": "boa-4b6744ee-837f-4f60-9051-897aed6c7623",
-  "operation": "reboot",
-  "start_time": "2023-06-23T20:57:34.352623Z",
-  "status_link": "/v1/session/4b6744ee-837f-4f60-9051-897aed6c7623/status",
-  "stop_time": "2023-06-23 21:24:14.647779",
-  "templateName": "knn-boot-x3000c0s28b4n0"
-}
-```
-
-The `templateName` parameter is the name of the BOS session template used to boot or reboot the node.
-
-## BOS Version 2 (V2)
-
-Ask BOS V2 to describe the component. The session that last acted upon the
+Ask BOS to describe the component. The session that last acted upon the
 node is listed in this description.
 
-### Instructions
+## Instructions
 
-(`ncn-mw#`) Set an environment variable to the xname of the node in question. For example:
+1. (`ncn-mw#`) Set an environment variable to the xname of the node in question.
 
-```bash
-export NODE_XNAME="x3000c0s17b0n0"
-```
+    For example:
 
-(`ncn-mw#`) Query the BOS component for that node:
+    ```bash
+    export NODE_XNAME="x3000c0s17b0n0"
+    ```
 
-```bash
-BOS_SESSION_ID=$(cray bos v2 components describe $NODE_XNAME --format json | jq -r .session)
-echo $BOS_SESSION_ID
-```
+1. (`ncn-mw#`) Query the BOS component for that node.
 
-The output will be the BOS session ID. For example:
+    ```bash
+    BOS_SESSION_ID=$(cray bos v2 components describe $NODE_XNAME --format json | jq -r .session)
+    echo $BOS_SESSION_ID
+    ```
 
-```text
-94e712ab-df76-40ee-8cfb-7ac487fd8a13
-```
+    The output will be the BOS session ID. For example:
 
-(`ncn-mw#`) Describe the BOS session using the Cray CLI:
+    ```text
+    94e712ab-df76-40ee-8cfb-7ac487fd8a13
+    ```
 
-```bash
-cray bos v2 sessions describe $BOS_SESSION_ID --format json
-```
+1. (`ncn-mw#`) Describe the BOS session.
 
-This will output information about the BOS session. For example:
+    ```bash
+    cray bos v2 sessions describe $BOS_SESSION_ID --format json
+    ```
 
-```json
-{
-  "components": "x3000c0s17b0n0",
-  "limit": "x3000c0s17b0n0",
-  "name": "94e712ab-df76-40ee-8cfb-7ac487fd8a13",
-  "operation": "reboot",
-  "stage": false,
-  "status": {
-    "end_time": "2023-06-27T00:55:58",
-    "error": null,
-    "start_time": "2023-06-27T00:33:17",
-    "status": "complete"
-  },
-  "template_name": "gdr-tmpl"
-}
-```
+    This will output information about the BOS session. For example:
 
-The `template_name` parameter is the name of the BOS session template used to boot or reboot the node.
+    ```json
+    {
+      "components": "x3000c0s17b0n0",
+      "limit": "x3000c0s17b0n0",
+      "name": "94e712ab-df76-40ee-8cfb-7ac487fd8a13",
+      "operation": "reboot",
+      "stage": false,
+      "status": {
+        "end_time": "2023-06-27T00:55:58",
+        "error": null,
+        "start_time": "2023-06-27T00:33:17",
+        "status": "complete"
+      },
+      "template_name": "gdr-tmpl"
+    }
+    ```
+
+    The `template_name` parameter is the name of the BOS session template used to boot or reboot the node.

--- a/operations/boot_orchestration/Healthy_Compute_Node_Boot_Process.md
+++ b/operations/boot_orchestration/Healthy_Compute_Node_Boot_Process.md
@@ -1,8 +1,9 @@
 # Healthy Compute Node Boot Process
 
-In order to investigate node boot-related issues, it is important to understand the flow of a healthy boot process and the associated components. This section outlines the normal flow of components that play a role in booting compute nodes, including DHCP, BSS, and TPTP.
+In order to investigate node boot-related issues, it is important to understand the flow of a healthy boot process and the associated components.
+This section outlines the normal flow of components that play a role in booting compute nodes, including DHCP, BSS, and TPTP.
 
-### DHCP
+## DHCP
 
 A healthy DHCP exchange between server and client looks like the following:
 
@@ -19,7 +20,7 @@ The following figure shows what a healthy DHCP discover process looks like via W
 
 The DHCP client uses port 68, whereas the DHCP server uses port 67. Unlike most Kubernetes pods, the DHCP pod is located on the host network.
 
-### TFTP
+## TFTP
 
 A healthy TFTP exchange between server and client looks like the following.
 
@@ -36,23 +37,22 @@ A healthy TFTP exchange between server and client looks like the following.
 
 The last two steps repeat until the file transfer is complete. The last block from the server will be labeled as \(`Last`\). The TFTP server listens on port 69. Kubernetes forwards port 69 on every node in the Kubernetes cluster to the TFTP pod.
 
-### Boot Script Service \(BSS\)
+## Boot Script Service \(BSS\)
 
-A healthy transaction with the Boot Script Service \(BSS\) looks similar to the following:
+(`ncn-mw#`) A healthy transaction with the Boot Script Service \(BSS\) looks similar to the following:
 
 ```bash
 cray bss bootscript list --mac a4:bf:01:3e:c0:a2
 ```
 
-Example output:
+Example output (lines truncated because of extreme length):
 
-```bash
+```text
 #!ipxe
-kernel --name kernel http://rgw.local:8080/boot-images/29c2cc23-a9d6-4e9a-ab1a-b5fa9270c975/kernel?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5RN45WD0L8KY8W4317WP%2F20200326%2Fdefault%2Fs3%2Faws4_request&X-Amz-Date=20200326T185958Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=43f5b0c5909ee51dabc564d2b72401983ff8fd03cc6fc309b04cb16e67f1989d initrd=initrd console=ttyS0,115200 bad_page=panic crashkernel=360M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell k8s_gw=api-gw-service-nmn.local quiet turbo_boost_limit=999 root=craycps-s3:s3://boot-images/29c2cc23-a9d6-4e9a-ab1a-b5fa9270c975/rootfs:8c274aecef9e1668a8a44e8cfc2b24b5-165:dvs:api-gw-service-nmn.local:300:eth0 xname=x3000c0s17b4n0 nid=4 || goto boot_retry
-initrd --name initrd http://rgw.local:8080/boot-images/29c2cc23-a9d6-4e9a-ab1a-b5fa9270c975/initrd?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5RN45WD0L8KY8W4317WP%2F20200326%2Fdefault%2Fs3%2Faws4_request&X-Amz-Date=20200326T185958Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=d18f8da89108b9f2e659d7bbefcd106d5f13703a59f8ca837bcbc5938a9f9cc5 || goto boot_retry
+kernel --name kernel http://rgw.local:8080/boot-images/29c2cc23-a9d6-4e9a-ab1a-b5fa9270c975/kernel?X-Amz-A...
+initrd --name initrd http://rgw.local:8080/boot-images/29c2cc23-a9d6-4e9a-ab1a-b5fa9270c975/initrd?X-Amz-A...
 boot || goto boot_retry
 :boot_retry
 sleep 30
 chain https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript?mac=a4:bf:01:3e:f9:28&retry=1
 ```
-


### PR DESCRIPTION
* Remove BOS v1 references that were accidentally added to the CSM 1.6 branch
* Add a missing BOS page link to the operations index
* Linting

Backports (just for the missing link):
1.5: https://github.com/Cray-HPE/docs-csm/pull/5446
1.4: https://github.com/Cray-HPE/docs-csm/pull/5447