### PR TITLE
CASMINST-7027: Correct variable name to fix script failures

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -193,7 +193,7 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
 
     SNAPSHOT_DIR_BASENAME=$(basename "${SNAPSHOT_DIR}")
     TARFILE_BASENAME="${SNAPSHOT_DIR_BASENAME}.tgz"
-    TARFILE_FULLPATH="/tmp/${TARFILE_FULLPATH}"
+    TARFILE_FULLPATH="/tmp/${TARFILE_BASENAME}"
     echo "Creating compressed tarfile of snapshot data: ${TARFILE_FULLPATH}"
     tar -C /root -czf "${TARFILE_FULLPATH}" "${SNAPSHOT_DIR_BASENAME}"
 

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -272,7 +272,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
 
     SNAPSHOT_DIR_BASENAME=$(basename "${SNAPSHOT_DIR}")
     TARFILE_BASENAME="${SNAPSHOT_DIR_BASENAME}.tgz"
-    TARFILE_FULLPATH="/tmp/${TARFILE_FULLPATH}"
+    TARFILE_FULLPATH="/tmp/${TARFILE_BASENAME}"
     echo "Creating compressed tarfile of backup data: ${TARFILE_FULLPATH}"
     tar -C /root -czf "${TARFILE_FULLPATH}" "${SNAPSHOT_DIR_BASENAME}"
 


### PR DESCRIPTION
This fixes a typo in two scripts causing them to fail. This was introduced by [my PR for CASMINST-7025](https://github.com/Cray-HPE/docs-csm/pull/5444).

No backports needed.