### PR TITLE
CASMTRIAGE-7185: Add Power_Off_Management_Cabinets.md procedure

### DIFF
--- a/operations/power_management/Power_Off_Management_Cabinets.md
+++ b/operations/power_management/Power_Off_Management_Cabinets.md
@@ -1,0 +1,32 @@
+# Power Off Management Cabinets
+
+Power off PDUs and any remaining components in management cabinets which are powered on, such as HPE Slingshot switches, management switches, and a KVM device.
+
+## Power Off Management Cabinet PDU circuit breakers
+
+**CAUTION:** The nodes and switches in management cabinets should only
+be powered off when it has been confirmed that the management Kubernetes cluster and any Lustre or Spectrum Scale filesystems in the cabinets have been cleanly shut down. See the procedures in
+[Power Off the External File Systems](System_Power_Off_Procedures.md#Power_off_the_External_File_systems)
+and [Shut Down and Power Off the Management Kubernetes Cluster](Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md).
+
+1. (Optional) Power down the modular coolant distribution unit (MCDU) in a liquid-cooled HPE Cray EX2000 cabinet.
+
+   The MCDU in a liquid-cooled HPE Cray EX2000 cabinet (also
+referred to as a Hill or TDS cabinet) typically receives power from its management cabinet PDUs. If the
+system includes an EX2000 cabinet, then do not power off the management cabinet PDUs until the MCDU has
+been powered off.
+
+   **WARNING:** Dropping power to the management cabinet PDUs without powering off the MCDU will cause an emergency power off (EPO) of the cabinet and may
+result in data loss or equipment damage.
+
+1. Set each management cabinet PDU circuit breaker to `OFF`.
+
+   A slotted screwdriver may be required to open PDU circuit breakers.
+
+1. To power off Motivair liquid-cooled chilled doors and CDUs, locate the power off switch on the CDU control panel and set it to `OFF`.
+
+    Refer to vendor documentation for the chilled-door cooling system for power control procedures when chilled doors are installed on standard racks.
+
+## Next step
+
+Return to [System Power Off Procedures](System_Power_Off_Procedures.md) and continue with next step.

--- a/operations/power_management/System_Power_Off_Procedures.md
+++ b/operations/power_management/System_Power_Off_Procedures.md
@@ -41,6 +41,10 @@ To power off standard racks which have only storage nodes and switches, refer to
 
 To shut down the management Kubernetes cluster, refer to [Shut Down and Power Off the Management Kubernetes Cluster](Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md).
 
+## Power Off Management Cabinets
+
+To power off management cabinets, refer to [Power Off Management Cabinets](Power_Off_Management_Cabinets.md).
+
 ## `Lockout Tagout` Facility Power
 
 If facility power must be removed from a single cabinet or cabinet group for maintenance, follow proper `lockout-tagout` procedures for the site.


### PR DESCRIPTION
This content is correct in CSM 1.4, but missing in CSM 1.5 and 1.6.

For power off, the compute cabinets (liquid-cooled and air-cooled) have a procedure which includes flipping the circuit breakers on CDU and PDUs and so do the storage cabinets. However, once the "Shut Down the Management Kubernetes Cluster" procedure is done, the management cabinets have not been powered off. This means that the PDUs in this cabinet will still be providing power to the powered up components: Slingshot switches and management network switches and the KVM device in the cabinet.

This change adds the Power_Off_Management_Cabinets.md procedure.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
