### PR TITLE
CASMCMS-9167 - document known issue with ims image deletion losing arch information.

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -73,7 +73,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Product Catalog Upgrade Error](known_issues/product_catalog_upgrade_error.md)
 - [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
 - [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
-* [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
+- [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
 
 ## Booting
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -73,6 +73,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Product Catalog Upgrade Error](known_issues/product_catalog_upgrade_error.md)
 - [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
 - [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
+* [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/ims_image_delete_loses_arch.md
+++ b/troubleshooting/known_issues/ims_image_delete_loses_arch.md
@@ -1,0 +1,123 @@
+# Known Issue: IMS Image Delete Loses `arch`
+
+When an image is deleted in IMS the `deleted image` record will get its `arch` value set to `x86_64` no
+matter what the original value was. This will cause an error if the image is subsequently undeleted and
+used.
+
+1. (`ncn-mw#`) Set an environment variable for the ID of the image:
+
+  ```bash
+  IMS_IMAGE_ID=YOUR_IMAGE_ID
+  ```
+
+1. (`ncn-mw#`) View the original image description:
+
+  ```bash
+  cray ims images describe $IMS_IMAGE_ID
+  ```
+
+  Expected output:
+
+  ```text
+  {
+    "arch": "aarch64",
+    "created": "2024-10-18T17:15:08.436814",
+    "id": "e4523677-1ad8-4b2f-a352-69df23d3607d",
+    "link": {
+      "etag": "79232e07d78091f6dd1a13397158d53b",
+      "path": "s3://boot-images/e4523677-1ad8-4b2f-a352-69df23d3607d/manifest.json",
+      "type": "s3"
+    },
+    "metadata": {},
+    "name": "compute-csm-1.5-6.1.86-aarch64"
+  }
+  ```
+
+1. (`ncn-mw#`) Delete the image:
+
+  ```bash
+  cray ims images delete $IMS_IMAGE_ID
+  ```
+
+1. (`ncn-mw#`) Describe the deleted image record:
+
+  ```bash
+  cray ims deleted images describe $IMS_IMAGE_ID
+  ```
+
+  Expected output (note the `arch` value is now `x86_64`):
+
+  ```text
+  {
+    "arch": "x86_64",
+    "created": "2024-10-18T17:15:08.436814",
+    "deleted": "2024-10-18T17:26:05.796157",
+    "id": "e4523677-1ad8-4b2f-a352-69df23d3607d",
+    "link": {
+      "etag": "",
+      "path": "s3://boot-images/deleted/e4523677-1ad8-4b2f-a352-69df23d3607d/deleted_manifest.json",
+      "type": "s3"
+    },
+    "metadata": {},
+    "name": "compute-csm-1.5-6.1.86-aarch64"
+  }
+  ```
+
+## Fix
+
+This is only an issue if the image is `undeleted`. To resolve this issue, `undelete` the image, then manually
+correct the `arch` value.
+
+1. (`ncn-mw#`) Undelete the image:
+
+  ```bash
+  cray ims deleted images update --operation undelete $IMS_IMAGE_ID
+  ```
+
+1. (`ncn-mw#`) Describe the image again:
+
+  ```bash
+  cray ims images describe $IMS_IMAGE_ID
+  ```
+
+  Expected output:
+
+  ```text
+  {
+    "arch": "x86_64",
+    "created": "2024-10-18T17:15:08.436814",
+    "id": "e4523677-1ad8-4b2f-a352-69df23d3607d",
+    "link": {
+      "etag": "79232e07d78091f6dd1a13397158d53b",
+      "path": "s3://boot-images/e4523677-1ad8-4b2f-a352-69df23d3607d/manifest.json",
+      "type": "s3"
+    },
+    "metadata": {},
+    "name": "compute-csm-1.5-6.1.86-aarch64"
+  }
+  ```
+
+1. (`ncn-mw#`) Correct the value of `arch`:
+
+  ```bash
+  cray ims images update --arch aarch64 $IMS_IMAGE_ID
+  ```
+
+  Expected output:
+
+  ```text
+  {
+    "arch": "aarch64",
+    "created": "2024-10-18T17:15:08.436814",
+    "id": "e4523677-1ad8-4b2f-a352-69df23d3607d",
+    "link": {
+      "etag": "79232e07d78091f6dd1a13397158d53b",
+      "path": "s3://boot-images/e4523677-1ad8-4b2f-a352-69df23d3607d/manifest.json",
+      "type": "s3"
+    },
+    "metadata": {},
+    "name": "compute-csm-1.5-6.1.86-aarch64"
+  }
+  ```
+
+Now the image may be used.


### PR DESCRIPTION
# Description

This is the backport of https://github.com/Cray-HPE/docs-csm/pull/5484 to release/1.5 branch.

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9167

There is a bug with IMS where if the image is deleted, then undeleted the image will not retain the original arch if the arch was `aarch64`. It will automatically be changed to `x86_64` instead. This documents the known issue.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.


