### PR TITLE
CASMPET-7265-release-1.3 add docs to restart goss-servers after each node power cycle and before NCN validation

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -50,6 +50,14 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
 
     Refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md) for an overview of the health checks.
 
+    1. (`ncn-mw#`) Restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
+
+        ```bash
+        ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+        ncn_nodes=${ncn_nodes%,}
+        pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+        ```
+
     1. (`ncn-mw#`) Run the platform health script.
 
         Run this on any master or worker node. The output of the following script will need to be referenced in some of the remaining sub-steps.

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -26,6 +26,13 @@ echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
+> **`NOTE:`** (`ncn#`) Restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
+> This is necessary because of a timing issue that is fixed in CSM 1.6.1.
+>
+> ```bash
+> ssh "${NODE}" 'systemctl restart goss-servers'
+> ```
+
 - [Worker node](#worker-node)
 - [Master node](#master-node)
 - [Storage node](#storage-node)

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -62,6 +62,27 @@ The Cray CLI must be configured on all NCNs and the PIT node. The following proc
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
 
+Before running health checks, restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue that is fixed in CSM 1.6.1.
+
+Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
+
+- (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
+
+    ```bash
+    ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
+    ncn_nodes=${ncn_nodes%,}
+    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+    ```
+
+- (`pit#`) Run the following from the PIT node to restart `goss-servers`.
+
+    ```bash
+    mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt'
+    ncn_nodes=$(grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | sed -e "s/-mgmt//" | tr -t '\n' ',')
+    ncn_nodes=${ncn_nodes%,}
+    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
+    ```
+
 Available platform health checks:
 
 1. [NCN health checks](#11-ncn-health-checks)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In CSM 1.6.0, the iSCSI Goss tests due not run on worker nodes after an upgrade. This is due to the fact that these tests are designed to only run on worker nodes. To determine what node they are on requires the hostname to be found. However, goss-servers starts early in the node booting process and often before the hostname is available. This means that the Goss tests are not correctly added to the service and they are skipped. This is fixed in CSM 1.6.1 by [CASMPET-7263](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7263). This PR addresses CSM 1.3. In order to resolve this problem, goss-servers needs to be manually restarted after a node upgrade, after a node reboot, and before CSM validation is run just to be sure we are running all goss tests.

This is a manual backport of https://github.com/Cray-HPE/docs-csm/pull/5506.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
