### PR TITLE
CASMTRIAGE-7616 make certmanager upgrade more robust, redo upgrade if issuers chart deploy fails

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -730,6 +730,14 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
       fi
     fi
 
+    # check if the cray-certmanager-issuers chart failed to deploy
+    # this will be entered if the certmanager upgrade failed on or before
+    # the certmanager-issuer chart install
+    if ! helm history -n cert-manager cray-certmanager-issuers > /dev/null 2>&1; then
+      printf "note: no helm install exists for cert-manager-issuers. Cert-manager upgrade is needed to install cert-manager-issuers\n"
+      ((needs_upgrade += 1))
+    fi
+
     # cert-manager will need to be upgraded if cray-drydock version is less than 2.18.4.
     # This will only be the case in some CSM 1.6 to CSM 1.6 upgrades.
     # It only needs to be checked if cert-manager is not already being upgraded.
@@ -757,12 +765,12 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
       fi
     fi
 
+    # make this name unique for CSM 1.6 in case CSM 1.5 secret still exists
+    backup_secret="cm-restore-data-16"
+
     # Only run if we need to and detected not 1.12.9 or ""
     if [ "${needs_upgrade}" -gt 0 ]; then
       cmns="cert-manager"
-
-      # make this name unique for CSM 1.6 in case CSM 1.5 secret still exists
-      backup_secret="cm-restore-data-16"
 
       # We need to backup before any helm uninstalls.
       needs_backup=0
@@ -882,9 +890,23 @@ EOF
     # The warning statement above needs to stay a warning. It does not exit 0 because Issuers should already exist.
     # 5 is an arbitrary number, expect ~21 certificates
     if [[ $(kubectl get certificates -A | wc -l) -lt 5 ]]; then
-      echo "ERROR: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates."
+      echo "WARNING: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates."
       echo "Certificates should have been restored from backup: 'kubectl get secret ${backup_secret?}'"
-      exit 1
+      if helm history -n cert-manager cray-certmanager-issuers > /dev/null 2>&1 && helm history -n cert-manager cray-certmanager > /dev/null 2>&1; then
+        echo "cray-certmanager and cray-certmanager-issuers have been installed. Attempting to restore cert-manager backup"
+        if kubectl get secret "${backup_secret?}" > /dev/null 2>&1; then
+          kubectl get secret "${backup_secret?}" -o jsonpath='{.data.data}' | base64 -d | kubectl apply -f -
+        fi
+        if [[ $(kubectl get certificates -A | wc -l) -lt 5 ]]; then
+          echo "ERROR: certificates failed to restore. 'kubectl get certificates -A' does not show certificates."
+          exit 1
+        else
+          echo "Certificates were successfully restored"
+        fi
+      else
+        echo "ERROR: cray-certmanager and/or cray-certmanager-issers charts failed to deploy"
+        exit 1
+      fi
     fi
     # delete CSM 1.5 cert-manager backup if it exists
     backup_secret_csm_15="cm-restore-data"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

If the cray-certmanger-issuers chart fails to deploy, the cert-manager upgrade step in prerequisites.sh will not reattempt to upgrade cert-manger because it doesn't test if the cray-certmanager-issuers chart is deployed.

The following changes were made to make the certmanager upgrade more robust:
- Check if the cray-certmanager-issuers chart is deployed, if not, redo the cert-manager upgrade
- Make the backup_secret variable global inside the cert-manager upgrade block. This way it can be used even if the upgrade section is skipped.
- If certificates don't exist at the end of the upgrade section and both cray-certmanager and cray-certmanager-issers have been installed, then retry to apply the certificates. 

# Testing

### Case 1: Certmanager and certmanager-issers have been upgraded but no certificates exist.

