### PR TITLE
CASMTRIAGE-7226 Docs: cfs-api pods in CLBO due to absence of Kafka pods

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -89,6 +89,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 
 * [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md)
 * [Incrementally Configuring Images](incrementally_configuring_images.md)
+* [CFS-API pods in CLBO state](known_issues/cfs-api_pods_in_CLBO_state.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md
+++ b/troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md
@@ -16,7 +16,7 @@ Also, `CFS-API` pods will be in CLBO state.
 
 The logs from `strimzi-cluster-operator-*` pod in the operators namespace will be throwing errors as follows:
 
-```sh
+```text
 2024-10-04T22:16:54.899932465Z 2024-10-04 22:16:54 ERROR StaticHostProvider:148 - Unable to resolve address: cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc/<unresolved>:2181
 2024-10-04T22:16:54.899952739Z java.net.UnknownHostException: cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc: Name or service not known
 

--- a/troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md
+++ b/troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md
@@ -1,0 +1,40 @@
+# `CFS-API` pods in CLBO state during CSM install
+
+## Issue Description
+
+When installing CSM 1.6, `cray-shared-kafka-kafka-*` pods in the services namespace fail to come up which results in `CFS-API` pods in CLBO state. This happens because of an issue with Zookeeper related to slow DNS.
+Zookeeper fails to come up if the DNS is not set up for all hosts at startup. When this happens, the cluster gets stuck at Zookeeper pods running, but brokers not coming up.
+
+### Related Issue
+
+- [Zookeeper Issue #4708](https://issues.apache.org/jira/browse/ZOOKEEPER-4708)
+
+## Error Identification
+
+When the issue occurs, the `cray-shared-kafka-kafka-*` pods in the services namespace fail to come up and will not be present.
+Also, `CFS-API` pods will be in CLBO state.
+
+The logs from `strimzi-cluster-operator-*` pod in the operators namespace will be throwing errors as follows:
+
+```sh
+2024-10-04T22:16:54.899932465Z 2024-10-04 22:16:54 ERROR StaticHostProvider:148 - Unable to resolve address: cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc/<unresolved>:2181
+2024-10-04T22:16:54.899952739Z java.net.UnknownHostException: cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc: Name or service not known
+
+2024-10-04T22:21:54.061164856Z 2024-10-04 22:21:54 ERROR VertxUtil:127 - Reconciliation #1(watch) Kafka(services/cray-shared-kafka):Exceeded timeout of 300000ms while waiting for ZooKeeperAdmin connection to cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc:2181,cray-shared-kafka-zookeeper-1.cray-shared-kafka-zookeeper-nodes.services.svc:2181,cray-shared-kafka-zookeeper-2.cray-shared-kafka-zookeeper-nodes.services.svc:2181 to be connected
+2024-10-04T22:21:54.061644246Z 2024-10-04 22:21:54 WARN  ZookeeperScaler:157 - Reconciliation #1(watch) Kafka(services/cray-shared-kafka): Failed to connect to Zookeeper cray-shared-kafka-zookeeper-0.cray-shared-kafka-zookeeper-nodes.services.svc:2181,cray-shared-kafka-zookeeper-1.cray-shared-kafka-zookeeper-nodes.services.svc:2181,cray-shared-kafka-zookeeper-2.cray-shared-kafka-zookeeper-nodes.services.svc:2181. Connection was not ready in 300000 ms.
+2024-10-04T22:21:54.466771715Z 2024-10-04 22:21:54 WARN  ZooKeeperReconciler:834 - Reconciliation #1(watch) Kafka(services/cray-shared-kafka): Failed to verify Zookeeper configuration
+```
+
+## Error Conditions
+
+This problem can be triggered by events like:
+
+- Slow DNS propagation to Kubernetes DNS subsystem
+
+## Fix Description
+
+The workaround is to delete the zookeeper pods and let them be re-created by the Strimzi operator.
+
+```bash
+kubectl delete pods -n services -l strimzi.io/controller-name=cray-shared-kafka-zookeeper
+```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Documentation PR for CASMTRIAGE-7226 Docs: cfs-api pods in CLBO due to absence of Kafka pods. This issue is intermittently seen on vshasta and was a known issue from Zookeeper (confirmed with Strimzi team). It was first time observed on bare metal this week. Documenting the issue in troubleshooting. 
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
