### PR TITLE
CASMMON-468 update-customizations.sh breaks customizations template for 1.6

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -160,7 +160,7 @@ if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-
   yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].alertmanager.externalAuthority }}/\"" -i $c
   yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.externalAuthority = "grafana.cmn.{{ network.dns.external }}"' -i $c
   if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus' $c)" != null ]; then
-      yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus)' -i $c
+    yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus)' -i $c
   fi
 fi
 #sma-vm-cluster

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -151,16 +151,17 @@ if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-
   yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].grafana.externalAuthority }}\"" -i $c
   yq4 eval 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*kube-prometheus-stack*"))' -i $c
   yq4 eval ".spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.external_services.grafana.url = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].grafana.externalAuthority }}/\"" -i $c
-  yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack = .spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack | del(.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)" -i $c
+  yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)' -i $c
   yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmagent.vmagentSpec.externalAuthority = "vmagent.cmn.{{ network.dns.external }}"' -i $c
   yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmselect.vmselectSpec.externalAuthority = "vmselect.cmn.{{ network.dns.external }}"' -i $c
   yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.externalAuthority = "alertmanager.cmn.{{ network.dns.external }}"' -i $c
   yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmagent.vmagentSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmagent.vmagentSpec.externalAuthority }}/\"" -i $c
   yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmselect.vmselectSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmselect.vmselectSpec.externalAuthority }}/\"" -i $c
   yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].alertmanager.externalAuthority }}/\"" -i $c
-  yq4 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.alertmanagerSpec)' -i $c
-  yq4 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus)' -i $c
-  yq4 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.thanos)' -i $c
+  yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.externalAuthority = "grafana.cmn.{{ network.dns.external }}"' -i $c
+  if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus' $c)" != null ]; then
+      yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus)' -i $c
+  fi
 fi
 #sma-vm-cluster
 if [ "$(yq4 eval '.spec.kubernetes.services.sma-vm-cluster' $c)" == null ]; then


### PR DESCRIPTION
update-customizations.sh breaks customizations template for 1.6 > 1.6 and 1.6 > 1.7 upgrades

https://jira-pro.it.hpe.com:8443/browse/CASMMON-468

tested on fanta

manifestgen -i shs.yaml -c customizations-1.yaml -o shs-cust-1.yaml


ncn-m001:/mnt/developer/ram # cat shs-cust-1.yaml
apiVersion: manifests/v1beta1
metadata:
  name: cray-sysmgmt-health
spec:
  charts:
  - name: cray-sysmgmt-health
    namespace: sysmgmt-health
    values:
      cephExporter:
        endpoints:
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      cephNodeExporter:
        enabled: true
        endpoints:
        - 10.252.1.4
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      imageHost: registry.local
      prometheus-snmp-exporter:
        serviceMonitor:
          enabled: false
      victoria-metrics-k8s-stack:
        alertmanager:
          externalAuthority: alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net
          externalUrl: https://alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net/
        grafana:
          externalAuthority: grafana.cmn.fanta.hpc.amslabs.hpecorp.net
          plugins: ''
        kubeEtcd:
          endpoints:
          - 10.252.1.8
          - 10.252.1.9
          - 10.252.1.10
        prometheus-node-exporter:
          resources:
            limits:
              cpu: '6'
              memory: 2Gi
            requests:
              cpu: 10m
              memory: 64Mi
        vmagent:
          vmagentSpec:
            externalAuthority: vmagent.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmagent.cmn.fanta.hpc.amslabs.hpecorp.net/
        vmselect:
          vmselectSpec:
            externalAuthority: vmselect.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmselect.cmn.fanta.hpc.amslabs.hpecorp.net/
    version: 1.1.5


