### PR TITLE
CASMCMS-9194/CASMCMS-9195: Update CFS import/export tools

### DIFF
--- a/scripts/operations/configuration/export_cfs_data.py
+++ b/scripts/operations/configuration/export_cfs_data.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Usage: export_cfs_data.py <output-directory>
+This script exports all CFS data to JSON files in the specified directory.
+"""
+
+import argparse
+import json
+import os
+from typing import Union
+
+from python_lib.args import readable_directory
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES, CfsResourceTypeData
+from python_lib.types import JsonDict, JsonList
+
+
+def write_data_to_file(output_dir: str, file_name: str, data: Union[JsonDict, JsonList]) -> None:
+    """
+    Write the specified data in JSON format to a the specified file in the specified directory
+    """
+    output_file = os.path.join(output_dir, file_name)
+    print(f"Writing data to {output_file}")
+    with open(output_file, "wt") as outfile:
+        json.dump(data, outfile, indent=2)
+
+
+def export_data(resource_type: str, resource_data: CfsResourceTypeData, output_dir: str) -> None:
+    """
+    Get all of the data for the specified resource type from CFS, and then write it to a JSON file.
+    """
+    print(f"Reading {resource_type} data from CFS")
+    data = resource_data.list_function()
+    write_data_to_file(output_dir, resource_data.json_file_name, data)
+
+
+def main() -> None:
+    """
+    Export the CFS data for each CFS data type and write it to JSON files
+    """
+    parser = argparse.ArgumentParser(
+        description="Exports all CFS data to JSON files in the specified directory")
+    parser.add_argument(metavar="output_directory", type=readable_directory,
+                        dest="output_directory", help="Target directory for CFS data files")
+    parsed_args = parser.parse_args()
+    output_dir = parsed_args.output_directory
+    print(f"Writing CFS data to following directory: {output_dir}")
+    for resource_type, resource_data in CFS_RESOURCE_TYPES.items():
+        export_data(resource_type, resource_data, output_dir)
+    print("Successfully completed writing CFS data to JSON files")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -37,7 +37,9 @@ import sys
 from typing import Dict, Generator, List, NamedTuple, Union
 
 from python_lib import args, cfs
-from python_lib.cfs_import_export import CFS_RESOURCE_TYPES
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES, list_cfs_components, \
+                                         remove_components_with_empty_ids
+from python_lib.common import print_err
 from python_lib.types import JsonDict, JSONDecodeError
 
 NameObjectMap = Dict[str,JsonDict]
@@ -92,17 +94,6 @@ class CfsData(NamedTuple):
 class CfsError(Exception):
     pass
 
-def print_stderr(msg: str) -> None:
-    """
-    Outputs the specified message to stderr
-    """
-    sys.stderr.write(f"{msg}\n")
-
-def print_err(msg: str) -> None:
-    """
-    Prepends "ERROR: " and outputs the specified message to stderr
-    """
-    print_stderr(f"ERROR: {msg}")
 
 def snapshot_cfs_data() -> None:
     """
@@ -138,18 +129,36 @@ def json_data_from_directory(directory_string: str) -> CfsData:
     configs_file = args.readable_file(os.path.join(dirpath, CFG_JSON))
     options_file = args.readable_file(os.path.join(dirpath, OPT_JSON))
 
+    print("Reading CFS component data from JSON file")
+    cfs_component_list=remove_components_with_empty_ids(json_data_from_file(comps_file))
+
+    print("Reading CFS configuration data from JSON file")
+    cfs_config_list=json_data_from_file(configs_file)
+
+    print("Reading CFS option data from JSON file")
+    cfs_options_map=json_data_from_file(options_file)
+
     # Finally, read in their JSON data and return it
-    return CfsData.from_api(cfs_component_list=json_data_from_file(comps_file),
-                            cfs_config_list=json_data_from_file(configs_file),
-                            cfs_options_map=json_data_from_file(options_file))
+    return CfsData.from_api(cfs_component_list=cfs_component_list,
+                            cfs_config_list=cfs_config_list,
+                            cfs_options_map=cfs_options_map)
 
 def load_cfs_data() -> CfsData:
     """
     Make API calls to list the CFS components, configurations, and options on the live system.
     """
