### PR TITLE
CASMINST-5657 Add common WorkflowTemplate to sync secret to Argo namespace

### DIFF
--- a/workflows/iuf/operations/nexus-setup/cleanup-nexus-admin-credential.yaml
+++ b/workflows/iuf/operations/nexus-setup/cleanup-nexus-admin-credential.yaml
@@ -1,0 +1,57 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: cleanup-nexus-admin-credential-template
+  namespace: argo
+  annotations:
+    sidecar.istio.io/inject: "false"
+spec:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+  entrypoint: cleanup-nexus-admin-credential
+  arguments:
+    parameters:
+      - name: nexus_admin_credential_secret_name
+  templates:
+    - name: cleanup-nexus-admin-credential
+      inputs:
+        parameters:
+          - name: nexus_admin_credential_secret_name
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}
+          echo "DEBUG Deleting secret $nexus_secret_name from argo workspace"
+          result=$(kubectl -n argo delete secret/$nexus_secret_name 2>&1)
+          if [ $? -ne 0 ]; then
+            result=$(echo "$result" | sed -e 's/^/DEBUG /')
+            echo "ERROR Deleting secret $nexus_secret_name failed in argo namespace"
+            echo -e "DEBUG <kubectl -n argo delete secret/$nexus_secret_name> failed with\n\n$result"
+          fi

--- a/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
@@ -60,7 +60,9 @@ spec:
           name: workflow-template-record-time-template
           template: record-time-template
     - - name: nexus-get-prerequisites
-        template: nexus-get-prerequisites-template
+        templateRef:
+          name: nexus-get-prerequisites-template
+          template: nexus-get-prerequisites
         arguments:
           parameters:
           - name: global_params
@@ -68,8 +70,10 @@ spec:
     - - name: nexus-docker-load
         template: nexus-docker-load-template
         hooks:
-          exit: 
-            template: cleanup-template
+          exit:
+            templateRef:
+              name: cleanup-nexus-admin-credential-template
+              template: cleanup-nexus-admin-credential
             arguments:
               parameters:
               - name: nexus_admin_credential_secret_name
@@ -152,103 +156,6 @@ spec:
       command: [sh, -c]
       args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 ### Templates ###
-## nexus-get-prerequisites-template ##
-  - name: nexus-get-prerequisites-template
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    inputs:
-      parameters:
-      - name: global_params
-        value: "{{workflow.parameters.global_params}}"
-    outputs:
-      parameters:
-        - name: secret_name
-          valueFrom:
-            path: /tmp/secret_name
-        - name: current_product_manifest
-          valueFrom:
-            path: /tmp/current_product_manifest
-        - name: product_directory
-          valueFrom:
-            path: /tmp/product_directory
-    retryStrategy:
-        limit: "2"
-        retryPolicy: "Always"
-        backoff:
-          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
-          factor: "2"
-          maxDuration: "1m"
-    script:
-      # TBD: This is a repeated function. Can this change to a reference?
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        function sync_item() {
-          item_name="$1"
-          source_ns="$2"
-          destination_name="$3-$RANDOM"
-          destination_ns="$4"
-          result=$(kubectl get $item_name -n $source_ns 2>&1)
-          if [ $? -eq 0 ]; then
-            echo "DEBUG Syncing $item_name from $source_ns to $destination_ns as $destination_name"
-            kubectl get $item_name -n $source_ns -o json | \
-              jq 'del(.metadata.namespace)' | \
-              jq 'del(.metadata.creationTimestamp)' | \
-              jq 'del(.metadata.resourceVersion)' | \
-              jq 'del(.metadata.selfLink)' | \
-              jq 'del(.metadata.uid)' | \
-              jq 'del(.metadata.ownerReferences)' | \
-              jq 'del(.metadata.name)' | \
-              jq '.metadata |= . + {"name":"'$destination_name'"}' | \
-              kubectl apply -n $destination_ns -f -
-              rc=$?
-              if [ $rc -ne 0 ]; then
-                echo "ERROR Failed to create secret $destination_name in $destination_ns namespace from $item_name in $source_ns namespace"
-              fi
-              return $rc
-          else
-            echo "ERROR $item_name not found in $source_ns namespace"
-            result=$(echo "$result" | sed -e 's/^/DEBUG /')
-            echo -e "DEBUG <kubectl get $item_name -n $source_ns> failed with\n\n$result"
-            return 1
-          fi
-        }
-        err=0
-        sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
-        if [ $? -ne 0 ]; then
-          err=1
-        fi
-        echo $destination_name > /tmp/secret_name
-
-        # Retrieve the content of the current product manifest as json.
-        product_name={{inputs.parameters.global_params}} | jq -r '.product_manifest.current_product.name'
-        echo "DEBUG Fetching the product manifest for $product_name"
-        cat <<EOF | jq '.product_manifest.current_product.manifest.content' > /tmp/current_product_manifest
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          err=1
-          echo "ERROR Failed to fetch product manifest for $product_name. Rerun with valid product tarball from 'process-media' stage"
-        fi
-
-        # Retrieve the product directory.
-        echo "DEBUG Retrieving the product directory for $product_name"
-        cat <<EOF | jq -r '.product_manifest.current_product.original_location' > /tmp/product_directory
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          echo "ERROR Failed to fetch product directory for $product_name. Rerun with valid product tarball from 'process-media' stage"
-          err=1
-        fi
-
-        # Exit with an error if we had any.
-        exit $err
 ## nexus-docker-load-template ##
   - name: nexus-docker-load-template
     inputs:
