### PR TITLE
CASMPET-7618 specify in the IUF upgrade to install the target version of docs-csm

### DIFF
--- a/operations/iuf/workflows/preparation.md
+++ b/operations/iuf/workflows/preparation.md
@@ -3,9 +3,10 @@
 This section defines environment variables and directory content that is used throughout the workflow.
 
 - [1. Prepare for the install or upgrade](#1-prepare-for-the-install-or-upgrade)
-- [2. Use of `iuf activity`](#2-use-of-iuf-activity)
-- [3. Save system state before upgrade](#3-save-system-state-before-upgrade)
-- [4. Next steps](#4-next-steps)
+- [2. Install the latest documentation](#2-install-the-latest-documentation)
+- [3. Use of `iuf activity`](#3-use-of-iuf-activity)
+- [4. Save system state before upgrade](#4-save-system-state-before-upgrade)
+- [5. Next steps](#5-next-steps)
 
 ## 1. Prepare for the install or upgrade
 
@@ -35,15 +36,14 @@ This section defines environment variables and directory content that is used th
 
     - Environment variables have been set and required IUF directories have been created
 
-1. Ensure that the
-   [latest version of `docs-csm`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
-    is installed for the target CSM version being installed or upgraded.
+## 2. Install the latest documentation
 
-    **`NOTE`** When using IUF to upgrade CSM, please skip this subsection.
+Ensure that the [latest version of `docs-csm`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/update_product_stream/README.md#check-for-latest-documentation)
+is installed. If CSM is being upgraded, install the **target** version of the CSM documentation.
 
-    For example: when upgrading from CSM version 1.5.0 to version 1.5.1, install `docs-csm-1.5.1.noarch`
+For example, when upgrading from CSM version 1.5.0 to version 1.6.0, install `docs-csm-1.6.0.noarch`.
 
-## 2. Use of `iuf activity`
+## 3. Use of `iuf activity`
 
 **`NOTE`** This section is informational only. There are no operations to perform.
 
@@ -60,7 +60,7 @@ iuf -a "${ACTIVITY_NAME}" activity --create --comment "download complete" waitin
 
 The install and upgrade workflow instructions will not use `iuf activity` in this manner, deferring to the administrator to use it as desired.
 
-## 3. Save system state before upgrade
+## 4. Save system state before upgrade
 
 (`ncn-m001#`) Before performing the install/upgrade, it is important to save specific system state information so that it can be referenced later if needed.
 Run the script below to save the state information. The information gathered by this script is SAT status, SAT site information,
@@ -70,7 +70,7 @@ HSN status, Ceph status, and SDU and RDA configurations. This information will b
 /usr/share/doc/csm/upgrade/scripts/upgrade/util/pre-upgrade-status.sh
 ```
 
-## 4. Next steps
+## 5. Next steps
 
 - If performing an initial install or an upgrade of non-CSM products only, return to the
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -72,16 +72,19 @@ if [[ -z ${CSM_RELEASE} ]]; then
 fi
 
 # Make sure this prerequisites.sh version matches the CSM_RELEASE version
-# This prerequisites script should only be run if upgrading to CSM 1.6
-prereq_vers_major=1
-prereq_vers_minor=6
+# This prerequisites script should only be if docs-csm and CSM_RELEASE vesion match
+docs_rpm_vers=$(rpm -qa docs-csm)
+docs_trimmed_vers=${docs_rpm_vers#"docs-csm-"}
+docs_spaced_vers=$(echo "$docs_trimmed_vers" | tr "." " ")
+docs_major=$(echo "$docs_spaced_vers" | awk '{ print $1 }')
+docs_minor=$(echo "$docs_spaced_vers" | awk '{ print $2 }')
 csm_release_spaced=$(echo "$CSM_RELEASE" | tr "." " ")
 csm_release_major=$(echo "$csm_release_spaced" | awk '{ print $1 }')
 csm_release_minor=$(echo "$csm_release_spaced" | awk '{ print $2 }')
 
-if [[ $prereq_vers_major -ne $csm_release_major ]] || [[ $prereq_vers_minor -ne $csm_release_minor ]]; then
-  echo "ERROR This version of the 'prerequisistes.sh' script should be run on CSM ${prereq_vers_major}.${prereq_vers_minor}."
-  echo "ERROR Make sure docs-csm for $CSM_RELEASE is installed so that the correct prerequisites.sh script is used."
+if [[ $docs_major -ne $csm_release_major ]] || [[ $docs_minor -ne $csm_release_minor ]]; then
+  echo "ERROR This version of the 'prerequisites.sh' script should be run when upgrading to CSM ${docs_major}.${docs_minor}."
+  echo "ERROR Make sure docs-csm for CSM $CSM_RELEASE is installed so that the correct prerequisites.sh script is used."
   exit 1
 fi
 

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -71,6 +71,20 @@ if [[ -z ${CSM_RELEASE} ]]; then
   exit 1
 fi
 
+# Make sure this prerequisites.sh version matches the CSM_RELEASE version
+# This prerequisites script should only be run if upgrading to CSM 1.6
+prereq_vers_major=1
+prereq_vers_minor=6
+csm_release_spaced=$(echo "$CSM_RELEASE" | tr "." " ")
+csm_release_major=$(echo "$csm_release_spaced" | awk '{ print $1 }')
+csm_release_minor=$(echo "$csm_release_spaced" | awk '{ print $2 }')
+
+if [[ $prereq_vers_major -ne $csm_release_major ]] || [[ $prereq_vers_minor -ne $csm_release_minor ]]; then
+  echo "ERROR This version of the 'prerequisistes.sh' script should be run on CSM ${prereq_vers_major}.${prereq_vers_minor}."
+  echo "ERROR Make sure docs-csm for $CSM_RELEASE is installed so that the correct prerequisites.sh script is used."
+  exit 1
+fi
+
 if [[ -z ${CSM_ARTI_DIR} ]]; then
   echo "CSM_ARTI_DIR environment variable has not been set"
   echo "make sure you have run: prepare-assets.sh"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The IUF documentation needs to be improved so that the correct version of docs-csm is installed and the correct version of prerequisites.sh is run. The upgrade fails if the docs-csm rpm version installed and the CSM_RELEASE version are different.

This PR corrects the documentation and tells the user to install the target version of docs-csm. It also adds a check to the prerequisites.sh script and makes sure that that version is running on csm 1.6 only.

## Test

### Test 1 - Successful run

```text
ncn-m001:~/leliasen # iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -r pre-install-check
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/prereqtest/log/20241219173903
INFO [ACTIVITY: prereqtest                                     ] BEG Install started at 2024-12-19 17:39:04.003495
INFO Neither --recipe-vars nor --bootprep-config-dir were specified, so
product_vars.yaml will be pulled from the branch
cray/hpc-csm-software-recipe/25.1.0-alpha2 of the hpc-csm-software-recipe git
repo.
INFO [IUF SESSION: prereqtest-vwbka                            ] BEG Started at 2024-12-19 17:39:08.906031
INFO [STAGE: pre-install-check                                 ] BEG Argo workflow: prereqtest-vwbka-pre-install-check-864bc
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check-wdx         ] BEG csm-1-6-1-alpha-4-pre-hook-pre-install-check-wdx49
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] BEG call-hook-script
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] BEG call-hook-script(0)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Running Prehook for pre-install-check
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Upgrading CSM to 1.6.1-alpha.4
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up myenv file
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade cray-site-init (CSI)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CSI upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade CSM Automatic Network Utility (CANU)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CANU upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up the prerequisites for CSM upgrade
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Prerequisites setup for CSM upgrade successfully completed
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Prehook for pre-install-check completed
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check-wdx         ] END csm-1-6-1-alpha-4-pre-hook-pre-install-check-wdx49 [Succeeded]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script [Succeeded]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script(0) [Succeeded]
INFO [preflight-checks-for-services                            ] BEG preflight-checks-for-services
INFO [preflight-checks-for-services                            ] BEG start-operation
INFO [preflight-checks-for-services                            ] END start-operation [Succeeded]
INFO [preflight-checks-for-services                            ] BEG preflight-checks
INFO [preflight-checks-for-services                            ] BEG preflight-checks(0)
fi
INFO [preflight-checks-for-services                            ]       S3 passes basic functionality test
INFO [preflight-checks-for-services                            ]       CFS passes basic functionality test
INFO [preflight-checks-for-services                            ]       VCS passes basic functionality test
INFO [preflight-checks-for-services                            ]       IMS passes basic functionality test
INFO [preflight-checks-for-services                            ]       NEXUS passes basic functionality test
INFO [preflight-checks-for-services                            ]       Cray Product Catalog configmap exists
INFO [preflight-checks-for-services                            ] END preflight-checks [Succeeded]
INFO [preflight-checks-for-services                            ] END preflight-checks(0) [Succeeded]
INFO [preflight-checks-for-services                            ] BEG end-operation
INFO [preflight-checks-for-services                            ] END end-operation [Succeeded]
INFO [preflight-checks-for-services                            ] BEG prom-metrics
INFO [preflight-checks-for-services                            ] END preflight-checks-for-services [Succeeded]
INFO [preflight-checks-for-services                            ] END prom-metrics [Succeeded]
INFO [STAGE: pre-install-check                                 ] END Succeeded in 0:01:14
INFO [IUF SESSION: prereqtest-vwbka                            ] END Completed at 2024-12-19 17:40:29.744734
INFO [ACTIVITY: prereqtest                                     ] END Completed in 0:01:25
----------------
Install Summary
command line: iuf -a prereqtest -m /etc/cray/upgrade/csm/media/csm-prereq-test run -r pre-install-check
activity: prereqtest
media dir: /etc/cray/upgrade/csm/media/csm-prereq-test
state dir: /etc/cray/upgrade/csm/iuf/prereqtest/state
log dir: /etc/cray/upgrade/csm/iuf/prereqtest/log/20241219173903
site vars: /etc/cray/upgrade/csm/iuf/prereqtest/state/session_vars.yaml
----------------
```

### Test 2 - Forced Failed run

I changed prerequisites.sh so that the docs-csm minor version is 5 so it automatically fails.

```text
ncn-m001:~/leliasen # iuf -a ${ACTIVITY_NAME} -m "${MEDIA_DIR}" run -r pre-install-check
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/prereqtest/log/20241219174154
INFO [ACTIVITY: prereqtest                                     ] BEG Install started at 2024-12-19 17:41:54.936662
INFO Neither --recipe-vars nor --bootprep-config-dir were specified, so
product_vars.yaml will be pulled from the branch
cray/hpc-csm-software-recipe/25.1.0-alpha2 of the hpc-csm-software-recipe git
repo.
INFO [IUF SESSION: prereqtest-pa5k8                            ] BEG Started at 2024-12-19 17:42:00.485606
INFO [STAGE: pre-install-check                                 ] BEG Argo workflow: prereqtest-pa5k8-pre-install-check-kkshr
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l       ] BEG csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] BEG call-hook-script
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] BEG call-hook-script(0)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Running Prehook for pre-install-check
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Upgrading CSM to 1.6.1-alpha.4
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up myenv file
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade cray-site-init (CSI)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CSI upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade CSM Automatic Network Utility (CANU)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CANU upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up the prerequisites for CSM upgrade
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       This version of the '\''prerequisistes.sh'\'' script should be run when upgrading to CSM 1.6.
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Make sure docs-csm for CSM 1.6.1-alpha.4 is installed so that the correct prerequisites.sh script is used.
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script(0) [Failed]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script(0) [Failed]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] BEG call-hook-script(1)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Running Prehook for pre-install-check
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Upgrading CSM to 1.6.1-alpha.4
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up myenv file
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade cray-site-init (CSI)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CSI upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Trying to upgrade CSM Automatic Network Utility (CANU)
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       CANU upgraded successfully
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Setting up the prerequisites for CSM upgrade
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       This version of the '\''prerequisistes.sh'\'' script should be run when upgrading to CSM 1.6.
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Make sure docs-csm for CSM 1.6.1-alpha.4 is installed so that the correct prerequisites.sh script is used.
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script(1) [Failed]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script(1) [Failed]
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l       ] END csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l [Failed]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l       ] END csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l [Failed]
ERR  [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script [Failed]
INFO [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ] END call-hook-script [Failed]
INFO [preflight-checks-for-services                            ] BEG preflight-checks-for-services
WARN [preflight-checks-for-services                            ] END preflight-checks-for-services [Omitted]
INFO [STAGE: pre-install-check                                 ] END Failed in 0:00:58

INFO Aborting install after 0:01:07

Install Summary
command line: iuf -a prereqtest -m /etc/cray/upgrade/csm/media/csm-prereq-test run -r pre-install-check
activity: prereqtest
media dir: /etc/cray/upgrade/csm/media/csm-prereq-test
state dir: /etc/cray/upgrade/csm/iuf/prereqtest/state
log dir: /etc/cray/upgrade/csm/iuf/prereqtest/log/20241219174154
site vars: /etc/cray/upgrade/csm/iuf/prereqtest/state/session_vars.yaml

Error Summary:
   [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       This version of the '\''prerequisistes.sh'\'' script should be run when upgrading to CSM 1.6.
   [csm-1-6-1-alpha-4-pre-hook-pre-install-check             ]       Make sure docs-csm for CSM 1.6.1-alpha.4 is installed so that the correct prerequisites.sh script is used.
   [csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l       ] END csm-1-6-1-alpha-4-pre-hook-pre-install-check-sql3l [Failed]
```
### Test 3 - ran prerequisites.sh with CSM_RELEASE set to different versions

```text
_______________________
Using CSM_RELEASE: 1.5.2


 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log

ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.6.
ERROR Make sure docs-csm for CSM 1.5.2 is installed so that the correct prerequisites.sh script is used.
1 /usr/share/doc/csm/upgrade/scripts/upgrade/prerequisites.sh
exit 1

[ERROR] - Unexpected errors, check logs: /root/output.log

_______________________
Using CSM_RELEASE: 1.3.0-rc2


 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log

ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.6.
ERROR Make sure docs-csm for CSM 1.3.0-rc2 is installed so that the correct prerequisites.sh script is used.
1 /usr/share/doc/csm/upgrade/scripts/upgrade/prerequisites.sh
exit 1

[ERROR] - Unexpected errors, check logs: /root/output.log

_______________________
Using CSM_RELEASE: 1.6.1


 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log


[OK] - Successfully completed

_______________________
Using CSM_RELEASE: 1.6.0-beta5


 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log


[OK] - Successfully completed
```

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
