### PR TITLE
CASMCMS-9160: Add missing link to operations index

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -119,6 +119,7 @@ Use the Boot Orchestration Service \(BOS\) to boot, configure, and shut down col
     - [Clean Up After a BOS/BOA Job is Completed or Cancelled](boot_orchestration/Clean_Up_After_a_BOS-BOA_Job_is_Completed_or_Cancelled.md)
     - [Troubleshoot UAN Boot Issues](boot_orchestration/Troubleshoot_UAN_Boot_Issues.md)
     - [Troubleshoot Booting Nodes with Hardware Issues](boot_orchestration/Troubleshoot_Booting_Nodes_with_Hardware_Issues.md)
+    - [Determine Which BOS Session Booted A Node](boot_orchestration/Determine_Which_BOS_Session_Booted_A_Node.md)
 - [BOS Options](boot_orchestration/Options.md)
 - [Exporting and Importing BOS Data](boot_orchestration/Exporting_and_Importing_BOS_Data.md)
 - [Exporting and Importing BSS Data](boot_orchestration/Exporting_and_Importing_BSS_Data.md)


### PR DESCRIPTION
Partial backport of https://github.com/Cray-HPE/docs-csm/pull/5445