### PR TITLE
CASMPET-7618-release-1.5 check in prerequisites if correct version of docs-csm is installed

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -69,6 +69,23 @@ if [[ -z ${CSM_RELEASE} ]]; then
   exit 1
 fi
 
+# Make sure this prerequisites.sh version matches the CSM_RELEASE version
+# This prerequisites script should only be if docs-csm and CSM_RELEASE vesion match
+docs_rpm_vers=$(rpm -qa docs-csm)
+docs_trimmed_vers=${docs_rpm_vers#"docs-csm-"}
+docs_spaced_vers=$(echo "$docs_trimmed_vers" | tr "." " ")
+docs_major=$(echo "$docs_spaced_vers" | awk '{ print $1 }')
+docs_minor=$(echo "$docs_spaced_vers" | awk '{ print $2 }')
+csm_release_spaced=$(echo "$CSM_RELEASE" | tr "." " ")
+csm_release_major=$(echo "$csm_release_spaced" | awk '{ print $1 }')
+csm_release_minor=$(echo "$csm_release_spaced" | awk '{ print $2 }')
+
+if [[ $docs_major -ne $csm_release_major ]] || [[ $docs_minor -ne $csm_release_minor ]]; then
+  echo "ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM ${docs_major}.${docs_minor}."
+  echo "ERROR Make sure docs-csm for CSM $CSM_RELEASE is installed so that the correct prerequisites.sh script is used."
+  exit 1
+fi
+
 if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
   echo "SW_ADMIN_PASSWORD environment variable has not been set"
   exit 1

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -81,7 +81,7 @@ csm_release_major=$(echo "$csm_release_spaced" | awk '{ print $1 }')
 csm_release_minor=$(echo "$csm_release_spaced" | awk '{ print $2 }')
 
 if [[ $docs_major -ne $csm_release_major ]] || [[ $docs_minor -ne $csm_release_minor ]]; then
-  echo "ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM ${docs_major}.${docs_minor}."
+  echo "ERROR This version of the 'prerequisites.sh' script should be run when upgrading to CSM ${docs_major}.${docs_minor}."
   echo "ERROR Make sure docs-csm for CSM $CSM_RELEASE is installed so that the correct prerequisites.sh script is used."
   exit 1
 fi


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This PR adds a check to prerequisites.sh to make sure the correct version of prerequisites is being run and that it matches CSM_RELEASE.

Tested the logic with different hardcoded CSM_RELEASE versions and different docs-csm rpm versions. The output is below.

```text
docs-vers: docs-csm-1.5.2000     csm-release: 1.5.0-rc3

docs-vers: docs-csm-1.5.2000     csm-release: 1.6.7-beta2
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.5.
ERROR Make sure docs-csm for CSM 1.6.7-beta2 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.5.2000     csm-release: 1.4.3
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.5.
ERROR Make sure docs-csm for CSM 1.4.3 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.6.30     csm-release: 1.5.0-rc3
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.6.
ERROR Make sure docs-csm for CSM 1.5.0-rc3 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.6.30     csm-release: 1.6.7-beta2

docs-vers: docs-csm-1.6.30     csm-release: 1.4.3
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.6.
ERROR Make sure docs-csm for CSM 1.4.3 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.4.xxx     csm-release: 1.5.0-rc3
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.4.
ERROR Make sure docs-csm for CSM 1.5.0-rc3 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.4.xxx     csm-release: 1.6.7-beta2
ERROR This version of the 'prerequisistes.sh' script should be run when upgrading to CSM 1.4.
ERROR Make sure docs-csm for CSM 1.6.7-beta2 is installed so that the correct prerequisites.sh script is used.

docs-vers: docs-csm-1.4.xxx     csm-release: 1.4.3
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
