### PR TITLE
CASMPET-6863: Document how to get past a statefulset error when doing a helm rollback

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -87,6 +87,8 @@ victoria
 5.15.itb
 64-port
 7060CX2-32S
+8.x
+8.x.x
 802.1Q
 802.1p
 802.1s
@@ -95,6 +97,8 @@ victoria
 802.3cd/bs
 8325-23C
 8325-48Y8C
+9.x
+9.x.x
 ACLs
 AOS-CX
 API

--- a/troubleshooting/error_rolling_back_service_chart_with_etcd.md
+++ b/troubleshooting/error_rolling_back_service_chart_with_etcd.md
@@ -1,0 +1,140 @@
+# Error Rolling Back Service Chart With etcd
+
+If rolling back a service with Bitnami etcd, the `helm rollback` could fail when going from an etcd chart 9.x version to an etcd chart 8.x version.
+This is because the Bitnami 9.x etcd cluster StatefulSet and Pods have the `app.kubernetes.io/component=etcd` label and the
+Bitnami 8.x etcd cluster StatefulSet and Pods do not, causing the StatefulSet to complain on rollback.
+
+## Prerequisites
+
+If you are hitting the etcd chart version issue on rollback, helm will throw this error:
+
+```text
+Error: cannot patch "cray-hmnfd-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-hmnfd-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+```
+
+You will also see the error in the `helm history` output.
+
+Example output:
+
+```text
+# helm history -n services cray-hms-hmnfd
+REVISION    UPDATED                     STATUS      CHART                   APP VERSION DESCRIPTION
+1           Mon Dec  9 21:00:24 2024    superseded  cray-hms-hmnfd-3.0.2    1.18.1      Install complete
+2           Thu Dec 19 13:53:27 2024    deployed    cray-hms-hmnfd-4.0.4    1.21.0      Upgrade complete
+3           Fri Dec 20 19:50:42 2024    failed      cray-hms-hmnfd-3.0.2    1.18.1      Rollback "cray-hms-hmnfd" failed: cannot patch "cray-hmnfd-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-hmnfd-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+```
+
+If `helm.sh/chart` is `etcd-9.x.x` or greater and the StatefulSet and Pods have the `app.kubernetes.io/component=etcd` label, you can get past the error by removing the offending label from the etcd cluster Pods and StatefulSet.
+
+1. (`ncn-m001#`) Check which etcd helm chart version is currently running using `kubectl describe pod`.
+
+    ```bash
+    kubectl describe pod -n services cray-hmnfd-bitnami-etcd-0 | grep "helm.sh/chart"
+    ```
+
+    Example output:
+
+    ```text
+    ncn-m001:~ # kubectl describe pod -n services cray-hmnfd-bitnami-etcd-0 | grep "helm.sh/chart"
+                helm.sh/chart=etcd-9.5.6
+    ncn-m001:~ #
+    ```
+
+1. (`ncn-m001#`) Check that the StatefulSet and the pods have the `app.kubernetes.io/component` label.
+
+    1. Check if the StatefulSet has the label.
+
+        ```bash
+        kubectl get statefulset -n services -l app.kubernetes.io/component=etcd | grep hmnfd
+        ```
+
+        Example output:
+
+        ```text
+        ncn-m001:~ # kubectl get statefulset -n services -l app.kubernetes.io/component=etcd | grep hmnfd
+        cray-hmnfd-bitnami-etcd           3/3     26h
+        ncn-m001:~ #
+        ```
+
+    1. Check if the Pods have the label.
+
+        ```bash
+        kubectl get pods -n services -l app.kubernetes.io/component=etcd | grep hmnfd
+        ```
+
+        Example output:
+
+        ```text
+        ncn-m001:~ # kubectl get pods -n services -l app.kubernetes.io/component=etcd | grep hmnfd
+        cray-hmnfd-bitnami-etcd-0           2/2     Running   0          33m
+        cray-hmnfd-bitnami-etcd-1           2/2     Running   0          34m
+        cray-hmnfd-bitnami-etcd-2           2/2     Running   0          35m
+        ncn-m001:~ #
+        ```
+
+## Create a Manual Backup of the etcd Cluster
+
+If a manual backup of the etcd cluster was not done prior to running `helm rollback`, do so now by following [Create a Manual Backup of a Healthy etcd Cluster](../operations/kubernetes/Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md)
+
+## Run Script to Remove Label
+
+Run the script `remove_label_from_etcd_cluster.sh` in `/usr/share/doc/csm/troubleshooting/scripts/` to remove the `app.kubernetes.io/component=etcd` label from the StatefulSet and Pods in the etcd cluster.
+
+`remove_label_from_etcd_cluster.sh` usage:
+
+```text
+Usage:
+
+./remove_label_from_etcd_cluster.sh <namespace> <etcd-cluster>
+
+    <namespace>    - The Kubernetes namespace the etcd cluster pods are running in.
+                    Example, 'services'.
+    <etcd-cluster> - The base name of the etcd cluster pods. Example, 'cray-hmnfd'.
+```
+
+(`ncn-m001#`) Run `remove_label_from_etcd_cluster.sh`.
+
+```bash
+/usr/share/doc/csm/troubleshooting/scripts/remove_label_from_etcd_cluster.sh services cray-hmnfd
+```
+
+Example output:
+
+```bash
+ncn-m001:/usr/share/doc/csm/troubleshooting/scripts # ./remove_label_from_etcd_cluster.sh services cray-hmnfd
+Ensuring cray-hmnfd-bitnami-etcd members do not have 'app.kubernetes.io/component=etcd' label for rollback to bitnami 8.x chart...
+Removing 'app.kubernetes.io/component=etcd' label from cray-hmnfd-bitnami-etcd-0...
+pod/cray-hmnfd-bitnami-etcd-0 unlabeled
+Removing 'app.kubernetes.io/component=etcd' label from cray-hmnfd-bitnami-etcd-1...
+pod/cray-hmnfd-bitnami-etcd-1 unlabeled
+Removing 'app.kubernetes.io/component=etcd' label from cray-hmnfd-bitnami-etcd-2...
+pod/cray-hmnfd-bitnami-etcd-2 unlabeled
+Removing label 'app.kubernetes.io/component=etcd' from statefulset for cray-hmnfd-bitnami-etcd
+statefulset.apps/cray-hmnfd-bitnami-etcd unlabeled
+Label 'app.kubernetes.io/component=etcd' was removed from pods and 'cray-hmnfd-bitnami-etcd' statefulset. Continue with rollback.
+ncn-m001:/usr/share/doc/csm/troubleshooting/scripts #
+```
+
+The label `app.kubernetes.io/component=etcd` that was causing the StatefulSet error has been removed from the StatefulSet and etcd cluster Pods. Re-running the `helm rollback` should now succeed.
+
+## Re-run `helm rollback`
+
+(`ncn-m001#`) With the label `app.kubernetes.io/component=etcd` removed from the etcd cluster Pods and the StatefulSet, re-run `helm rollback`. The rollback should succeed and the expected revision should be running.
+
+```bash
+helm rollback -n services cray-hms-hmnfd 1
+```
+
+Example output:
+
+```bash
+ncn-m001:~ # helm rollback -n services cray-hms-hmnfd 1
+Rollback was a success! Happy Helming!
+ncn-m001:~ #
+ncn-m001:~ # helm history -n services cray-hms-hmnfd
+REVISION    UPDATED                     STATUS      CHART                   APP VERSION DESCRIPTION
+1           Mon Dec  9 21:00:24 2024    superseded  cray-hms-hmnfd-3.0.2    1.18.1      Install complete
+2           Thu Dec 19 13:53:27 2024    superseded  cray-hms-hmnfd-4.0.4    1.21.0      Upgrade complete
+3           Fri Dec 20 19:50:42 2024    failed      cray-hms-hmnfd-3.0.2    1.18.1      Rollback "cray-hms-hmnfd" failed: cannot patch "cray-hmnfd-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-hmnfd-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+4           Fri Dec 20 20:06:38 2024    deployed    cray-hms-hmnfd-3.0.2    1.18.1      Rollback to 1
+```