-    return CfsData.from_api(cfs_component_list=cfs.list_components(),
-                            cfs_config_list=cfs.list_configurations(),
-                            cfs_options_map=cfs.list_options())
+    print("Reading component data from CFS")
+    cfs_component_list=list_cfs_components()
+
+    print("Reading configuration data from CFS")
+    cfs_config_list=cfs.list_configurations()
+
+    print("Reading option data from CFS")
+    cfs_options_map=cfs.list_options()
+
+    return CfsData.from_api(cfs_component_list=cfs_component_list,
+                            cfs_config_list=cfs_config_list,
+                            cfs_options_map=cfs_options_map)
 
 def get_configs_to_create(configs_to_import: NameObjectMap,
                           current_configs: NameObjectMap) -> List[str]:

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -37,15 +37,16 @@ import sys
 from typing import Dict, Generator, List, NamedTuple, Union
 
 from python_lib import args, cfs
+from python_lib.cfs_import_export import CFS_RESOURCE_TYPES
 from python_lib.types import JsonDict, JSONDecodeError
 
 NameObjectMap = Dict[str,JsonDict]
 
-CMP_JSON = "components.json"
-CFG_JSON = "configurations.json"
-OPT_JSON = "options.json"
 CFS_EXPORT_TOOL = "/usr/share/doc/csm/scripts/operations/configuration/export_cfs_data.sh"
 
+CFG_JSON = CFS_RESOURCE_TYPES["configurations"].json_file_name
+CMP_JSON = CFS_RESOURCE_TYPES["components"].json_file_name
+OPT_JSON = CFS_RESOURCE_TYPES["options"].json_file_name
 
 class CfsData(NamedTuple):
     """
@@ -207,7 +208,7 @@ def get_comps_to_update(comps_to_import: NameObjectMap, current_comps: NameObjec
     # For these, we must then check if there is already a desired configuration set on the live
     # system.
     for comp_id in sorted(list(comps_to_import.keys() & current_comps.keys())):
-        imported_desired_config_name = comps_to_import[comp_id]["desiredConfig"]
+        imported_desired_config_name = comps_to_import[comp_id]["desired_config"]
         if not imported_desired_config_name:
             comps_no_desired_config.append(comp_id)
             continue
@@ -217,7 +218,7 @@ def get_comps_to_update(comps_to_import: NameObjectMap, current_comps: NameObjec
             print(f"Component {comp_id} will not be updated because its import data specifies"
                   f" a nonexistent desired configuration: '{imported_desired_config_name}'")
             continue
-        if current_comps[comp_id]["desiredConfig"]:
+        if current_comps[comp_id]["desired_config"]:
             comps_have_config_set.append(comp_id)
         else:
             comps_to_update.append(comp_id)
@@ -310,14 +311,14 @@ def update_components(comps_map: NameObjectMap, comp_ids_to_update: List[str]) -
     print("")
     comps_to_update_by_desired_config = {}
     for comp_id in comp_ids_to_update:
-        desired_config_name = comps_map[comp_id]["desiredConfig"]
+        desired_config_name = comps_map[comp_id]["desired_config"]
         if desired_config_name in comps_to_update_by_desired_config:
             comps_to_update_by_desired_config[desired_config_name].append(comp_id)
         else:
             comps_to_update_by_desired_config[desired_config_name] = [comp_id]
 
     for desired_config_name, comp_id_list in comps_to_update_by_desired_config.items():
-        update_data = { "desiredConfig": desired_config_name }
+        update_data = { "desired_config": desired_config_name }
         for comp_sublist in chunk_list(comp_id_list):
             print(f"Updating desired configuration to '{desired_config_name}' for components: {comp_sublist}")
             cfs.update_components_by_ids(comp_ids=comp_sublist, update_data=update_data)
@@ -353,11 +354,12 @@ def main() -> None:
             cfs.delete_configuration(config_name)
             del current_cfs_data.configurations[config_name]
 
-        comp_clear_data = {"errorCount": 0, "state": [], "desiredConfig": "", "tags": {}}
+        comp_clear_data = {"error_count": 0, "state": [], "desired_config": "", "tags": {}}
         for comp_sublist in chunk_list(list(current_cfs_data.components)):
             print(f"Clearing error count, desired configuration, state, and tags for components: '{comp_sublist}'")
-            updated_comps = cfs.update_components_by_ids(comp_ids=comp_sublist, update_data=comp_clear_data)
-            current_cfs_data.components.update({updated_comp["id"]: updated_comp for updated_comp in updated_comps})
+            updated_comp_ids = cfs.update_components_by_ids(comp_ids=comp_sublist, update_data=comp_clear_data)
+            for comp_id in updated_comp_ids:
+                current_cfs_data.components[comp_id].update(comp_clear_data)
 
     # Determine the necessary updates
     print("\nExamining CFS configurations...")

--- a/scripts/operations/configuration/monitor_comp_cfs_config_status.py
+++ b/scripts/operations/configuration/monitor_comp_cfs_config_status.py
@@ -82,7 +82,7 @@ def get_comp_status_map(id_list: List[str]) -> JsonDict:
     their config status
     """
     return {
-        comp["id"]: comp["configurationStatus"] for comp in cfs.list_components(id_list=id_list) }
+        comp["id"]: comp["configuration_status"] for comp in cfs.list_components(id_list=id_list) }
 
 
 class ComponentStatus:

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -33,11 +33,13 @@ from . import common
 from .types import JsonDict, JsonObject, JSONDecodeError
 
 CFS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/cfs"
