### PR TITLE
CASMINST-7116 add known issue page for when iuf cli reports management-rollout failed

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -128,6 +128,9 @@ Refer to that table and any corresponding product documents before continuing to
 
     > **`NOTE`** If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
     then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading and restore the directory after the node has been upgraded.
+    >
+    > **Known Issue:** If the IUF CLI reports the error: `The management-nodes-rollout stage failed, but argo must run to the completion of the stage`,
+    then see [IUF CLI reports false error that `management-nodes-rollout` failed](../../../troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md).
 
     1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m002`. This will rebuild `ncn-m002` with the new CFS configuration and image built in
     previous steps of the workflow.
@@ -174,6 +177,9 @@ Refer to that table and any corresponding product documents before continuing to
 
     > **`NOTE`** If Kubernetes encryption has been enabled via the [Kubernetes Encryption Documentation](../../kubernetes/encryption/README.md),
     then backup the `/etc/cray/kubernetes/encryption` directory on the master node before upgrading and restore the directory after the node has been upgraded.
+    >
+    > **Known Issue:** If the IUF CLI reports the error: `The management-nodes-rollout stage failed, but argo must run to the completion of the stage`,
+    then see [IUF CLI reports false error that `management-nodes-rollout` failed](../../../troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md).
 
     1. Authenticate with the Cray CLI on `ncn-m002`.
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -71,6 +71,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
 * [Spire pods stuck in `PodInitializing`](known_issues/spire_pod_initializing.md)
 * [CFS Component With Zero-Length ID](known_issues/CFS_Component_With_Zero_Length_ID.md)
+* [IUF CLI reports false error that `management-nodes-rollout` failed](known_issues/iuf_cli_false_error_management_rollout_failed.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md
+++ b/troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md
@@ -1,0 +1,66 @@
+# Known Issue: IUF CLI reports false error that `management-nodes-rollout` failed
+
+## Problem Description
+
+When upgrading master nodes with IUF during the CSM 1.6.0 upgrade, the IUF CLI may say that the master node upgrade failed.
+The specific error is: `The management-nodes-rollout stage failed, but argo must run to the completion of the stage`.
+This is a bug in the IUF CLI and it happens because while master nodes are upgrading, the IUF CLI is momentarily unable to connect to the `cray-nls` service.
+The IUF CLI erroneously reports that the `management-nodes-rollout stage failed` even though `management-nodes-rollout` is likely continuing successfully in the background.
+
+This problem has been resolved in CSM 1.6.1.
+
+## Observed Error
+
+The following error can be seen when upgrading master nodes with IUF.
+
+```text
+INFO [backup-m ] BEG backup-m001
+INFO [backup-m ] BEG backup-m001(0)
+INFO [backup-m ] END backup-m001 [Succeeded]
+INFO [backup-m ] END backup-m001(0) [Succeeded]
+INFO [upgrade-m ] BEG upgrade-m001
+INFO [upgrade-m ] BEG upgrade-m001(0)
+ERR Workflow activity1-wjtdt-management-nodes-rollout-bf9nx not found.
+INFO [STAGE: management-nodes-rollout ] END Unknown in 0:03:18
+WARN The management-nodes-rollout stage failed, but argo must run to the completion of the stage.
+WARN Still waiting for workflow startup after 15 seconds.
+WARN Still waiting for workflow startup after 30 seconds.
+
+[...]
+
+ERR Giving up after 10 minutes. Check to ensure the ARGO backend is functional then try again.
+
+Error Summary:
+Workflow activity1-wjtdt-management-nodes-rollout-bf9nx not found.
+Giving up after 10 minutes. Check to ensure the ARGO backend is functional then try again.
+
+Error Summary:
+   Giving up after 10 minutes.  Check to ensure the ARGO backend is functional then try again.
+```
+
+## Resolution
+
+The error seen above is a false failure. There is no action needed other than to manually monitor the `management-nodes-rollout` Argo workflow that is continuing successfully in the background.
+The IUF workflow can be monitored in either of the following two ways.
+
+1. Use the Argo UI to monitor the workflow. See [using the Argo UI](../../operations/argo/Using_the_Argo_UI.md) for details on accessing the UI.
+
+1. (`ncn-m001#`) Monitor the logs of the pod running the `management-nodes-rollout` Argo workflow.
+
+    1. Get pods in the `argo` namespace, `grep` for 'management'.
+
+        ```bash
+        kubectl get pods -n argo | grep management
+        ```
+
+    1. Follow the logs for the pod running the `management-nodes-rollout` stage.
+
+        ```bash
+        kubectl logs -n argo <pod_name> -f
+        ```
+
+Continue monitoring the `management-nodes-rollout` workflow until it completes. It should complete successfully.
+If it fails to complete successfully, investigate the logs from the sources above to find the error.
+Additionally, a master node upgrade will print its upgrade output to `/root/output.log`.
+This file will be on `ncn-m001` when `ncn-m002` or `ncn-m003` are being upgraded and the file will be on `ncn-m002` when `ncn-m001` is being upgraded.
+This file can be used to debug a failed master node upgrade.

