### PR TITLE
CASMTRIAGE-7495 make sure new cert-manager backup is taken before cert-manager upgrade

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -794,12 +794,6 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
             sleep 5
             data=$(kubectl get --all-namespaces -o yaml clusterissuer,cert,issuer)
             kubectl create secret generic "${backup_secret?}" --from-literal=data="${data?}"
-          elif kubectl get secret "${backup_secret?}" -o jsonpath='{.data.data}' | base64 -d | grep v1alpha3 > /dev/null 2>&1; then
-            # check the backup doesn't have v1alpha3 references, this API will not work on CSM 1.6
-            # This block is never expected to be entered but it is here just in case
-            echo "Cert-manager backup ${backup_secret} has references to an old API: 'cert-manager.io/v1alpha3'"
-            echo "This api does not work in CSM 1.6. Make sure cert-manager has been upgraded to version 1.5.5"
-            exit 1
           fi
         fi
       fi

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -761,7 +761,8 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     if [ "${needs_upgrade}" -gt 0 ]; then
       cmns="cert-manager"
 
-      backup_secret="cm-restore-data"
+      # make this name unique for CSM 1.6 in case CSM 1.5 secret still exists
+      backup_secret="cm-restore-data-16"
 
       # We need to backup before any helm uninstalls.
       needs_backup=0
@@ -780,6 +781,26 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
         if ! kubectl get secret "${backup_secret?}" > /dev/null 2>&1; then
           data=$(kubectl get --all-namespaces -o yaml clusterissuer,cert,issuer)
           kubectl create secret generic "${backup_secret?}" --from-literal=data="${data?}"
+        else
+          # check the amount of time between the date of backup and the current date
+          backup_date=$(kubectl get secret "${backup_secret?}" -o jsonpath='{.metadata.creationTimestamp}')
+          backup_date_sec=$(date -d"${backup_date}" +%s)
+          current_date_sec=$(date +%s)
+          days_since_backup=$(((current_date_sec - backup_date_sec) / (60 * 60 * 24)))
+          # if backup is more than 30 days old and certificates are present on the system
+          # delete old backup and take new backup
+          if [[ $days_since_backup -gt 30 ]] && [[ $(kubectl get certificates -A | wc -l) -gt 5 ]]; then
+            kubectl delete secret "${backup_secret}"
+            sleep 5
+            data=$(kubectl get --all-namespaces -o yaml clusterissuer,cert,issuer)
+            kubectl create secret generic "${backup_secret?}" --from-literal=data="${data?}"
+          elif kubectl get secret "${backup_secret?}" -o jsonpath='{.data.data}' | base64 -d | grep v1alpha3 > /dev/null 2>&1; then
+            # check the backup doesn't have v1alpha3 references, this API will not work on CSM 1.6
+            # This block is never expected to be entered but it is here just in case
+            echo "Cert-manager backup ${backup_secret} has references to an old API: 'cert-manager.io/v1alpha3'"
+            echo "This api does not work in CSM 1.6. Make sure cert-manager has been upgraded to version 1.5.5"
+            exit 1
+          fi
         fi
       fi
 
@@ -862,6 +883,20 @@ EOF
           printf "warn: kubectl apply of %s encountered errors, restore of cert-manager data may be incomplete or simply tried to restore existing data\n" "${backup_secret}" >&2
         fi
       fi
+    fi
+    # Verify that certificates exist. Fail if no certificates exist.
+    # The warning statement above needs to stay a warning. It does not exit 0 because Issuers should already exist.
+    # 5 is an arbitrary number, expect ~21 certificates
+    if [[ $(kubectl get certificates -A | wc -l) -lt 5 ]]; then
+      echo "ERROR: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates."
+      echo "Certificates should have been restored from backup: 'kubectl get secret ${backup_secret?}'"
+      exit 1
+    fi
+    # delete CSM 1.5 cert-manager backup if it exists
+    backup_secret_csm_15="cm-restore-data"
+    if kubectl get secret "${backup_secret_csm_15?}" > /dev/null 2>&1; then
+      echo "Deleting cert-manager backup from CSM 1.5 upgrade"
+      kubectl delete secret "${backup_secret_csm_15}"
     fi
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

We have seen that when an upgrade from CSM 1.4 to 1.5 to 1.6 is done, the cert-manager backup from the 1.4 to 1.5 still exists and a new backup is not taken for the CSM 1.5 to 1.6 upgrade. This causes the certificates restore to fail because the certificates are from CSM 1.4 and use an API that is no longer available in cert-manager in CSM 1.6. 

I have made multiple improvements to the cert-manager upgrade in this PR. They are listed below:

- The certmanager backup in CSM 1.6 has a different name than the 1.5 backup. This way, even if the backup from CSM 1.5 exists, a new backup will be taken.
- If the CSM 1.6 backup is older than 30 days and certificates are present on the system (they haven't been deleted during an upgrade) a new backup will be taken.
- After the cert-manager upgrade, it is checked that certificates were restored and it fails if they were not.
- After the cert-manager upgrade, the CSM 1.5 cert-manager backup is deleted if it still exists.

# Testing

Tested on vsahsta upgrade from CSM 1.4 -> 1.5 -> 1.6.

The following is output from the cert-manager upgrade executed in prerequisites.sh during the CSM 1.5 to 1.6 upgrade.
The most important info in the output below is `secret/cm-restore-data-16 created`, all certificates are successfully restored at the end, and the CSM 1.5 certmanager backup is deleted: `secret "cm-restore-data" deleted`.

```bash
====> UPGRADE_CERTMANAGER_155_CHART ...
note: found old cert-manager that needs upgrades 1.5.5
secret/cm-restore-data-16 created
release "cray-certmanager" uninstalled
namespace "cert-manager" deleted
2024-11-20T20:16:20Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2024-11-20T20:16:20Z INF Initializing helm client object command=ship
...
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-certmanager-issuers v0.7.2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2024-11-20T20:17:21Z INF Running helm install/upgrade with arguments: upgrade --install cray-certmanager-issuers /etc/cray/upgrade/csm/csm-1.6.0-rc.6/tarball/csm-1.6.0-rc.6/helm/cray-certmanager-issuers-0.7.2.tgz --namespace cert-manager --create-namespace --set global.chart.name=cray-certmanager-issuers --set global.chart.version=0.7.2 chart=cray-certmanager-issuers command=ship namespace=cert-manager version=0.7.2
2024-11-20T20:17:22Z INF Release "cray-certmanager-issuers" does not exist. Installing it now.
NAME: cray-certmanager-issuers
LAST DEPLOYED: Wed Nov 20 20:17:21 2024
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Installed namespace specific, cert-manager Issuers via cray-certmanager-issuers.

Your release is named cray-certmanager-issuers.
 chart=cray-certmanager-issuers command=ship namespace=cert-manager version=0.7.2
2024-11-20T20:17:22Z INF Ship status: success. Recording status, manifest to configmap loftsman-cray-certmanager-images-tmp-manifest in namespace loftsman command=ship
2024-11-20T20:17:22Z INF Recording log data to configmap loftsman-cray-certmanager-images-tmp-manifest-ship-log in namespace loftsman command=ship
certificate.cert-manager.io/dvs-mqtt-cert created
certificate.cert-manager.io/ingress-gateway-cert created
certificate.cert-manager.io/cfs-ara-postgres-tls created
certificate.cert-manager.io/cray-console-data-postgres-tls created
certificate.cert-manager.io/cray-dns-powerdns-postgres-tls created
certificate.cert-manager.io/cray-hms-rts-default-tls created
certificate.cert-manager.io/cray-hms-rts-snmp-default-tls created
certificate.cert-manager.io/cray-oauth2-proxies-customer-access created
certificate.cert-manager.io/cray-oauth2-proxies-customer-high-speed created
certificate.cert-manager.io/cray-oauth2-proxies-customer-management created
certificate.cert-manager.io/cray-sls-postgres-tls created
certificate.cert-manager.io/cray-smd-postgres-tls created
certificate.cert-manager.io/gitea-vcs-postgres-tls created
certificate.cert-manager.io/keycloak-postgres-tls created
certificate.cert-manager.io/cray-spire-postgres-tls created
certificate.cert-manager.io/cray-spire-tokens-tls created
certificate.cert-manager.io/spire-postgres-tls created
certificate.cert-manager.io/spire-tokens-tls created
certificate.cert-manager.io/tapms-webhook-server-cert created
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource issuers/cert-manager-issuer-common is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
warn: kubectl apply of cm-restore-data-16 encountered errors, restore of cert-manager data may be incomplete or simply tried to restore existing data
Deleting cert-manager backup from CSM 1.5 upgrade
secret "cm-restore-data" deleted
====> UPGRADE_CERTMANAGER_155_CHART has been completed
```

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
