### PR TITLE
CASMTRIAGE-7446: Add known issue for containerd not allowing spire server to restart

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -69,6 +69,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
 * [Istio-Proxy failing with too many open files](known_issues/Istio-Proxy_failing_with_too_many_open_files.md)
 * [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
+* [Spire pods stuck in `PodInitializing`](known_issues/spire_pod_initializing.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/spire_pod_initializing.md
+++ b/troubleshooting/known_issues/spire_pod_initializing.md
@@ -1,0 +1,62 @@
+# Spire Server Pods stuck in Pod Initializing
+
+## Description
+
+There is a known issue when the Spire servers are started and Spire Postgres is not ready, where the pod will get stuck in a `PodInitializing` state and not be able to be restarted.
+
+Starting the Spire server when its Postgres cluster is not ready leads to the pod crashing. However due to how the Spire servers are registered when the main process crashes
+there is a loop that never killed in a side process. That leads to the pod crashing but never getting cleaned up to be restarted. There is no way to manually restart that pod
+without restarting `Containerd` to forcefully clean up the running container.
+
+## Symptoms
+
+* The `spire-server` or `cray-spire-server` pods may be in a `PodInitializing` state.
+* The `spire-agent` or `cray-spire-agent` pods may be in a `Init:CrashLoopBackOff` state.
+* Services may fail to acquire tokens from the `spire-server` or `cray-spire-server`.
+* The `spire-server` or `cray-spire-server` pods contain the following error in the logs.
+
+  ```text
+  time="2024-10-25T10:13:50Z" level=info msg="Opening SQL database" db_type=postgres subsystem_name=built-in_plugin.sql
+  time="2024-10-25T10:13:50Z" level=error msg="Fatal run error" error="datastore-sql: dial tcp: lookup spire-postgres-pooler.spire.svc.cluster.local: no such host"
+  time="2024-10-25T10:13:50Z" level=error msg="Server crashed" error="datastore-sql: dial tcp: lookup spire-postgres-pooler.spire.svc.cluster.local: no such host"
+  ```
+
+## Solution
+
+### Apply workaround
+
+1. Find the node that the first Spire Server is attempting to start on.
+
+   ```bash
+   kubectl get pods -n spire -o wide
+   ```
+
+   Output example:
+
+   ```text
+   spire-server-0                                0/2     PodInitializing         0                5h32m   10.34.0.129   ncn-w004   <none>           <none>
+   ```
+
+1. Make sure Postgres is running
+
+   ```bash
+   kubectl get pods -n spire | grep spire-postgres
+   ```
+
+1. Delete the pod
+
+   ```bash
+   kubectl delete pod -n spire spire-server-0
+   ```
+
+1. SSH to the node it was running on and restart `Containerd`
+
+   ```bash
+   ssh ncn-w004 systemctl restart containerd
+   ```
+
+1. Check to make sure the spire-server started up
+
+   ```bash
+   kubectl get pods -n spire
+   ```

--- a/troubleshooting/known_issues/spire_pod_initializing.md
+++ b/troubleshooting/known_issues/spire_pod_initializing.md
@@ -28,7 +28,7 @@ without restarting `Containerd` to forcefully clean up the running container.
 1. Find the node that the first Spire Server is attempting to start on.
 
    ```bash
-   kubectl get pods -n spire -o wide
+   kubectl get pods -n spire -o wide | grep spire-server-0
    ```
 
    Output example:

--- a/troubleshooting/known_issues/spire_pod_initializing.md
+++ b/troubleshooting/known_issues/spire_pod_initializing.md
@@ -25,7 +25,7 @@ without restarting `Containerd` to forcefully clean up the running container.
 
 ### Apply workaround
 
-1. Find the node that the first Spire Server is attempting to start on.
+1. Find the node that the first Spire server is attempting to start on.
 
    ```bash
    kubectl get pods -n spire -o wide | grep spire-server-0
@@ -37,25 +37,25 @@ without restarting `Containerd` to forcefully clean up the running container.
    spire-server-0                                0/2     PodInitializing         0                5h32m   10.34.0.129   ncn-w004   <none>           <none>
    ```
 
-1. Make sure Postgres is running
+1. Verify that Postgres is running.
 
    ```bash
    kubectl get pods -n spire | grep spire-postgres
    ```
 
-1. Delete the pod
+1. Delete the pod.
 
    ```bash
    kubectl delete pod -n spire spire-server-0
    ```
 
-1. SSH to the node it was running on and restart `Containerd`
+1. SSH to the node it was running on and restart `Containerd`.
 
    ```bash
    ssh ncn-w004 systemctl restart containerd
    ```
 
-1. Check to make sure the spire-server started up
+1. Check that the spire-server started up.
 
    ```bash
    kubectl get pods -n spire

--- a/troubleshooting/known_issues/spire_pod_initializing.md
+++ b/troubleshooting/known_issues/spire_pod_initializing.md
@@ -5,7 +5,7 @@
 There is a known issue when the Spire servers are started and Spire Postgres is not ready, where the pod will get stuck in a `PodInitializing` state and not be able to be restarted.
 
 Starting the Spire server when its Postgres cluster is not ready leads to the pod crashing. However due to how the Spire servers are registered when the main process crashes
-there is a loop that never killed in a side process. That leads to the pod crashing but never getting cleaned up to be restarted. There is no way to manually restart that pod
+there is a loop that never gets killed in a side process. That leads to the pod crashing but never getting cleaned up to be restarted. There is no way to manually restart that pod
 without restarting `Containerd` to forcefully clean up the running container.
 
 ## Symptoms


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This adds a new known issue for spire-servers failing to start up. This is only seen on CSM 1.6 after the containerd update. Currently there is not a solution to the issue other than restarting containerd. 
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