@@ -294,31 +201,3 @@ spec:
     - name: image
       hostPath:
         path: "{{inputs.parameters.product_directory}}"
-## cleanup-template ##
-## Remove the secret created earlier.
-# TBD: This is a repeated function. Can this change to a reference?
-  - name: cleanup-template
-    inputs:
-      parameters:
-      - name: nexus_admin_credential_secret_name
-        value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}
-        echo "DEBUG Deleting secret $nexus_secret_name from argo workspace"
-        result=$(kubectl -n argo delete secret/$nexus_secret_name 2>&1)
-        if [ $? -ne 0 ]; then
-          result=$(echo "$result" | sed -e 's/^/DEBUG /')
-          echo "ERROR Deleting secret $nexus_secret_name failed in argo namespace"
-          echo -e "DEBUG <kubectl -n argo delete secret/$nexus_secret_name> failed with\n\n$result"
-        fi

--- a/workflows/iuf/operations/nexus-setup/nexus-get-prerequisites-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-get-prerequisites-template.yaml
@@ -1,0 +1,124 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: nexus-get-prerequisites-template
+  namespace: argo
+  annotations:
+    sidecar.istio.io/inject: "false"
+spec:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+  entrypoint: nexus-get-prerequisites
+  templates:
+    - name: nexus-get-prerequisites
+      inputs:
+        parameters:
+          - name: global_params
+      outputs:
+        parameters:
+          - name: secret_name
+            valueFrom:
+              path: /tmp/secret_name
+          - name: current_product_manifest
+            valueFrom:
+              path: /tmp/current_product_manifest
+          - name: product_directory
+            valueFrom:
+              path: /tmp/product_directory
+      retryStrategy:
+        limit: "2"
+        retryPolicy: "Always"
+        backoff:
+          duration: "10s"
+          factor: "2"
+          maxDuration: "1m"
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          function sync_item() {
+            item_name="$1"
+            source_ns="$2"
+            destination_name="$3-$RANDOM"
+            destination_ns="$4"
+            result=$(kubectl get $item_name -n $source_ns 2>&1)
+            if [ $? -eq 0 ]; then
+              echo "DEBUG Syncing $item_name from $source_ns to $destination_ns as $destination_name"
+              kubectl get $item_name -n $source_ns -o json | \
+                jq 'del(.metadata.namespace)' | \
+                jq 'del(.metadata.creationTimestamp)' | \
+                jq 'del(.metadata.resourceVersion)' | \
+                jq 'del(.metadata.selfLink)' | \
+                jq 'del(.metadata.uid)' | \
+                jq 'del(.metadata.ownerReferences)' | \
+                jq 'del(.metadata.name)' | \
+                jq '.metadata |= . + {"name":"'$destination_name'"}' | \
+                kubectl apply -n $destination_ns -f -
+                rc=$?
+                if [ $rc -ne 0 ]; then
+                  echo "ERROR Failed to create secret $destination_name in $destination_ns namespace from $item_name in $source_ns namespace"
+                fi
+                return $rc
+            else
+              echo "ERROR $item_name not found in $source_ns namespace"
+              result=$(echo "$result" | sed -e 's/^/DEBUG /')
+              echo -e "DEBUG <kubectl get $item_name -n $source_ns> failed with\n\n$result"
+              return 1
+            fi
+          }
+          err=0
+          sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
+          if [ $? -ne 0 ]; then
+            err=1
+          fi
+          echo $destination_name > /tmp/secret_name
+
+          # Retrieve the content of the current product manifest as json.
+          product_name={{inputs.parameters.global_params}} | jq -r '.product_manifest.current_product.name'
+          echo "DEBUG Fetching the product manifest for $product_name"
+          cat <<EOF | jq '.product_manifest.current_product.manifest.content' > /tmp/current_product_manifest
+            {{inputs.parameters.global_params}}
+          EOF
+          if [ $? -ne 0 ]; then
+            err=1
+            echo "ERROR Failed to fetch product manifest for $product_name. Rerun with valid product tarball from 'process-media' stage"
+          fi
+
+          # Retrieve the product directory.
+          echo "DEBUG Retrieving the product directory for $product_name"
+          cat <<EOF | jq -r '.product_manifest.current_product.original_location' > /tmp/product_directory
+            {{inputs.parameters.global_params}}
+          EOF
+          if [ $? -ne 0 ]; then
+            echo "ERROR Failed to fetch product directory for $product_name. Rerun with valid product tarball from 'process-media' stage"
+            err=1
+          fi
+
+          # Exit with an error if we had any.
+          exit $err

