### PR TITLE
CASMCMS-9178: Update kubectl command in BOS v1 workaround procedure

### DIFF
--- a/troubleshooting/known_issues/Hang_Listing_BOS_V1_Sessions.md
+++ b/troubleshooting/known_issues/Hang_Listing_BOS_V1_Sessions.md
@@ -43,7 +43,7 @@ The remedy to the situation is to manually delete the BOS v1 sessions from the u
 1. (`ncn-mw#`) Identify the name of a BOS etcd pod.
 
     ```bash
-    BOS_ETCD_POD=$(kubectl get pods -n services -l app=etcd,etcd_cluster=cray-bos-etcd \
+    BOS_ETCD_POD=$(kubectl get pods -n services -l app.kubernetes.io/name=etcd,app.kubernetes.io/instance=cray-bos \
                     | grep Running | head -1 | awk '{ print $1 }')
     echo "${BOS_ETCD_POD}"
     ```
@@ -51,7 +51,7 @@ The remedy to the situation is to manually delete the BOS v1 sessions from the u
     Example output:
 
     ```text
-    cray-bos-etcd-hwb88pqklg
+    cray-bos-bitnami-etcd-0
     ```
 
 1. (`ncn-mw#`) Optionally, list the number of entries in the BOS v1 session database.


### PR DESCRIPTION
Changes made to etcd in CSM 1.5 meant that a workaround procedure no longer worked. Specifically, the kubectl command being used to list the BOS etcd pods was no longer correct. This PR updates the command (and its example output) for CSM 1.5. I tested this on baldar.

```
ncn-m001:~ #     BOS_ETCD_POD=$(kubectl get pods -n services -l app.kubernetes.io/name=etcd,app.kubernetes.io/instance=cray-bos \
>                     | grep Running | head -1 | awk '{ print $1 }')
ncn-m001:~ #     echo "${BOS_ETCD_POD}"
cray-bos-bitnami-etcd-0
ncn-m001:~ #
```

No backports needed -- prior to CSM 1.5, the existing procedure works. After CSM 1.5, this workaround is not in the docs, because BOS v1 is gone.