### PR TITLE
CASMCMS-9194/CASMCMS-9195: Update CFS import/export tools

### DIFF
--- a/scripts/operations/configuration/export_cfs_data.py
+++ b/scripts/operations/configuration/export_cfs_data.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Usage: export_cfs_data.py <output-directory>
+This script exports all CFS data to JSON files in the specified directory.
+"""
+
+import argparse
+import json
+import os
+from typing import Union
+
+from python_lib.args import readable_directory
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES, CfsResourceTypeData
+from python_lib.types import JsonDict, JsonList
+
+
+def write_data_to_file(output_dir: str, file_name: str, data: Union[JsonDict, JsonList]) -> None:
+    """
+    Write the specified data in JSON format to a the specified file in the specified directory
+    """
+    output_file = os.path.join(output_dir, file_name)
+    print(f"Writing data to {output_file}")
+    with open(output_file, "wt") as outfile:
+        json.dump(data, outfile, indent=2)
+
+
+def export_data(resource_type: str, resource_data: CfsResourceTypeData, output_dir: str) -> None:
+    """
+    Get all of the data for the specified resource type from CFS, and then write it to a JSON file.
+    """
+    print(f"Reading {resource_type} data from CFS")
+    data = resource_data.list_function()
+    write_data_to_file(output_dir, resource_data.json_file_name, data)
+
+
+def main() -> None:
+    """
+    Export the CFS data for each CFS data type and write it to JSON files
+    """
+    parser = argparse.ArgumentParser(
+        description="Exports all CFS data to JSON files in the specified directory")
+    parser.add_argument(metavar="output_directory", type=readable_directory,
+                        dest="output_directory", help="Target directory for CFS data files")
+    parsed_args = parser.parse_args()
+    output_dir = parsed_args.output_directory
+    print(f"Writing CFS data to following directory: {output_dir}")
+    for resource_type, resource_data in CFS_RESOURCE_TYPES.items():
+        export_data(resource_type, resource_data, output_dir)
+    print("Successfully completed writing CFS data to JSON files")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -37,15 +37,16 @@ import sys
 from typing import Dict, Generator, List, NamedTuple, Union
 
 from python_lib import args, cfs
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES
 from python_lib.types import JsonDict, JSONDecodeError
 
 NameObjectMap = Dict[str,JsonDict]
 
-CMP_JSON = "components.json"
-CFG_JSON = "configurations.json"
-OPT_JSON = "options.json"
 CFS_EXPORT_TOOL = "/usr/share/doc/csm/scripts/operations/configuration/export_cfs_data.sh"
 
+CFG_JSON = CFS_RESOURCE_TYPES["configurations"].json_file_name
+CMP_JSON = CFS_RESOURCE_TYPES["components"].json_file_name
+OPT_JSON = CFS_RESOURCE_TYPES["options"].json_file_name
 
 class CfsData(NamedTuple):
     """

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -37,7 +37,9 @@ import sys
 from typing import Dict, Generator, List, NamedTuple, Union
 
 from python_lib import args, cfs
-from python_lib.cfs_import_export import CFS_RESOURCE_TYPES
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES, list_cfs_components, \
+                                         remove_components_with_empty_ids
+from python_lib.common import print_err
 from python_lib.types import JsonDict, JSONDecodeError
 
 NameObjectMap = Dict[str,JsonDict]
@@ -92,17 +94,6 @@ class CfsData(NamedTuple):
 class CfsError(Exception):
     pass
 
