### PR TITLE
STP-3667: Tech pubs clean-up for `docs-sat` move to `docs-csm`

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -274,8 +274,8 @@ REST APIs into easily usable commands.
 
 ## Cray Operating System (COS)
 
-The Cray Operating System is a Cray product that may be installed on CSM systems.
-COS is comprised of [COS Base](#cray-operating-system-base-cos-base) and [User Services Software](#user-services-software-uss) components.
+HPE Cray Supercomputing Operating System Software (or COS) is a Cray product that may be installed on CSM systems.
+COS is comprised of [COS Base](#cray-operating-system-base-cos-base), HPE SUSE Linux Enterprise Operating System (SLE), and [User Services Software](#user-services-software-uss) components.
 
 ## Cray Operating System Base (COS Base)
 
@@ -688,7 +688,7 @@ valves are closed during operation, the action automatically causes the [CMMs](#
 
 ## System Admin Toolkit (SAT)
 
-The System Admin Toolkit (SAT) product provides the `sat` command line interface which interacts
+System Admin Toolkit (SAT) provides the `sat` command line interface which interacts
 with the REST APIs of many services to perform more complex system management tasks.
 
 For more information, see [System Admin Toolkit](operations/system_admin_toolkit/README.md).

--- a/introduction/README.md
+++ b/introduction/README.md
@@ -56,13 +56,11 @@ For information on deprecated features in CSM releases, see [Deprecated Features
 ## Documentation conventions
 
 The CSM documentation follows conventions to ensure consistency across documentation and provide a
-better experience for readers.
+better experience for readers. These conventions must be followed when writing or updating documentation.
 
-These conventions must be followed when writing or updating documentation.
-
-See [Documentation Conventions](documentation_conventions.md).
+For more information, see [Documentation Conventions](documentation_conventions.md).
 
 ## Viewing CSM documentation
 
-The CSM documentation can be viewed in multiple ways, both online and offline. See
-[Viewing CSM documentation](viewing_csm_documentation.md) for more details and tips.
+The CSM documentation can be viewed in multiple ways, both online and offline. For
+more details and tips, see [Viewing CSM documentation](viewing_csm_documentation.md).

--- a/introduction/documentation_conventions.md
+++ b/introduction/documentation_conventions.md
@@ -6,20 +6,20 @@ This outlines conventions and standards that are used in this documentation.
 - [File formats](#file-formats)
 - [Typographic conventions](#typographic-conventions)
 - [Command prompt conventions](#command-prompt-conventions)
-  - [Host and user name in command prompts](#host-and-user-name-in-command-prompts)
-  - [Node abbreviations](#node-abbreviations)
-  - [Command prompt reference](#command-prompt-reference)
-  - [Command prompt location](#command-prompt-location)
-  - [Command prompts inside new shells](#command-prompts-inside-new-shells)
-    - [`chroot` example](#chroot-example)
-    - [`kubectl exec` example](#kubectl-exec-example)
-    - [Combined `ssh` and `chroot` example](#combined-ssh-and-chroot-example)
-    - [`sat bash` example](#sat-bash-example)
-  - [Command prompts in Python virtual environments](#command-prompts-in-python-virtual-environments)
-  - [Directory path in command prompt](#directory-path-in-command-prompt)
+    - [Host and user name in command prompts](#host-and-user-name-in-command-prompts)
+    - [Node abbreviations](#node-abbreviations)
+    - [Command prompt reference](#command-prompt-reference)
+    - [Command prompt location](#command-prompt-location)
+    - [Command prompts inside new shells](#command-prompts-inside-new-shells)
+        - [`chroot` example](#chroot-example)
+        - [`kubectl exec` example](#kubectl-exec-example)
+        - [Combined `ssh` and `chroot` example](#combined-ssh-and-chroot-example)
+        - [`sat bash` example](#sat-bash-example)
+    - [Command prompts in Python virtual environments](#command-prompts-in-python-virtual-environments)
+    - [Directory path in command prompt](#directory-path-in-command-prompt)
 - [Ability to pause and resume procedures](#ability-to-pause-and-resume-procedures)
-  - [Bad example](#bad-example)
-  - [Good example](#good-example)
+    - [Bad example](#bad-example)
+    - [Good example](#good-example)
 - [Templates](#templates)
 
 ## Markdown format
@@ -58,14 +58,14 @@ The host name in a command prompt indicates where the command must be run. The u
 
 ### Node abbreviations
 
-The following list contains abbreviations for nodes used below
+The following list contains abbreviations for nodes used below:
 
 - CN - Compute Node
 - NCN - Non-Compute Node
-  - `ncn-m` - Master NCN
-  - `ncn-s` - Storage NCN
-  - `ncn-w` - Worker NCN
-  - These can also be used in combination. For example, `ncn-mw` in a command prompt indicates that the command may be run on a master or worker NCN.
+    - `ncn-m` - Master NCN
+    - `ncn-s` - Storage NCN
+    - `ncn-w` - Worker NCN
+    - These can also be used in combination. For example, `ncn-mw` in a command prompt indicates that the command may be run on a master or worker NCN.
 - AN - Application Node (special type of NCN)
 - UAN - User Access Node (special type of AN)
 - PIT - Pre-Install Toolkit (initial node used as the inception node during software installation, booted from the LiveCD)
@@ -118,7 +118,7 @@ the documentation of CSM 1.2 and earlier.
 ### Command prompts inside new shells
 
 Some commands open new shells when they are executed (for example, `chroot`, `kubectl exec`, `ssh`,
-and `sat bash`). When these commands are used, the prompt changes to indicate that subsequent
+and `sat bash`). When these commands are used, the command prompt changes to indicate that subsequent
 commands are to be run inside the new shell.
 
 #### `chroot` example
@@ -184,17 +184,17 @@ changes to indicate that it is inside this environment. This example uses `$PORT
 
 #### `sat bash` example
 
-The `sat bash` command opens a shell inside the `cray-sat` container image. The shell prompt changes
+The `sat bash` command opens a shell inside the `cray-sat` container image. The command prompt changes
 to indicate the ID of the Podman container where the shell is executing.
 
-1. (`ncn-m#`) Enter a SAT shell:
+1. (`ncn-m#`) Enter a SAT shell.
 
    ```bash
    sat bash
    ```
 
 1. (`(CONTAINER_ID) sat-container#`) Execute the `sat status` command inside the shell in the
-   `cray-sat` container started by `sat bash`:
+   `cray-sat` container started by `sat bash`.
 
    ```bash
    sat status
@@ -203,7 +203,7 @@ to indicate the ID of the Podman container where the shell is executing.
 ### Command prompts in Python virtual environments
 
 Some documentation may involve running commands inside a Python virtual environment. When a Python
-virtual environment is activated, the command prompt will change to reflect the active virtual
+virtual environment is activated, the command prompt changes to reflect the active virtual
 environment.
 
 1. (`user@hostname>`) Activate the Python virtual environment.

--- a/introduction/viewing_csm_documentation.md
+++ b/introduction/viewing_csm_documentation.md
@@ -1,44 +1,48 @@
-# Viewing CSM documentation
+# View CSM documentation
 
-The CSM documentation can be viewed in different formats both online and offline.
+View the CSM documentation online or offline in one of the following formats:
 
-## Online CSM documentation in HTML format
+- [Online in HTML](#online-csm-documentation-in-html)
+- [Online in GitHub](#online-csm-documentation-in-github)
+- [Offline in markdown](#offline-csm-documentation-in-markdown)
 
-The CSM documentation can be viewed online in HTML format at the following URL in a browser:
+## Online CSM documentation in HTML
+
+View the CSM documentation online in HTML format by putting the following URL into a web browser:
 [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm).
 
-Multiple versions of the documentation are available at this location, and they can be selected
-using a drop-down menu in the top left corner of the browser window, as shown below:
+Multiple versions of the documentation are available at this location. Select the desired version
+using the drop-down menu in the top, left corner of the browser window.
 
 ![CSM Documentation Version Selection](img/html_docs_csm_version_selection.png)
 
-The navigation pane on the left of the HTML page orders topics alphabetically. Navigate an
-individual topic's headings by using the **Headings** icon at the top left side of the header bar at
-the top the page, as shown in the following image.
+The navigation pane on the left side of the HTML page orders CSM topics alphabetically. To view
+the headings of an individual topic, select the **Headings** icon above the topic's title.
 
 ![HTML Heading Icon](img/html_heading_icon.png)
 
-Once the icon is clicked, a navigation pane opens as shown.
+Once the **Headings** icon is selected, a navigation pane opens and allows quick access to any
+topic heading chosen.
 
 ![HTML Heading Navigation](img/html_heading_navigation.png)
 
 ## Online CSM documentation in GitHub
 
-The documentation can also be viewed online in GitHub directly by navigating to the `README.md` file
-in the [`docs-csm` repository](https://github.com/Cray-HPE/docs-csm). Navigate an individual topic's
-headings with a **Headings** icon at the top right side of the file header bar, as shown in the
-following image.
+View the CSM documentation online in GitHub by navigating to the `README.md` file in the
+[`docs-csm` repository](https://github.com/Cray-HPE/docs-csm). To view the headings of an
+individual CSM topic, select the **Headings** icon on the right side of the topic header bar.
 
 ![GitHub Heading Icon](img/github_heading_icon.png)
 
-Once the icon is clicked, a navigation pane opens as shown.
+Once the **Headings** icon is selected, a navigation pane opens and allows quick access to any
+topic heading chosen.
 
 ![GitHub Heading Navigation](img/github_heading_navigation.png)
 
-## Offline Documentation
+## Offline CSM documentation in markdown
 
-The CSM documentation is available offline as markdown, which can be viewed with a markdown viewer
-or with a text editor. The offline documentation is available in the `docs/` directory of the CSM
-release distribution as well as in RPM package format. The RPM package is installed as a part of the
+View the CSM documentation offline in markdown format with either a markdown viewer
+or a text editor. The offline documentation is available in the `docs/` directory of the CSM
+release distribution as well as in the RPM package. The RPM package is installed as a part of the
 Ansible plays launched by the Configuration Framework Service (CFS). Its files are installed to
 `/usr/share/doc/csm`.

--- a/operations/image_management/Troubleshoot_Large_Image.md
+++ b/operations/image_management/Troubleshoot_Large_Image.md
@@ -104,7 +104,7 @@ RuntimeError('IMS reported an error when packaging artifacts for job=%s.Consult 
 determine the cause of failure.IMS response: %s', 'ac6f6ba0-f399-480b-b49f-396a192c9390',
 {'arch': 'x86_64', 'artifact_id': '00ce7971-8b42-4012-8895-42ae6fc44c0c', 'build_env_size': 15,
 'created': '2023-12-01T16:01:24.298632+00:00', 'enable_debug': False, 'id': 'ac6f6ba0-f399-480b-b49f-396a192c9390',
-'image_root_archive_name': 'uan-shs-cne-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan', 'initrd_file_name': 'initrd',
+'image_root_archive_name': 'uan-shs-uss-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan', 'initrd_file_name': 'initrd',
 'job_mem_size': 8, 'job_type': 'customize', 'kernel_file_name': 'vmlinuz', 'kernel_parameters_file_name':
 'kernel-parameters', 'kubernetes_configmap': 'cray-ims-ac6f6ba0-f399-480b-b49f-396a192c9390-configmap',
 'kubernetes_job': 'cray-ims-ac6f6ba0-f399-480b-b49f-396a192c9390-customize', 'kubernetes_namespace': 'ims',
@@ -119,9 +119,9 @@ determine the cause of failure.IMS response: %s', 'ac6f6ba0-f399-480b-b49f-396a1
 The IMS job log for the `buildenv-sidecar` container will have the following:
 
 ```text
-+ time mksquashfs /mnt/image/image-root /mnt/image/uan-shs-cne-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan.sqsh
++ time mksquashfs /mnt/image/image-root /mnt/image/uan-shs-uss-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan.sqsh
 Parallel mksquashfs: Using 57 processors
-Creating 4.0 filesystem on /mnt/image/uan-shs-cne-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan.sqsh, block size 131072.
+Creating 4.0 filesystem on /mnt/image/uan-shs-uss-1.0.0-45-csm-1.5.x86_64-231106_cfs_gpu-2296-uan.sqsh, block size 131072.
 Write failed because No space left on device
 FATAL ERROR: Failed to write to output filesystem
 [======================================================-   ] 588500/619268  95%

--- a/operations/iuf/stages/prepare_images.md
+++ b/operations/iuf/stages/prepare_images.md
@@ -183,8 +183,7 @@ in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files
 in `/usr/share/doc/csm/workflows/iuf/operations/`
 for details on the commands executed.
 
-See the [HPE Cray EX System Admin Toolkit (SAT) Guide](https://cray-hpe.github.io/docs-sat/) documentation for details
-on `sat bootprep`.
+For more information, see [SAT Bootprep](../../../operations/system_admin_toolkit/usage/SAT_Bootprep.md).
 
 ## Example
 

--- a/operations/iuf/stages/update_cfs_config.md
+++ b/operations/iuf/stages/update_cfs_config.md
@@ -38,7 +38,7 @@ The following arguments are most often used with the `update-cfs-config` stage. 
 The code executed by this stage utilizes `sat bootprep` to create CFS configurations. See the `update-cfs-config` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files in
 `/usr/share/doc/csm/workflows/iuf/operations/` for details on the commands executed.
 
-See the [HPE Cray EX System Admin Toolkit (SAT) Guide](https://cray-hpe.github.io/docs-sat/) documentation for details on `sat bootprep`.
+For more information, see [SAT Bootprep](../../../operations/system_admin_toolkit/usage/SAT_Bootprep.md).
 
 ## Example
 

--- a/operations/power_management/Power_Off_Compute_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_Cabinets.md
@@ -21,8 +21,8 @@ HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU model
 
 ## Prerequisites
 
-* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
-  documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+* An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+  [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 * This procedure assumes all system software and user jobs were shut down. See
   [Shut Down and Power Off Managed Nodes](Shut_Down_and_Power_Off_Managed_Nodes.md).
 

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -13,9 +13,8 @@ power-on command from Cray System Management \(CSM\) software.
 ## Prerequisites
 
 * The cabinet PDUs and coolant distribution units are connected to facility power and are healthy.
-* An authentication token is required to access the API gateway and to use the `sat` command. See
-  the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for
-  instructions on how to acquire a SAT authentication token.
+* An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+  [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 
 ## Procedure
 

--- a/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Managed_Nodes.md
@@ -9,8 +9,8 @@ This procedure boots all managed nodes in the context of a full system power-up.
 
 * All compute cabinet PDUs, servers, and switches must be powered on.
 * All external file systems, such as Lustre or Spectrum Scale (GPFS), should be available to be mounted by clients
-* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section
-  of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+* An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+  [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 
 ## Procedure
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -5,8 +5,8 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 ## Prerequisites
 
 * All management rack PDUs are connected to facility power and facility power is on.
-* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT)
-  product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+* An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+  [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 * To avoid slow `sat` commands, ensure `/root/.bashrc` has proper handling of `kubectl` commands on all master and worker nodes. See [Prepare the System for Power Off](Prepare_the_System_for_Power_Off.md).
 
 ## Procedure

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -6,8 +6,8 @@ The `sat bootsys shutdown` and `sat bootsys boot` commands are used to shut down
 
 ## Prerequisites
 
-An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the
-HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+[Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 
 ## Procedure
 
@@ -23,9 +23,10 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
 1. Use `sat auth` to authenticate to the API gateway within SAT.
 
-   If SAT has already been authenticated to the API gateway, this step may be skipped.
+   For information on acquiring a SAT authentication token, see
+   [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 
-   See the "SAT Authentication" section in the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+   If SAT has already been authenticated to the API gateway, this step may be skipped.
 
 ### Check shell initialization scripts
 

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -6,10 +6,10 @@ nodes, which are powered off later.
 
 ## Prerequisites
 
-The `cray` and `sat` commands must be initialized and authenticated with valid credentials for Keycloak. If these have not been prepared, then see
-[Configure the Cray Command Line Interface (`cray` CLI)](../configure_cray_cli.md) and refer to the "SAT Authentication" section of the *HPE Cray EX
-System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructions on how to acquire a SAT authentication token.
-The BOS session templates to use for shutting down all managed nodes in the system have been identified as described in [Identify BOS session templates for managed nodes](./Prepare_the_System_for_Power_Off.md#identify-bos-session-templates-for-managed-nodes).
+- The `cray` and `sat` commands must be initialized and authenticated with valid credentials for Keycloak. If these have not been prepared, see
+[Configure the Cray Command Line Interface (`cray` CLI)](../configure_cray_cli.md) and
+[Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
+- The BOS session templates to use for shutting down all managed nodes in the system have been identified as described in [Identify BOS session templates for managed nodes](./Prepare_the_System_for_Power_Off.md#identify-bos-session-templates-for-managed-nodes).
 
 ## Procedure
 

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -33,8 +33,8 @@ The `sat bootsys` command automates the shutdown of Ceph and the Kubernetes mana
 
 ## Prerequisites
 
-- An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
-documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+- An authentication token is required to access the API gateway and to use the `sat` command. For more information, see
+  [Authenticate SAT Commands](../../operations/system_admin_toolkit/configuration/Authenticate_SAT_Commands.md).
 - To avoid slow `sat` commands, ensure `/root/.bashrc` has proper handling of `kubectl` commands on all master and worker nodes. See [Prepare the System for Power Off](Prepare_the_System_for_Power_Off.md)
 
 ## Check health of the management cluster

--- a/operations/system_admin_toolkit/about_sat/SAT_Dependencies.md
+++ b/operations/system_admin_toolkit/about_sat/SAT_Dependencies.md
@@ -41,7 +41,7 @@ CSM dependencies:
 - Kubernetes
 - S3
 
-HPE Cray Supercomputing [Compute Node](../../../glossary.md#compute-node-cn) Software Environment dependencies:
+HPE Cray Supercomputing [User Services Software (USS)](../../../glossary.md#user-services-software-uss) dependencies:
 
 - [Node Memory Dump (NMD)](../../../glossary.md#node-memory-dump-nmd)
 

--- a/operations/system_admin_toolkit/usage/SAT_Bootprep.md
+++ b/operations/system_admin_toolkit/usage/SAT_Bootprep.md
@@ -203,38 +203,38 @@ images:
 #### Use base images or recipes from a product
 
 Here is an example showing the definition of two images. The first image is
-built from a recipe provided by the `cne` product. The second image uses the
+built from a recipe provided by the `uss` product. The second image uses the
 first image as a base and configures it with a configuration named
 `example-compute-config`. The value of the first image's `ref_name` key is used
 in the second image's `base.image_ref` key to specify it as a dependency.
 Running `sat bootprep` against this input file results in two images, the
-first named `example-cne-image` and the second named `example-compute-image`.
+first named `example-uss-image` and the second named `example-compute-image`.
 
 ```yaml
 images:
-- name: example-cne-image
-  ref_name: example-cne-image
+- name: example-uss-image
+  ref_name: example-uss-image
   description: >
-    An example image built from the recipe provided by the CNE product.
+    An example image built from the recipe provided by the USS product.
   base:
     product:
-      name: cne
+      name: uss
       version: 1.0.0
       type: recipe
 - name: example-compute-image
   description: >
     An example image that is configured from an image built from the recipe provided
-    by the CNE product.
+    by the USS product.
   base:
-    image_ref: example-cne-image
+    image_ref: example-uss-image
   configuration: example-compute-config
   configuration_group_names:
   - Compute
 ```
 
-This example assumes that the given version of the `cne` product provides
+This example assumes that the given version of the `uss` product provides
 only a single IMS recipe. If more than one recipe is provided by the
-given version of the `cne` product, use a filter as described in
+given version of the `uss` product, use a filter as described in
 [Filter Base Images or Recipes from a Product](#filter-base-images-or-recipes-from-a-product).
 
 #### Filter base images or recipes from a product
@@ -306,34 +306,34 @@ images:
   - Management_Storage
 ```
 
-Here is an example of two IMS images built from recipes provided by the `cne`
+Here is an example of two IMS images built from recipes provided by the `uss`
 product. This example uses an architecture filter to select from the multiple
-recipes provided by the CNE product. The first image will be built from the
+recipes provided by the USS product. The first image will be built from the
 `x86_64` version of the IMS recipe provided by the specified version of the
-`cne` product. The second image will be built from the `aarch64` version of
-the IMS recipe provided by the specified version of the `cne` product.
+`uss` product. The second image will be built from the `aarch64` version of
+the IMS recipe provided by the specified version of the `uss` product.
 
 ```yaml
 images:
-- name: example-cne-image-x86_64
-  ref_name: example-cne-image-x86_64
+- name: example-uss-image-x86_64
+  ref_name: example-uss-image-x86_64
   description: >
-    An example image built from the x86_64 recipe provided by the CNE product.
+    An example image built from the x86_64 recipe provided by the USS product.
   base:
     product:
-      name: cne
+      name: uss
       version: 1.0.0
       type: recipe
       filter:
         arch: x86_64
 
-- name: example-cne-image-aarch64
-  ref_name: example-cne-image-aarch64
+- name: example-uss-image-aarch64
+  ref_name: example-uss-image-aarch64
   description: >
-    An example image built from the aarch64 recipe provided by the CNE product.
+    An example image built from the aarch64 recipe provided by the USS product.
   base:
     product:
-      name: cne
+      name: uss
       version: 1.0.0
       type: recipe
       filter:
@@ -532,7 +532,7 @@ variable for `slingshot-host-software` in the bootprep input file, write
 
 #### HPC CSM Software Recipe variable substitution example
 
-The following example bootprep input file shows how a variable of a CNE version
+The following example bootprep input file shows how a variable of a USS version
 can be used in an input file that creates a CFS configuration for computes.
 Only one layer is shown for brevity.
 
@@ -541,12 +541,12 @@ Only one layer is shown for brevity.
 configurations:
 - name: "{{default.note}}compute-{{recipe.version}}{{default.suffix}}"
   layers:
-  - name: cne-compute-{{cne.working_branch}}
+  - name: uss-compute-{{uss.working_branch}}
     playbook: cos-compute.yml
     product:
-      name: cne
-      version: "{{cne.version}}"
-      branch: "{{cne.working_branch}}"
+      name: uss
+      version: "{{uss.version}}"
+      branch: "{{uss.working_branch}}"
 ```
 
 **Note:** When the value of a key in the bootprep input file is a Jinja2
@@ -554,7 +554,7 @@ expression, it must be quoted to pass YAML syntax checking.
 
 Jinja2 expressions can also use filters and Python's built-in string methods to
 manipulate the variable values. For example, suppose only the major and minor
-components of a CNE version are to be used in the branch name for the CNE
+components of a USS version are to be used in the branch name for the USS
 layer of the CFS configuration. Use the `split` string method to
 achieve this as follows:
 
@@ -563,12 +563,12 @@ achieve this as follows:
 configurations:
 - name: "{{default.note}}compute-{{recipe.version}}{{default.suffix}}"
   layers:
-  - name: cne-compute-{{cne.working_branch}}
+  - name: uss-compute-{{uss.working_branch}}
     playbook: cos-compute.yml
     product:
-      name: cne
-      version: "{{cne.version}}"
-      branch: integration-{{cne.version.split('.')[0]}}-{{cne.version.split('.')[1]}}
+      name: uss
+      version: "{{uss.version}}"
+      branch: integration-{{uss.version.split('.')[0]}}-{{uss.version.split('.')[1]}}
 ```
 
 ### Dynamic variable substitutions
@@ -615,12 +615,12 @@ bootprep file for the entire CSM product.
 configurations:
 - name: "{{default.note}}compute-{{recipe.version}}{{default.suffix}}"
   layers:
-  - name: cne-compute-{{cne.working_branch}}
+  - name: uss-compute-{{uss.working_branch}}
     playbook: cos-compute.yml
     product:
-      name: cne
-      version: "{{cne.version}}"
-      branch: "{{cne.working_branch}}"
+      name: uss
+      version: "{{uss.version}}"
+      branch: "{{uss.working_branch}}"
   - name: cpe-pe_deploy-{{cpe.working_branch}}
     playbook: pe_deploy.yml
     product:
@@ -630,17 +630,17 @@ configurations:
 
 images:
 - name: "{{default.note}}{{base.name}}{{default.suffix}}"
-  ref_name: base_cne_image
+  ref_name: base_uss_image
   base:
     product:
-      name: cne
+      name: uss
       type: recipe
-      version: "{{cne.version}}"
+      version: "{{uss.version}}"
 
 - name: "compute-{{base.name}}"
   ref_name: compute_image
   base:
-    image_ref: base_cne_image
+    image_ref: base_uss_image
   configuration: "{{default.note}}compute-{{recipe.version}}{{default.suffix}}"
   configuration_group_names:
   - Compute

--- a/troubleshooting/incrementally_configuring_images.md
+++ b/troubleshooting/incrementally_configuring_images.md
@@ -47,7 +47,7 @@ can be adapted for other image types.
    1. View the log and look for a line that includes `Creation of image`.
 
       ```text
-      INFO: Creation of image ssi-cne-1.0.0-32-csm-1.5.x86_64-csm-1.5.0.beta37-10 succeeded: ID f5374c4c-8c5a-4b79-a5e5-aef778ed36cd
+      INFO: Creation of image ssi-uss-1.0.0-32-csm-1.5.x86_64-csm-1.5.0.beta37-10 succeeded: ID f5374c4c-8c5a-4b79-a5e5-aef778ed36cd
       ```
 
    1. Set `BASE_IMAGE_ID` to the value of the image ID.


### PR DESCRIPTION
## Description

Tech pubs is reviewing the work that moved `docs-sat` content into `docs-csm` for the CSM 1.6 release. This is part of tech pubs' handoff of the SAT product documentation to engineering going forward. 

The initial work to move `docs-sat` into `docs-csm` was done by Ryan Haasken in PR #4476. That work is described in more detail as part of Ryan's [Confluence page](https://rndwiki-pro.its.hpecorp.net/display/CASMSAT/2023-11-15+SAT+full+inclusion+in+CSM+v1.6.0 ). This PR includes some clean-up work as described in [STP-3667](https://jira-pro.it.hpe.com:8443/browse/STP-3667).

- Update "CNE" references to "USS" since the product was renamed before release
- Remove references to SAT as an independent product with independent documentation
- Clean-up work to pass repo checks and improve wording

## Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
