### PR TITLE
CASMINST-7138: Update CSM 1.4 upgrade prep links; add CSM 1.5 upgrade prep

### DIFF
--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -28,13 +28,15 @@ the steps below it provide detailed instructions which must be executed in the o
 
 ![Upgrade CSM and additional products with IUF](../../../img/operations/diagram_csm_stack_upgrade_14_04142023.png)
 
+1. [Prepare for Upgrade to Next CSM Major Version](https://github.com/Cray-HPE/docs-csm/tree/release/1.3/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md)
+   in the CSM 1.3 documentation.
+
 1. CSM preparation, Stage 0.1, and Stage 0.2
 
    Read the _Important Notes_ section of the
    [CSM 1.3.0 or later to 1.4.0 Upgrade Process](../../../upgrade/Upgrade_Management_Nodes_and_CSM_Services.md)
    documentation and then follow only these CSM instructions in order:
 
-   1. [Prepare for Upgrade](../../../upgrade/prepare_for_upgrade.md)
    1. [Stage 0.1 - Prepare assets](../../../upgrade/Stage_0_Prerequisites.md#stage-01---prepare-assets)
    1. [Stage 0.2 - Prerequisites](../../../upgrade/Stage_0_Prerequisites.md#stage-02---prerequisites)
 

--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -1,8 +1,7 @@
 <!-- markdownlint-disable MD013 -->
-# Prepare For Upgrade
+# Prepare for Upgrade to Next CSM Major Version
 
-Before beginning an upgrade to a new version of CSM, there are a few things to do on the system
-first.
+Before beginning an upgrade from CSM 1.4 to CSM 1.5, there are a few things to do on the system first.
 
 - [Reduced resiliency during upgrade](#reduced-resiliency-during-upgrade)
 - [Preparation steps]
@@ -51,6 +50,7 @@ When resuming a procedure after a break, always be sure that a typescript is run
 Before following the steps to prepare for the upgrade, make sure that the latest CSM documentation RPMs are
 installed on any NCNs where preparation procedures are being performed. These should be for the **`CURRENT`**
 CSM version on the system -- not the target version of the upgrade.
+
 See [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation) for instructions.
 
 ### 3. Export Nexus data
@@ -60,7 +60,6 @@ during scheduled maintenance periods.
 
 Prior to the upgrade it is recommended that a Nexus export is taken. This is not a required step but
 highly recommend to protect the data in Nexus.
-If there is no maintenance period available, then skip this step until after the upgrade process.
 
 Reference [Nexus Export and Restore Procedure](../operations/package_repository_management/Nexus_Export_and_Restore.md)
 for details.
@@ -140,8 +139,6 @@ Return here after verifying that SNMP is properly configured on the management n
 
    > This [System Admin Toolkit (SAT)](../glossary.md#system-admin-toolkit-sat) command has `shutdown` as one of the command line options,
    > but it will **not** start a shutdown process on the system.
-   >
-   > **Note:** This step may take a longer time if there are many BOS sessions. It is recommended to keep the sessions count minimal to reduce the overall time taken.
 
    ```bash
    sat bootsys shutdown --stage session-checks
@@ -177,9 +174,7 @@ Return here after verifying that SNMP is properly configured on the management n
    starts. After the upgrade is completed, another health check is performed, and it is important to know
    if any problems observed at that time existed prior to the upgrade.
 
-   **`IMPORTANT`**: See the `CSM Install Validation and Health Checks` procedures in the
-   documentation for the **`CURRENT`** CSM version on the system. The validation procedures in the CSM
-   documentation are only intended to work with that specific version of CSM.
+   Reference [Validate CSM Health](../operations/validate_csm_health.md) for details.
 
 1. Validate Lustre health.
 

--- a/upgrade/Upgrade_Only_CSM.md
+++ b/upgrade/Upgrade_Only_CSM.md
@@ -22,7 +22,7 @@ sections, but there is also a general troubleshooting topic.
 
 ## 1. Prepare for upgrade
 
-See [Prepare for Upgrade](prepare_for_upgrade.md).
+See [Prepare for Upgrade to Next CSM Major Version](https://github.com/Cray-HPE/docs-csm/tree/release/1.3/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md) in the CSM 1.3 documentation.
 
 ## 2. Upgrade management nodes and CSM services
 


### PR DESCRIPTION
The CSM 1.4 PR for https://github.com/Cray-HPE/docs-csm/pull/5683

(Note: the link checker for this PR will fail until the above PR merges)