-CFS_V2_BASE_URL = f"{CFS_BASE_URL}/v2"
-CFS_V2_COMPS_URL = f"{CFS_V2_BASE_URL}/components"
-CFS_V2_CONFIGS_URL = f"{CFS_V2_BASE_URL}/configurations"
-CFS_V2_OPTIONS_URL = f"{CFS_V2_BASE_URL}/options"
-CFS_V2_SESSIONS_URL = f"{CFS_V2_BASE_URL}/sessions"
+CFS_VERSIONS_URL = f"{CFS_BASE_URL}/versions"
+CFS_V3_BASE_URL = f"{CFS_BASE_URL}/v3"
+CFS_V3_COMPS_URL = f"{CFS_V3_BASE_URL}/components"
+CFS_V3_CONFIGS_URL = f"{CFS_V3_BASE_URL}/configurations"
+CFS_V3_OPTIONS_URL = f"{CFS_V3_BASE_URL}/options"
+CFS_V3_SESSIONS_URL = f"{CFS_V3_BASE_URL}/sessions"
+CFS_V3_SOURCES_URL = f"{CFS_V3_BASE_URL}/sources"
 
 CfsOptions = Dict[str, Union[bool, int, str]]
 
@@ -59,19 +61,38 @@ def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None]
 # CFS component functions
 
 
+def __list_and_merge(object_field_name: str, url: str,
+                     params: Union[JsonDict, None]=None) -> List[JsonObject]:
+    """
+    For paginated CFS list endpoints, this repeatedly queries them until all items
+    are found, then returns the list.
+    """
+    request_kwargs = { "url": url,
+                       "add_api_token": True,
+                       "expected_status_codes": {200} }
+    if params is None:
+        resp_json = api_requests.get_retry_validate_return_json(**request_kwargs)
+    else:
+        resp_json = api_requests.get_retry_validate_return_json(params=params, **request_kwargs)
+    obj_list = resp_json[object_field_name]
+    while resp_json["next"] is not None:
+        resp_json = api_requests.get_retry_validate_return_json(params=resp_json["next"],
+                                                                **request_kwargs)
+        obj_list.extend(resp_json[object_field_name])
+    return obj_list
+
+
 def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonObject]:
     """
     Queries CFS to list all components, and returns the list.
     If an id_list is specified, query CFS for just those components.
+    Merges paged responses together
     """
