### PR TITLE
CASMTRIAGE-7437 run upload-rebuild-templates again after IUF product-delivery stage

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -14,7 +14,7 @@ This section ensures the product content is loaded onto the system and available
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `process-media` or `pre-install-check` stages.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Run `upload-rebuild-templates.sh` to update all the workflows that will be used by IUF and to ensure the correct CSM product versions will be used by IUF.
+1. Run `upload-rebuild-templates.sh` to update all the workflows that will be used by IUF and to make sure the workflow templates are the latest versions.
 
     (`ncn-m001#`) Execute the `upload-rebuild-templates.sh` script.
 
@@ -71,6 +71,14 @@ Refer to that table and any corresponding product documents before continuing to
       iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run --site-vars \
       "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r deliver-product
       ```
+
+1. Run `upload-rebuild-templates.sh` to ensure the correct CSM product versions will be used by IUF now that all product artifacts have been uploaded.
+
+    (`ncn-m001#`) Execute the `upload-rebuild-templates.sh` script.
+
+    ```bash
+    /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+    ```
 
 Once this step has completed:
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

`upload-rebuild-templates` needs to be run again after the IUF product-delivery stage. This is necessary because product-delivery puts the latest SAT container image in Nexus. Running `upload-rebuild-templates` then patches the workflow template that is used by IUF steps involving SAT, so that these steps use the latest SAT container image. The latest SAT container image is necessary so that the prepare images stage runs successfully. There has been a recent jinja templating change in SAT and there are problems if the most recent container image is not used to create images.

This ordering of the upgrade steps was tested on the noname install somewhat by accident. But when this ordering was used on noname, this issue was not seen.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
