### PR TITLE
Revert "Changing iuf image version iuf:v0.1.13"

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,7 +70,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
+                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
                 command: [sh]
                 source: |
                   #!/bin/sh

--- a/workflows/templates/base/echo.template.argo.yaml
+++ b/workflows/templates/base/echo.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,7 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
+        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
         command: [sh]
         source: |
           #!/usr/bin/bash

--- a/workflows/templates/base/iufBase.template.argo.yaml
+++ b/workflows/templates/base/iufBase.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ spec:
          factor: "2"
          maxDuration: "1m"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
+        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
         command: [sh]
         source: |
           #!/usr/bin/bash


### PR DESCRIPTION
Reverts Cray-HPE/docs-csm#5629
We need to keep backwards compatibility with CSM 1.6.0. New image iuf v0.1.13 is not going to be shipped with CSM 1.6.0.