### PR TITLE
CASMTRIAGE-7220

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -551,6 +551,7 @@ iSCSI
 in_progress
 inband
 init
+initrd
 iscsi
 keychain
 known_hosts


### PR DESCRIPTION
# Description

WAR for nodes that kernel panic when unpacking initrd
- [CASMTRIAGE-7220](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7220)

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.