### PR TITLE
CASMCMS-9246: Fix error in code used to determine whether BOS database pod is running

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -191,7 +191,7 @@ if [[ $state_recorded == "0" ]] && k8s_job_exists "${ns}" "${job_name}"; then
     while [[ $attempt -le 12 ]]; do
       [[ $attempt -eq 1 ]] || sleep 5
       let attempt+=1
-      kubectl get pods -n services -l 'app.kubernetes.io/instance=cray-bos-db' --no-headers | grep -w Running || continue
+      kubectl get pods -n services -l 'app.kubernetes.io/name=cray-bos-db' --no-headers | grep -w Running || continue
       echo "BOS database pod found in Running state"
       db_running=Y
       break


### PR DESCRIPTION
The code used to determine whether the BOS database is running had an error -- it used the incorrect selector string to identify the pod. This updates the script to use the correct selector string for CSM 1.6.

No backports needed -- this code only exists in CSM 1.6.

I have manually verified the fix on vex (where the issue was found), and Mikhail is re-ran the upgrade on there using the docs-csm RPM from this PR and verified that it corrected the issue