### PR TITLE
CASMTRIAGE-7471: Add sub-section Populate admin directory in product-delivery.md and remove in configuration.md #5532

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -4,6 +4,7 @@ This section ensures the product content is loaded onto the system and available
 
 1. [Execute the IUF `process-media` and `pre-install-check` stages](#1-execute-the-iuf-process-media-and-pre-install-check-stages)
 1. [Update `customizations.yaml`](#2-update-customizationsyaml)
+1. [Populate admin directory with files defining site preference](#3-populate-admin-directory-with-files-defining-site-preferences)
 1. [Execute the IUF `deliver-product` stage](#4-execute-the-iuf-deliver-product-stage)
 1. [Perform manual product delivery operations](#5-perform-manual-product-delivery-operations)
 1. [Next steps](#6-next-steps)


### PR DESCRIPTION
# Description

CASMTRIAGE-7471 : Add sub-section Populate admin directory in product-delivery.md before IUF deliver-product stage and remove in configuration.md

Add missing Reference to 3rd sub section in product_delivery.md

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