-def print_stderr(msg: str) -> None:
-    """
-    Outputs the specified message to stderr
-    """
-    sys.stderr.write(f"{msg}\n")
-
-def print_err(msg: str) -> None:
-    """
-    Prepends "ERROR: " and outputs the specified message to stderr
-    """
-    print_stderr(f"ERROR: {msg}")
 
 def snapshot_cfs_data() -> None:
     """
@@ -138,18 +129,36 @@ def json_data_from_directory(directory_string: str) -> CfsData:
     configs_file = args.readable_file(os.path.join(dirpath, CFG_JSON))
     options_file = args.readable_file(os.path.join(dirpath, OPT_JSON))
 
+    print("Reading CFS component data from JSON file")
+    cfs_component_list=remove_components_with_empty_ids(json_data_from_file(comps_file))
+
+    print("Reading CFS configuration data from JSON file")
+    cfs_config_list=json_data_from_file(configs_file)
+
+    print("Reading CFS option data from JSON file")
+    cfs_options_map=json_data_from_file(options_file)
+
     # Finally, read in their JSON data and return it
-    return CfsData.from_api(cfs_component_list=json_data_from_file(comps_file),
-                            cfs_config_list=json_data_from_file(configs_file),
-                            cfs_options_map=json_data_from_file(options_file))
+    return CfsData.from_api(cfs_component_list=cfs_component_list,
+                            cfs_config_list=cfs_config_list,
+                            cfs_options_map=cfs_options_map)
 
 def load_cfs_data() -> CfsData:
     """
     Make API calls to list the CFS components, configurations, and options on the live system.
     """
-    return CfsData.from_api(cfs_component_list=cfs.list_components(),
-                            cfs_config_list=cfs.list_configurations(),
-                            cfs_options_map=cfs.list_options())
+    print("Reading component data from CFS")
+    cfs_component_list=list_cfs_components()
+
+    print("Reading configuration data from CFS")
+    cfs_config_list=cfs.list_configurations()
+
+    print("Reading option data from CFS")
+    cfs_options_map=cfs.list_options()
+
+    return CfsData.from_api(cfs_component_list=cfs_component_list,
+                            cfs_config_list=cfs_config_list,
+                            cfs_options_map=cfs_options_map)
 
 def get_configs_to_create(configs_to_import: NameObjectMap,
                           current_configs: NameObjectMap) -> List[str]:

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -33,11 +33,13 @@ from . import common
 from .types import JsonDict, JsonObject, JSONDecodeError
 
 CFS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/cfs"
+CFS_VERSIONS_URL = f"{CFS_BASE_URL}/versions"
 CFS_V3_BASE_URL = f"{CFS_BASE_URL}/v3"
 CFS_V3_COMPS_URL = f"{CFS_V3_BASE_URL}/components"
 CFS_V3_CONFIGS_URL = f"{CFS_V3_BASE_URL}/configurations"
 CFS_V3_OPTIONS_URL = f"{CFS_V3_BASE_URL}/options"
 CFS_V3_SESSIONS_URL = f"{CFS_V3_BASE_URL}/sessions"
+CFS_V3_SOURCES_URL = f"{CFS_V3_BASE_URL}/sources"
 
 CfsOptions = Dict[str, Union[bool, int, str]]
 
@@ -267,3 +269,28 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
     except JSONDecodeError as exc:
         log_error_raise_exception("Response from CFS has unexpected format", exc)
     return json_object
+
+def list_sessions() -> List[JsonObject]:
+    """
+    Queries CFS to list all sessions, and returns the list.
+    """
+    return __list_and_merge("sessions", CFS_V3_SESSIONS_URL)
+
+# CFS sources functions
+
+def list_sources() -> List[JsonObject]:
+    """
+    Queries CFS to list all sources, and returns the list.
+    """
+    return __list_and_merge("sources", CFS_V3_SOURCES_URL)
+
+# CFS versions functions
+
+def list_versions() -> JsonDict:
+    """
+    Queries CFS for its version and returns the data
+    """
+    request_kwargs = {"url": CFS_VERSIONS_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    return api_requests.get_retry_validate_return_json(**request_kwargs)

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -82,7 +82,7 @@ def __list_and_merge(object_field_name: str, url: str,
     return obj_list
 
 
-def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonObject]:
+def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonDict]:
     """
     Queries CFS to list all components, and returns the list.
     If an id_list is specified, query CFS for just those components.

