### PR TITLE
CASMCMS-9191: Provide troubleshooting/remediation for CFS components with zero-length ID fields

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,8 +31,6 @@ StatefulSet
 StatefulSets
 
 
-0-length
-0-Length
 1.0.x
 1.2.x
 1.3.x

--- a/.spelling
+++ b/.spelling
@@ -31,6 +31,8 @@ StatefulSet
 StatefulSets
 
 
+0-length
+0-Length
 1.0.x
 1.2.x
 1.3.x

--- a/operations/configuration_management/CFS_Components.md
+++ b/operations/configuration_management/CFS_Components.md
@@ -12,7 +12,7 @@ See [Automatic Configuration Management](Automatic_Configuration_Management.md) 
 - [Disable component configuration](#disable-component-configuration)
 - [Force component reconfiguration](#force-component-reconfiguration)
 - [Update components in bulk](#update-components-in-bulk)
-- [Component with 0-length ID](#component-with-0-length-id)
+- [Component with zero-length ID](#component-with-zero-length-id)
 
 ## Component data
 
@@ -165,8 +165,8 @@ Updating multiple components at once is not currently available in the CLI due t
 However for those programmatically interacting with the CFS API, it is possible to update multiple components at once by calling `/v3/components` with a `PATCH` operation.
 It is possible to either provide patches for multiple components in a list, or to provide a single patch and filters for which components to apply the patch to. See the [CFS API specification](../../api/cfs.md) for more information.
 
-## Component with 0-length ID
+## Component with zero-length ID
 
-It is possible for CFS to end up with an invalid component whose ID field is a 0-length string. See
-[CFS Component With 0-Length ID](../../troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md)
+It is possible for CFS to end up with an invalid component whose ID field is a zero-length string. See
+[CFS Component With Zero-Length ID](../../troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md)
 for more details.

--- a/operations/configuration_management/CFS_Components.md
+++ b/operations/configuration_management/CFS_Components.md
@@ -12,6 +12,7 @@ See [Automatic Configuration Management](Automatic_Configuration_Management.md) 
 * [Disable component configuration](#disable-component-configuration)
 * [Force component reconfiguration](#force-component-reconfiguration)
 * [Update components in bulk](#update-components-in-bulk)
+* [Component with 0-length ID](#component-with-0-length-id)
 
 ## Component data
 
@@ -163,3 +164,9 @@ cray cfs v3 components update <xname> --state [] --enabled true
 Updating multiple components at once is not currently available in the CLI due to limitations with the CLI.
 However for those programmatically interacting with the CFS API, it is possible to update multiple components at once by calling `/v3/components` with a `PATCH` operation.
 It is possible to either provide patches for multiple components in a list, or to provide a single patch and filters for which components to apply the patch to. See the [CFS API specification](../../api/cfs.md) for more information.
+
+## Component with 0-length ID
+
+It is possible for CFS to end up with an invalid component whose ID field is a 0-length string. See
+[CFS Component With 0-Length ID](../../troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md)
+for more details.

--- a/operations/configuration_management/CFS_Components.md
+++ b/operations/configuration_management/CFS_Components.md
@@ -6,61 +6,61 @@ When new nodes are added to the HSM database, the `CFS-Hardware-Sync-Agent` ente
 Administrators are able to set a desired CFS configuration for each component, and the `CFS-Batcher` ensures the desired configuration state and the current configuration state match.
 See [Automatic Configuration Management](Automatic_Configuration_Management.md) for more information.
 
-* [Component data](#component-data)
-* [View components](#view-components)
-* [Set a desired component configuration](#set-a-desired-component-configuration)
-* [Disable component configuration](#disable-component-configuration)
-* [Force component reconfiguration](#force-component-reconfiguration)
-* [Update components in bulk](#update-components-in-bulk)
-* [Component with 0-length ID](#component-with-0-length-id)
+- [Component data](#component-data)
+- [View components](#view-components)
+- [Set a desired component configuration](#set-a-desired-component-configuration)
+- [Disable component configuration](#disable-component-configuration)
+- [Force component reconfiguration](#force-component-reconfiguration)
+- [Update components in bulk](#update-components-in-bulk)
+- [Component with 0-length ID](#component-with-0-length-id)
 
 ## Component data
 
 The following fields are tracked for each component to determine the status and state of the component:
 
-* **`configuration_status`**
+- **`configuration_status`**
 
-  The status of the component's configuration. Valid status values are:
+    The status of the component's configuration. Valid status values are:
 
-  * **`unconfigured`** - The component has no recorded state and no desired configuration or no valid desired configuration.
-  * **`failed`** - One of the configuration layers for the component has failed and the retry limit has been exceeded.
-  * **`pending`** - The component's desired state and actual state do not match. The component will be configured automatically if enabled.
-  * **`configured`** - The component's desired state and actual state match.
+    - **`unconfigured`** - The component has no recorded state and no desired configuration or no valid desired configuration.
+    - **`failed`** - One of the configuration layers for the component has failed and the retry limit has been exceeded.
+    - **`pending`** - The component's desired state and actual state do not match. The component will be configured automatically if enabled.
+    - **`configured`** - The component's desired state and actual state match.
 
-* **`desired_config`**
+- **`desired_config`**
 
-  The CFS configuration assigned to this component.
+    The CFS configuration assigned to this component.
 
-* **`enabled`**
+- **`enabled`**
 
-  Indicates whether the component will be automatically configured by CFS or not.
+    Indicates whether the component will be automatically configured by CFS or not.
 
-* **`error_count`**
+- **`error_count`**
 
-  The number of times configuration sessions have failed to configure this component.
+    The number of times configuration sessions have failed to configure this component.
 
-* **`retry_policy`**
+- **`retry_policy`**
 
-  The number of times the configuration will be attempted if it fails. If `error_count` \>= `retry_policy`, CFS will not continue attempts to apply the `desired_config`.
+    The number of times the configuration will be attempted if it fails. If `error_count` \>= `retry_policy`, CFS will not continue attempts to apply the `desired_config`.
 
-* **`state`**
+- **`state`**
 
-  The list of configuration layers that have been applied to the component. This information is not returned by default but can be requested by adding `--state-details true` to any components query.
-  For each layer in the component state the status can be one of the following:
+    The list of configuration layers that have been applied to the component. This information is not returned by default but can be requested by adding `--state-details true` to any components query.
+    For each layer in the component state the status can be one of the following:
 
-  * **`applied`** - The playbook completed successfully.
-  * **`failed`** - The playbook encountered an error while configuring this component.
-  * **`incomplete`** - The playbook exited due to an error on another component and will be re-run against this component.
-  * **`skipped`** - The playbook completed, but this component was not a valid target.
+    - **`applied`** - The playbook completed successfully.
+    - **`failed`** - The playbook encountered an error while configuring this component.
+    - **`incomplete`** - The playbook exited due to an error on another component and will be re-run against this component.
+    - **`skipped`** - The playbook completed, but this component was not a valid target.
 
-* **`desired_state`**
+- **`desired_state`**
 
-  The list of configuration layers that should be applied to the component based on the `desired_config`, and the status of each of these layers.
-  This information is not returned by default but can be requested by adding `--config-details true` to any components query.
+    The list of configuration layers that should be applied to the component based on the `desired_config`, and the status of each of these layers.
+    This information is not returned by default but can be requested by adding `--config-details true` to any components query.
 
-* **`logs`**
+- **`logs`**
 
-  A link to the ARA UI for all Ansible logs related to this component.
+    A link to the ARA UI for all Ansible logs related to this component.
 
 ## View components
 

--- a/operations/configuration_management/Troubleshoot_CFS_Issues.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Issues.md
@@ -1,5 +1,8 @@
 # Troubleshoot CFS Issues
 
+> For known issues and troubleshooting information not covered on this page, see
+> [CSM Troubleshooting Information](../../troubleshooting/README.md).
+
 Due to CFS' nature as a framework that runs arbitrary Ansible content, there are any number of issues that can arise when attempting to configure a system.
 Many of the issues are transient, especially on larger systems or when a long configuration is applied.
 Because of this, CFS automatically retries configuration in many cases and a single failing session is often not an issue.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -74,7 +74,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
 - [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
 - [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
-- [CFS Component With 0-Length ID](known_issues/CFS_Component_With_0_Length_ID.md)
+- [CFS Component With Zero-Length ID](known_issues/CFS_Component_With_Zero_Length_ID.md)
 
 ## Booting
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -74,6 +74,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
 - [PCS and CAPMC Transaction Size Limitation](known_issues/pcs_and_capmc_transaction_size_limitation.md)
 - [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
+- [CFS Component With 0-Length ID](known_issues/CFS_Component_With_0_Length_ID.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md
+++ b/troubleshooting/known_issues/CFS_Component_With_0_Length_ID.md
@@ -1,0 +1,46 @@
+# CFS Component With 0-Length ID
+
+It is possible in some situations for a CFS component to be created with a 0-length string for an `id` field.
+Such a component cannot be deleted using the Cray CLI or the CFS API.
+
+## Symptoms
+
+An administrator may notice the invalid component when listing components in CFS. The presence of such a component
+could cause problems in different ways:
+
+- It may also cause the `cmsdev` test to fail. For details on these test failure symptoms, see
+  [Invalid CFS component](sms_health_check.md#invalid-cfs-component).
+- Any tooling which parses CFS component listings may fail in unexpected ways when confronted with
+  the 0-length ID string.
+
+## Remediation
+
+Follow this procedure to remove the invalid CFS component.
+
+1. (`ncn-mw#`) Identify a running CFS server Kubernetes pod.
+
+    ```bash
+    POD=$(kubectl get pods -n services -l 'app.kubernetes.io/instance=cray-cfs-api' --no-headers | grep -w Running | awk '{ print $1 }' | head -1)
+    echo "${POD}"
+    ```
+
+    Example output:
+
+    ```text
+    cray-cfs-api-7dfb78c7b8-clrjq
+    ```
+
+1. (`ncn-mw#`) Delete the CFS component with the 0-length ID.
+
+    > No output is expected from the following command.
+
+    ```bash
+    kubectl exec -it -n services "${POD}" -- python3 -c 'from cray.cfs.api.controllers.components import delete_component_v2 ; delete_component_v2("")'
+    ```
+
+1. (`ncn-mw#`) Verify that the invalid component has been removed from CFS. If this problem was detected by `cmsdev`, then run
+   the following command to perform only the CFS subtest.
+
+    ```bash
+    /usr/local/bin/cmsdev test -q cfs
+    ```

--- a/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
+++ b/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
@@ -1,6 +1,6 @@
-# CFS Component With 0-Length ID
+# CFS Component With Zero-Length ID
 
-It is possible in some situations for a CFS component to be created with a 0-length string for an `id` field.
+It is possible in some situations for a CFS component to be created with a zero-length string for an `id` field.
 Such a component cannot be deleted using the Cray CLI or the CFS API.
 
 ## Symptoms
@@ -11,7 +11,7 @@ could cause problems in different ways:
 - It may also cause the `cmsdev` test to fail. For details on these test failure symptoms, see
   [Invalid CFS component](sms_health_check.md#invalid-cfs-component).
 - Any tooling which parses CFS component listings may fail in unexpected ways when confronted with
-  the 0-length ID string.
+  the zero-length ID string.
 
 ## Remediation
 
@@ -30,7 +30,7 @@ Follow this procedure to remove the invalid CFS component.
     cray-cfs-api-7dfb78c7b8-clrjq
     ```
 
-1. (`ncn-mw#`) Delete the CFS component with the 0-length ID.
+1. (`ncn-mw#`) Delete the CFS component with the zero-length ID.
 
     > No output is expected from the following command.
 

--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -82,7 +82,7 @@ For more details, see [CFS V2 Failures On Large Systems](CFS_V2_Failures_On_Larg
 
 ### Invalid CFS component
 
-If a CFS component exists with a 0-length string for its `id` field, then it may cause the `cmsdev`
+If a CFS component exists with a zero-length string for its `id` field, then it may cause the `cmsdev`
 CFS subtest to fail. The `cmsdev` test failure symptom will depend on the version of `cmsdev` being run.
 (See the [Version](#version) section above for details on how to find the version).
 
@@ -107,4 +107,4 @@ CFS subtest to fail. The `cmsdev` test failure symptom will depend on the versio
     ERROR (run tag fhn3C-cfs): First list item has empty value for "id" field
     ```
 
-For details on how to correct this problem, see [CFS Component With 0-Length ID](CFS_Component_With_0_Length_ID.md).
+For details on how to correct this problem, see [CFS Component With Zero-Length ID](CFS_Component_With_Zero_Length_ID.md).

--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -6,6 +6,7 @@
     - [Cray CLI](#cray-cli)
     - [BOS subtest hangs](#bos-subtest-hangs)
     - [CFS components errors](#cfs-components-errors)
+    - [Invalid CFS component](#invalid-cfs-component)
 
 ## SMS test execution
 
@@ -43,6 +44,14 @@ transfer subtest, as noted in the previous paragraph).
 
 Additional test execution details can be found in `/opt/cray/tests/install/logs/cmsdev/cmsdev.log`.
 
+## Version
+
+(`ncn-mw#`) The following command displays the version of the `cmsdev` test tool.
+
+```bash
+/usr/local/bin/cmsdev version
+```
+
 ## Known issues with SMS tests
 
 ### Cray CLI
@@ -70,3 +79,32 @@ ERROR (run tag qdthp-cfs): CLI command (cfs components list --format json) faile
 ```
 
 For more details, see [CFS V2 Failures On Large Systems](CFS_V2_Failures_On_Large_Systems.md).
+
+### Invalid CFS component
+
+If a CFS component exists with a 0-length string for its `id` field, then it may cause the `cmsdev`
+CFS subtest to fail. The `cmsdev` test failure symptom will depend on the version of `cmsdev` being run.
+(See the [Version](#version) section above for details on how to find the version).
+
+- For `cmsdev` versions 1.25 or higher, the CFS subtest failures will resemble the following:
+
+    ```text
+    ERROR (run tag fhn3C-cfs): In first item listed, 'id' field maps to a 0-length string, but it should have non-0 length
+    ```
+
+- For `cmsdev` versions less than 1.25 but at least 1.16.2, the CFS subtest failures will resemble the following:
+
+    ```text
+    ERROR (run tag sosdD-cfs): GET https://api-gw-service-nmn.local/apis/cfs/v3/components/: expected status code 200, got 404
+    ERROR (run tag sosdD-cfs): GET https://api-gw-service-nmn.local/apis/cfs/v2/components/: expected status code 200, got 404
+    ERROR (run tag sosdD-cfs): CLI command (cfs v3 components describe  --format json) failed with exit code 2
+    ERROR (run tag sosdD-cfs): CLI command (cfs v2 components describe  --format json) failed with exit code 2
+    ```
+
+- For `cmsdev` versions less than 1.16.2, the CFS subtest failure will resemble the following:
+
+    ```text
+    ERROR (run tag fhn3C-cfs): First list item has empty value for "id" field
+    ```
+
+For details on how to correct this problem, see [CFS Component With 0-Length ID](CFS_Component_With_0_Length_ID.md).


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/docs-csm/pull/5526