-    request_kwargs = {"url": CFS_V2_COMPS_URL,
-                      "add_api_token": True,
-                      "expected_status_codes": {200}}
     if id_list is None:
-        return api_requests.get_retry_validate_return_json(**request_kwargs)
+        params = None
     else:
         params = { "ids": id_list if isinstance(id_list, str) else ",".join(id_list) }
-        return api_requests.get_retry_validate_return_json(params=params, **request_kwargs)
+    return __list_and_merge("components", CFS_V3_COMPS_URL, params=params)
 
 
 def update_component(comp_id: str, **update_data: JsonObject) -> JsonObject:
@@ -81,7 +102,7 @@ def update_component(comp_id: str, **update_data: JsonObject) -> JsonObject:
     """
     # Even though it does not follow convention for patch operations,
     # the status code when successful is 200
-    request_kwargs = {"url": f"{CFS_V2_COMPS_URL}/{comp_id}",
+    request_kwargs = {"url": f"{CFS_V3_COMPS_URL}/{comp_id}",
                       "add_api_token": True,
                       "expected_status_codes": {200},
                       "json": update_data}
@@ -93,7 +114,7 @@ def update_component_desired_config(comp_id: str, config_name: str) -> JsonObjec
     Updates the specified component to use the specified configuration.
     Returns the updated component.
     """
-    return update_component(comp_id, desiredConfig=config_name)
+    return update_component(comp_id, desired_config=config_name)
 
 
 def update_components_by_ids(comp_ids: List[str], update_data: JsonObject) -> JsonObject:
@@ -103,7 +124,7 @@ def update_components_by_ids(comp_ids: List[str], update_data: JsonObject) -> Js
     """
     # Even though it does not follow convention for patch operations,
     # the status code when successful is 200
-    request_kwargs = {"url": CFS_V2_COMPS_URL,
+    request_kwargs = {"url": CFS_V3_COMPS_URL,
                       "add_api_token": True,
                       "expected_status_codes": {200},
                       "json": {"patch": update_data, "filters": {"ids": ",".join(comp_ids)}}}
@@ -116,11 +137,11 @@ def create_configuration(config_name: str, layers: List[Dict[str, str]]) -> Json
     """
     Creates or updates a CFS configuration with the specified name and layers.
     The layers should be dictionaries with the following fields set:
-        cloneUrl, commit, name, playbook
+        clone_url, commit, name, playbook
 
     The CFS configuration is returned if successful. Otherwise an exception is raised.
     """
-    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+    request_kwargs = {"url": f"{CFS_V3_CONFIGS_URL}/{config_name}",
                       "json": {"layers": layers},
                       "add_api_token": True,
                       "expected_status_codes": {200}}
@@ -133,7 +154,7 @@ def get_configuration(config_name: str, expected_to_exist: bool = True) -> Union
     is not found, unless expected_to_exist is set to False, in which case None is
     returned.
     """
-    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+    request_kwargs = {"url": f"{CFS_V3_CONFIGS_URL}/{config_name}",
                       "add_api_token": True,
                       "expected_status_codes": {200}}
 
