### PR TITLE
CASMPET-7280 add troubleshooting page: kubernetes pods failing to mount pvcs

### DIFF
--- a/operations/utility_storage/Identify_Ceph_Latency_Issues.md
+++ b/operations/utility_storage/Identify_Ceph_Latency_Issues.md
@@ -73,9 +73,9 @@ Based on the output from `ceph -s` (using our example above) we can correlate so
    1. The recommended remediation is to do a rolling restart of the Ceph `MON` and `MGR` daemons.
       1. Get `MON` and `MGR` daemons.
 
-            ```bash
-            ceph orch ps | grep -E 'mgr|mon'
-            ```
+         ```bash
+         ceph orch ps | grep -E 'mgr|mon'
+         ```
 
       1. Restart each `MON` and `MGR` daemons. Make sure each daemon starts before restarting the next one.
 

--- a/operations/utility_storage/Identify_Ceph_Latency_Issues.md
+++ b/operations/utility_storage/Identify_Ceph_Latency_Issues.md
@@ -18,7 +18,7 @@ This procedure requires admin privileges.
 
     Example output:
 
-    ```
+    ```bash
     cluster:
        id:     73084634-9534-434f-a28b-1d6f39cf1d3d
        health: HEALTH_WARN
@@ -69,11 +69,27 @@ Based on the output from `ceph -s` (using our example above) we can correlate so
        1. As an initial step, restart the OSDs, if the slow ops go away and do not return, then we can investigate the logs for possible software bugs or memory issues.
        1. If the slow ops come right back, then there is an issue with replication between the 2 OSDs which tends to be network-related.
 
-1. When reporting slow ops for `MONs`, then it is typically an issue with the process.
-   1. The most common cause here is either an abrupt clock skew or a hung mon/mgr process.
-      1. The recommended remediation is to do a rolling restart of the Ceph `MON` and `MGR` daemons.
+1. When reporting slow ops for `MONs`, then it is typically an issue with the process. The most common cause is either an abrupt clock skew or a hung mon/mgr process.
+   1. The recommended remediation is to do a rolling restart of the Ceph `MON` and `MGR` daemons.
+      1. Get `MON` and `MGR` daemons.
+
+            ```bash
+            ceph orch ps | grep -E 'mgr|mon'
+            ```
+
+      1. Restart each `MON` and `MGR` daemons. Make sure each daemon starts before restarting the next one.
+
+         ```bash
+         ceph orch daemon restart <daemon_name>
+         ```
+
+   1. Failover the active MDS server.
+
+         ```bash
+         ceph mds fail 0
+         ```
 
 1. When reporting slow ops for MDS, then are multiple possible causes.
    1. If listed in addition to OSDs, then the root cause for this is typically the OSDs, and the process above should be used, followed by restarting the `MDS` daemons.
    1. If it is only listing MDS, then restart the MDS daemons. If the problem persists, then examine the logs in order to determine the root cause.
-   1. See [Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client](Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client.md) for additional steps to help identify MDS slow ops
+   1. See [Troubleshoot Ceph MDS reporting slow requests and failure on client](Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client.md) for additional steps to help identify MDS slow ops

--- a/operations/utility_storage/Identify_Ceph_Latency_Issues.md
+++ b/operations/utility_storage/Identify_Ceph_Latency_Issues.md
@@ -18,7 +18,7 @@ This procedure requires admin privileges.
 
     Example output:
 
-    ```bash
+    ```text
     cluster:
        id:     73084634-9534-434f-a28b-1d6f39cf1d3d
        health: HEALTH_WARN

