### PR TITLE
CASMINST-7138: Update CSM 1.7 upgrade prep links; add CSM 1.8 upgrade prep

### DIFF
--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -29,13 +29,12 @@ For more detail about about the CSM upgrade hooks, see the section [description 
 
 ![Upgrade CSM and additional products with IUF](../../../img/operations/diagram_csm_stack_upgrade_01132025.png)
 
-1. CSM preparation
-
-   Read the _Important Notes_ section of the
+1. Read the _Important Notes_ section of the
    [CSM 1.5.0 or later to 1.6.0 Upgrade Process](../../../upgrade/Upgrade_Management_Nodes_and_CSM_Services.md)
-   documentation and then follow only these CSM instructions in order:
+   documentation.
 
-   1. [Prepare for Upgrade](../../../upgrade/prepare_for_upgrade.md)
+1. [Prepare for Upgrade to Next CSM Major Version](https://github.com/Cray-HPE/docs-csm/tree/release/1.6/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md)
+   in the CSM 1.6 documentation.
 
 1. Prepare for the upgrade procedure and download product media
 

--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -1,8 +1,7 @@
 <!-- markdownlint-disable MD013 -->
-# Prepare For Upgrade
+# Prepare for Upgrade to Next CSM Major Version
 
-Before beginning an upgrade to a new version of CSM, there are a few things to do on the system
-first.
+Before beginning an upgrade from CSM 1.7 to CSM 1.8, there are a few things to do on the system first.
 
 - [Reduced resiliency during upgrade](#reduced-resiliency-during-upgrade)
 - [Preparation steps]
@@ -51,6 +50,7 @@ When resuming a procedure after a break, always be sure that a typescript is run
 Before following the steps to prepare for the upgrade, make sure that the latest CSM documentation RPMs are
 installed on any NCNs where preparation procedures are being performed. These should be for the **`CURRENT`**
 CSM version on the system -- not the target version of the upgrade.
+
 See [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation) for instructions.
 
 ### 3. Export Nexus data
@@ -155,9 +155,7 @@ Return here after verifying that SNMP is properly configured on the management n
    starts. After the upgrade is completed, another health check is performed, and it is important to know
    if any problems observed at that time existed prior to the upgrade.
 
-   **`IMPORTANT`**: See the [`CSM Install Validation and Health Checks`](../operations/validate_csm_health.md) procedures in the
-   documentation for the **`CURRENT`** CSM version on the system. The validation procedures in the CSM
-   documentation are only intended to work with that specific version of CSM.
+   Reference [Validate CSM Health](../operations/validate_csm_health.md) for details.
 
 1. Validate Lustre health.
 

--- a/upgrade/Upgrade_Only_CSM_with_iuf.md
+++ b/upgrade/Upgrade_Only_CSM_with_iuf.md
@@ -13,13 +13,12 @@ section of the [Upgrade CSM and additional products with IUF](../operations/iuf/
 
 ## Upgrade Procedure
 
-1. CSM preparation
-
-   Read the _Important Notes_ section of the
+1. Read the _Important Notes_ section of the
    [CSM 1.5.0 or later to 1.6.0 Upgrade Process](Upgrade_Management_Nodes_and_CSM_Services.md)
-   documentation and then follow only these CSM instructions in order:
+   documentation.
 
-   1. [Prepare for Upgrade](prepare_for_upgrade.md)
+1. [Prepare for Upgrade to Next CSM Major Version](https://github.com/Cray-HPE/docs-csm/tree/release/1.6/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md)
+   in the CSM 1.6 documentation.
 
 1. Prepare for the upgrade procedure and download product media
 


### PR DESCRIPTION
CSM 1.7 PR for https://github.com/Cray-HPE/docs-csm/pull/5683

(Note, the link check for this PR will fail until https://github.com/Cray-HPE/docs-csm/pull/5686 merges)