### PR TITLE
SSI-14310 Update docs to reflect that USS now contains multiple component areas

### DIFF
--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -110,7 +110,7 @@ required for initial installation scenarios.
     - PBS Pro Configuration
         - UAS
             - Configure UAS network settings
-                 - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
+                - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
         - CSM Diags
             - Update CSM Diags network attachment definition
 

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -100,7 +100,7 @@ required for initial installation scenarios.
         - Enable CAN, LDAP, and set MOTD
         - Move DVS and LNet settings to USS branch
         - Set the UAN root password in HashiCorp Vault
-        - _Tech Preview_ - Enable UAIs on UAN
+        - Enable UAIs on UAN
     - SLURM Configuration
         - UAS
             - Configure UAS network settings

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -100,19 +100,19 @@ required for initial installation scenarios.
         - Enable CAN, LDAP, and set MOTD
         - Move DVS and LNet settings to USS branch
         - Set the UAN root password in HashiCorp Vault
-        - *Tech Preview* - Enable UAIs on UAN
+        - _Tech Preview_ - Enable UAIs on UAN
     - SLURM Configuration
         - UAS
             - Configure UAS network settings
                 - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
         - CSM Diags
-             - Update CSM Diags network attachment definition
+            - Update CSM Diags network attachment definition
     - PBS Pro Configuration
         - UAS
-             - Configure UAS network settings
+            - Configure UAS network settings
                  - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
         - CSM Diags
-             - Update CSM Diags network attachment definition
+            - Update CSM Diags network attachment definition
 
 - SHS
     - Update release information in `group_vars` (done for each product release)

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -91,14 +91,29 @@ The following highlights some of the areas that require manual configuration cha
 required for initial installation scenarios.
 
 - USS
-    - Configure DVS and LNet with appropriate Slingshot settings
-    - Configure DVS and LNet for use on application nodes
-    - Enable site-specific file system mounts
-    - Set the USS root password in HashiCorp Vault
-- UAN
-    - Enable CAN, LDAP, and set MOTD
-    - Move DVS and LNet settings to USS branch
-    - Set the UAN root password in HashiCorp Vault
+    - Compute Configuration
+       - Configure DVS and LNet with appropriate Slingshot settings
+       - Configure DVS and LNet for use on application nodes
+       - Enable site-specific file system mounts
+       - Set the USS root password in HashiCorp Vault
+    - UAN Configuration
+       - Enable CAN, LDAP, and set MOTD
+       - Move DVS and LNet settings to USS branch
+       - Set the UAN root password in HashiCorp Vault
+       - *Tech Preview* - Enable UAIs on UAN
+    - SLURM Configuration
+       - UAS
+          - Configure UAS network settings
+            - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
+       - CSM Diags
+          - Update CSM Diags network attachment definition
+    - PBS Pro Configuration
+       - UAS
+          - Configure UAS network settings
+            - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
+       - CSM Diags
+         - Update CSM Diags network attachment definition
+
 - SHS
     - Update release information in `group_vars` (done for each product release)
 - CPE
@@ -109,18 +124,6 @@ required for initial installation scenarios.
     - Configure SAT authentication via `sat auth`
     - Generate SAT S3 credentials
     - Configure system revision information via `sat setrev`
-- SLURM
-    - UAS
-        - Configure UAS network settings
-            - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
-    - CSM Diags
-        - Update CSM Diags network attachment definition
-- PBS Pro
-    - UAS
-        - Configure UAS network settings
-            - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
-    - CSM Diags
-        - Update CSM Diags network attachment definition
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -102,15 +102,9 @@ required for initial installation scenarios.
         - Set the UAN root password in HashiCorp Vault
         - Enable UAIs on UAN
     - SLURM Configuration
-        - UAS
-            - Configure UAS network settings
-                - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
         - CSM Diags
             - Update CSM Diags network attachment definition
     - PBS Pro Configuration
-        - UAS
-            - Configure UAS network settings
-                - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
         - CSM Diags
             - Update CSM Diags network attachment definition
 

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -92,27 +92,27 @@ required for initial installation scenarios.
 
 - USS
     - Compute Configuration
-       - Configure DVS and LNet with appropriate Slingshot settings
-       - Configure DVS and LNet for use on application nodes
-       - Enable site-specific file system mounts
-       - Set the USS root password in HashiCorp Vault
+        - Configure DVS and LNet with appropriate Slingshot settings
+        - Configure DVS and LNet for use on application nodes
+        - Enable site-specific file system mounts
+        - Set the USS root password in HashiCorp Vault
     - UAN Configuration
-       - Enable CAN, LDAP, and set MOTD
-       - Move DVS and LNet settings to USS branch
-       - Set the UAN root password in HashiCorp Vault
-       - *Tech Preview* - Enable UAIs on UAN
+        - Enable CAN, LDAP, and set MOTD
+        - Move DVS and LNet settings to USS branch
+        - Set the UAN root password in HashiCorp Vault
+        - *Tech Preview* - Enable UAIs on UAN
     - SLURM Configuration
-       - UAS
-          - Configure UAS network settings
-            - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
-       - CSM Diags
-          - Update CSM Diags network attachment definition
+        - UAS
+            - Configure UAS network settings
+                - The network settings for UAS must match the SLURM WLM to allow job submission from UAIs
+        - CSM Diags
+             - Update CSM Diags network attachment definition
     - PBS Pro Configuration
-       - UAS
-          - Configure UAS network settings
-            - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
-       - CSM Diags
-         - Update CSM Diags network attachment definition
+        - UAS
+             - Configure UAS network settings
+                 - The network settings for UAS must match the PBS Pro WLM to allow job submission from UAIs
+        - CSM Diags
+             - Update CSM Diags network attachment definition
 
 - SHS
     - Update release information in `group_vars` (done for each product release)


### PR DESCRIPTION
# Description
This change updated the IUF documentation for product configuration to group several products that formerly were release independently to be included under the User Services Software (USS) name.    This also adds a note that the UAI on UAN tech preview can be enabled.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