--- a/troubleshooting/scripts/remove_label_from_etcd_cluster.sh
+++ b/troubleshooting/scripts/remove_label_from_etcd_cluster.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+usage() {
+  echo "
+Usage:
+
+$0 <namespace> <etcd-cluster>
+
+    <namespace>    - The Kubernetes namespace the etcd cluster pods are running in.
+                     Example, 'services'.
+    <etcd-cluster> - The base name of the etcd cluster pods. Example, 'cray-hmnfd'.
+"
+}
+
+# Print usage if there are less than two args
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+ns=$1
+cluster=$2
+ss_name="${cluster}-bitnami-etcd"
+label_key="app.kubernetes.io/component"
+label_value="etcd"
+label="${label_key}=${label_value}"
+
+if ! kubectl get endpoints ${cluster}-etcd-client -n ${ns} -o json > /dev/null 2>&1; then
+  #
+  # There is no old etcd-operator managed chart installed, let's see if this
+  # is a fresh install or upgrade with new label.
+  #
+  has_label=$(kubectl get statefulsets.apps -n ${ns} -l ${label} --no-headers 2> /dev/null | awk "/${ss_name}/")
+  if [ -z "$has_label" ]; then
+    #
+    # The new label has not been applied, so no need to delete label before rollback.
+    #
+    echo "The '${label}' label has already been removed from ${ss_name}, continue with rollback."
+    exit 0
+  fi
+
+  #
+  # The new label has been applied, so we need to remove the label from the pods and
+  # the statefulset before rolling back.
+  #
+  members=$(kubectl get pod -n $ns -o wide -o=custom-columns=NAME:.metadata.name | awk "/${ss_name}/ && !/snapshotter|defrag/")
+  if [ -n "$members" ]; then
+    echo "Ensuring ${ss_name} members do not have '${label}' label for rollback to bitnami 8.x chart..."
+    for member in ${members}; do
+      echo "Removing '${label}' label from ${member}..."
+      kubectl label pod -n ${ns} ${member} ${label_key}-
+    done
+    echo "Removing label '${label}' from statefulset for ${ss_name}"
+    kubectl label statefulset -n ${ns} ${ss_name} ${label_key}-
+    echo "Label '${label}' was removed from pods and '${ss_name}' statefulset. Continue with rollback."
+  else
+    echo "No installations detected requiring special handling, continue with rollback."
+  fi
+  exit 0
+fi
+
+echo "Nothing to do. Found ${cluster}-etcd-client, so an older version without the ${label} label is already running."


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
CASMPET-6863: Document how to get past a statefulset error when doing a helm rollback from a service chart with etcd bitnami 9.x to a chart with etcd bitnami 8.x.

