### PR TITLE
CASMINST-6968 Fixes for 1.6

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -49,7 +49,7 @@ if [ "$(yq4 eval '.extraArgs.audit-log-path' "${workdir}/ClusterConfiguration.ya
   cm_auditing_enabled=1
 fi
 
-if [[ ${manifest_auditing_enabled} -eq 1 && ${cm_auditing_enabled} -ne 1 ]]; then
+if [ ${manifest_auditing_enabled} -eq 1 ] && [ ${cm_auditing_enabled} -eq 1 ]; then
   echo "Updating kubeadm-config configmap with audit configuration"
   yq4 eval -i -P '.apiServer.extraArgs.audit-log-maxbackup = "100"' "${workdir}/ClusterConfiguration.yaml"
   yq4 eval -i -P '.apiServer.extraArgs.audit-log-path = "/var/log/audit/kl8s/apiserver/audit.log"' "${workdir}/ClusterConfiguration.yaml"

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -32,8 +32,12 @@ kubectl get configmap kubeadm-config -n kube-system -o yaml > "${workdir}/kubead
 cp "${workdir}/kubeadm-config.yaml" "${workdir}/kubeadm-config.yaml.back"
 yq4 eval -P '.data.ClusterConfiguration' "${workdir}/kubeadm-config.yaml" > "${workdir}/ClusterConfiguration.yaml"
 
-yq4 eval -i -P '.imageRepository = "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io"' "${workdir}/ClusterConfiguration.yaml"
-yq4 eval -i -P '.dns = {"type": "CoreDNS", "imageRepository": "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns"}' "${workdir}/ClusterConfiguration.yaml"
+if [ "$(yq4 eval '.dns' "${workdir}/ClusterConfiguration.yaml")" = "null" ] || [ "$(yq4 eval '.dns' "${workdir}/ClusterConfiguration.yaml")" == "{}" ]; then
+  yq4 eval -i -P '.dns = {"type": "CoreDNS", "imageRepository": "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns"}' "${workdir}/ClusterConfiguration.yaml"
+fi
+if [ "$(yq4 eval '.imageRepository' "${workdir}/ClusterConfiguration.yaml")" = 'k8s.gcr.io' ]; then
+  yq4 eval -i -P '.imageRepository = "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io"' "${workdir}/ClusterConfiguration.yaml"
+fi
 yq4 eval -i -P '.apiServer.extraArgs.api-audiences = "api,istio-ca"' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.apiServer.extraArgs.enable-admission-plugins = "NodeRestriction,PodSecurityPolicy"' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.controllerManager.extraArgs.bind-address = "0.0.0.0"' "${workdir}/ClusterConfiguration.yaml"

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -35,9 +35,9 @@ yq4 eval -P '.data.ClusterConfiguration' "${workdir}/kubeadm-config.yaml" > "${w
 yq4 eval -i -P '.imageRepository = "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io"' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.dns = {"type": "CoreDNS", "imageRepository": "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns"}' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.apiServer.extraArgs.api-audiences = "api,istio-ca"' "${workdir}/ClusterConfiguration.yaml"
+yq4 eval -i -P '.apiServer.extraArgs.enable-admission-plugins = "NodeRestriction,PodSecurityPolicy"' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.controllerManager.extraArgs.bind-address = "0.0.0.0"' "${workdir}/ClusterConfiguration.yaml"
 yq4 eval -i -P '.scheduler.extraArgs.bind-address = "0.0.0.0"' "${workdir}/ClusterConfiguration.yaml"
-yq4 eval -i -P '.scheduler.extraArgs.enable-admission-plugins = "NodeRestriction,PodSecurityPolicy"' "${workdir}/ClusterConfiguration.yaml"
 
 manifest_auditing_enabled=0
 if ! grep -q '/var/log/audit' /etc/kubernetes/manifests/kube-apiserver.yaml; then

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -45,7 +45,7 @@ if ! grep -q '/var/log/audit' /etc/kubernetes/manifests/kube-apiserver.yaml; the
 fi
 
 cm_auditing_enabled=0
-if [ "$(yq4 eval '.audit-log-path' "${workdir}/ClusterConfiguration.yaml")" != "null" ]; then
+if [ "$(yq4 eval '.extraArgs.audit-log-path' "${workdir}/ClusterConfiguration.yaml")" != "null" ]; then
   cm_auditing_enabled=1
 fi
 
@@ -68,7 +68,7 @@ fi
 if IFS= read -rd '' -a cluster_configuration; then
   :
 fi <<< "$(cat "${workdir}/ClusterConfiguration.yaml")"
-cluster_configuration=$cluster_configuration yq4 eval '.data.ClusterConfiguration = strenv(cluster_configuration)' "${workdir}/kubeadm-config.yaml"
+cluster_configuration=$cluster_configuration yq4 eval -i '.data.ClusterConfiguration = strenv(cluster_configuration)' "${workdir}/kubeadm-config.yaml"
 
 # Apply the new Kubernetes config.
 kubectl -n kube-system apply -f "${workdir}/kubeadm-config.yaml"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Fixes the following issues:
- Missing `PodSecurityPolicy` from the Cluster configuration's API Server
- Missing the updated `ClusterConfiguration` in `kubeadm-config.yaml`
- A false positive leading to the enabling of auditing
- ImagePull errors


I tested the 1.6 and 1.5 PRs (#5641) by comparing their generated `kubeadm-config.yaml` file with the sed-based version ([old script can be found here](https://github.com/Cray-HPE/docs-csm/blob/v1.6.124/upgrade/scripts/k8s/upgrade_control_plane.sh)). I only found innocuous white-space differences. Furthermore, the 1.6/1.5 PR’s script’s generated `kubeadm-config.yaml` was applied successfully, with the PDP enabled.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
