### PR TITLE
CASMTRIAGE-7358 add known_issue page for storage cloud-init failing to create pool

### DIFF
--- a/install/troubleshooting_ceph_csi.md
+++ b/install/troubleshooting_ceph_csi.md
@@ -19,7 +19,7 @@ Verify that the `ceph-csi` requirements are in place.
       ceph -s
       ```
 
-      If it returns a connection error, then assume Ceph is not installed. See [Rerun storage node `cloud-init`](#2-rerun-storage-node-cloud-init).
+      If it returns a connection error, then assume Ceph is not installed. See [Rerun storage node `cloud-init`](#3-rerun-storage-node-cloud-init).
 
    1. (`ncn-s001#`) Verify all post-Ceph-install tasks have run.
 
@@ -32,7 +32,7 @@ Verify that the `ceph-csi` requirements are in place.
 
       Check the results against this example.
 
-      If any components are missing, see [Rerun storage node `cloud-init`](#2-rerun-storage-node-cloud-init).
+      If any components are missing, see [Rerun storage node `cloud-init`](#3-rerun-storage-node-cloud-init).
 
    1. (`ncn#`) Check to see if `ceph-csi` prerequisites have been created in Kubernetes.
 
@@ -59,7 +59,8 @@ Verify that the `ceph-csi` requirements are in place.
 
 ## 2. Check if Ceph pools failed to create
 
-Follow the [Ceph OSD pool fails to create document](../troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md). If that document resolves the `Ceph CSI` problems, then the next step can be skipped. If the that document did not solve the `Ceph CSI` problems, then continue to the next step.
+Follow the [Ceph OSD pool fails to create document](../troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md). If that document resolves the `Ceph CSI` problems, then the next step can be skipped.
+If that document did not solve the `Ceph CSI` problems, then continue to the next step.
 
 ## 3. Rerun storage node `cloud-init`
 

--- a/install/troubleshooting_ceph_csi.md
+++ b/install/troubleshooting_ceph_csi.md
@@ -6,7 +6,8 @@ If there has been a failure to initialize all Ceph CSI components on `ncn-s001`,
 ## Topics
 
 1. [Verify Ceph CSI](#1-verify-ceph-csi)
-1. [Rerun storage node `cloud-init`](#2-rerun-storage-node-cloud-init)
+1. [Check if Ceph pools failed to create](#2-check-if-ceph-pools-failed-to-create)
+1. [Rerun storage node `cloud-init`](#3-rerun-storage-node-cloud-init)
 
 ## 1. Verify Ceph CSI
 
@@ -54,9 +55,13 @@ Verify that the `ceph-csi` requirements are in place.
 
       Check your results against the above examples.
 
-      If any components are missing, see [Rerun storage node `cloud-init`](#2-rerun-storage-node-cloud-init).
+      If any components are missing, continue to the next step.
 
-## 2. Rerun storage node `cloud-init`
+## 2. Check if Ceph pools failed to create
+
+Follow the [Ceph OSD pool fails to create document](../troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md). If that document resolves the `Ceph CSI` problems, then the next step can be skipped. If the that document did not solve the `Ceph CSI` problems, then continue to the next step.
+
+## 3. Rerun storage node `cloud-init`
 
    This procedure will restart the storage node `cloud-init` process to prepare Ceph for use by the utility storage nodes.
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -46,6 +46,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Gigabyte BMC Missing Redfish Data](known_issues/Gigabyte_BMC_Missing_Redfish_Data.md)
 * [`admin*client-auth` Not Found](known_issues/admin_client_auth_not_found.md)
 * [Ceph OSD latency](known_issues/ceph_osd_latency.md)
+* [Ceph OSD pool fails to create](known_issues/ceph_osd_pool_fails_to_create.md)
 * [Cray CLI 403 Forbidden Errors](known_issues/craycli_403_forbidden_errors.md)
 * [Flags Set For Nodes In HSM](known_issues/flags_set_for_nodes_in_hsm.md)
 * [Goss Test Fails with Connection Refused](known_issues/goss_tests_fails_with_connection_refused.md)

--- a/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
+++ b/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
@@ -9,7 +9,7 @@ Additionally, the `csi-kube-secret` and/or the `csi-sma-secret` will not exist i
 
 ## Observed Error
 
-(`ncn-s001#`) Look at `cloud-init-output.log` on `ncn-s001` and check if an ansible task `Create Ceph OSD pool` failed when creating the `kube` and/or `smf` pool..
+(`ncn-s001#`) Look at `cloud-init-output.log` on `ncn-s001` and check if an Ansible task `Create Ceph OSD pool` failed when creating the `kube` and/or `smf` pool..
 
 ```bash
 cat /var/log/cloud-init-output.log | grep -A 2 'Create Ceph OSD pool'
@@ -24,10 +24,12 @@ changed: [ncn-s001.nmn] => (item={'name': 'k8s-block-replicated', 'args': '64 64
 
 --
 TASK [ceph-rbd : Create Ceph OSD pool] *****************************************
-failed: [ncn-s001.nmn] (item={'name': 'sma-block-replicated', 'args': '64 64', 'user': 'sma-block-replicated', 'secret': 'ceph-rbd-sma', 'storage_class': 'sma-block-replicated', 'compression_algorithm': 'snappy', 'compression_mode': 'aggressive', 'compression_required_ratio': 0.7, 'namespace': 'sma-block', 'pool_name': 'smf'}) => {"ansible_loop_var": "item", "changed": false, "cmd": ["ceph", "osd", "pool", "create", "smf", "64", "64"], "delta": "0:00:01.414139", "end": "2025-01-14 03:06:55.659707", "item": {"args": "64 64", "compression_algorithm": "snappy", "compression_mode": "aggressive", "compression_required_ratio": 0.7, "name": "sma-block-replicated", "namespace": "sma-block", "pool_name": "smf", "secret": "ceph-rbd-sma", "storage_class": "sma-block-replicated", "user": "sma-block-replicated"}, "msg": "non-zero return code", "rc": 34, "start": "2025-01-14 03:06:54.245568", "stderr": "Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250", "stderr_lines": ["Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250"], "stdout": "", "stdout_lines": []}
+failed: [ncn-s001.nmn] (item={'name': 'sma-block-replicated', 'args': '64 64', 'user': 'sma-block-replicated', 'secret': 'ceph-rbd-sma', 'storage_class': 'sma-block-replicated', 'compression_algorithm': 'snappy', 'compression_mode': 'aggressive', 'compression_required_ratio': 0.7, 'namespace': 'sma-block', 'pool_name': 'smf'}) => {"ansible_loop_var": "item", "changed": false, "cmd": ["ceph", "osd", "pool", "create", "smf", "64", "64"], "delta": "0:00:01.414139", "end": "2025-01-14 03:06:55.659707",
+"item": {"args": "64 64", "compression_algorithm": "snappy", "compression_mode": "aggressive", "compression_required_ratio": 0.7, "name": "sma-block-replicated", "namespace": "sma-block", "pool_name": "smf", "secret": "ceph-rbd-sma", "storage_class": "sma-block-replicated", "user": "sma-block-replicated"}, "msg": "non-zero return code", "rc": 34, "start": "2025-01-14 03:06:54.245568",
+"stderr": "Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250", "stderr_lines": ["Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250"], "stdout": "", "stdout_lines": []}
 ```
 
-The above error would also cause the`csi-kube-secret` or `csi-rbd-secret` secret to be missing from the defult namespace and the `kube` and/or `smf` Ceph pools to not be created.
+The above error would also cause the`csi-kube-secret` or `csi-rbd-secret` secret to be missing from the default namespace and the `kube` and/or `smf` Ceph pools to not be created.
 
 1. (`ncn-m001#`) Check if both `csi-kube-secret` and `csi-rbd-secret` secrets exist in the default namespace.
 
@@ -43,17 +45,18 @@ The above error would also cause the`csi-kube-secret` or `csi-rbd-secret` secret
 
 ## Recovery Procedure
 
-If `cloud-init-output.log` on `ncn-s001` shows that a `Create Ceph OSD pool` task failed, then follow the steps below. All of the following steps should be run from `ncn-s001`. 
+If `cloud-init-output.log` on `ncn-s001` shows that a `Create Ceph OSD pool` task failed, then follow the steps below.
+All of the following steps should be run from `ncn-s001`.
 
-1. (`ncn-s001#`) Execute the ansible playbook to create OSD pools.
+1. (`ncn-s001#`) Execute the Ansible playbook to create OSD pools.
 
     ```bash
     . /etc/ansible/boto3_ansible/bin/activate
     ansible-playbook /etc/ansible/ceph-rgw-users/install.yml --start-at-task="Determine if running on cloud or metal"
     deactivate
-    ``` 
+    ```
 
-1. (`ncn-s001#`) Execute steps to create neccessary secrets and configmaps.
+1. (`ncn-s001#`) Execute steps to create necessary secrets and ConfigMaps.
 
     ```bash
     . /srv/cray/scripts/common/csi-configuration.sh

--- a/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
+++ b/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
@@ -1,0 +1,82 @@
+# Ceph OSD pool fails to create
+
+## Description
+
+Cloud-init on `ncn-s001` can partially fail if not enough OSDs are up when Ceph OSD pools are being created.
+This problem has only been observed on CSM 1.6.0 and has been fixed in CSM 1.6.1.
+If not enough OSDs are up when Ceph attempts to create pools, the `kube` and/or `smf` pool will not be created.
+Additionally, the `csi-kube-secret` and/or the `csi-sma-secret` will not exist in the default namespace.
+
+## Observed Error
+
+(`ncn-s001#`) Look at `cloud-init-output.log` on `ncn-s001` and check if an ansible task `Create Ceph OSD pool` failed when creating the `kube` and/or `smf` pool..
+
+```bash
+cat /var/log/cloud-init-output.log | grep -A 2 'Create Ceph OSD pool'
+```
+
+Expected output if the `smf` pool failed to be created:
+
+```text
+ncn-s001:~ # cat /var/log/cloud-init-output.log | grep -A 2 'Create Ceph OSD pool'
+TASK [ceph-rbd : Create Ceph OSD pool] *****************************************
+changed: [ncn-s001.nmn] => (item={'name': 'k8s-block-replicated', 'args': '64 64', 'user': 'k8s-block-replicated', 'secret': 'ceph-rbd-kube', 'storage_class': 'k8s-block-replicated', 'compression_algorithm': 'snappy', 'compression_mode': 'aggressive', 'compression_required_ratio': 0.7, 'namespace': 'k8s-block', 'pool_name': 'kube'})
+
+--
+TASK [ceph-rbd : Create Ceph OSD pool] *****************************************
+failed: [ncn-s001.nmn] (item={'name': 'sma-block-replicated', 'args': '64 64', 'user': 'sma-block-replicated', 'secret': 'ceph-rbd-sma', 'storage_class': 'sma-block-replicated', 'compression_algorithm': 'snappy', 'compression_mode': 'aggressive', 'compression_required_ratio': 0.7, 'namespace': 'sma-block', 'pool_name': 'smf'}) => {"ansible_loop_var": "item", "changed": false, "cmd": ["ceph", "osd", "pool", "create", "smf", "64", "64"], "delta": "0:00:01.414139", "end": "2025-01-14 03:06:55.659707", "item": {"args": "64 64", "compression_algorithm": "snappy", "compression_mode": "aggressive", "compression_required_ratio": 0.7, "name": "sma-block-replicated", "namespace": "sma-block", "pool_name": "smf", "secret": "ceph-rbd-sma", "storage_class": "sma-block-replicated", "user": "sma-block-replicated"}, "msg": "non-zero return code", "rc": 34, "start": "2025-01-14 03:06:54.245568", "stderr": "Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250", "stderr_lines": ["Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250"], "stdout": "", "stdout_lines": []}
+```
+
+The above error would also cause the`csi-kube-secret` or `csi-rbd-secret` secret to be missing from the defult namespace and the `kube` and/or `smf` Ceph pools to not be created.
+
+1. (`ncn-m001#`) Check if both `csi-kube-secret` and `csi-rbd-secret` secrets exist in the default namespace.
+
+    ```bash
+    kubectl get secret -n default | grep 'csi-kube-secret\|csi-sma-secret'
+    ```
+
+1. (`ncn-m001#`) Check if the `kube` and/or `smf` pools exist in Ceph. List the Ceph pools in order to see if these pools exist.
+
+    ```bash
+    ceph osd pool ls
+    ```
+
+## Recovery Procedure
+
+If `cloud-init-output.log` on `ncn-s001` shows that a `Create Ceph OSD pool` task failed, then follow the steps below. All of the following steps should be run from `ncn-s001`. 
+
+1. (`ncn-s001#`) Execute the ansible playbook to create OSD pools.
+
+    ```bash
+    . /etc/ansible/boto3_ansible/bin/activate
+    ansible-playbook /etc/ansible/ceph-rgw-users/install.yml --start-at-task="Determine if running on cloud or metal"
+    deactivate
+    ``` 
+
+1. (`ncn-s001#`) Execute steps to create neccessary secrets and configmaps.
+
+    ```bash
+    . /srv/cray/scripts/common/csi-configuration.sh
+
+    echo "creating k8s storage class pre-reqs"
+    create_k8s_ceph_secrets
+    create_k8s_storage_class
+
+    echo "creating sma storage class pre-reqs"
+    create_sma_ceph_secrets
+    create_sma_storage_class
+    ```
+
+## Verify new pools have been created and secrets exist
+
+1. (`ncn-m001#`) Verify `kube` and `smf` pool exist.
+
+    ```bash
+    ceph osd pool ls | grep 'kube\|smf'
+    ```
+
+1. (`ncn-m001#`) Verify both `csi-kube-secret` and `csi-rbd-secret` secrets exist in the default namespace.
+
+    ```bash
+    kubectl get secret -n default | grep 'csi-kube-secret\|csi-sma-secret'
+    ```

--- a/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
+++ b/troubleshooting/known_issues/ceph_osd_pool_fails_to_create.md
@@ -29,9 +29,9 @@ failed: [ncn-s001.nmn] (item={'name': 'sma-block-replicated', 'args': '64 64', '
 "stderr": "Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250", "stderr_lines": ["Error ERANGE:  pg_num 64 size 3 for this pool would result in 288 cumulative PGs per OSD (1155 total PG replicas on 4 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250"], "stdout": "", "stdout_lines": []}
 ```
 
-The above error would also cause the`csi-kube-secret` or `csi-rbd-secret` secret to be missing from the default namespace and the `kube` and/or `smf` Ceph pools to not be created.
+The above error would also cause the`csi-kube-secret` or `csi-sma-secret` secret to be missing from the default namespace and the `kube` and/or `smf` Ceph pools to not be created.
 
-1. (`ncn-m001#`) Check if both `csi-kube-secret` and `csi-rbd-secret` secrets exist in the default namespace.
+1. (`ncn-m001#`) Check if both `csi-kube-secret` and `csi-sma-secret` secrets exist in the default namespace.
 
     ```bash
     kubectl get secret -n default | grep 'csi-kube-secret\|csi-sma-secret'
@@ -78,7 +78,7 @@ All of the following steps should be run from `ncn-s001`.
     ceph osd pool ls | grep 'kube\|smf'
     ```
 
-1. (`ncn-m001#`) Verify both `csi-kube-secret` and `csi-rbd-secret` secrets exist in the default namespace.
+1. (`ncn-m001#`) Verify both `csi-kube-secret` and `csi-sma-secret` secrets exist in the default namespace.
 
     ```bash
     kubectl get secret -n default | grep 'csi-kube-secret\|csi-sma-secret'


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Storage cloud init can fail if not enough OSDs are up when Ceph pools are created. This causes the pool to fail to create and causes a few other effects. This problem has only been seen in Vshasta on CSM 1.6.0. It has been fixed in CSM 1.6.1 and on. 

This PR adds a troubleshooting page for fixing the issue where Ceph pools are failed to be created.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