--- a/operations/utility_storage/Troubleshoot_System_Clock_Skew.md
+++ b/operations/utility_storage/Troubleshoot_System_Clock_Skew.md
@@ -107,3 +107,9 @@ This procedure requires admin privileges.
     ```
 
     If clocks are in sync and Ceph is still reporting skew, refer to [Manage Ceph Services](Manage_Ceph_Services.md) on restarting services.
+
+1. Failover the active Ceph MDS server. After there has been clock skew, the Ceph MDS server may have issues which will cause Kubernetes pods to not be able to mount PVCs. The active MDS server should be failed over to prevent this issue.
+
+    ```bash
+    ceph mds fail 0
+    ```

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -139,6 +139,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Restore Postgres](../operations/kubernetes/Restore_Postgres.md)
 * [Disaster Recovery for Postgres](../operations/kubernetes/Disaster_Recovery_Postgres.md)
 * [Postgres Database is in Recovery](known_issues/postgres_database_recovery.md)
+* [Kubernetes Pods Failing to Mount PVCs](kubernetes/Kubernetes_Pods_Failing_to_Mount_PVCs.md)
 
 ## MetalLB
 

--- a/troubleshooting/kubernetes/Kubernetes_Pods_Failing_to_Mount_PVCs.md
+++ b/troubleshooting/kubernetes/Kubernetes_Pods_Failing_to_Mount_PVCs.md
@@ -8,7 +8,7 @@
 
 Pods may fail because they are unable to mount PVCs. The root cause of this problem can be the Ceph MDS server daemon.
 The symptoms of a Ceph MDS problem are generally Kubernetes issues.
-Ceph MDS issues can be caused by clock skew on storage nodes currently or if there was clock skew previously.
+Ceph MDS issues can be caused by a current or previous clock skew on the storage nodes.
 
 ## Example errors
 
@@ -16,11 +16,11 @@ The following are errors that may be observed due to this issue:
 
 - Pods failing because they are unable to mount PVCs. A pod description could contain the following errors.
 
-    ```bash
+    ```text
     Warning  FailedMount      98s (x11 over 24m)  kubelet            (combined from similar events): Unable to attach or mount volumes: unmounted volumes=[snapshot-volume], unattached volumes=[snapshot-volume istio-podinfo istiod-ca-cert istio-data istio-envoy istio-token kube-api-access-w9sjw etcd-jwt-token etcd-config data]: timed out waiting for the condition
     ```
 
-    ```bash
+    ```text
     Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085783   63627 kubelet_pods.go:226] failed to prepare subPath for volumeMount "slurm-data" of container "slurmctld": error resolving symlinks in "/var/lib/kubelet/pods/8c006150-1473-4299-a2c5-429d6bd145ed/volumes/kubernetes.io~cephfs/pvc-1a2bd4b7-1fee-4175-9f53-ff5b7ef8dea2": lstat /var/lib/kubelet/pods/8c006150-1473-4299-a2c5-429d6bd145ed/volumes/kubernetes.io~cephfs/pvc-1a2bd4b7-1fee-4175-9f53-ff5b7ef8dea2: permission denied
     Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085818   63627 kuberuntime_manager.go:803] container start failed: CreateContainerConfigError: failed to prepare subPath for volumeMount "slurm-data" of container "slurmctld"
     Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085852   63627 pod_workers.go:191] Error syncing pod 8c006150-1473-4299-a2c5-429d6bd145ed ("slurmctld-6cb8c4fd66-h4wx6_user(8c006150-1473-4299-a2c5-429d6bd145ed)"), skipping: failed to "StartContainer" for "slurmctld" with CreateContainerConfigError: "failed to prepare subPath for volumeMount \"slurm-data\" of container \"slurmctld\""
@@ -31,7 +31,7 @@ The problem can exist even if not all files have a permission denied error.
 
     Example error:
 
-    ```bash
+    ```text
     ncn-w003:~ # ls -al /var/lib/kubelet/pods/4ff6d8ee-e9ab-4516-87d4-a94567f28ded/volumes/kubernetes.io~csi/pvc-419ef8b3-e7ba-4a82-8d0b-e35a819336cc
     ls: cannot access '/var/lib/kubelet/pods/4ff6d8ee-e9ab-4516-87d4-a94567f28ded/volumes/kubernetes.io~csi/pvc-419ef8b3-e7ba-4a82-8d0b-e35a819336cc/mount': Permission denied
     total 4
@@ -43,7 +43,7 @@ The problem can exist even if not all files have a permission denied error.
 
     Expected output when not experiencing this problem:
 
-    ```bash
+    ```text
     ncn-w003:~ # ls -al /var/lib/kubelet/pods/05c2b44e-2a8b-4015-bf5d-4c472fc772c6/volumes/kubernetes.io~csi/pvc-d43ac606-4302-4682-a195-13aeb2bc34fb
     total 8
     drwxr-x--- 3 root root   40 Nov 16 05:53 .

