### PR TITLE
CASMCMS-9234: Add code to correct BOS migration bug during upgrades

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -206,6 +206,10 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
       --insecure-skip-tls-verify-backend --tail=-1 \
       -l 'app.kubernetes.io/instance in (cray-bos, cray-bos-db)' > "${K8S_POD_LOGS}"
 
+    # Apply fix for CASMCMS-9234
+    echo "Applying fix for CASMCMS-9234, if needed"
+    "${basedir}/workarounds/CASMCMS-9234/fix.sh" "${SNAPSHOT_DIR}"
+
     SNAPSHOT_DIR_BASENAME=$(basename "${SNAPSHOT_DIR}")
     TARFILE_BASENAME="${SNAPSHOT_DIR_BASENAME}.tgz"
     TARFILE_FULLPATH="/tmp/${TARFILE_BASENAME}"

--- a/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix.sh
+++ b/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# In CSM 1.6.0, there is a bug in the BOS migration code which runs automatically after the
+# service is upgraded. The result is that some session templates may be rendered unusable.
+# Running this tool after the service upgrade corrects the problem. It does not hurt to
+# run it unnecessarily (it will do nothing if the problem is not detected).
+
+# Usage: fix.sh <target directory for BOS data export, if any templates are renamed>
+
+set -euo pipefail
+
+locOfScript=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+pyScriptBase=fix_template_db_keys.py
+pyScriptPath="${locOfScript}/${pyScriptBase}"
+pyScriptPodPath="/tmp/${pyScriptBase}"
+bosExportScriptPath="/usr/share/doc/csm/scripts/operations/configuration/export_bos_data.sh"
+
+function err_exit {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+function run_cmd {
+  "$@" || err_exit "Command failed with rc $?: $*"
+}
+
+[[ $# -eq 1 ]] || err_exit "$0: Script requires exactly 1 argument but received $#: $*"
+[[ -n $1 ]] || err_exit "$0: Argument to script may not be blank"
+[[ -e $1 ]] || err_exit "$0: Directory does not exist: '$1'"
+[[ -d $1 ]] || err_exit "$0: Exists but is not a directory: '$1'"
+OUTDIR="$1"
+
+pod=$(run_cmd kubectl get pods -n services -l 'app.kubernetes.io/name=cray-bos' --no-headers | grep Running | head -1 | awk '{ print $1 }') \
+  || err_exit "Unable to find Running BOS server pod"
+
+echo "Copying repair script to BOS server pod ${pod}"
+run_cmd kubectl -n services cp "${pyScriptPath}" "${pod}:${pyScriptPodPath}"
+kubectl -n services exec "${pod}" -- python3 "${pyScriptPodPath}" && exit 0 || rc=$?
+[[ $rc -eq 57 ]] || err_exit "Unexpected failure trying to apply BOS session template fix for CASMCMS-9234"
+echo "Exit code 57 means that at least one template needed its database key fixed. Taking a fresh export of BOS data to ${OUTDIR}"
+run_cmd "${bosExportScriptPath}" "${OUTDIR}"
+echo "SUCCESS"

--- a/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix_template_db_keys.py
+++ b/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix_template_db_keys.py
@@ -1,0 +1,47 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from bos.common.tenant_utils import get_tenant_aware_key
+from bos.server.redis_db_utils import get_wrapper
+import sys
+
+temp_db = get_wrapper(db='session_templates')
+renamed = 0
+for db_key, data in temp_db.get_all_as_dict().items():
+    if not data:
+        continue
+    st_name = data.get('name', None)
+    if not st_name:
+        continue
+    st_tenant = data.get('tenant', "")
+    expected_db_key = get_tenant_aware_key(st_name, st_tenant)
+    if expected_db_key == db_key:
+        continue
+    print(f"Fixing: Template '{st_name}' (tenant: '{st_tenant}') db_key = '{db_key}' does not match expected db_key = '{expected_db_key}'")
+    temp_db.rename(db_key, expected_db_key)
+    renamed+=1
+print(f"{renamed} templates renamed")
+if renamed:
+    # Exit 57 to communicate that templates were renamed, so a fresh export of BOS data should be performed
+    sys.exit(57)


### PR DESCRIPTION
In CSM 1.6.0, there is a bug in the BOS migration code that automatically runs when the service is upgraded. The result is that some session templates may end up being stored under incorrect keys in the database, rendering them unusable. The bug in the migration code is being fixed in CSM 1.6.1. For CSM 1.6.0, this PR adds a script which runs after the BOS upgrade is performed. This script corrects these errors in the BOS database, if they are found. It will not hurt to run in cases where the problem does not exist -- in that case, it will do nothing. Because of this, there is no harm in leaving this code in place for CSM 1.6.1+.

For CSM 1.7, it can safely be removed, since no upgrades to CSM 1.7 should be to a version of BOS that has this bug (although it won't hurt anything for this to run during CSM 1.7 upgrades -- it just isn't needed). I've opened [CASMCMS-9235](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9235) to remove it in CSM 1.7.

I tested this on rocket (where the problem was discovered) and verified that it fixes the problem and works as expected.