### PR TITLE
CASMTRIAGE-7402: IUF does not run the next stage for an activity

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1094,6 +1094,20 @@ Expat-15
 # To allow Site Init
 Init
 
+- troubleshooting/known_issues/iuf_unable_to_run_next_stage.md
+_cm_backup.yaml
+activity
+argo
+cli
+configmap
+cray-nls
+current_state
+iuf
+kubectl
+o
+session_name
+yaml
+
 - operations/configuration_management/iSCSI_SBPS_Node_Personalization.md
 enablement
 LUNs

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -41,6 +41,8 @@ nodes. This initial test node is referred to as the "canary node". Modify the pr
 **`NOTE`** Additional arguments are available to control the behavior of the `management-nodes-rollout` stage, for example `--limit-management-rollout` and `-cmrp`. See the
 [`management-nodes-rollout` stage documentation](../stages/management_nodes_rollout.md) for details and adjust the examples below if necessary.
 
+**`NOTE`** Known Issue: If IUF reports that multiple sessions are in progress for an activity, refer to [IUF does not run the next stage for an activity.](../../../troubleshooting/known_issues/iuf_unable_to_run_next_stage.md)
+
 **`IMPORTANT`** There is a different procedure for `management-nodes-rollout` depending on whether or not CSM is being upgraded. The two procedures differ in the handling of NCN storage nodes and NCN master nodes. If CSM is not
 being upgraded, then NCN storage nodes and NCN master nodes will not be upgraded with new images and will be updated by the CFS configuration created in [update-cfs-config](../stages/update_cfs_config.md) only. If CSM is being
 upgraded, the NCN storage nodes and NCN master nodes will be upgraded with new images and the new CFS configuration. Both procedures use the same steps for rebuilding/upgrading NCN worker nodes. Select **one** of the following

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -33,6 +33,8 @@ Refer to that table and any corresponding product documents before continuing to
 
 > **`IMPORTANT`*** If upgrading CSM manually, ensure that the `docs-csm-latest.noarch.rpm` and `libcsm-latest.noarch.rpm` RPMs are available at path `/root/<rpm>` before executing the above command.
 
+**`NOTE`** Known Issue: If IUF reports that multiple sessions are in progress for an activity, refer to [IUF does not run the next stage for an activity.](../../../troubleshooting/known_issues/iuf_unable_to_run_next_stage.md)
+
 Once this step has completed:
 
 - Product content has been extracted from the product distribution files in `${MEDIA_DIR}`

--- a/troubleshooting/known_issues/iuf_unable_to_run_next_stage.md
+++ b/troubleshooting/known_issues/iuf_unable_to_run_next_stage.md
@@ -1,0 +1,58 @@
+# IUF does not run the next stage for an activity
+
+## Issue Description
+
+During the CSM upgrade, IUF reports that multiple sessions are in progress for an activity. The next stage for the activity does not run due to above error.
+This issue is seen after pre-install-check stage or management-nodes-rollout stage of iuf run.
+
+This issue causes the session associated with the activity to continue to be in "in progress" even after workflow associated with the stage has successfully completed.
+
+## Error Identification
+
+When the issue occurs the following errors are emitted by iuf cli:
+
+```sh
+iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ${WORKER_CANARY}
+INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/update-csm-1.6.0/log/20241021025621
+INFO [ACTIVITY: update-csm-1.6.0                               ] BEG Install started at 2024-10-21 02:56:21.778284
+INFO Neither --recipe-vars nor --bootprep-config-dir were specified, so
+product_vars.yaml will be pulled from the branch
+cray/hpc-csm-software-recipe/25.1.0-alpha-20241019174014-8f492eb of the
+hpc-csm-software-recipe git repo.
+INFO [IUF SESSION:                                             ] BEG Started at 2024-10-21 02:56:30.375445
+WARN multiple sessions found.  Taking the first one...
+INFO [IUF SESSION:                                             ] END Completed at 2024-10-21 02:56:30.568155
+INFO [ACTIVITY: update-csm-1.6.0                               ] END Completed in 0:00:08
+```
+
+## Error Conditions
+
+There is a race condition in `cray-nls` that is hit when multiple `cray-nls` pods are starting at the same time.
+This happens during a `cray-nls` chart upgrade and sometimes when a node with multiple `cray-nls` pods is drained, which causes these pods to start simultaneously on another node.
+
+## Workaround Description
+
+Step 1: Identify the session for the previous stage which ran successfully for the activity being run.
+
+```bash
+2024-10-21T01:40:09.731277Z INFO [IUF SESSION: update-csm-1-6-0-h0y63                 ] BEG Started at 2024-10-21 01:40:09.731167
+2024-10-21T01:40:13.585718Z DBG  Next workflow update-csm-1-6-0-h0y63-management-nodes-rollout-wnbpb
+```
+
+Step 2: Find the configmap associated with the session from previous step in argo namespace.
+
+```bash
+kubectl get cm -n argo --selector type=iuf_session |grep <session_name>
+```
+
+Step 3: Make a backup of the configmap since it will be edited in the next step.
+
+```bash
+kubectl get cm -n argo <session_name> -o yaml > <session_name>_cm_backup.yaml
+```
+
+Step 4: Edit the configmap to modify "current_state" to "completed" if "current_state" is "in_progress".
+
+```bash
+kubectl edit configmap -n argo <session_name> -o json
+```


### PR DESCRIPTION
# Description

There is a race condition in cray-nls that is hit when multiple cray-nls pods are starting at the same time. This happens during a cray-nls chart upgrade and sometimes when a node with multiple cray-nls pods is drained which causes these pods to start simultaneously on another node. This issue has caused problems with the IUF CLI which uses the cray-nls pods. 

In order to troubleshoot this problem, this PR has Error Identification and Workaround Description

## Issues and Related PRs

* Resolves [CASMTRIAGE-7402](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7402) for CSM 1.6.1 only. CSM 1.6 needs docs changes

* CSM 1.6.1 code fix in cray-nls [CASMTRIAGE-7425](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7425) : https://github.com/Cray-HPE/cray-nls/pull/216

## Testing

Tested on wasp

### Test description:

Step 1: Identify the session for the previous stage which ran successfully for the activity being run.

```bash
2024-10-21T01:40:09.731277Z INFO [IUF SESSION: update-csm-1-6-0-h0y63                 ] BEG Started at 2024-10-21 01:40:09.731167
2024-10-21T01:40:13.585718Z DBG  Next workflow update-csm-1-6-0-h0y63-management-nodes-rollout-wnbpb
```

Step 2: Find the configmap associated with the session from previous step in argo namespace.

```bash
kubectl get cm -n argo --selector type=iuf_session |grep <session_name>
```
Step 3: Make a backup of the configmap since it will be edited in the next step.

```bash
kubectl get cm -n argo <session_name> -o yaml > <session_name>_cm_backup.yaml
```

Step 4: Edit the configmap to modify "current_state" to "completed" if "current_state" is "in_progress".

```bash
kubectl edit configmap -n argo <session_name> -o json
```

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.