@@ -158,7 +179,7 @@ def delete_configuration(config_name: str, expected_to_exist: bool = True) -> No
     Deletes the specified configuration. Throws an exception if it is not found,
     unless expected_to_exist is set to False.
     """
-    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+    request_kwargs = {"url": f"{CFS_V3_CONFIGS_URL}/{config_name}",
                       "add_api_token": True,
                       "expected_status_codes": {204}}
 
@@ -172,10 +193,7 @@ def list_configurations() -> List[JsonObject]:
     """
     Queries CFS to list all configurations, and returns the list.
     """
-    request_kwargs = {"url": CFS_V2_CONFIGS_URL,
-                      "add_api_token": True,
-                      "expected_status_codes": {200}}
-    return api_requests.get_retry_validate_return_json(**request_kwargs)
+    return __list_and_merge("configurations", CFS_V3_CONFIGS_URL)
 
 
 # CFS options functions
@@ -185,7 +203,7 @@ def list_options() -> CfsOptions:
     """
     Queries CFS for a dictionary of all options, and returns that dictionary.
     """
-    request_kwargs = {"url": CFS_V2_OPTIONS_URL,
+    request_kwargs = {"url": CFS_V3_OPTIONS_URL,
                       "add_api_token": True,
                       "expected_status_codes": {200}}
     return api_requests.get_retry_validate_return_json(**request_kwargs)
@@ -198,7 +216,7 @@ def update_options(new_options: CfsOptions) -> CfsOptions:
     """
     # Even though it does not follow convention for patch operations,
     # the status code when successful is 200
