### PR TITLE
CASMCMS-9205: Add missing fields to CFS config imports

### DIFF
--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -137,7 +137,7 @@ def update_components_by_ids(comp_ids: List[str], update_data: JsonObject) -> Js
 
 # CFS configuration functions
 
-def create_configuration(config_name: str, layers: List[Dict[str, str]]) -> JsonObject:
+def create_configuration(config_name: str, layers: List[Dict[str, str]], **config_fields) -> JsonObject:
     """
     Creates or updates a CFS configuration with the specified name and layers.
     The layers should be dictionaries with the following fields set:
@@ -145,8 +145,9 @@ def create_configuration(config_name: str, layers: List[Dict[str, str]]) -> Json
 
     The CFS configuration is returned if successful. Otherwise an exception is raised.
     """
+    config_fields["layers"] = layers
     request_kwargs = {"url": f"{CFS_V3_CONFIGS_URL}/{config_name}",
-                      "json": {"layers": layers},
+                      "json": config_fields,
                       "add_api_token": True,
                       "expected_status_codes": {200}}
     return api_requests.put_retry_validate_return_json(**request_kwargs)


### PR DESCRIPTION
Currently, when the CFS import tool imports a CFS configuration, it ignores the `description` and `additional_inventory` fields. This PR rectifies that. I have tested it on mug.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/5543
1.4: https://github.com/Cray-HPE/docs-csm/pull/5544
1.3: https://github.com/Cray-HPE/docs-csm/pull/5545

No earlier backports needed, as the CFS import tool was introduced in CSM 1.3