```text
note: cert-manager helm chart version 1.12.9
note: no cert-manager upgrade steps needed, cert-manager 1.5.5 is not installed
WARNING: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates.
Certificates should have been restored from backup: 'kubectl get secret cm-restore-data-16'
cray-certmanager and cray-certmanager-issuers have been installed. Attempting to restore cert-manager backup
certificate.cert-manager.io/cfs-ara-postgres-tls created
certificate.cert-manager.io/cray-console-data-postgres-tls created
certificate.cert-manager.io/cray-dhcp-kea-postgres-tls created
certificate.cert-manager.io/cray-dns-powerdns-postgres-tls created
certificate.cert-manager.io/cray-hms-rts-default-tls created
certificate.cert-manager.io/cray-oauth2-proxies-customer-access created
certificate.cert-manager.io/cray-oauth2-proxies-customer-high-speed created
certificate.cert-manager.io/cray-oauth2-proxies-customer-management created
certificate.cert-manager.io/cray-sls-postgres-tls created
certificate.cert-manager.io/cray-smd-postgres-tls created
certificate.cert-manager.io/gitea-vcs-postgres-tls created
certificate.cert-manager.io/keycloak-postgres-tls created
certificate.cert-manager.io/cray-spire-postgres-tls created
certificate.cert-manager.io/cray-spire-tokens-tls created
certificate.cert-manager.io/tapms-webhook-server-cert created
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11766"}}
to:
Resource: "cert-manager.io/v1, Resource=certificates", GroupVersionKind: "cert-manager.io/v1, Kind=Certificate"
Name: "dvs-mqtt-cert", Namespace: "istio-system"
for: "STDIN": Operation cannot be fulfilled on certificates.cert-manager.io "dvs-mqtt-cert": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11764"}}
to:
Resource: "cert-manager.io/v1, Resource=certificates", GroupVersionKind: "cert-manager.io/v1, Kind=Certificate"
Name: "ingress-gateway-cert", Namespace: "istio-system"
for: "STDIN": Operation cannot be fulfilled on certificates.cert-manager.io "ingress-gateway-cert": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11732"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "ceph-rgw"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11735"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "istio-system"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11780"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "services"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11374"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "slurm-operator"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11372"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "sma"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11577"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "spire"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Error from server (Conflict): error when applying patch:
{"metadata":{"resourceVersion":"11545"}}
to:
Resource: "cert-manager.io/v1, Resource=issuers", GroupVersionKind: "cert-manager.io/v1, Kind=Issuer"
Name: "cert-manager-issuer-common", Namespace: "tapms-operator"
for: "STDIN": Operation cannot be fulfilled on issuers.cert-manager.io "cert-manager-issuer-common": the object has been modified; please apply your changes to the latest version and try again
Certificates were successfully restored
```    

### Case 2: Error message when certificates failed to restore

```text
note: cert-manager helm chart version 1.12.9
note: no cert-manager upgrade steps needed, cert-manager 1.5.5 is not installed
WARNING: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates.
Certificates should have been restored from backup: 'kubectl get secret cm-restore-data-16'
cray-certmanager and cray-certmanager-issuers have been installed. Attempting to restore cert-manager backup
# did nothing
ERROR: certificates failed to restore. 'kubectl get certificates -A' does not show certificates.
```

### Case 3: Uninstalled cray-certmanager. 

Upgrade ran smoothly and certificates were restored.

### Case 4: Uninstalled cray-certmanager-issuers

```text
note: cert-manager helm chart version 1.12.9
note: no cert-manager upgrade steps needed, cert-manager 1.5.5 is not installed
note: no helm install exists for cert-manager-issuers. Cert-manager upgrade is needed to install cert-manager-issuers
secret/cm-restore-data-16 created
W1217 16:27:52.588163   28802 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1217 16:27:52.588183   28802 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1217 16:27:52.588165   28802 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
release "cray-certmanager" uninstalled
namespace "cert-manager" deleted
2024-12-17T16:28:00Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2024-12-17T16:28:00Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2024-12-17T16:28:00Z INF Ensuring that the loftsman namespace exists command=ship
2024-12-17T16:28:00Z INF Loftsman will use the packaged charts at /var/www/ephemeral/csm-1.6.1-alpha.5/helm as the Helm install source command=ship
2024-12-17T16:28:00Z INF Running a release for the provided manifest at /tmp/certmanager-tmp-manifest.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-drydock v2.18.4
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
```

### Case 5: Check that if certmanager or certmanager-issuers are not deployed, certificates will not be attempted to be restored

```text
WARNING: certificates were not restored after certmanager upgrade. 'kubectl get certificates -A' does not show certificates.
Certificates should have been restored from backup: 'kubectl get secret cm-restore-data-16'
ERROR: cray-certmanager and/or cray-certmanager-issers charts failed to deploy
```

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
