### PR TITLE
CASMINST-6711 - Command Mismatch When Setting up SNMP on Dell and Mellanox switches

### DIFF
--- a/operations/network/management_network/dell/snmp-community.md
+++ b/operations/network/management_network/dell/snmp-community.md
@@ -8,17 +8,17 @@ The switch supports SNMPv2c community-based security for read-only and read-writ
 
 1. Enter configuration mode.
 
-   ```text
+   ```console
    configure terminal
    ```
 
 1. Configure the SNMPv2c community name
 
-   ```text
+   ```console
    snmp-server community community-name access-mode
    ```
 
-   Parameters
+   Parameters:
 
    | Parameter        | Description                                                                                  |
    |------------------|----------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ When successful this command returns no output.
 
 The following command displays information about any SNMP community that may have been configured.
 
-```text
+```console
 show snmp community
 ```
 

--- a/operations/network/management_network/dell/snmp-community.md
+++ b/operations/network/management_network/dell/snmp-community.md
@@ -1,25 +1,59 @@
-# Configure SNMPv2c Community
+# Configure SNMPv2c community
 
-The switch supports SNMPv2c community-based security for read-only access.
+The switch supports SNMPv2c community-based security for read-only and read-write access.
 
-## Configuration Commands
+## Configuration commands
 
-Configure an SNMPv2c community name:
+### Configure the SNMP community
+
+1. Enter configuration mode.
+
+   ```text
+   configure terminal
+   ```
+
+1. Configure the SNMPv2c community name
+
+   ```text
+   snmp-server community community-name access-mode
+   ```
+
+   Parameters
+
+   | Parameter        | Description                                                                                  |
+   |------------------|----------------------------------------------------------------------------------------------|
+   | `community-name` | The user defined name for this community.                                                    |
+   | `access-mode`    | The access level for this community. Can be `ro` for read-only or `rw` for read-write access |
+
+### Example
+
+The following command configures a read-only SNMP community called "public".
 
 ```text
-snmp-server community community-name
+snmp-server community public ro
 ```
 
-Show commands to validate functionality:
+When successful this command returns no output.
+
+### Show configured SNMP community
+
+The following command displays information about any SNMP community that may have been configured.
 
 ```text
 show snmp community
 ```
 
+Example output:
+
+```text
+Community      : public
+Access         : read-only
+```
+
 ## Expected Results
 
-1. Administrators can configure the community name
-2. Administrators can bind the SNMP server to the default VRF
-3. Administrators can connect from the workstation using the community name
+1. Administrators can configure the community name.
+2. Administrators can bind the SNMP server to the default VRF.
+3. Administrators can connect from the workstation using the community name.
 
 [Back to Index](../README.md)

--- a/operations/network/management_network/mellanox/snmpv3_users.md
+++ b/operations/network/management_network/mellanox/snmpv3_users.md
@@ -17,7 +17,7 @@ switch(config)# snmp-server user testuser v3 require-privacy
 Show Commands to Validate Functionality
 
 ```console
-show snmp users
+show snmp user
 ```
 
 [Back to Index](../README.md)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Correct syntax of commands to configure SNMPv2 for Dell and Mellanox switches.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
