### PR TITLE
CASMINST-7039 cleanup old images and overlayFS on upgrade

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -81,6 +81,22 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+state_name="CLEANUP_LIVE_IMAGES"
+state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+if [[ $state_recorded == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    if [[ $ssh_keys_done == "0" ]]; then
+      ssh_keygen_keyscan "${target_ncn}"
+      ssh_keys_done=1
+    fi
+    ssh ${target_ncn} "/srv/cray/scripts/metal/cleanup-live-images.sh -y"
+  } >> ${LOG_FILE} 2>&1
+  record_state "${state_name}" ${target_ncn}
+else
+  echo "====> ${state_name} has been completed"
+fi
+
 ${basedir}/../common/ncn-rebuild-common.sh $target_ncn
 
 state_name="INSTALL_TARGET_SCRIPT"


### PR DESCRIPTION
# Description
Cleanup previous/old SquashFS images during upgrade
https://jira-pro.it.hpe.com:8443/browse/CASMINST-7039

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.