--- a/scripts/operations/configuration/python_lib/cfs_import_export.py
+++ b/scripts/operations/configuration/python_lib/cfs_import_export.py
@@ -1,0 +1,51 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: CFS import/export"""
+
+from typing import Callable, NamedTuple
+
+from . import cfs
+
+class CfsResourceTypeData(NamedTuple):
+    """
+    Data needed for import/export work for a given CFS resource type
+    (configurations, components, etc)
+    """
+    list_function: Callable
+    json_file_name: str
+
+CFS_RESOURCE_TYPES = {
+    "components":     CfsResourceTypeData(list_function=cfs.list_components,
+                                          json_file_name="components.json"),
+    "configurations": CfsResourceTypeData(list_function=cfs.list_configurations,
+                                          json_file_name="configurations.json"),
+    "options":        CfsResourceTypeData(list_function=cfs.list_options,
+                                          json_file_name="options.json"),
+    "sessions":       CfsResourceTypeData(list_function=cfs.list_sessions,
+                                          json_file_name="sessions.json"),
+    "sources":        CfsResourceTypeData(list_function=cfs.list_sources,
+                                          json_file_name="sources.json"),
+    "versions":       CfsResourceTypeData(list_function=cfs.list_versions,
+                                          json_file_name="versions.json")
+}

--- a/scripts/operations/configuration/python_lib/cfs_import_export.py
+++ b/scripts/operations/configuration/python_lib/cfs_import_export.py
@@ -23,9 +23,36 @@
 #
 """Shared Python function library: CFS import/export"""
 
-from typing import Callable, NamedTuple
+from typing import Callable, List, NamedTuple
 
 from . import cfs
+from . import common
+from .types import JsonDict
+
+
+_BAD_COMPONENT_MD = 'troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md'
+
+
+def remove_components_with_empty_ids(components: List[JsonDict]) -> List[JsonDict]:
+    """
+    CASMCMS-9195: Check import data for component IDs with 0-length. If any are
+    found, remove them, because they are not valid components (and we could not patch
+    them in CFS even if we wanted to)
+    """
+    filtered_list = [ comp for comp in components if comp["id"] ]
+    diff = len(components) - len(filtered_list)
+    if diff > 0:
+        common.print_warn(f"Skipping {diff} component(s) with empty ID field "
+                          f"(see CSM documentation: {_BAD_COMPONENT_MD}")
+    return filtered_list
+
+
+def list_cfs_components() -> List[JsonDict]:
+    """
+    Wrapper for API call to CFS to list components that also filters out ones with empty IDs
+    """
+    return remove_components_with_empty_ids(cfs.list_components())
+
 
 class CfsResourceTypeData(NamedTuple):
     """
@@ -35,8 +62,9 @@ class CfsResourceTypeData(NamedTuple):
     list_function: Callable
     json_file_name: str
 
+
 CFS_RESOURCE_TYPES = {
-    "components":     CfsResourceTypeData(list_function=cfs.list_components,
+    "components":     CfsResourceTypeData(list_function=list_cfs_components,
                                           json_file_name="components.json"),
     "configurations": CfsResourceTypeData(list_function=cfs.list_configurations,
                                           json_file_name="configurations.json"),

--- a/scripts/operations/configuration/python_lib/common.py
+++ b/scripts/operations/configuration/python_lib/common.py
@@ -62,11 +62,32 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise ScriptException(msg) from parent_exception
 
 
+def print_stderr(msg: str) -> None:
+    """
+    Outputs the specified message to stderr
+    """
+    sys.stderr.write(f"{msg}\n")
+
+
+def print_err(msg: str) -> None:
+    """
+    Prepends "ERROR: " and outputs the specified message to stderr
+    """
+    print_stderr(f"ERROR: {msg}")
+
+
+def print_warn(msg: str) -> None:
+    """
+    Prepends "WARNING: " and outputs the specified message to stderr
+    """
+    print_stderr(f"WARNING: {msg}")
+
+
 def print_err_exit(msg: str) -> None:
     """
     Print the specified error message to stderr and exit the script with return code 1
     """
-    sys.stderr.write(f"ERROR: {msg}\n")
+    print_err(msg)
     sys.stderr.flush()
     sys.exit(1)
 


### PR DESCRIPTION
The CFS export tools have been broken since the release of CFS v3, in two ways. First, the v3 endpoints added pagination, and the export tool did not handle this. Since the CLI defaults to using v2, the export tool still works a lot of the time, but on systems where there are enough CFS resources, attempts to list them using the v2 CLI will fail.

In addition, CFS sources are a new resource that have been added in CFS v3, and those were not exported by the tool.

This PR addresses both points. It also adds the collection of the CFS version as part of the export, since that could be useful for debugging.

I tested these changes on fanta and verified that they work as expected.

The backup files generated by the export tool are still in the same format that the import tool expects, so from that perspective there is no issue. However, the import tool does not handle CFS sources currently, and there may be some other v3-related issues I need to accommodate. That work for the import tool will be done with CASMCMS-8793. The changes in this PR are useful even without those changes, which is why I am splitting them up.

This also pulls in changes for CASMCMS-9195, to filter out invalid components during imports and exports.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/5523
1.4 (not of the v3 content, but of some of the general improvements): https://github.com/Cray-HPE/docs-csm/pull/5524
13 (not of the v3 content, but of some of the general improvements): https://github.com/Cray-HPE/docs-csm/pull/5525
