### PR TITLE
CASMINST-7033: Add hotfix reference to 1.5.{1,2} upgrade instructions

### DIFF
--- a/upgrade/1.5.1/README.md
+++ b/upgrade/1.5.1/README.md
@@ -170,6 +170,11 @@ This step updates the CFS configuration which is set as the desired configuratio
 nodes (NCNs). It ensures that the CFS configuration layers reference the correct commit hash for the
 version of CSM being installed. It then waits for the components to reach a configured state in CFS.
 
+1. **IMPORTANT**: The `update-mgmt-ncn-cfs-config.sh` script has a bug in CSM 1.5.1. This bug has
+   been addressed in a hotfix. See [customer advisory `a00144661en_us`](https://support.hpe.com/hpesc/docDisplay?docId=emr_na-a00144661en_us).
+   Download and apply the hotfix from that customer advisory before proceeding. If this hotfix is
+   not applied, certain properties of the CFS configuration will be lost during its modification.
+
 1. (`ncn-m001#`)
 
    ```bash

--- a/upgrade/1.5.2/README.md
+++ b/upgrade/1.5.2/README.md
@@ -164,6 +164,11 @@ This step updates the CFS configuration which is set as the desired configuratio
 nodes (NCNs). It ensures that the CFS configuration layers reference the correct commit hash for the
 version of CSM being installed. It then waits for the components to reach a configured state in CFS.
 
+1. **IMPORTANT**: The `update-mgmt-ncn-cfs-config.sh` script has a bug in CSM 1.5.2. This bug has
+   been addressed in a hotfix. See [customer advisory `a00144661en_us`](https://support.hpe.com/hpesc/docDisplay?docId=emr_na-a00144661en_us).
+   Download and apply the hotfix from that customer advisory before proceeding. If this hotfix is
+   not applied, certain properties of the CFS configuration will be lost during its modification.
+
 1. (`ncn-m001#`)
 
    ```bash


### PR DESCRIPTION
# Description

A hotfix is required to fix the functionality of the `update-mgmt-ncn-cfs-config.sh` script in the CSM 1.5.1 and 1.5.2 patch installation instructions. Add a reference to this patch, instructing the admin to install the hotfix before proceeding with the next step.

# Dependencies

- [x] This depends on the creation of the hotfix (see Cray-HPE/csm-hotfixes#60) and the associated field notice. **PLEASE DO NOT MERGE UNTIL THIS IS DONE**

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.