### PR TITLE
CASMINST-7137: Backport requirements for write_sw_admin_pw_to_vault, update procedure to use it

### DIFF
--- a/operations/network/management_network/README.md
+++ b/operations/network/management_network/README.md
@@ -41,22 +41,21 @@ including `goss-switch-bgp-neighbor-aruba-or-mellanox` use these credentials to 
 is not required to configure the management network. If Vault is unavailable, this step can be temporarily skipped. Any
 automated tests that depend on the switch credentials being in Vault will fail until they are added.
 
-1. (`ncn-mw#`) Write the switch admin password to the `SW_ADMIN_PASSWORD` variable if it is not already set.
+(`ncn-mw#`) The following script will prompt for the password, write it to Vault, and then read it back
+to verify that it was written correctly.
 
-   > The use of `read -s` is a convention used throughout this documentation which allows for the
-   > user input of secrets without echoing them to the terminal or saving them in history.
+```bash
+/usr/share/doc/csm/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
+```
 
-    ```bash
-    read -s SW_ADMIN_PASSWORD
-    ```
+On success, the script will exit with return code 0 and have the following final lines
+of output:
 
-1. (`ncn-mw#`) Run the following commands to add the password to Vault.
-
-    ```bash
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
-    vault kv put secret/net-creds/switch_admin admin=$SW_ADMIN_PASSWORD
-    ```
+```text
+Writing switch admin password to Vault
+Password read from Vault matches what was written
+SUCCESS
+```
 
 ## Starting points
 

--- a/operations/network/management_network/README.md
+++ b/operations/network/management_network/README.md
@@ -30,9 +30,9 @@ exactly match installed products.
 * [Minimum software version requirements](#minimum-software-version-requirements)
 * [Transceiver and cable guide](transceiver_cable_guide.md)
 * [Changes](#changes)
-  * [Enhancements](#enhancements-and-features)
-  * [Issues and workarounds](#issues-and-workarounds)
-  * [Security Bulletin Subscription Service](#security-bulletin-subscription-service)
+    * [Enhancements](#enhancements-and-features)
+    * [Issues and workarounds](#issues-and-workarounds)
+    * [Security Bulletin Subscription Service](#security-bulletin-subscription-service)
 
 ## Adding switch admin password to Vault
 

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,6 +39,8 @@ K8S_SECRET_NAME = "cray-vault-unseal-keys"
 K8S_SERVICE_NAME = "cray-vault"
 
 CSM_ROOT_SECRET_KEY = "csm/users/root"
+SW_ADMIN_PW_KEY = "net-creds/switch_admin"
+SW_ADMIN_PW_FIELD = "admin"
 
 API_STATUS_OK_WITH_DATA = 200
 API_STATUS_OK_EMPTY = 204
@@ -282,8 +284,21 @@ class Vault():
         """
         return self.get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
 
+    def get_sw_admin_password(self) -> str:
+        """
+        Wrapper function that supplies the switch admin password key to get_secret(),
+        and extracts the SW_ADMIN_PW_FIELD field from the result
+        """
+        return self.get_secret(secret_key=SW_ADMIN_PW_KEY, must_exist=True)[SW_ADMIN_PW_FIELD]
+
     def write_csm_root_secret(self, **kwargs) -> None:
         """
         Wrapper function that supplies the CSM root secret key to write_secret()
         """
         self.write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+
+    def write_sw_admin_password(self, pw_string: str) -> None:
+        """
+        Wrapper function that supplies the switch admin password key to write_secret()
+        """
+        self.write_secret(secret_key=SW_ADMIN_PW_KEY, secret_data={ SW_ADMIN_PW_FIELD: pw_string })


### PR DESCRIPTION
https://github.com/Cray-HPE/docs-csm/pull/5473 backported the `write_sw_admin_pw_to_vault` script to 1.5, but it did not backport the required `vault.py` module. This resulted in the script being broken.

This PR backports that dependency. It also then updates the corresponding procedure to use the script, instead of the old manual procedure.

No backports needed -- this is only needed for 1.5.