--- a/troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md
+++ b/troubleshooting/known_issues/iuf_cli_false_error_management_rollout_failed.md
@@ -1,6 +1,6 @@
-# Known Issue: IUF CLI reports false error that `management-nodes-rollout` failed
+# IUF CLI reports false error that `management-nodes-rollout` failed
 
-## Problem Description
+## Problem description
 
 When upgrading master nodes with IUF during the CSM 1.6.0 upgrade, the IUF CLI may say that the master node upgrade failed.
 The specific error is: `The management-nodes-rollout stage failed, but argo must run to the completion of the stage`.
@@ -9,7 +9,7 @@ The IUF CLI erroneously reports that the `management-nodes-rollout stage failed`
 
 This problem has been resolved in CSM 1.6.1.
 
-## Observed Error
+## Observed error
 
 The following error can be seen when upgrading master nodes with IUF.
 
@@ -40,7 +40,7 @@ Error Summary:
 
 ## Resolution
 
-The error seen above is a false failure. There is no action needed other than to manually monitor the `management-nodes-rollout` Argo workflow that is continuing successfully in the background.
+The [Observed error](#observed-error) is a false negative. No action is needed other than manually monitoring the `management-nodes-rollout` Argo workflow continuing successfully in the background.
 The IUF workflow can be monitored in either of the following two ways.
 
 1. Use the Argo UI to monitor the workflow. See [using the Argo UI](../../operations/argo/Using_the_Argo_UI.md) for details on accessing the UI.
@@ -59,8 +59,8 @@ The IUF workflow can be monitored in either of the following two ways.
         kubectl logs -n argo <pod_name> -f
         ```
 
-Continue monitoring the `management-nodes-rollout` workflow until it completes. It should complete successfully.
-If it fails to complete successfully, investigate the logs from the sources above to find the error.
+Continue monitoring the `management-nodes-rollout` workflow until it completes successfully.
+If it fails, investigate the logs from the sources above to find the error.
 Additionally, a master node upgrade will print its upgrade output to `/root/output.log`.
 This file will be on `ncn-m001` when `ncn-m002` or `ncn-m003` are being upgraded and the file will be on `ncn-m002` when `ncn-m001` is being upgraded.
 This file can be used to debug a failed master node upgrade.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

I added a troubleshooting/known_issue page for when upgrading master nodes with IUF during the CSM 1.6.0 upgrade, the IUF CLI may say that the master node upgrade failed.
The specific error is: `The management-nodes-rollout stage failed, but argo must run to the completion of the stage`.
This is a bug in the IUF CLI and it happens becuase while master nodes are upgrading, the IUF CLI is momentarily unable to connect to the `cray-nls` service.
The IUF CLI erroneously reports that the `management-nodes-rollout stage failed` even though `management-nodes-rollout` is likely continuing successfully in the background.

I have linked the troubleshooting page in the management_rollout steps so that it can be easily referenced. This has been fixed in CSM 1.6.1 and does not exist in CSM 1.5 or CSM 1.7.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
