### PR TITLE
CASMTRIAGE-7431 upgrade cray-product-catalog in prerequisites to be compatible with SAT

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -892,6 +892,8 @@ do_upgrade_csm_chart cray-drydock platform.yaml
 do_upgrade_csm_chart cray-sysmgmt-health platform.yaml
 do_upgrade_csm_chart cray-tftp sysmgmt.yaml
 do_upgrade_csm_chart cray-tftp-pvc sysmgmt.yaml
+# cray-product-catalog needs to be upgraded here in CSM 1.6 so it is compatible with SAT when building images/cfs configs
+do_upgrade_csm_chart cray-product-catalog sysmgmt.yaml
 
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Building CFS configs and images with IUF is failing with the following error.

```bash
[update-management-cfs-config                             ]       Failed to create layers[1] of configuration management-main_no_recipe-1101823: No clone URL present for version 11.1.0-35-cos-3.2-x86-64 of product slingshot-host-software
   [update-management-cfs-config                             ]       Failed to create layers[2] of configuration management-main_no_recipe-1101823: No clone URL present for version 1.2.0-95-csm of product uss
   [update-management-cfs-config                             ]       Failed to create layers[3] of configuration management-main_no_recipe-1101823: No clone URL present for version 1.6.7 of product csm-diags
   [update-management-cfs-config                             ]       Failed to create layers[4] of configuration management-main_no_recipe-1101823: No clone URL present for version 1.10.3 of product sma
   [update-management-cfs-config                             ]       Failed to create layers[5] of configuration management-main_no_recipe-1101823: No clone URL present for version 1.10.3 of product sma
   [update-management-cfs-config                             ]       Failed to create layers[6] of configuration management-main_no_recipe-1101823: No clone URL present for version 1.0.1 of product spc
   [update-management-cfs-config                             ]       Failed to create layers[7] of configuration management-main_no_recipe-1101823: Unable to get product data from product catalog: No installed products with name csm and version 1.6.0-rc.2.
   [update-management-cfs-config                             ]       Failed to create layers[8] of configuration management-main_no_recipe-1101823: Unable to get product data from product catalog: No installed products with name csm and version 1.6.0-rc.2.
   [update-management-cfs-config                             ]       Failed to create CFS configuration at index 0 with name=management-main_no_recipe-1101823: Failed to create configuration management-main_no_recipe-1101823 due to failure to create 9 layer(s)
...
```

This failure is due to the fact that a new SAT version is used by prepare images and create CFS configs and this SAT version is not compatible with the old cray-product-catalog. The cray-product-catalog needs to be migrated to the new version early in the upgrade which is why is being upgraded in prerequisites.sh.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
