### PR TITLE
CASMINST-7038: Upgrade NCN test/CLI RPMs after upgrading CSM services

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -157,8 +157,20 @@ fi
 # Restart CFS deployments to avoid CASMINST-6852
 "${basedir}/../common/restart-cfs.sh"
 
-# Update test/CLI RPMs on NCNs
-"${basedir}/util/upgrade-test-rpms.sh"
+state_name="UPDATE_TEST_CLI_RPMS"
+#shellcheck disable=SC2046
+state_recorded=$(is_state_recorded "${state_name}" $(hostname))
+if [[ $state_recorded == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    # Update test/CLI RPMs on NCNs
+    "${basedir}/util/upgrade-test-rpms.sh"
+  } >> ${LOG_FILE} 2>&1
+  #shellcheck disable=SC2046
+  record_state ${state_name} $(hostname)
+else
+  echo "====> ${state_name} has been completed"
+fi
 
 # Back up BOS data post-sysmgmt upgrade, and record contents of the migration pod
 # This only needs to be done if the cray-bos-migration job exists

--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -157,6 +157,9 @@ fi
 # Restart CFS deployments to avoid CASMINST-6852
 "${basedir}/../common/restart-cfs.sh"
 
+# Update test/CLI RPMs on NCNs
+"${basedir}/util/upgrade-test-rpms.sh"
+
 # Back up BOS data post-sysmgmt upgrade, and record contents of the migration pod
 # This only needs to be done if the cray-bos-migration job exists
 job_name=cray-bos-migration

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -40,6 +40,9 @@ if [[ $# -eq 0 ]]; then
   echo "Enabling and restarting goss-servers"
   pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl restart goss-servers'
 
+  echo "Waiting for goss-servers service to start"
+  pdsh -S -b -w ${ncns} 'for X in 1 2 3 4 5; do [[ $X -gt 1 ]] && sleep 3; systemctl is-active goss-servers && exit 0; done; exit 1'
+
 elif [[ $# -eq 1 && $1 == --local ]]; then
 
   echo "Installing updated versions of RPMs: ${RPM_LIST}"
@@ -47,6 +50,14 @@ elif [[ $# -eq 1 && $1 == --local ]]; then
 
   echo "Enabling and restarting goss-servers"
   systemctl enable goss-servers && systemctl restart goss-servers
+
+  echo "Waiting for goss-servers service to start"
+  started=n
+  for X in 1 2 3 4 5; do
+    [[ $X -gt 1 ]] && sleep 3
+    systemctl is-active goss-servers && started=y && break
+  done
+  [[ ${started} == y ]] || exit 1
 
 else
 


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/docs-csm/pull/5512