--- a/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
@@ -60,7 +60,9 @@ spec:
           name: workflow-template-record-time-template
           template: record-time-template
     - - name: nexus-get-prerequisites
-        template: nexus-get-prerequisites-template
+        templateRef:
+          name: nexus-get-prerequisites-template
+          template: nexus-get-prerequisites
         arguments:
           parameters:
           - name: global_params
@@ -68,8 +70,10 @@ spec:
     - - name: nexus-helm-load
         template: nexus-helm-load-template
         hooks:
-          exit: 
-            template: cleanup-template
+          exit:
+            templateRef:
+              name: cleanup-nexus-admin-credential-template
+              template: cleanup-nexus-admin-credential
             arguments:
               parameters:
               - name: nexus_admin_credential_secret_name
@@ -151,103 +155,6 @@ spec:
       command: [sh, -c]
       args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 ### Templates ###
-## nexus-get-prerequisites-template ##
-  - name: nexus-get-prerequisites-template
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    inputs:
-      parameters:
-      - name: global_params
-        value: "{{workflow.parameters.global_params}}"
-    outputs:
-      parameters:
-        - name: secret_name
-          valueFrom:
-            path: /tmp/secret_name
-        - name: current_product_manifest
-          valueFrom:
-            path: /tmp/current_product_manifest
-        - name: product_directory
-          valueFrom:
-            path: /tmp/product_directory
-    retryStrategy:
-        limit: "2"
-        retryPolicy: "Always"
-        backoff:
-          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
-          factor: "2"
-          maxDuration: "1m"
-    script:
-      # TBD: This is a repeated function. Can this change to a reference?
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        function sync_item() {
-          item_name="$1"
-          source_ns="$2"
-          destination_name="$3-$RANDOM"
-          destination_ns="$4"
-          result=$(kubectl get $item_name -n $source_ns 2>&1)
-          if [ $? -eq 0 ]; then
-            echo "DEBUG Syncing $item_name from $source_ns to $destination_ns as $destination_name"
-            kubectl get $item_name -n $source_ns -o json | \
-              jq 'del(.metadata.namespace)' | \
-              jq 'del(.metadata.creationTimestamp)' | \
-              jq 'del(.metadata.resourceVersion)' | \
-              jq 'del(.metadata.selfLink)' | \
-              jq 'del(.metadata.uid)' | \
-              jq 'del(.metadata.ownerReferences)' | \
-              jq 'del(.metadata.name)' | \
-              jq '.metadata |= . + {"name":"'$destination_name'"}' | \
-              kubectl apply -n $destination_ns -f -
-              rc=$?
-              if [ $rc -ne 0 ]; then
-                echo "ERROR Failed to create secret $destination_name in $destination_ns namespace from $item_name in $source_ns namespace"
-              fi
-              return $rc
-          else
-            echo "ERROR $item_name not found in $source_ns namespace"
-            result=$(echo "$result" | sed -e 's/^/DEBUG /')
-            echo -e "DEBUG <kubectl get $item_name -n $source_ns> failed with\n\n$result"
-            return 1
-          fi
-        }
-        err=0
-        sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
-        if [ $? -ne 0 ]; then
-          err=1
-        fi
-        echo $destination_name > /tmp/secret_name
-
-        # Retrieve the content of the current product manifest as json.
-        product_name={{inputs.parameters.global_params}} | jq -r '.product_manifest.current_product.name'
-        echo "DEBUG Fetching the product manifest for $product_name"
-        cat <<EOF | jq '.product_manifest.current_product.manifest.content' > /tmp/current_product_manifest
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          err=1
-          echo "ERROR Failed to fetch product manifest for $product_name. Rerun with valid product tarball from 'process-media' stage"
-        fi
-
-        # Retrieve the product directory.
-        echo "DEBUG Retrieving the product directory for $product_name"
-        cat <<EOF | jq -r '.product_manifest.current_product.original_location' > /tmp/product_directory
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          echo "ERROR Failed to fetch product directory for $product_name. Rerun with valid product tarball from 'process-media' stage"
-          err=1
-        fi
-
-        # Exit with an error if we had any.
-        exit $err
 ## nexus-helm-load-template ##
   - name: nexus-helm-load-template
     inputs:
