### PR TITLE
CASMTRIAGE-7346 / CASMNET-2270 - Fix rebuild script race condition and Cilium deployment template.

### DIFF
--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -85,6 +85,10 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+if [[ ${target_ncn} == ncn-m* ]]; then
+	drain_node ${target_ncn}
+fi
+
 state_name="SET rd.live.dir AND rd.live.overlay.reset"
 state_recorded=$(is_state_recorded "${state_name}" "${target_ncn}")
 if [[ ${state_recorded} == "0" ]]; then

--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -86,7 +86,7 @@ else
 fi
 
 if [[ ${target_ncn} == ncn-m* ]]; then
-	drain_node ${target_ncn}
+  drain_node ${target_ncn}
 fi
 
 state_name="SET rd.live.dir AND rd.live.overlay.reset"

--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -136,8 +136,6 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
   fi
 fi
 
-drain_node $target_ncn
-
 # Validate SLS health before calling csi handoff bss-update-*, since
 # it relies on SLS
 check_sls_health

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -139,8 +139,6 @@ fi
   fi
 } >> ${LOG_FILE} 2>&1
 
-drain_node $target_ncn
-
 # Validate SLS health before calling csi handoff bss-update-*, since
 # it relies on SLS
 check_sls_health >> "${LOG_FILE}" 2>&1

--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -1,26 +1,26 @@
-#
-# MIT License
-#
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
+{{/*
+MIT License
+
+(C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:

--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -122,7 +122,7 @@ spec:
                   for i in $(kubectl get netpol -A --no-headers | awk '{print $1}' | sort -u );do
                     echo "--- namespace ${i} ---"
                     # Not stashing network policies for cray-shared-kafka because they get recreated by the operator
-                    for j in $(kubectl -n ${i} get netpol --no-headers | grep -v cray-shared-kafka-network-policy | awk '{print $1}');do
+                    for j in $(kubectl -n ${i} get netpol --no-headers | grep -v cray-shared-kafka | awk '{print $1}');do
                       echo "Saving off network policy ${j}"
                       echo "---" >> /tmp/netpol.yaml
                       kubectl -n ${i} get netpol ${j} -o yaml >> /tmp/netpol.yaml


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This PR corrects a race condition that can occur during a control plane node upgrade or rebuild. The `DRAIN_NODE` step occurs before the `FORCE_TIME_SYNC` step.

`FORCE_TIME_SYNC` requires access to the API gateway however the `DRAIN_NODE` step removes the node from the Kubernetes cluster which starts shutting down pods. Once the kube-proxy and weave-net pods terminate access to the API gateway from the node being rebuilt is no longer possible and if this occurs before `FORCE_TIME_SYNC` runs then that step can fail.

This PR moves `DRAIN_NODE` to after `FORCE_TIME_SYNC` and `CSI_VALIDATE_BSS_NTP` to eliminate this race condition.

This PR also addresses a minor problem in the `cilium.deploy` workflow . An operator managed `cray-shared-kafka-entity-operator` network policy also needs to be excluded from the network policy backup as restoring it will fail because the operator recreate it after it is deleted.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- [CASMTRIAGE-7346](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7346)
- [CASMNET-2270](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2270)
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
