### PR TITLE
CASMINST-7035: Improve "SAT and IUF" section

### DIFF
--- a/operations/system_admin_toolkit/usage/SAT_and_IUF.md
+++ b/operations/system_admin_toolkit/usage/SAT_and_IUF.md
@@ -7,106 +7,80 @@ to use `sat bootprep`.
 For more information on IUF, see [Install and Upgrade Framework](../../iuf/IUF.md). For more
 information on `sat bootprep`, see [SAT Bootprep](SAT_Bootprep.md).
 
-## Variable Substitutions
+## IUF variable substitutions
 
-Both IUF and `sat bootprep` allow variable substitutions into the default HPC
-CSM Software Recipe bootprep input files. The default variables of the HPC
-CSM Software Recipe are available in a `product_vars.yaml` file. To override
-the default variables, specify any site variables in a `site_vars.yaml` file.
-Variables are sourced from the command line, any variable files directly
-provided, and the HPC CSM Software Recipe files used, in that order.
+As described in [Variable substitutions](SAT_Bootprep.md#variable-substitutions),
+the `sat bootprep` command supports variable substitutions in the `bootprep`
+input files. IUF merges variables from multiple sources and then passes the
+resulting merged variables to `sat bootprep` using the `--vars-file` option. The
+sources used by IUF, in order of highest to lowest precedence are as follows:
 
-### IUF Session Variables
+1. The versions of products found in the media directory for the IUF activity.
+1. The site variables (`site_vars.yaml`) passed to IUF with the `--site-vars`
+   option.
+1. The variables in the HPC CSM Software Recipe `product_vars.yaml` file passed
+   to IUF.
+1. The most recent versions of products from the product catalog.
 
-IUF also has special session variables internal to the `iuf` command that
-override any matching entries. Session variables are the set of product and
-version combinations being installed by the current IUF activity, and they are
-found inside IUF's internal `session_vars.yaml` file. For more information on
-IUF and variable substitutions, see [Install and Upgrade Framework](../../iuf/IUF.md).
+See [Customer branch name](../../iuf/stages/update_vcs_config.md#customer-branch-name)
+in the IUF documentation for further details on how these variables are
+constructed.
 
-### SAT Variable Limitations
+When IUF merges these variable sources, it performs an additional rendering pass
+that allows the expansion of variables in other variables defined in the
+`product_vars.yaml` file. For example, the `product_vars.yaml` may contain the
+following:
 
-When using `sat bootprep` outside of IUF, substituting variables into the
-default bootprep input files might cause problems. Complex variables like
-`"{{ working_branch }}"` cannot be completely resolved outside of IUF and
-its internal session variables. Thus, the default `product_vars.yaml` file is
-unusable with only the `sat bootprep` command when variables like
-`"{{ working_branch }}"` are used. To work around this limitation when
-substituting complex variables, use the internal IUF `session_vars.yaml` file
-with `sat bootprep` and the default bootprep input files.
+```yaml
+default:
+  working_branch: "integration-{{version_x_y_z}}"
 
-1. Find the `session_vars.yaml` file from the most recent IUF activity on the
-   system.
-
-   This process is documented below. See
-   steps 1-6 of [Using `sat bootprep` with IUF generated input files](#using-sat-bootprep-with-iuf-generated-input-files).
-
-1. (`ncn-m001#`) Use the `session_vars.yaml` file to substitute variables into the default
-   bootprep input files.
-
-   ```bash
-   sat bootprep run --vars-file session_vars.yaml
-   ```
-
-## Limit SAT Bootprep Run into Stages
-
-The `sat bootprep run` command uses information from the bootprep input files
-to create CFS configurations, IMS images, and BOS session templates. To restrict
-this creation into separate stages, use the `--limit` option and list whether
-to create `configurations`, `images`, `session_templates`, or some
-combination of these. IUF uses the `--limit` option in this way to install,
-upgrade, and deploy products on a system in stages.
-
-(`ncn-m001#`) For example, to create only CFS configurations, run the following command used
-by the IUF `update-cfs-config` stage:
-
-```bash
-sat bootprep run --limit configurations example-bootprep-input-file.yaml
+uss:
+  version: 1.2.0-95-csm
+  working_branch: "{{working_branch}}"
 ```
 
-Example output:
+IUF first determines the appropriate value of `uss.version` using the previously
+described precedence rules. Then it substitutes `{{working_branch}}` in the
+value of `uss.working_branch` with the value `"integration-{{version_x_y_z}}"`.
+Finally, it renders this string and replaces `{{version_x_y_z}}` using the value
+of `uss.version`. Assuming IUF determines the value of `uss.version` to be
+`1.2.0-95-csm`, the rendered variables for `uss` are as follows:
 
-```text
-INFO: Validating given input file example-bootprep-input-file.yaml
-INFO: Input file successfully validated against schema
-INFO: Creating 3 CFS configurations
-...
-INFO: Skipping creation of IMS images based on value of --limit option.
-INFO: Skipping creation of BOS session templates based on value of --limit option.
+```yaml
+uss:
+  version: 1.2.0-95-csm
+  working_branch: "integration-1.2.0"
 ```
 
-(`ncn-m001#`) To create only IMS images and BOS session templates, run the following command
-used by the IUF `prepare-images` stage:
+Since this variable substitution requires multiple passes of rendering and
+knowledge of the versions of products being installed by IUF, this rendering
+cannot be performed by `sat bootprep` alone. If the `product_vars.yaml` file
+shown above is passed to `sat bootprep` directly without being rendered by the
+IUF, it will not use the intended value for `uss.working_branch`.
 
-```bash
-sat bootprep run --limit images --limit session_templates example-bootprep-input-file.yaml
-```
+In order to use a `sat bootprep` file that depends on a complex variable as
+described above, the merged and rendered `session_vars.yaml` file can be
+obtained from an IUF activity, and that file can be provided to `sat bootprep`
+with the `--vars-file` option.
 
-Example output:
+### Obtaining IUF session variables and bootprep files
 
-```text
-INFO: Validating given input file example-bootprep-input-file.yaml
-INFO: Input file successfully validated against schema
-INFO: Skipping creation of CFS configurations based on value of --limit option.
-```
+When IUF constructs the variables as described in [IUF Variable
+Substitutions](#iuf-variable-substitutions), it saves these variables to a file
+named `session_vars.yaml` in the directory for the IUF activity. The following
+procedure describes how to obtain a copy of the `session_vars.yaml` and `sat
+bootprep` input files used in an IUF activity. These files can then be used
+directly with `sat bootprep` if desired. This can be useful for debugging
+purposes.
 
-## Using `sat bootprep` with IUF generated input files
-
-**This section is purely for workaround purposes.**
-
-This section is not expected to be used in a normal upgrade or install process. These steps are automatically done through IUF.
-This section is here in case `sat bootprep` needs to be run manually or in case CSM NCN images need to be built manually.
-Again, it is not expected that these steps will be needed during an upgrade or install.
-
-Below is a procedure to use `sat bootprep` with IUF generated input files.
-Once `sat bootprep` is run, this procedure sets the CFS configuration and IMS images on NCNs.
-
-In order to follow this procedure, you will need to know the name of the IUF activity used to
-perform the initial installation of the HPE Cray EX software products. See the
-[Activities](../../iuf/IUF.md#activities) section of the IUF documentation for more
-information on IUF activities. See [`list-activities`](../../iuf/IUF.md#list-activities)
-for information about listing the IUF activities on the system. The first step provides an
-example showing how to find the IUF activity.
+In order to follow this procedure, you will need to know the name of the IUF
+activity used to perform the initial installation of the HPE Cray EX software
+products. See the [Activities](../../iuf/IUF.md#activities) section of the IUF
+documentation for more information on IUF activities. See
+[`list-activities`](../../iuf/IUF.md#list-activities) for information about
+listing the IUF activities on the system. The first step provides an example
+showing how to find the IUF activity.
 
 1. (`ncn-m001#`) Find the IUF activity used for the most recent install of the system.
 
@@ -144,22 +118,24 @@ example showing how to find the IUF activity.
    /etc/cray/upgrade/csm/media/24.01-recipe-install
    ```
 
-1. (`ncn-m001#`) Create a directory for the `sat bootprep` input files and the `session_vars.yaml` file.
+1. (`ncn-m001#`) Create a directory for the `sat bootprep` input files and the `session_vars.yaml`
+   file.
 
-   This example uses a directory under the RBD mount used by the IUF:
+   This example uses a directory under the RBD mount used by IUF:
 
    ```bash
    export BOOTPREP_DIR="/etc/cray/upgrade/csm/admin/bootprep-csm-${CSM_RELEASE}"
    mkdir -pv "${BOOTPREP_DIR}"
    ```
 
-1. (`ncn-m001#`) Copy the `sat bootprep` input file for management nodes into the directory.
+1. (`ncn-m001#`) Copy the desired `sat bootprep` input file(s) into the directory.
 
-   It is possible that the file name will differ from `management-bootprep.yaml` if a different
-   file was used during the IUF activity.
+   The example below shows copying the two default bootprep files
+   `management-bootprep.yaml` and `compute-and-uan-bootprep.yaml`.
 
    ```bash
    cp -pv "${MEDIA_DIR}/.bootprep-${ACTIVITY_NAME}/management-bootprep.yaml" "${BOOTPREP_DIR}"
+   cp -pv "${MEDIA_DIR}/.bootprep-${ACTIVITY_NAME}/compute-and-uan-bootprep.yaml" "${BOOTPREP_DIR}"
    ```
 
 1. (`ncn-m001#`) Copy the `session_vars.yaml` file into the directory.
@@ -168,62 +144,54 @@ example showing how to find the IUF activity.
    cp -pv "${ACTIVITY_DIR}/state/session_vars.yaml" "${BOOTPREP_DIR}"
    ```
 
-1. (`ncn-m001#`) Modify the CSM version in the copied `session_vars.yaml`:
+1. (`ncn-m001#`) It is recommended to modify the `default.suffix` value in the
+   copied `session_vars.yaml`.
+
+   As long as the `sat bootprep` input file uses `{{default.suffix}}` in the
+   names of the CFS configurations, IMS images, and BOS session templates, this
+   will ensure new CFS configurations and IMS images are created with different
+   names from the ones created in the IUF activity.
+
+   The example below sets the suffix to "-debug":
 
    ```bash
-   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.version' "${CSM_RELEASE}"
+   yq w -i -- "${BOOTPREP_DIR}/session_vars.yaml" 'default.suffix' "-debug"
    ```
 
-1. (`ncn-m001#`) Update the `working_branch` if one is used for the CSM product.
+In order use `sat bootprep` with the variables defined in this
+`session_vars.yaml` file, pass `--vars-file session_vars.yaml` to `sat bootprep
+run`.
 
-   By default, a `working_branch` is not used for the CSM product. Check if there is a
-   `working_branch` specified for CSM:
+## Manually building and applying management node images and configurations
 
-   ```bash
-   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
-   ```
+**This section is purely for workaround purposes.**
 
-   If this produces no output, a `working_branch` is not in use for the CSM product, and this step
-   can be skipped. Otherwise, it shows the name of the working branch. For example:
+This section is not expected to be used in a normal upgrade or install process.
+These steps are automatically done through IUF. This section is here in case
+`sat bootprep` needs to be run manually or in case CSM NCN images need to be
+built manually. These steps are not needed during a normal upgrade or install.
 
-   ```text
-   integration-1.4.0
-   ```
+The procedure below describes how to create CFS configurations and IMS images
+for management nodes and assign them to the management nodes.
 
-   In this case, be sure to manually update the version string in the working branch to match the
-   new working branch. Then check it again. For example:
+1. Follow the procedure in [Obtaining IUF session variables and bootprep files](#obtaining-iuf-session-variables-and-bootprep-files)
+   to obtain the appropriate `session_vars.yaml` and `management-bootprep.yaml`
+   files.
 
-   ```bash
-   yq w -i "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch' "integration-${CSM_RELEASE}"
-   yq r "${BOOTPREP_DIR}/session_vars.yaml" 'csm.working_branch'
-   ```
-
-   This should output the name of the new CSM working branch.
-
-1. (`ncn-m001#`) Modify the `default.suffix` value in the copied `session_vars.yaml`:
-
-   As long as the `sat bootprep` input file uses `{{default.suffix}}` in the names of the CFS
-   configurations and IMS images, this will ensure new CFS configurations and IMS images are created
-   with different names from the ones created in the IUF activity.
-
-   ```bash
-   yq w -i -- "${BOOTPREP_DIR}/session_vars.yaml" 'default.suffix' "-csm-${CSM_RELEASE}"
-   ```
-
-1. (`ncn-m001#`) Change directory to the `BOOTPREP_DIR` and run `sat bootprep`.
-
-   This will create a CFS configuration for management nodes, and it will use that CFS configuration
-   to customize the images for the master, worker, and storage management nodes.
+1. (`ncn-m001#`) Change directory to the `BOOTPREP_DIR` and run `sat bootprep`,
+   passing the `session_vars.yaml` file as the value of the `--vars-file`
+   option:
 
    ```bash
    cd "${BOOTPREP_DIR}"
    sat bootprep run --vars-file session_vars.yaml management-bootprep.yaml
    ```
 
-1. (`ncn-m001#`) Gather the CFS configuration name, and the IMS image names from the output of `sat bootprep`.
+1. (`ncn-m001#`) Gather the CFS configuration name, and the IMS image names from
+   the output of `sat bootprep`.
 
-   `sat bootprep` will print a report summarizing the CFS configuration and IMS images it created.
-   For example:
+   `sat bootprep` will print a report summarizing the CFS configuration and IMS
+   images it created. For example:
 
    ```text
    ################################################################################
@@ -292,10 +260,10 @@ example showing how to find the IUF activity.
 
 1. (`ncn-m001#`) Assign the CFS configuration to the management nodes.
 
-   This deliberately only sets the desired configuration of the components in CFS. It
-   disables the components and does not clear their configuration states or error counts. When the
-   nodes are rebooted to their new images later in the CSM upgrade, they will automatically be
-   enabled in CFS, and node personalization will occur.
+   This deliberately only sets the desired configuration of the components in
+   CFS. It disables the components and does not clear their configuration states
+   or error counts. When the nodes are rebooted to their new images, they will
+   automatically be enabled in CFS, and node personalization will occur.
   
    1. Get the xnames of the master and worker management nodes.
 
@@ -307,7 +275,8 @@ example showing how to find the IUF activity.
       echo "${MASTER_XNAMES},${WORKER_XNAMES}"
       ```
 
-   1. Apply the CFS configuration to master nodes and worker nodes using the xnames and CFS configuration name found in the previous steps.
+   1. Apply the CFS configuration to master nodes and worker nodes using the
+      xnames and CFS configuration name found in the previous steps.
 
       ```bash
       /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
@@ -329,7 +298,8 @@ example showing how to find the IUF activity.
       echo $STORAGE_XNAMES
       ```
 
-   1. Apply the CFS configuration to storage nodes using the xnames and CFS configuration name found in the previous steps.
+   1. Apply the CFS configuration to storage nodes using the xnames and CFS
+      configuration name found in the previous steps.
 
       ```bash
       /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \

--- a/troubleshooting/incrementally_configuring_images.md
+++ b/troubleshooting/incrementally_configuring_images.md
@@ -219,7 +219,8 @@ can be adapted for other image types.
 
 1. Create a copy of the original SAT `bootprep` file.
 
-   Instructions for this procedure can be found in steps 1-4 of [Using `sat bootprep` with IUF generated input files](../operations/system_admin_toolkit/usage/SAT_and_IUF.md#using-sat-bootprep-with-iuf-generated-input-files) documentation.
+   Follow steps 1-5 of [Obtaining IUF session variables and bootprep files](../operations/system_admin_toolkit/usage/SAT_and_IUF.md#obtaining-iuf-session-variables-and-bootprep-files)
+   in the SAT documentation.
 
 1. Edit the [Boot Orchestration Service (BOS)](../glossary.md#boot-orchestration-service-bos) session templates in the SAT `bootprep` file.
 


### PR DESCRIPTION
# Description
Improve the "SAT and IUF" section of the documentation that describes the relationship between SAT and IUF, specifically how `sat bootprep` is executed in IUF and how variable substitution works in that context.

Include a procedure to obtain the `session_vars.yaml` file and bootprep input files from the IUF activity and use them to create CFS configurations, images, and session templates manually. This can be a useful debugging procedure.

Include another procedure that describes how to assign the CFS configurations and IMS images to management NCNs as a non-standard debugging procedure. This procedure used to be used when performing an upgrade of only CSM on a system that also contains other products that were previously installed by IUF.

Move a section about limiting `sat bootprep run` into separate stages into the `SAT_Bootprep.md` file because it's really more appropriate with the general `sat bootprep` usage information.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
