### PR TITLE
CASMTRIAGE-7570 - Error setting ip address while adding storage node to cluster

### DIFF
--- a/operations/network/customer_accessible_networks/can_to_chn/scripts/sls/add_computes_to_chn.py
+++ b/operations/network/customer_accessible_networks/can_to_chn/scripts/sls/add_computes_to_chn.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/operations/network/customer_accessible_networks/can_to_chn/scripts/sls/add_computes_to_chn.py
+++ b/operations/network/customer_accessible_networks/can_to_chn/scripts/sls/add_computes_to_chn.py
@@ -29,7 +29,7 @@ import re
 
 import click
 
-from sls_utils.ipam import next_free_ipv4_address
+from sls_utils.ipam import next_free_ipv4_address, last_free_ipv4_address
 from sls_utils.Managers import NetworkManager
 from sls_utils.Reservations import Reservation
 
@@ -242,6 +242,10 @@ def main(
                 ),
             },
         )
+
+    dhcp_start = next_free_ipv4_address(chn_subnet)
+    click.secho(f"Updating DHCP start IPv4 address {dhcp_start}", fg="bright_white")
+    chn_subnet.dhcp_start_address(next_free_ipv4_address(chn_subnet))
 
     click.secho(
         f"CHN now has {len(chn_subnet.reservations()) + 1} IP reservations",

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
+#
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,7 +21,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
+#
 from kubernetes import client, config
 import base64
 import sys
@@ -391,6 +392,10 @@ def add_ncn_network_update(add_ncn_count, network_list, api_header, sls_networks
         print()
         print(f'Checking {network}.')
         print(f'last_reserved_ip: {last_reserved_ip}    start_dhcp_pool:{start_dhcp_pool}')
+        if ip_white_space < 0:
+            print(f'FATAL last_reserved_ip {last_reserved_ip} exceeds start_dhcp_pool {start_dhcp_pool}')
+            print(f'Verify DHCPStart and DHCPEnd are correct for the {network} network in SLS.')
+            sys.exit(1)
         print(f'The space between last_reserved_ip and start_dhcp_pool is {ip_white_space} IP.\n')
         log.info(f'Unsorted static ips:'
                   f' {ip_set}')


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The `add_computes_to_chn.py` did not correctly update the CHN subnet DHCPStart value after adding compute nodes into the CHN. This resulted in bad data in SLS causing an NCN add operation to fail.

This PR modifies the `add_computes_to_chn.py` script to correctly update the DHCPStart value.
This PR also modified the `add_ncn_pre-req.py` script to abort if the last allocated static IP overlaps with the DHCPStart value promting the user to investigate.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