-    request_kwargs = {"url": CFS_V2_OPTIONS_URL,
+    request_kwargs = {"url": CFS_V3_OPTIONS_URL,
                       "add_api_token": True,
                       "expected_status_codes": {200},
                       "json": new_options}
@@ -218,12 +236,12 @@ def create_dynamic_session(session_name: str, config_name: str,
 
     The CFS session entry is returned if successful. Otherwise an exception is raised.
     """
-    request_kwargs = {"url": CFS_V2_SESSIONS_URL,
-                      "json": {"name": session_name, "configurationName": config_name},
+    request_kwargs = {"url": CFS_V3_SESSIONS_URL,
+                      "json": {"name": session_name, "configuration_name": config_name},
                       "add_api_token": True,
                       "expected_status_codes": {200}}
     if xname_limit:
-        request_kwargs["json"]["ansibleLimit"] = ",".join(xname_limit)
+        request_kwargs["json"]["ansible_limit"] = ",".join(xname_limit)
     return api_requests.post_retry_validate_return_json(**request_kwargs)
 
 
@@ -233,7 +251,7 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
     is not found, unless expected_to_exist is set to False, in which case None is
     returned.
     """
-    request_kwargs = {"url": f"{CFS_V2_SESSIONS_URL}/{session_name}",
+    request_kwargs = {"url": f"{CFS_V3_SESSIONS_URL}/{session_name}",
                       "add_api_token": True,
                       "expected_status_codes": {200}}
 
@@ -251,3 +269,28 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
     except JSONDecodeError as exc:
         log_error_raise_exception("Response from CFS has unexpected format", exc)
     return json_object
+
+def list_sessions() -> List[JsonObject]:
+    """
+    Queries CFS to list all sessions, and returns the list.
+    """
+    return __list_and_merge("sessions", CFS_V3_SESSIONS_URL)
+
+# CFS sources functions
+
+def list_sources() -> List[JsonObject]:
+    """
+    Queries CFS to list all sources, and returns the list.
+    """
+    return __list_and_merge("sources", CFS_V3_SOURCES_URL)
+
+# CFS versions functions
+
+def list_versions() -> JsonDict:
+    """
+    Queries CFS for its version and returns the data
+    """
+    request_kwargs = {"url": CFS_VERSIONS_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    return api_requests.get_retry_validate_return_json(**request_kwargs)

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -82,7 +82,7 @@ def __list_and_merge(object_field_name: str, url: str,
     return obj_list
 
 
-def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonObject]:
+def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonDict]:
     """
     Queries CFS to list all components, and returns the list.
     If an id_list is specified, query CFS for just those components.

--- a/scripts/operations/configuration/python_lib/cfs_import_export.py
+++ b/scripts/operations/configuration/python_lib/cfs_import_export.py
@@ -1,0 +1,51 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: CFS import/export"""
+
+from typing import Callable, NamedTuple
+
+from . import cfs
+
+class CfsResourceTypeData(NamedTuple):
+    """
+    Data needed for import/export work for a given CFS resource type
+    (configurations, components, etc)
+    """
+    list_function: Callable
+    json_file_name: str
+
+CFS_RESOURCE_TYPES = {
+    "components":     CfsResourceTypeData(list_function=cfs.list_components,
+                                          json_file_name="components.json"),
+    "configurations": CfsResourceTypeData(list_function=cfs.list_configurations,
+                                          json_file_name="configurations.json"),
+    "options":        CfsResourceTypeData(list_function=cfs.list_options,
+                                          json_file_name="options.json"),
+    "sessions":       CfsResourceTypeData(list_function=cfs.list_sessions,
+                                          json_file_name="sessions.json"),
+    "sources":        CfsResourceTypeData(list_function=cfs.list_sources,
+                                          json_file_name="sources.json"),
+    "versions":       CfsResourceTypeData(list_function=cfs.list_versions,
+                                          json_file_name="versions.json")
+}

--- a/scripts/operations/configuration/python_lib/cfs_import_export.py
+++ b/scripts/operations/configuration/python_lib/cfs_import_export.py
@@ -23,9 +23,36 @@
 #
 """Shared Python function library: CFS import/export"""
 
-from typing import Callable, NamedTuple
+from typing import Callable, List, NamedTuple
 
 from . import cfs
+from . import common
+from .types import JsonDict
+
+
+_BAD_COMPONENT_MD = 'troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md'
+
+
+def remove_components_with_empty_ids(components: List[JsonDict]) -> List[JsonDict]:
+    """
+    CASMCMS-9195: Check import data for component IDs with 0-length. If any are
+    found, remove them, because they are not valid components (and we could not patch
+    them in CFS even if we wanted to)
+    """
+    filtered_list = [ comp for comp in components if comp["id"] ]
+    diff = len(components) - len(filtered_list)
+    if diff > 0:
+        common.print_warn(f"Skipping {diff} component(s) with empty ID field "
+                          f"(see CSM documentation: {_BAD_COMPONENT_MD}")
+    return filtered_list
+
+
+def list_cfs_components() -> List[JsonDict]:
+    """
+    Wrapper for API call to CFS to list components that also filters out ones with empty IDs
+    """
+    return remove_components_with_empty_ids(cfs.list_components())
+
 
 class CfsResourceTypeData(NamedTuple):
     """
@@ -35,8 +62,9 @@ class CfsResourceTypeData(NamedTuple):
     list_function: Callable
     json_file_name: str
 
+
 CFS_RESOURCE_TYPES = {
-    "components":     CfsResourceTypeData(list_function=cfs.list_components,
+    "components":     CfsResourceTypeData(list_function=list_cfs_components,
                                           json_file_name="components.json"),
     "configurations": CfsResourceTypeData(list_function=cfs.list_configurations,
                                           json_file_name="configurations.json"),

--- a/scripts/operations/configuration/python_lib/common.py
+++ b/scripts/operations/configuration/python_lib/common.py
@@ -62,11 +62,32 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise ScriptException(msg) from parent_exception
 
 
+def print_stderr(msg: str) -> None:
+    """
+    Outputs the specified message to stderr
+    """
+    sys.stderr.write(f"{msg}\n")
+
+
+def print_err(msg: str) -> None:
+    """
+    Prepends "ERROR: " and outputs the specified message to stderr
+    """
+    print_stderr(f"ERROR: {msg}")
+
+
+def print_warn(msg: str) -> None:
+    """
+    Prepends "WARNING: " and outputs the specified message to stderr
+    """
+    print_stderr(f"WARNING: {msg}")
+
+
 def print_err_exit(msg: str) -> None:
     """
     Print the specified error message to stderr and exit the script with return code 1
     """
-    sys.stderr.write(f"ERROR: {msg}\n")
+    print_err(msg)
     sys.stderr.flush()
     sys.exit(1)
 


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/docs-csm/pull/5522

It touches more files because some other stuff in the 1.5 branch is still using CFS v2 endpoints, but uses the libraries I modified with this PR to do it. It's safest to switch them over to v3 anyway at this point.