### PR TITLE
CASMCMS-9244: Make CASMCMS-9234 workaround more resilient

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -183,7 +183,24 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
   {
     # Make sure the BOS migration job is complete (succeeded or failed)
     job_error=""
-    wait_for_k8s_job_to_succeed "${ns}" "${job_name}" || job_error="migration_job_not_successful."
+    wait_for_k8s_job_to_succeed "${ns}" "${job_name}" || job_error+="migration_job_not_successful."
+
+    # CASMCMS-9244: Wait for BOS database pod to be Running
+    db_running=N
+    attempt=1
+    while [[ $attempt -le 12 ]]; do
+      [[ $attempt -eq 1 ]] || sleep 5
+      let attempt+=1
+      kubectl get pods -n services -l 'app.kubernetes.io/instance=cray-bos-db' --no-headers | grep -w Running || continue
+      echo "BOS database pod found in Running state"
+      db_running=Y
+      break
+    done
+
+    if [[ ${db_running} != Y ]]; then
+      echo "ERROR: BOS database Kubernetes pod not running" >&2
+      exit 1
+    fi
 
     DATESTRING=$(date +%Y-%m-%d_%H-%M-%S)
     SNAPSHOT_DIR=$(mktemp -d --tmpdir=/root "csm_upgrade.post_bos_upgrade_snapshot.${job_error}${DATESTRING}.XXXXXX")
@@ -191,8 +208,16 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
 
     # Record BOS data, because the upgrade to CSM 1.6 deleted all BOS v1 data, and sanitized
     # the BOS v2 data
-    echo "Backing up BOS data"
-    /usr/share/doc/csm/scripts/operations/configuration/export_bos_data.sh "${SNAPSHOT_DIR}"
+    attempt=1
+    backed_up=N
+    while [[ $attempt -le 3 ]]; do
+      [[ $attempt -eq 1 ]] || sleep 20
+      echo "Backing up BOS data (attempt $attempt)"
+      let attempt+=1
+      /usr/share/doc/csm/scripts/operations/configuration/export_bos_data.sh "${SNAPSHOT_DIR}" || continue
+      backed_up=Y
+      break
+    done
 
     # Record state of BOS Kubernetes pods.
     K8S_PODS_SNAPSHOT=${SNAPSHOT_DIR}/k8s_bos_pods.txt
@@ -202,9 +227,15 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
 
     # Record pod logs
     K8S_POD_LOGS=${SNAPSHOT_DIR}/k8s_bos_pod_logs.txt
+    echo "Taking snapshot of current BOS Kubernetes pod logs to ${K8S_POD_LOGS}"
     kubectl logs -n services --ignore-errors --all-containers --timestamps --prefix --max-log-requests 500 \
       --insecure-skip-tls-verify-backend --tail=-1 \
       -l 'app.kubernetes.io/instance in (cray-bos, cray-bos-db)' > "${K8S_POD_LOGS}"
+
+    if [[ ${backed_up} != Y ]]; then
+      echo "ERROR: BOS data export not successful" >&2
+      exit 1
+    fi
 
     # Apply fix for CASMCMS-9234
     echo "Applying fix for CASMCMS-9234, if needed"

--- a/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix_template_db_keys.py
+++ b/upgrade/scripts/upgrade/workarounds/CASMCMS-9234/fix_template_db_keys.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,25 +22,50 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+import sys
+import time
+
 from bos.common.tenant_utils import get_tenant_aware_key
 from bos.server.redis_db_utils import get_wrapper
-import sys
 
-temp_db = get_wrapper(db='session_templates')
+MAX_WAIT_SECONDS=300
+SLEEP_SECONDS_BETWEEN_TRIES=10
 renamed = 0
-for db_key, data in temp_db.get_all_as_dict().items():
-    if not data:
-        continue
-    st_name = data.get('name', None)
-    if not st_name:
-        continue
-    st_tenant = data.get('tenant', "")
-    expected_db_key = get_tenant_aware_key(st_name, st_tenant)
-    if expected_db_key == db_key:
-        continue
-    print(f"Fixing: Template '{st_name}' (tenant: '{st_tenant}') db_key = '{db_key}' does not match expected db_key = '{expected_db_key}'")
-    temp_db.rename(db_key, expected_db_key)
-    renamed+=1
+
+def apply_fix():
+    global renamed
+    temp_db = get_wrapper(db='session_templates')
+    for db_key, data in temp_db.get_all_as_dict().items():
+        if not data:
+            continue
+        st_name = data.get('name', None)
+        if not st_name:
+            continue
+        st_tenant = data.get('tenant', "")
+        expected_db_key = get_tenant_aware_key(st_name, st_tenant)
+        if expected_db_key == db_key:
+            continue
+        print(f"Fixing: Template '{st_name}' (tenant: '{st_tenant}') db_key = '{db_key}' does not match expected db_key = '{expected_db_key}'")
+        temp_db.rename(db_key, expected_db_key)
+        renamed+=1
+
+def apply_fix_with_retries():
+    start_time = time.time()
+    # Try for up to MAX_WAIT_SECONDS
+    attempt = 1
+    while time.time() - start_time <= MAX_WAIT_SECONDS:
+        if attempt > 1:
+            print(f"Sleeping for {SLEEP_SECONDS_BETWEEN_TRIES} seconds and retrying")
+            time.sleep(SLEEP_SECONDS_BETWEEN_TRIES)
+        attempt+=1
+        try:
+            apply_fix()
+            return
+        except Exception as err:
+            print(f"Error on attempt {attempt}: {type(err).__name__} {err}")
+    sys.exit(1)
+
+apply_fix_with_retries()
 print(f"{renamed} templates renamed")
 if renamed:
     # Exit 57 to communicate that templates were renamed, so a fresh export of BOS data should be performed


### PR DESCRIPTION
Mikhail observed a problem during an upgrade to CSM 1.6.1 where the workaround for CASMCMS-9234 failed because the BOS database was temporarily unavailable. This PR does a couple of things to address this:

1. Verifies that the BOS database pod is Running before the workaround is attempted
2. Inside the workaround itself, add limited retries in case of such failures.

I tested the changes on vex (where the problem was reported, and where I simulated the problem to force the code down the bad path).

No backports needed.