--- a/troubleshooting/kubernetes/Kubernetes_Pods_Failing_to_Mount_PVCs.md
+++ b/troubleshooting/kubernetes/Kubernetes_Pods_Failing_to_Mount_PVCs.md
@@ -1,0 +1,68 @@
+# Kubernetes pods failing to mount PVCs
+
+- [Introduction](#introduction)
+- [Example errors](#example-errors)
+- [Resolution](#resolution)
+
+## Introduction
+
+Pods may fail because they are unable to mount PVCs. The root cause of this problem can be the Ceph MDS server daemon.
+The symptoms of a Ceph MDS problem are generally Kubernetes issues.
+Ceph MDS issues can be caused by clock skew on storage nodes currently or if there was clock skew previously.
+
+## Example errors
+
+The following are errors that may be observed due to this issue:
+
+- Pods failing because they are unable to mount PVCs. A pod description could contain the following errors.
+
+    ```bash
+    Warning  FailedMount      98s (x11 over 24m)  kubelet            (combined from similar events): Unable to attach or mount volumes: unmounted volumes=[snapshot-volume], unattached volumes=[snapshot-volume istio-podinfo istiod-ca-cert istio-data istio-envoy istio-token kube-api-access-w9sjw etcd-jwt-token etcd-config data]: timed out waiting for the condition
+    ```
+
+    ```bash
+    Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085783   63627 kubelet_pods.go:226] failed to prepare subPath for volumeMount "slurm-data" of container "slurmctld": error resolving symlinks in "/var/lib/kubelet/pods/8c006150-1473-4299-a2c5-429d6bd145ed/volumes/kubernetes.io~cephfs/pvc-1a2bd4b7-1fee-4175-9f53-ff5b7ef8dea2": lstat /var/lib/kubelet/pods/8c006150-1473-4299-a2c5-429d6bd145ed/volumes/kubernetes.io~cephfs/pvc-1a2bd4b7-1fee-4175-9f53-ff5b7ef8dea2: permission denied
+    Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085818   63627 kuberuntime_manager.go:803] container start failed: CreateContainerConfigError: failed to prepare subPath for volumeMount "slurm-data" of container "slurmctld"
+    Mar 27 18:04:26 ncn-w001 kubelet[63627]: E0327 23:04:26.085852   63627 pod_workers.go:191] Error syncing pod 8c006150-1473-4299-a2c5-429d6bd145ed ("slurmctld-6cb8c4fd66-h4wx6_user(8c006150-1473-4299-a2c5-429d6bd145ed)"), skipping: failed to "StartContainer" for "slurmctld" with CreateContainerConfigError: "failed to prepare subPath for volumeMount \"slurm-data\" of container \"slurmctld\""
+    ```
+
+- The PVC mounts on worker nodes may have permission denied error.
+The problem can exist even if not all files have a permission denied error.
+
+    Example error:
+
+    ```bash
+    ncn-w003:~ # ls -al /var/lib/kubelet/pods/4ff6d8ee-e9ab-4516-87d4-a94567f28ded/volumes/kubernetes.io~csi/pvc-419ef8b3-e7ba-4a82-8d0b-e35a819336cc
+    ls: cannot access '/var/lib/kubelet/pods/4ff6d8ee-e9ab-4516-87d4-a94567f28ded/volumes/kubernetes.io~csi/pvc-419ef8b3-e7ba-4a82-8d0b-e35a819336cc/mount': Permission denied
+    total 4
+    drwxr-x--- 3 root root  40 Nov 16 05:52 .
+    drwxr-x--- 4 root root 102 Nov 16 05:52 ..
+    d????????? ? ?    ?      ?            ? mount
+    -rw-r--r-- 1 root root 353 Nov 16 05:52 vol_data.json
+    ```
+
+    Expected output when not experiencing this problem:
+
+    ```bash
+    ncn-w003:~ # ls -al /var/lib/kubelet/pods/05c2b44e-2a8b-4015-bf5d-4c472fc772c6/volumes/kubernetes.io~csi/pvc-d43ac606-4302-4682-a195-13aeb2bc34fb
+    total 8
+    drwxr-x--- 3 root root   40 Nov 16 05:53 .
+    drwxr-x--- 3 root root   54 Nov 16 05:53 ..
+    drwxrwsr-x 4 root  103 4096 Nov 15 19:36 mount
+    -rw-r--r-- 1 root root  350 Nov 16 05:53 vol_data.json
+    ```
+
+## Resolution
+
+Failover the active Ceph MDS server to a standby daemon.
+Running `ceph -s` will show that there are MDS daemons in standby.
+Ceph MDS coordinates access to the Ceph cluster.
+Failing the active MDS server should allow clients to successfully mount PVCs.
+
+(`ncn-m/s`#) Fail the active MDS server. In the command below, `0` refers to the MDS server rank and `0` is the primary MDS.
+
+```bash
+ceph mds fail 0
+```
+
+If necessary, refer to other [MDS troubleshooting documentation](../../operations/utility_storage/Utility_Storage.md#storage-troubleshooting-references).


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

We need a troubleshooting page for when pods are failing to mount PVCs. This has happened both internally and at a customer site recently. It can be very difficult to debug because the root cause is often a Ceph MDS issue but there are very few signs that this is the root cause. This PR adds a troubleshooting page for pods failing to mount PVCs. It also adds a step to failover the MDS when resolving storage node clock skew because clock skew is what causes the Ceph MDS issues.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
