### PR TITLE
CASMPET-7308: Update workflow template to use run_goss_tests helper function

### DIFF
--- a/workflows/templates/storage.goss-tests.yaml
+++ b/workflows/templates/storage.goss-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/templates/storage.goss-tests.yaml
+++ b/workflows/templates/storage.goss-tests.yaml
@@ -60,5 +60,4 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN="{{inputs.parameters.targetNcn}}"
-                    ssh $TARGET_NCN -t 'GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-storage.yaml \
-                      --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate'
+                    ssh $TARGET_NCN -t '/opt/cray/tests/install/ncn/automated/ncn-upgrade-tests-storage' 


### PR DESCRIPTION
# Description
This PR updates how ncn-upgrade-tests-storage.yaml is executed to call the storage testing script explicitly. This is needed because of a change in https://github.com/Cray-HPE/csm-testing/pull/647, which added a new tests to `ncn-storage-tests`, which requires the use of a `run_goss_tests` helper function defined in `/csm-testing/goss-testing/automated/run-ncn-tests.sh` (see [here](https://github.com/Cray-HPE/csm-testing/blob/fed3306018637e527c007385e328919e7b293b5f/goss-testing/automated/run-ncn-tests.sh#L637)). 

# Checklist
- [x] testing completed, ran on 2 Beau storages nodes, the tests were skipped, but that the test executed properly was all we were testing, since we have confirmed in other configurations that the test works as expected

