### PR TITLE
Skip Upgrade Kubernetes

### DIFF
--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -30,7 +30,9 @@ Once this step has completed:
 
 ## 2. Upgrade Kubernetes
 
-**`NOTE`** This subsection is optional and mandatory only if Upgrading CSM manually and additional products with IUF
+**`NOTE`** This subsection, `Upgrade Kubernetes`, should only be executed if upgrading CSM manually and additional products with IUF.
+This subsection should **not** be executed if upgrading CSM with IUF because this will automatically be executed as a hook script by IUF.
+Additionally, this step should **not** be executed if installing or upgrading additional products only with IUF because Kubernetes is only upgraded during a CSM upgrade.
 
 Follow the steps documented in [Stage 3.6 - Complete Kubernetes upgrade](../../../upgrade/Stage_3.md#stage-36---complete-kubernetes-upgrade).
 

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -30,7 +30,7 @@ Once this step has completed:
 
 ## 2. Upgrade Kubernetes
 
-**`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
+**`NOTE`** This subsection is optional and mandatory only if Upgrading CSM manually and additional products with IUF
 
 Follow the steps documented in [Stage 3.6 - Complete Kubernetes upgrade](../../../upgrade/Stage_3.md#stage-36---complete-kubernetes-upgrade).
 


### PR DESCRIPTION
# Description

CASMTRIAGE-7364

Upgrade Kubernetes is required only if Upgrading CSM manually as it is part of CSM hook script if running through IUF

# Checklist


- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
