### PR TITLE
CASMTRIAGE-7375-1.6 Add 3 missing certificate expiration checks

### DIFF
--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -136,7 +136,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       * See [Renew Etcd Certificate](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
       * See [Update Client Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
-   1. (`ncn-m#`) Check the kube-etcdbackup-etcd certificate expiration
+   1. (`ncn-m#`) Check the `kube-etcdbackup-etcd` certificate expiration
 
       ```bash
       kubectl get secret -n kube-system kube-etcdbackup-etcd -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
@@ -152,7 +152,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
-   1. (`ncn-m#`) Check the etcd-ca certificate expiration.
+   1. (`ncn-m#`) Check the `etcd-ca` certificate expiration.
 
       ```bash
       kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-ca" | @base64d' | openssl x509 -noout -enddate
@@ -164,11 +164,11 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       notAfter=Jan 13 18:01:48 2033 GMT
       ```
 
-      If the etcd-ca certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+      If the `etcd-ca` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
-   1. (`ncn-m#`) Check the etcd-client certificate expiration.
+   1. (`ncn-m#`) Check the `etcd-client` certificate expiration.
 
       ```bash
       kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-client" | @base64d' | openssl x509 -noout -enddate
@@ -180,7 +180,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       notAfter=Jan 16 18:01:49 2024 GMT
       ```
 
-      If either the etcd-client certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+      If either the `etcd-client` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -136,7 +136,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       * See [Renew Etcd Certificate](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
       * See [Update Client Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
-   1. (`ncn-m#`) Check the `kube-etcdbackup-etcd` certificate expiration
+   1. (`ncn-m#`) Check the `kube-etcdbackup-etcd` certificate expiration.
 
       ```bash
       kubectl get secret -n kube-system kube-etcdbackup-etcd -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
@@ -148,7 +148,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       notAfter=Apr 17 09:37:52 2025 GMT
       ```
 
-      If the certificate has expired or will expire while the system is powered off, see the procedure steps for changing the kube-etcdbackup-etcd secret and then restarting Prometheus after the change.
+      If the certificate has expired or will expire while the system is powered off, see the procedure steps for changing the `kube-etcdbackup-etcd` secret and then restarting Prometheus after the change.
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
@@ -164,7 +164,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       notAfter=Jan 13 18:01:48 2033 GMT
       ```
 
-      If the `etcd-ca` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+      If the `etcd-ca` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the `etcd-client-cert` secret and then restarting Prometheus after the change.
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 
@@ -180,7 +180,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       notAfter=Jan 16 18:01:49 2024 GMT
       ```
 
-      If either the `etcd-client` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+      If either the `etcd-client` certificate has expired or will expire while the system is powered off, see the procedure steps for changing the `etcd-client-cert` secret and then restarting Prometheus after the change.
 
       * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
 

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -79,6 +79,8 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
    To prevent this issue from happening, remove stale `ssh` host keys from `/root/.ssh/known_hosts` before running the `sat` command.
 
+### Check certificate expiration deadlines
+
 1. Check certificate expiration deadlines to ensure that a certificate will not expire while the system is powered off.
 
    1. (`ncn-mw#`) Check the expiration date of the Spire Intermediate CA Certificate.
@@ -133,6 +135,56 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
       * See [Renew All Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-all-certificates)
       * See [Renew Etcd Certificate](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
       * See [Update Client Certificates](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
+
+   1. (`ncn-m#`) Check the kube-etcdbackup-etcd certificate expiration
+
+      ```bash
+      kubectl get secret -n kube-system kube-etcdbackup-etcd -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+      ```
+
+      Example output:
+
+      ```text
+      notAfter=Apr 17 09:37:52 2025 GMT
+      ```
+
+      If the certificate has expired or will expire while the system is powered off, see the procedure steps for changing the kube-etcdbackup-etcd secret and then restarting Prometheus after the change.
+
+      * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
+
+   1. (`ncn-m#`) Check the etcd-ca certificate expiration.
+
+      ```bash
+      kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-ca" | @base64d' | openssl x509 -noout -enddate
+      ```
+
+      Example output:
+
+      ```text
+      notAfter=Jan 13 18:01:48 2033 GMT
+      ```
+
+      If the etcd-ca certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+
+      * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
+
+   1. (`ncn-m#`) Check the etcd-client certificate expiration.
+
+      ```bash
+      kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-client" | @base64d' | openssl x509 -noout -enddate
+      ```
+
+      Example output:
+
+      ```text
+      notAfter=Jan 16 18:01:49 2024 GMT
+      ```
+
+      If either the etcd-client certificate has expired or will expire while the system is powered off, see the procedure steps for changing the etcd-client-cert secret and then restarting Prometheus after the change.
+
+      * See [Update Client Secrets](../kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#update-client-secrets)
+
+### Check Nexus backup status
 
 1. (`ncn-mw#`) Check for a recent backup of Nexus data.
 
@@ -495,9 +547,13 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
     There is no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
 
+### Notify people of upcoming power off
+
 1. Notify users and operations staff about the upcoming full system power off.
 
    The notification method will vary by system, but might be email, messaging applications, `/etc/motd` on UANs, `wall` commands on UANs, and so on.
+
+### Prepare workload managers
 
 1. Follow the vendor workload manager documentation to drain processes running on compute nodes.
 
@@ -520,7 +576,7 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
        ```bash
        qstat -q
-       qmgr -c 'set queue workq enabled = False
+       qmgr -c 'set queue workq enabled = False'
        qmgr -c 'list queue workq enabled'
        ```
 


### PR DESCRIPTION
The full system power down and then power up procedures would have a problem during power up if some certificates expired while the system was down.

There were missing checks for expiration of these certificates:
* kube-etcdbackup-etcd
* etcd-ca
* etcd-client

Also added a few section headers to the MarkDown to match the style in CSM 1.6.

Corrected missing punctuation character from PBS pro qmgr command.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