@@ -295,31 +202,3 @@ spec:
     - name: product
       hostPath:
         path: "{{inputs.parameters.product_directory}}"
-## cleanup-template ##
-## Remove the secret created earlier.
-# TBD: This is a repeated function. Can this change to a reference?
-  - name: cleanup-template
-    inputs:
-      parameters:
-      - name: nexus_admin_credential_secret_name
-        value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}
-        echo "DEBUG Deleting secret $nexus_secret_name from argo workspace"
-        result=$(kubectl -n argo delete secret/$nexus_secret_name 2>&1)
-        if [ $? -ne 0 ]; then
-          result=$(echo "$result" | sed -e 's/^/DEBUG /')
-          echo "ERROR Deleting secret $nexus_secret_name failed in argo namespace"
-          echo -e "DEBUG <kubectl -n argo delete secret/$nexus_secret_name> failed with\n\n$result"
-        fi

--- a/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
@@ -60,7 +60,9 @@ spec:
           name: workflow-template-record-time-template
           template: record-time-template
     - - name: nexus-get-prerequisites
-        template: nexus-get-prerequisites-template
+        templateRef:
+          name: nexus-get-prerequisites-template
+          template: nexus-get-prerequisites
         arguments:
           parameters:
           - name: global_params
@@ -68,8 +70,10 @@ spec:
     - - name: nexus-rpm-load
         template: nexus-rpm-load-template
         hooks:
-          exit: 
-            template: cleanup-template
+          exit:
+            templateRef:
+              name: cleanup-nexus-admin-credential-template
+              template: cleanup-nexus-admin-credential
             arguments:
               parameters:
               - name: nexus_admin_credential_secret_name
@@ -140,102 +144,6 @@ spec:
       args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 
 ### Templates ###