If rolling back a service with bitnami etcd, the `helm rollback` could fail when going from an etcd chart version 9.x.x to an etcd chart version 8.x.x. This is because the bitnami 9.x etcd cluster statefulset and pods have the `app.kubernetes.io/component=etcd` label and the bitnami 8.x etcd cluster statefulset and pods do not, causing the statefulset to complain on rollback.

This documents how to determine if the bitnami label mismatch is the cause of the `helm rollback` failure and how to run the  new script `remove_label_from_etcd_cluster.sh`.  The script was taken and modified from the `etcd-base-chart` pre-upgrade hook to remove the label rather than add the label.

# Testing
Did a bunch of testing on `beau` with the `cray-etcd-test` chart contained in `cray-etcd` repo. Installed via helm a `cray-etcd-test` chart using etcd chart version 8.9.0 and then upgraded to a `cray-etcd-test` chart using version 9.5.6.  Once upgrade complete, ran `helm rollback` to the previous version to recreate the statefulset error.  Ran the `remove_label_from_etcd_cluster.sh` script and then re-ran `helm rollback` successfully.

```
# helm history -n services cray-etcd-test
REVISION	UPDATED                 	STATUS    	CHART                                      	APP VERSION    	DESCRIPTION
1       	Fri Dec 20 19:25:52 2024	superseded	cray-etcd-test-1.0.2-20241218164554+fa6aa14	1.0.0          	Install complete
2       	Fri Dec 20 19:38:54 2024	superseded	cray-etcd-test-1.0.2                       	1.0.0          	Upgrade complete
3       	Fri Dec 20 19:50:42 2024	failed    	cray-etcd-test-1.0.2-20241218164554+fa6aa14	1.0.0          	Rollback "cray-etcd-test" failed: cannot patch "cray-etcd-test-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-etcd-test-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
4       	Fri Dec 20 20:06:38 2024	deployed  	cray-etcd-test-1.0.2-20241218164554+fa6aa14	1.0.0          	Rollback to 1
```

Also, installed `cray-hms-hmnfd-3.0.2` chart on `beau` which already was running `cray-hms-hmnfd-4.0.4` and did `helm rollback`s between the versions to recreate the error, run the script, and have the `helm rollback` succeed.

```
# helm history -n services cray-hms-hmnfd
REVISION	UPDATED                 	STATUS    	CHART               	APP VERSION	DESCRIPTION
<snip>
6       	Thu Dec 19 19:51:15 2024	failed    	cray-hms-hmnfd-3.0.2	1.18.1     	Upgrade "cray-hms-hmnfd" failed: cannot patch "cray-hmnfd-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-hmnfd-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
7       	Thu Dec 19 19:53:51 2024	superseded	cray-hms-hmnfd-3.0.2	1.18.1     	Upgrade complete
8       	Thu Dec 19 19:58:03 2024	superseded	cray-hms-hmnfd-4.0.4	1.21.0     	Upgrade complete
9       	Fri Dec 20 21:00:44 2024	failed    	cray-hms-hmnfd-3.0.2	1.18.1     	Rollback "cray-hms-hmnfd" failed: cannot patch "cray-hmnfd-bitnami-etcd" with kind StatefulSet: StatefulSet.apps "cray-hmnfd-bitnami-etcd" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
10      	Fri Dec 20 21:13:16 2024	superseded	cray-hms-hmnfd-3.0.2	1.18.1     	Rollback to 7
11      	Fri Dec 20 21:27:50 2024	deployed  	cray-hms-hmnfd-4.0.4	1.21.0     	Rollback to 1
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
