### PR TITLE
CASMINST-7038: After upgrading CSM services, upgrade the test/CLI RPMs on NCNs

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -156,8 +156,20 @@ fi
 # Restart CFS deployments to avoid CASMINST-6852
 "${basedir}/../common/restart-cfs.sh"
 
-# Update test/CLI RPMs on NCNs
-"${basedir}/util/upgrade-test-rpms.sh"
+state_name="UPDATE_TEST_CLI_RPMS"
+#shellcheck disable=SC2046
+state_recorded=$(is_state_recorded "${state_name}" $(hostname))
+if [[ $state_recorded == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    # Update test/CLI RPMs on NCNs
+    "${basedir}/util/upgrade-test-rpms.sh"
+  } >> ${LOG_FILE} 2>&1
+  #shellcheck disable=SC2046
+  record_state ${state_name} $(hostname)
+else
+  echo "====> ${state_name} has been completed"
+fi
 
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."

--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -159,9 +159,6 @@ fi
 # Update test/CLI RPMs on NCNs
 "${basedir}/util/upgrade-test-rpms.sh"
 
-# Wait 10 seconds to make sure all of the restarted Goss servers are started up on the NCNs
-sleep 10
-
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."
 GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-post-csm-service-upgrade-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate

--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -156,6 +156,12 @@ fi
 # Restart CFS deployments to avoid CASMINST-6852
 "${basedir}/../common/restart-cfs.sh"
 
+# Update test/CLI RPMs on NCNs
+"${basedir}/util/upgrade-test-rpms.sh"
+
+# Wait 10 seconds to make sure all of the restarted Goss servers are started up on the NCNs
+sleep 10
+
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."
 GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-post-csm-service-upgrade-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -40,6 +40,9 @@ if [[ $# -eq 0 ]]; then
   echo "Enabling and restarting goss-servers"
   pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl restart goss-servers'
 
+  echo "Waiting for goss-servers service to start"
+  pdsh -S -b -w ${ncns} 'for X in 1 2 3 4 5; do [[ $X -gt 1 ]] && sleep 3; systemctl is-active goss-servers && exit 0; done; exit 1'
+
 elif [[ $# -eq 1 && $1 == --local ]]; then
 
   echo "Installing updated versions of RPMs: ${RPM_LIST}"
@@ -47,6 +50,14 @@ elif [[ $# -eq 1 && $1 == --local ]]; then
 
   echo "Enabling and restarting goss-servers"
   systemctl enable goss-servers && systemctl restart goss-servers
+
+  echo "Waiting for goss-servers service to start"
+  started=n
+  for X in 1 2 3 4 5; do
+    [[ $X -gt 1 ]] && sleep 3
+    systemctl is-active goss-servers && started=y && break
+  done
+  [[ ${started} == y ]] || exit 1
 
 else
 


### PR DESCRIPTION
[CAST-36752](https://jira-pro.it.hpe.com:8443/browse/CAST-36752) was opened because during an upgrade from CSM 1.4 to 1.5.1, when they ran the CSM health validation after upgrading services, it failed because the version of the CLI on the NCNs had not yet been updated.

We have a step to do this during our patch upgrade process, but it appears to be overlooked curing the regular upgrade process.

This PR adds a call to our existing "RPM update" script at the tail end of the CSM service upgrade, to address this issue.

1.6 backport: https://github.com/Cray-HPE/docs-csm/pull/5513
1.4 backport (of just the upgrade-test-rpm.sh script changes): https://github.com/Cray-HPE/docs-csm/pull/5521
