### PR TITLE
CASMTRIAGE-7719 export ceph.client.kube.keyring in Configure_a_remote_Build_Node.md

### DIFF
--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -485,7 +485,15 @@ NOTE: The Ceph storage described below has several important characteristics to 
     Running post-transaction scripts ...[done]
     ```
 
-1. (`ncn-mw#`) Copy the Ceph configuration and client admin keyring to the remote build node.
+1. (`ncn-m#`) Export the `ceph.client.kube.keyring` to a file if the file does not already exist.
+
+    ```bash
+    if [ ! -f /etc/ceph/ceph.client.kube.keyring ]; then
+      ceph auth export client.kube -o /etc/ceph/ceph.client.kube.keyring
+    fi
+    ```
+
+1. (`ncn-m#`) Copy the Ceph configuration and client admin keyring to the remote build node.
 
     ```bash
     scp /etc/ceph/ceph.conf ${IMS_REMOTE_NODE_XNAME}:/etc/ceph/ceph.conf


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The Configure_a_Remote_Build_Node.md procedure fails if the `/etc/ceph/ceph.client.kube.keyring` file does not exist. This PR adds a step to the procedure to export the `client.kube` keyring to a file so that the keyring can then be copied and used on a compute node. 

Additionally, I changed the directions so that the ceph commands should only be run from `ncn-m#` nodes. Originally, the instructions said these commands could be run on `ncn-mw#`, however they will not work from worker nodes.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
