### PR TITLE
CASMTRIAGE-7421: re-initialize cray CLI After  stage for management NCNs is completed

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -254,6 +254,8 @@ Refer to that table and any corresponding product documents before continuing to
            cray cfs components describe "${XNAME}"
            ```
 
+    > **`NOTE`** After `management-nodes-rollout` stage for management NCNs is completed, re-initialize cray CLI. Refer to [Configure the Cray Command Line Interface (cray CLI)](../../configure_cray_cli.md)
+
     Once this step has completed:
 
      - All management NCNs have been upgraded to the image and CFS configuration created in the previous steps of this workflow


### PR DESCRIPTION
# Description

CASMTRIAGE-7421

Add instructions in the IUF instructions to indicate that the the admin needs to reinitialize the "cray" command after upgrading ncn-m001

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
