### PR TITLE
CASMTRIAGE-7607: Grab docker-kubectl image from cacheImages for nexus upgrade

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -532,7 +532,8 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
 
     # Skopeo image is stored as "skopeo:csm-${CSM_RELEASE}", which may resolve to docker.io/lirary/skopeo or quay.io/skopeo, depending on configured shortcuts
     SKOPEO_IMAGE=$(podman load -q -i "${CSM_ARTI_DIR}/vendor/skopeo.tar" 2> /dev/null | sed -e 's/^.*: //')
-    nexus_images=$(yq r -j "${CSM_MANIFESTS_DIR}/platform.yaml" 'spec.charts.(name==cray-precache-images).values.cacheImages' | jq -r '.[] | select( . | contains("nexus"))')
+    # Grab nexus and docker-kubectl images from cacheImages list, remove duplicates.
+    nexus_images=$(yq r -j "${CSM_MANIFESTS_DIR}/platform.yaml" 'spec.charts.(name==cray-precache-images).values.cacheImages' | jq -r '.[] | select( . | contains("nexus", "docker-kubectl"))' | sort | uniq)
     worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u)
     while read -r nexus_image; do
       echo "Uploading $nexus_image into Nexus ..."
@@ -605,8 +606,9 @@ state_name="PRECACHE_ISTIO_IMAGES"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  # Grab istio and docker-kubectl images from cacheImages list, remove duplicates.
   {
-    istio_images=$(yq r -j "${CSM_MANIFESTS_DIR}/platform.yaml" 'spec.charts.(name==cray-precache-images).values.cacheImages' | jq -r '.[] | select( . | (contains("istio") or contains("docker-kubectl")))')
+    istio_images=$(yq r -j "${CSM_MANIFESTS_DIR}/platform.yaml" 'spec.charts.(name==cray-precache-images).values.cacheImages' | jq -r '.[] | select( . | (contains("istio", "docker-kubectl")))' | sort | uniq)
     worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u)
     while read -r istio_image; do
       while read -r worker_node; do


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Nexus requires the docker-kubectl image for pre-install and pre-upgrade hooks.  Add `docker-kubectl` to the `cray-precache-images` search.  Because this is a common image to require, return a unique list. 

Istio also requires `docker-kubectl` so modified istios precache list to return unique list.

JIRA:  https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7607
Related CSM PR:  https://github.com/Cray-HPE/csm/pull/3809

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
# Testing
Tested yq/jq statement changes via script on `beau` vShasta system.  Ran against a copy of `platform.yaml` that contained `docker-kubectl` in the nexus list.

```
pit:~/studenym # ./list_nexus_precache_images.sh
nexus images:
artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17

istio images:
artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
pit:~/studenym #
```



Notice that `docker-kubectl` is also listed is the `# cray-ceph-csi-rbd and cray-ceph-csi-cephfs` section, but not in the `# Istio` section even though istio requires it in pre-cache.  

```
<snip>
      cacheImages:
      # Kubernetes
      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
      # Istio
      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
      # Kyverno
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
      # OPA
      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
      # DNS
      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
      # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
      # cray-nexus
      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
<snip>
```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
