### PR TITLE
CASMCMS-9176: Make BOS importer grudgingly tolerate unknown BOS options

### DIFF
--- a/scripts/operations/configuration/import_bos_data.py
+++ b/scripts/operations/configuration/import_bos_data.py
@@ -56,6 +56,12 @@ def print_stderr(msg: str) -> None:
     """
     sys.stderr.write(f"{msg}\n")
 
+def print_warn(msg: str) -> None:
+    """
+    Prepends "WARNING: " and outputs the specified message to stderr
+    """
+    print_stderr(f"WARNING: {msg}")
+
 def print_err(msg: str) -> None:
     """
     Prepends "ERROR: " and outputs the specified message to stderr
@@ -109,14 +115,23 @@ def get_options_to_change(options_to_import: BosOptions, current_options: BosOpt
 
     Returns a list of the names of the options to be changed.
     """
-    options_to_change = [ opt_name for opt_name, opt_value in options_to_import.items()
-                            if current_options[opt_name] != opt_value ]
-    unchanged_options = sorted(list(options_to_import.keys() - options_to_change))
+    options_to_change = []
+    unchanged_options = []
+    for opt_name, opt_value in options_to_import.items():
+        try:
+            if current_options[opt_name] != opt_value:
+                options_to_change.append(opt_name)
+            else:
+                unchanged_options.append(opt_name)
+        except KeyError:
+            print_warn(f"Not restoring unknown option found in backup data: {opt_name} = {opt_value}")
     if unchanged_options:
+        unchanged_options.sort()
         print("The following options already have the value from the imported data and will not be"
               " updated:")
         print(", ".join(unchanged_options))
     if options_to_change:
+        options_to_change.sort()
         print("The following options will be updated to match the values in the imported data:")
         print(", ".join(options_to_change))
     return options_to_change


### PR DESCRIPTION
If the BOS import tool tries to import BOS data that contains an unknown BOS option, it fails in an ugly way. This is not technically a bug, since the importer should only be used on exports that came from the same CSM version, and thus it should never contain BOS options that do not exist at import time. We ran into this when trying to recover a system which had accidentally had its BOS version updated to a much higher level, which pulled in some new BOS options. We wanted to restore the data back on their older BOS version, and the importer barfed when it saw the unknown options.

This PR modifies the tool so that it instead issues warnings about unknown options, but still restores the options that it does know about.

This was tested on the customer system where the problem was originally hit.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/5494
1.4: https://github.com/Cray-HPE/docs-csm/pull/5495
1.3: https://github.com/Cray-HPE/docs-csm/pull/5496