### PR TITLE
CASMINST-7108 Workflow templates filename pattern override for license checker

### DIFF
--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+file_types:
+  "*/templates/*.yaml":
+    type: yaml
+    alternative_type: yaml


### PR DESCRIPTION
# Description

Files matching `workflows/templates/*.yaml` were previously recognized as Helm chart templates by license checker. This is the default setting which suits most of our repos, but for docs-csm this assumption is not correct - these files are Argo templates, not Helm templates. The follow YAML syntax, not go-template syntax. As a result, if license checker is run with `--fix` argument, it would apply wrong go-template formatting to files. This PR adds config override to set type of those files as YAML.

Checking that override worked:

    $ docker run -it --rm -v $(pwd):/github/workspace artifactory.algol60.net/csm-docker/stable/license-checker --log-level=debug workflows/templates/add-labels.yaml
    ...
    [DEBUG] Matching workflows/templates/add-labels.yaml against */templates/*.yaml to determine file type .... matched!
    [DEBUG] Trying main file comment type for workflows/templates/add-labels.yaml as yaml

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.