-## nexus-get-prerequisites-template ##
-  - name: nexus-get-prerequisites-template
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    inputs:
-      parameters:
-      - name: global_params
-    outputs:
-      parameters:
-        - name: secret_name
-          valueFrom:
-            path: /tmp/secret_name
-        - name: current_product_manifest
-          valueFrom:
-            path: /tmp/current_product_manifest
-        - name: product_directory
-          valueFrom:
-            path: /tmp/product_directory
-    retryStrategy:
-        limit: "2"
-        retryPolicy: "Always"
-        backoff:
-          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
-          factor: "2"
-          maxDuration: "1m"
-    script:
-      # TBD: This is a repeated function. Can this change to a reference?
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        function sync_item() {
-          item_name="$1"
-          source_ns="$2"
-          destination_name="$3-$RANDOM"
-          destination_ns="$4"
-          result=$(kubectl get $item_name -n $source_ns 2>&1)
-          if [ $? -eq 0 ]; then
-            echo "DEBUG Syncing $item_name from $source_ns to $destination_ns as $destination_name"
-            kubectl get $item_name -n $source_ns -o json | \
-              jq 'del(.metadata.namespace)' | \
-              jq 'del(.metadata.creationTimestamp)' | \
-              jq 'del(.metadata.resourceVersion)' | \
-              jq 'del(.metadata.selfLink)' | \
-              jq 'del(.metadata.uid)' | \
-              jq 'del(.metadata.ownerReferences)' | \
-              jq 'del(.metadata.name)' | \
-              jq '.metadata |= . + {"name":"'$destination_name'"}' | \
-              kubectl apply -n $destination_ns -f -
-              rc=$?
-              if [ $rc -ne 0 ]; then
-                echo "ERROR Failed to create secret $destination_name in $destination_ns namespace from $item_name in $source_ns namespace"
-              fi
-              return $rc
-          else
-            echo "ERROR $item_name not found in $source_ns namespace"
-            result=$(echo "$result" | sed -e 's/^/DEBUG /')
-            echo -e "DEBUG <kubectl get $item_name -n $source_ns> failed with\n\n$result"
-            return 1
-          fi
-        }
-        err=0
-        sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
-        if [ $? -ne 0 ]; then
-          err=1
-        fi
-        echo $destination_name > /tmp/secret_name
-
-        # Retrieve the content of the current product manifest as json.
-        product_name={{inputs.parameters.global_params}} | jq -r '.product_manifest.current_product.name'
-        echo "DEBUG Fetching the product manifest for $product_name"
-        cat <<EOF | jq '.product_manifest.current_product.manifest.content' > /tmp/current_product_manifest
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          err=1
-          echo "ERROR Failed to fetch product manifest for $product_name. Rerun with valid product tarball from 'process-media' stage"
-        fi
-
-        # Retrieve the product directory.
-        echo "DEBUG Retrieving the product directory for $product_name"
-        cat <<EOF | jq -r '.product_manifest.current_product.original_location' > /tmp/product_directory
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          echo "ERROR Failed to fetch product directory for $product_name. Rerun with valid product tarball from 'process-media' stage"
-          err=1
-        fi
-
-        # Exit with an error if we had any.
-        exit $err
 ## nexus-rpm-load-template ##
   - name: nexus-rpm-load-template
     inputs:
@@ -277,30 +185,3 @@ spec:
     - name: product
       hostPath:
         path: "{{inputs.parameters.product_directory}}"
-## cleanup-template ##
-## Remove the secret created earlier.
-# TBD: This is a repeated function. Can this change to a reference?
-  - name: cleanup-template
-    inputs:
-      parameters:
-      - name: nexus_admin_credential_secret_name
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}
-        echo "DEBUG Deleting secret $nexus_secret_name from argo workspace"
-        result=$(kubectl -n argo delete secret/$nexus_secret_name 2>&1)
-        if [ $? -ne 0 ]; then
-          result=$(echo "$result" | sed -e 's/^/DEBUG /')
-          echo "ERROR Deleting secret $nexus_secret_name failed in argo namespace"
-          echo -e "DEBUG <kubectl -n argo delete secret/$nexus_secret_name> failed with\n\n$result"
-        fi

--- a/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
@@ -60,7 +60,9 @@ spec:
           name: workflow-template-record-time-template
           template: record-time-template
     - - name: nexus-get-prerequisites
-        template: nexus-get-prerequisites-template
+        templateRef:
+          name: nexus-get-prerequisites-template
+          template: nexus-get-prerequisites
         arguments:
           parameters:
           - name: global_params
@@ -69,7 +71,9 @@ spec:
         template: nexus-setup-template
         hooks:
           exit:
-            template: cleanup-template
+            templateRef:
+              name: cleanup-nexus-admin-credential-template
+              template: cleanup-nexus-admin-credential
             arguments:
               parameters:
               - name: nexus_admin_credential_secret_name
@@ -153,102 +157,6 @@ spec:
       args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 
 ### Templates ###
