### PR TITLE
CASMCMS-9226 - fix mis-spelling.

### DIFF
--- a/operations/image_management/Configure_IMS_to_Use_DKMS.md
+++ b/operations/image_management/Configure_IMS_to_Use_DKMS.md
@@ -7,7 +7,7 @@ tool. This allows kernel modules to be built for the specific kernel used in the
 access to the running kernel that is not usually allowed by the Image Management Service (IMS). In order to safely
 allow the expanded access, the IMS configuration must be modified to enable the feature.
 
-## Requirements of DMKS
+## Requirements of DKMS
 
 Many DKMS build and install scripts require access to the system `/proc`, `/dev`, and `/sys` directories which
 allows access to running processes and system services. The IMS jobs run as an administrator user since preparing


### PR DESCRIPTION
# Description

This just fixes a mis-spelling in a section header.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
