### PR TITLE
CASMCMS-9209: Update CFS import tool to handle v3 response format

### DIFF
--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -366,7 +366,7 @@ def main() -> None:
         comp_clear_data = {"error_count": 0, "state": [], "desired_config": "", "tags": {}}
         for comp_sublist in chunk_list(list(current_cfs_data.components)):
             print(f"Clearing error count, desired configuration, state, and tags for components: '{comp_sublist}'")
-            updated_comp_ids = cfs.update_components_by_ids(comp_ids=comp_sublist, update_data=comp_clear_data)
+            updated_comp_ids = cfs.update_components_by_ids(comp_ids=comp_sublist, update_data=comp_clear_data)['component_ids']
             for comp_id in updated_comp_ids:
                 current_cfs_data.components[comp_id].update(comp_clear_data)
 


### PR DESCRIPTION
The response from doing a bulk update of CFS v3 components is of the form:

```json
{ "component_ids": [ "compid1", "compid2" ] }
```

The CFS import tool thinks it is just getting that inner array back. It needs to be modified to get it from the `component_ids` field.

I've tested this on mug and verified that it works as expected.

CSM 1.5 backport: https://github.com/Cray-HPE/docs-csm/pull/5547

No earlier backports needed, as this issue is unique to CFS V3.