### PR TITLE
CASMINST-6992: Add details on BOS data migration/deletion during upgrade to CSM 1.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,12 @@
 
 ### Documentation enhancements
 
+## Noteworthy changes
+
+* The [BOS](glossary.md#boot-orchestration-service-bos) API now enforces limits that previously had
+  only been recommended. When updating to CSM 1.6, BOS data is migrated to be in compliance with the
+  API specification. See [BOS data notice](upgrade/README.md#bos-data-notice) for more details.
+
 ## Bug fixes
 
 ## Deprecations

--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -40,6 +40,8 @@ in chronological order.
 ### Removals in CSM 1.6
 
 - [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) v1
+    - When upgrading to CSM 1.6, all BOS v1 session data is deleted. See [BOS data notice](../../upgrade/README.md#bos-data-notice)
+      for more details.
 - [Cray Advanced Platform Monitoring and Control (CAPMC)](../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
   is deprecated, starting in CSM 1.5, and may be removed in the future. It has been
   replaced with the [Power Control Service (PCS)](../../glossary.md#power-control-service-pcs).

--- a/operations/README.md
+++ b/operations/README.md
@@ -94,6 +94,7 @@ Build and customize image recipes with the Image Management Service (IMS).
 
 Use the Boot Orchestration Service \(BOS\) to boot, reboot, and shut down collections of nodes.
 
+- [BOS data notice](../upgrade/README.md#bos-data-notice)
 - [Boot Orchestration Service (BOS)](boot_orchestration/Boot_Orchestration.md)
       - [BOS Cheat Sheet](boot_orchestration/Cheatsheet.md)
       - [BOS Services](boot_orchestration/BOS_Services.md)

--- a/operations/boot_orchestration/BOS_API_Versions.md
+++ b/operations/boot_orchestration/BOS_API_Versions.md
@@ -3,6 +3,11 @@
 The Boot Orchestration Service \(BOS\) currently supports API version v2.
 The following is a summary of the changes BOS v2 made from v1, and the upgrade path from v1 to v2.
 
+## BOS v1 removal
+
+BOS v1 is removed in CSM 1.6. During the upgrade to CSM 1.6, all BOS v1 session data is deleted. Other BOS data
+may be modified or, in rare cases, deleted. See [BOS data notice](../../upgrade/README.md#bos-data-notice) for more details.
+
 ## BOS v2 improvements
 
 BOS v2 makes significant improvements to boot times, retries, and error handling, by allowing nodes to proceed through the boot process at their own pace.

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -4,6 +4,8 @@ There are several alternative procedures to perform an upgrade of Cray Systems M
 software. Choose the appropriate procedure from the sections below.
 
 * [Release Notes](#release-notes)
+    * [NVIDIA CPU and GPU notice](#nvidia-cpu-and-gpu-notice)
+    * [BOS data notice](#bos-data-notice)
 * [CSM major/minor version upgrade](#csm-majorminor-version-upgrade)
     * [Option 1: Upgrade CSM with additional HPE Cray EX software products](#option-1-upgrade-csm-with-additional-hpe-cray-ex-software-products)
     * [Option 2: Upgrade only additional HPE Cray EX software products](#option-2-upgrade-only-additional-hpe-cray-ex-software-products)
@@ -25,6 +27,23 @@ These software stacks were validated with NVIDIA HPC SDK 24.3.
 
 The March 2025 HPE HPC continuous and extended software stack releases will be validated with NVIDIA HPC SDK 24.11.
 The March 2025 (CSM 1.6.1) software stacks will support all HPE Cray EX systems.
+
+### BOS data notice
+
+In CSM 1.6, BOS v1 is removed and the BOS API is enforcing various limits that previously had only been recommended.
+Most of these limits are unlikely to be violated in practice (for example, the `description` field of session templates
+is limited to 1023 characters in length).
+
+When first upgrading to CSM 1.6, all BOS v1 session data is deleted, and all other BOS data is checked for
+compliance with the API specification. It will attempt to automatically convert data to be in compliance with the
+specification (for example, by truncating `description` fields that are longer than 1023 characters), but in rare
+cases it may delete data. In general, if the migration deletes a session template, then it likely contains a fatal problem that
+would have prevented it from working.
+
+Regardless of the upgrade path that is used, a backup of the current BOS data is made before the BOS service is upgraded,
+and a snapshot of the BOS data is also taken after the data migration completes. Both of these are uploaded to S3,
+in either the `config-data` or `vbis` buckets. In addition, the `cray-bos-migration-` Kubernetes pod log contains a record
+of any changes that were made during the migration. This pod log is also collected as part of the post-migration snapshot.
 
 ## CSM major/minor version upgrade
 


### PR DESCRIPTION
This documents the BOS data changes and deletions that happen during the upgrade to CSM 1.6. It also includes details on the backup/snapshot data that is collected during upgrades to ensure that no data is lost.