-## nexus-get-prerequisites-template ##
-  - name: nexus-get-prerequisites-template
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    inputs:
-      parameters:
-      - name: global_params
-    outputs:
-      parameters:
-        - name: secret_name
-          valueFrom:
-            path: /tmp/secret_name
-        - name: current_product_manifest
-          valueFrom:
-            path: /tmp/current_product_manifest
-        - name: product_directory
-          valueFrom:
-            path: /tmp/product_directory
-    retryStrategy:
-        limit: "2"
-        retryPolicy: "Always"
-        backoff:
-          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
-          factor: "2"
-          maxDuration: "1m"
-    script:
-      # TBD: This is a repeated function. Can this change to a reference?
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        function sync_item() {
-          item_name="$1"
-          source_ns="$2"
-          destination_name="$3-$RANDOM"
-          destination_ns="$4"
-          result=$(kubectl get $item_name -n $source_ns 2>&1)
-          if [ $? -eq 0 ]; then
-            echo "DEBUG Syncing $item_name from $source_ns to $destination_ns as $destination_name"
-            kubectl get $item_name -n $source_ns -o json | \
-              jq 'del(.metadata.namespace)' | \
-              jq 'del(.metadata.creationTimestamp)' | \
-              jq 'del(.metadata.resourceVersion)' | \
-              jq 'del(.metadata.selfLink)' | \
-              jq 'del(.metadata.uid)' | \
-              jq 'del(.metadata.ownerReferences)' | \
-              jq 'del(.metadata.name)' | \
-              jq '.metadata |= . + {"name":"'$destination_name'"}' | \
-              kubectl apply -n $destination_ns -f -
-              rc=$?
-              if [ $rc -ne 0 ]; then
-                echo "ERROR Failed to create secret $destination_name in $destination_ns namespace from $item_name in $source_ns namespace"
-              fi
-              return $rc
-          else
-            echo "ERROR $item_name not found in $source_ns namespace"
-            result=$(echo "$result" | sed -e 's/^/DEBUG /')
-            echo -e "DEBUG <kubectl get $item_name -n $source_ns> failed with\n\n$result"
-            return 1
-          fi
-        }
-        err=0
-        sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
-        if [ $? -ne 0 ]; then
-          err=1
-        fi
-        echo $destination_name > /tmp/secret_name
-
-        # Retrieve the content of the current product manifest as json.
-        product_name={{inputs.parameters.global_params}} | jq -r '.product_manifest.current_product.name'
-        echo "DEBUG Fetching the product manifest for $product_name"
-        cat <<EOF | jq '.product_manifest.current_product.manifest.content' > /tmp/current_product_manifest
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          err=1
-          echo "ERROR Failed to fetch product manifest for $product_name. Rerun with valid product tarball from 'process-media' stage"
-        fi
-
-        # Retrieve the product directory.
-        echo "DEBUG Retrieving the product directory for $product_name"
-        cat <<EOF | jq -r '.product_manifest.current_product.original_location' > /tmp/product_directory
-          {{inputs.parameters.global_params}}
-        EOF
-        if [ $? -ne 0 ]; then
-          echo "ERROR Failed to fetch product directory for $product_name. Rerun with valid product tarball from 'process-media' stage"
-          err=1
-        fi
-
-        # Exit with an error if we had any.
-        exit $err
 ## nexus-setup-template ##
   - name: nexus-setup-template
     inputs:
@@ -296,29 +204,3 @@ spec:
     - name: products
       hostPath:
         path: "{{inputs.parameters.product_directory}}"
-## cleanup-template ##
-## Remove the secret created earlier.
-  - name: cleanup-template
-    inputs:
-      parameters:
-      - name: nexus_admin_credential_secret_name
-    tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
-      command: [bash]
-      source: |
-        nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}
-        echo "DEBUG Deleting secret $nexus_secret_name from argo workspace"
-        result=$(kubectl -n argo delete secret/$nexus_secret_name 2>&1)
-        if [ $? -ne 0 ]; then
-          result=$(echo "$result" | sed -e 's/^/DEBUG /')
-          echo "ERROR Deleting secret $nexus_secret_name failed in argo namespace"
-          echo -e "DEBUG <kubectl -n argo delete secret/$nexus_secret_name> failed with\n\n$result"
-        fi


### PR DESCRIPTION
## Summary and Scope

Create common WorkflowTemplate to sync secret to Argo namespace by refactorin nexus prerequisites step out into its own workflow template and parameterize it properly 

CASMINST-5657

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams