### PR TITLE
CASMTRIAGE-7443 - Workaound for Postgres cluster failover occurring when a control-plane node is rebooted

### DIFF
--- a/troubleshooting/known_issues/postgres_database_recovery.md
+++ b/troubleshooting/known_issues/postgres_database_recovery.md
@@ -46,6 +46,12 @@ The Patroni database monitor usually relies on the `kubernetes` service to commu
 Patroni to resolve the list of API nodes behind the service and connect directly to them reducing the chance of timeout or failure when performing
 API calls.
 
+1. (`ncn-mw#`) Apply the `postgres-pod` `RoleBinding` to allow the PostgreSQL clusters to access the Kubernetes API endpoint.
+
+   ```bash
+   kubectl apply -f /usr/share/doc/csm/upgrade/scripts/upgrade/postgres-pod.yaml
+   ```
+
 1. (`ncn-mw#`) Update the `postgres-nodes-pod-env` ConfigMap.
 
    ```bash

--- a/upgrade/scripts/upgrade/postgres-pod.yaml
+++ b/upgrade/scripts/upgrade/postgres-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postgres-pod
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: postgres-pod
+subjects:
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: services
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: spire
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: argo
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: sma

--- a/upgrade/scripts/upgrade/postgres-pod.yaml
+++ b/upgrade/scripts/upgrade/postgres-pod.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1515,6 +1515,21 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# CASMTRIAGE-7443 Apply RoleBinding to allow PostgreSQL clusters to determine the endpoints behind the "kubernetes" service
+# to reduce the chance of failover when a control plane node is rebooted
+state_name="APPLY_POSTGRESQL_ROLEBINDING"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    kubectl apply -f ${locOfScript}/postgres-pod.yaml
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+  echo
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The workaround proposed in [CASMTRIAGE-7120](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7120) doesn't work as expected because the PostgreSQL pods do not have access to the `kubernetes` endpoint to determine what's behind it.

```
2024-11-14 00:49:39,974 WARNING: Kubernetes RBAC doesn't allow GET access to the 'kubernetes' endpoint in the 'default' namespace. Disabling 'bypass_api_service'.
```

This PR adds the required RoleBinding to allow the PostgreSQL pods to infer what's behind the `kubernetes` endpoint and use that instead.
```
2024-11-18 10:03:16,557 INFO: Selected new K8s API server endpoint https://10.252.1.6:6443
```
In the event of a failover a new endpoint is selecting rather than forcing a leader election.
```
services/cray-smd-postgres-0[postgres]: 2024-11-18 13:43:15,002 ERROR: Failed to get "kubernetes" endpoint from https://10.252.1.5:6443: MaxRetryError("HTTPSConnectionPool(host='10.252.1.5', port=6443): Max retries exceeded with url: /api/v1/namespaces/default/endpoints/kubernetes (Caused by ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))",)
services/cray-smd-postgres-0[postgres]: 2024-11-18 13:43:15,016 INFO: Selected new K8s API server endpoint https://10.252.1.6:6443
```

The required RoleBinding is added via `prerequisites.sh` and the existing workaround has also been updated to add it.

This was tested end to end on `wasp` by upgrading from csm-1.6.0-rc.4 to rc.6.

```
====> APPLY_POSTGRESQL_ROLEBINDING ...
rolebinding.rbac.authorization.k8s.io/postgres-pod created
====> APPLY_POSTGRESQL_ROLEBINDING has been completed
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
