### PR TITLE
CASMPET-7265 add node to management-nodes-rollout to restart goss-servers on worker nodes

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -499,7 +499,7 @@ Return to the procedure that was being followed for `management-nodes-rollout` t
 
 ## 4. Restart `goss-servers` on all NCNs
 
-> Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
+**`NOTE`** Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
 
 If the CSM version is 1.6.0 or lower, then the `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -499,7 +499,9 @@ Return to the procedure that was being followed for `management-nodes-rollout` t
 
 ## 4. Restart `goss-servers` on all NCNs
 
-The `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN. This is necessary due to a timing issue in the NCN's cloud-init which has been fixed in CSM 1.6.1.
+> Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
+
+If the CSM version is 1.6.0 or lower, then the `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
 
 (`ncn-m001#`) Restart `goss-servers`.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -8,8 +8,9 @@ This section updates the software running on management NCNs.
     - [3.1 `management-nodes-rollout` with CSM upgrade](#31-management-nodes-rollout-with-csm-upgrade)
     - [3.2 `management-nodes-rollout` without CSM upgrade](#32-management-nodes-rollout-without-csm-upgrade)
     - [3.3 NCN worker nodes](#33-ncn-worker-nodes)
-- [4. Update management host Slingshot NIC firmware](#4-update-management-host-slingshot-nic-firmware)
-- [5. Next steps](#5-next-steps)
+- [4. Restart `goss-servers` on all NCNs](#4-restart-goss-servers-on-all-ncns)
+- [5. Update management host Slingshot NIC firmware](#5-update-management-host-slingshot-nic-firmware)
+- [6. Next steps](#6-next-steps)
 
 ## 1. Perform Slingshot switch firmware updates
 
@@ -261,7 +262,7 @@ Refer to that table and any corresponding product documents before continuing to
      - All management NCNs have been upgraded to the image and CFS configuration created in the previous steps of this workflow
      - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
-Continue to the next section [4. Update management host Slingshot NIC firmware](#4-update-management-host-slingshot-nic-firmware).
+Continue to the next section [4. Restart `goss-servers` on all NCNs](#4-restart-goss-servers-on-all-ncns).
 
 ### 3.2 `management-nodes-rollout` without CSM upgrade
 
@@ -400,7 +401,7 @@ Once this step has completed:
 - Management NCN storage and NCN master nodes have be updated with the CFS configuration created in the previous steps of this workflow.
 - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
-Continue to the next section [4. Update management host Slingshot NIC firmware](#4-update-management-host-slingshot-nic-firmware).
+Continue to the next section [4. Restart `goss-servers` on all NCNs](#4-restart-goss-servers-on-all-ncns).
 
 ### 3.3 NCN worker nodes
 
@@ -496,7 +497,19 @@ Once this step has completed:
 Return to the procedure that was being followed for `management-nodes-rollout` to complete the next step, either [Management-nodes-rollout with CSM upgrade](#31-management-nodes-rollout-with-csm-upgrade) or
 [Management-nodes-rollout without CSM upgrade](#32-management-nodes-rollout-without-csm-upgrade).
 
-## 4. Update management host Slingshot NIC firmware
+## 4. Restart `goss-servers` on all NCNs
+
+The `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN. This is necessary due to a timing issue in the NCN's cloud-init which has been fixed in CSM 1.6.1.
+
+(`ncn-m001#`) Restart `goss-servers`.
+
+  ```bash
+  ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+  ncn_nodes=${ncn_nodes%,}
+  pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+  ```
+
+## 5. Update management host Slingshot NIC firmware
 
 **`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
@@ -511,7 +524,7 @@ Once this step has completed:
 - Service checks have been run to verify product microservices are executing as expected
 - Per-stage product hooks have executed for the `deploy-product` and `post-install-service-check` stages
 
-## 5. Next steps
+## 6. Next steps
 
 - If performing an initial install or an upgrade of non-CSM products only, return to the
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -503,11 +503,11 @@ The `goss-servers` service needs to be restarted on all NCNs. This ensures the c
 
 (`ncn-m001#`) Restart `goss-servers`.
 
-  ```bash
-  ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-  ncn_nodes=${ncn_nodes%,}
-  pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-  ```
+```bash
+ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+ncn_nodes=${ncn_nodes%,}
+pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+```
 
 ## 5. Update management host Slingshot NIC firmware
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -51,7 +51,9 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
 
     Refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md) for an overview of the health checks.
 
-    1. (`ncn-mw#`) Restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+    1. (`ncn-mw#`) If the CSM version is 1.6.0 or lower, then restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
+
+        > Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
 
         ```bash
         ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
@@ -714,13 +716,5 @@ Before rebooting NCNs:
 1. Validate CSM health.
 
     At a minimum, run the platform health checks.
-
-    (`ncn-m001#`) Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
-
-    ```bash
-    ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-    ncn_nodes=${ncn_nodes%,}
-    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-    ```
 
     See [Validate CSM Health](../validate_csm_health.md) for the platform health checks.

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -51,6 +51,14 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
 
     Refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md) for an overview of the health checks.
 
+    1. (`ncn-mw#`) Restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+
+        ```bash
+        ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+        ncn_nodes=${ncn_nodes%,}
+        pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+        ```
+
     1. (`ncn-mw#`) Run the platform health script.
 
         Run this on any master or worker node. The output of the following script will need to be referenced in some of the remaining sub-steps.
@@ -706,5 +714,13 @@ Before rebooting NCNs:
 1. Validate CSM health.
 
     At a minimum, run the platform health checks.
+
+    (`ncn-m001#`) Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+
+    ```bash
+    ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+    ncn_nodes=${ncn_nodes%,}
+    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+    ```
 
     See [Validate CSM Health](../validate_csm_health.md) for the platform health checks.

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -26,11 +26,11 @@ echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
-> **`NOTE:`** Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
+> **`NOTE:`** (`ncn#`) Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
 > This is necessary because of a timing issue that has been fixed in CSM 1.6.1.
 >
 >    ```bash
->    ssh $node 'systemctl restart goss-servers'
+>    ssh "${NODE}" 'systemctl restart goss-servers'
 >    ```
 
 - [Worker node](#worker-node)
@@ -41,13 +41,13 @@ Only follow the steps in the section for the node type that is being rebuilt.
 
 #### Option 1
 
-1. (`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for `ncn-w001`.
+(`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for `ncn-w001`.
 
-    Follow output of the script carefully. The script will pause for manual interaction.
+Follow output of the script carefully. The script will pause for manual interaction.
 
-    ```bash
-    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001
-    ```
+```bash
+/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001
+```
 
 > **`NOTES:`**
 >

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -26,6 +26,13 @@ echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
+> **`NOTE:`** Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
+> This is necessary because of a timing issue that has been fixed in CSM 1.6.1.
+>
+>    ```bash
+>    ssh $node 'systemctl restart goss-servers'
+>    ```
+
 - [Worker node](#worker-node)
 - [Master node](#master-node)
 - [Storage node](#storage-node)
@@ -34,13 +41,13 @@ Only follow the steps in the section for the node type that is being rebuilt.
 
 #### Option 1
 
-(`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for `ncn-w001`.
+1. (`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for `ncn-w001`.
 
-Follow output of the script carefully. The script will pause for manual interaction.
+    Follow output of the script carefully. The script will pause for manual interaction.
 
-```bash
-/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001
-```
+    ```bash
+    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001
+    ```
 
 > **`NOTES:`**
 >

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -29,9 +29,9 @@ Only follow the steps in the section for the node type that is being rebuilt.
 > **`NOTE:`** (`ncn#`) Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
 > This is necessary because of a timing issue that has been fixed in CSM 1.6.1.
 >
->    ```bash
->    ssh "${NODE}" 'systemctl restart goss-servers'
->    ```
+> ```bash
+> ssh "${NODE}" 'systemctl restart goss-servers'
+> ```
 
 - [Worker node](#worker-node)
 - [Master node](#master-node)

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -26,8 +26,9 @@ echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
-> **`NOTE:`** (`ncn#`) Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
-> This is necessary because of a timing issue that has been fixed in CSM 1.6.1.
+> **`NOTE:`** (`ncn#`) If the CSM version is 1.6.0 or lower, then restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
+> This is necessary because of a timing issue that is fixed in CSM 1.6.1.
+> The service restart will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
 >
 > ```bash
 > ssh "${NODE}" 'systemctl restart goss-servers'

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -58,7 +58,7 @@ All platform health checks are expected to pass. Each check has been implemented
 Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
 Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
 
-1. (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
+- (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
 
     ```bash
     ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
@@ -66,7 +66,7 @@ Run one of the two commands below depending on if it is being executed from `ncn
     pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
     ```
 
-1. (`pit#`) Run the following from the PIT node to restart `goss-servers`.
+- (`pit#`) Run the following from the PIT node to restart `goss-servers`.
 
     ```bash
     mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt'

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -59,6 +59,7 @@ If the CSM version is 1.6.0 or lower, then before running health checks, restart
 
 > Skip the `goss-servers` service restart if the CSM version is 1.6.1 or above.
 > The restart will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
+
 Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
 
 - (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -56,7 +56,7 @@ If running these checks after the initial CSM install, then to find details on c
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
 
 Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
-Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node. 
+Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
 
 1. (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -55,7 +55,10 @@ If running these checks after the initial CSM install, then to find details on c
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
 
-Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+If the CSM version is 1.6.0 or lower, then before running health checks, restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue that is fixed in CSM 1.6.1.
+
+> Skip the `goss-servers` service restart if the CSM version is 1.6.1 or above.
+> The restart will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
 Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
 
 - (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -56,14 +56,24 @@ If running these checks after the initial CSM install, then to find details on c
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
 
 Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node. 
 
-(`ncn-m#` or `pit#`) Restart `goss-servers`.
+1. (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
 
-```bash
-ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-ncn_nodes=${ncn_nodes%,}
-pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-```
+    ```bash
+    ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+    ncn_nodes=${ncn_nodes%,}
+    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+    ```
+
+1. (`pit#`) Run the following from the PIT node to restart `goss-servers`.
+
+    ```bash
+    mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt'
+    ncn_nodes=$(grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | sed -e "s/-mgmt//" | tr -t '\n' ',')
+    ncn_nodes=${ncn_nodes%,}
+    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+    ```
 
 Available platform health checks:
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -15,6 +15,16 @@ The areas should be tested in the order they are listed on this page. Errors in 
 Each section of this health check document provides links to relevant troubleshooting procedures. If additional help is needed, see
 [CSM Troubleshooting Information](../troubleshooting/README.md).
 
+Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+
+(`ncn-m#` or `pit#`) Restart `goss-servers`.
+
+  ```bash
+  ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+  ncn_nodes=${ncn_nodes%,}
+  pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+  ```
+
 ## Topics
 
 - [0. Cray command line interface](#0-cray-command-line-interface)

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -15,16 +15,6 @@ The areas should be tested in the order they are listed on this page. Errors in 
 Each section of this health check document provides links to relevant troubleshooting procedures. If additional help is needed, see
 [CSM Troubleshooting Information](../troubleshooting/README.md).
 
-Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
-
-(`ncn-m#` or `pit#`) Restart `goss-servers`.
-
-  ```bash
-  ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-  ncn_nodes=${ncn_nodes%,}
-  pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-  ```
-
 ## Topics
 
 - [0. Cray command line interface](#0-cray-command-line-interface)
@@ -64,6 +54,16 @@ If running these checks after the initial CSM install, then to find details on c
 ## 1. Platform health checks
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
+
+Before running health checks, restart `goss-servers` on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue on the nodes that has been fixed in CSM 1.6.1.
+
+(`ncn-m#` or `pit#`) Restart `goss-servers`.
+
+```bash
+ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+ncn_nodes=${ncn_nodes%,}
+pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+```
 
 Available platform health checks:
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In CSM 1.6.0, the iSCSI Goss tests due not run on worker nodes after an upgrade. This is due to the fact that these tests are designed to only run on worker nodes. To determine what node they are on requires the hostname to be found. However, goss-servers starts early in the node booting process and often before the hostname is available. This means that the Goss tests are not correctly added to the service and they are skipped. This is fixed in CSM 1.6.1 by [CASMPET-7263](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7263 ). This PR addresses CSM 1.6.0. In order to resolve this problem, goss-servers needs to be manually restarted after a node upgrade, after a node reboot, and before CSM validation is run just to be sure we are running all goss tests.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
