### PR TITLE
CASMTRIAGE-7545: handle idempotent annotation addition

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -98,7 +98,9 @@ yq4 eval '.spec.kubernetes.services.cray-vault.ingress.host = "vault.cmn.{{ netw
 # cray-istio
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-hmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' 'istio-ingressgateway-cmn.istio-system.svc.cluster.local'
-yq4 eval '.spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations."external-dns.alpha.kubernetes.io/hostname" += ",vault.cmn.{{ network.dns.external }}"' -i "$c"
+if [[ -z "$(yq4 eval '.spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations."external-dns.alpha.kubernetes.io/hostname" | select(. == "*vault.cmn*")' $c)" ]]; then
+  yq4 eval '.spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations."external-dns.alpha.kubernetes.io/hostname" += ",vault.cmn.{{ network.dns.external }}"' -i "$c"
+fi
 
 # cray-keycloak
 if [[ -n "$(yq r "$c" "spec.kubernetes.services.cray-keycloak.keycloak.keycloak")" ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When appending service annotations for cray-externaldns-external-dns, the original code did not check existing annotations and caused duplicate annotations if the upgrade is run multiple times. This PR fixes the issue by checking existing annotations before adding one.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
