### PR TITLE
CASMMON-468 update-customizations.sh breaks customizations template for 1.6

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -142,26 +142,16 @@ yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
 
 # victoria-metrics-k8s-stack
 if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack' $c)" != null ]; then
-  if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack' $c)" != null ]; then
-    yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack = (.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack * .spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)' -i $c
-  fi
+  yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)' -i $c
+  yq4 eval 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*kube-prometheus-stack*"))' -i $c
+  yq4 eval 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*victoria-metrics-k8s-stack*"))' -i $c
+
   yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmselect.vmselectSpec.externalAuthority }}\"" -i $c
   yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmagent.vmagentSpec.externalAuthority }}\"" -i $c
   yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].alertmanager.externalAuthority }}\"" -i $c
   yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].grafana.externalAuthority }}\"" -i $c
-  yq4 eval 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*kube-prometheus-stack*"))' -i $c
   yq4 eval ".spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.external_services.grafana.url = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].grafana.externalAuthority }}/\"" -i $c
-  yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack)' -i $c
-  yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmagent.vmagentSpec.externalAuthority = "vmagent.cmn.{{ network.dns.external }}"' -i $c
-  yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmselect.vmselectSpec.externalAuthority = "vmselect.cmn.{{ network.dns.external }}"' -i $c
-  yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.externalAuthority = "alertmanager.cmn.{{ network.dns.external }}"' -i $c
-  yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmagent.vmagentSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmagent.vmagentSpec.externalAuthority }}/\"" -i $c
-  yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.vmselect.vmselectSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].vmselect.vmselectSpec.externalAuthority }}/\"" -i $c
-  yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.alertmanager.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['victoria-metrics-k8s-stack'].alertmanager.externalAuthority }}/\"" -i $c
-  yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.grafana.externalAuthority = "grafana.cmn.{{ network.dns.external }}"' -i $c
-  if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus' $c)" != null ]; then
-    yq4 eval 'del(.spec.kubernetes.services.cray-sysmgmt-health.victoria-metrics-k8s-stack.prometheus)' -i $c
-  fi
+  yq4 -i eval ".spec.kubernetes.services.cray-sysmgmt-health[\"victoria-metrics-k8s-stack\"] += (load(\"${upgrade_customizations}\") | .spec.kubernetes.services.cray-sysmgmt-health[\"victoria-metrics-k8s-stack\"])" "$c"
 fi
 #sma-vm-cluster
 if [ "$(yq4 eval '.spec.kubernetes.services.sma-vm-cluster' $c)" == null ]; then


### PR DESCRIPTION
update-customizations.sh breaks customizations template for 1.6 > 1.6 and 1.6 > 1.7 upgrades

https://jira-pro.it.hpe.com:8443/browse/CASMMON-468

tested on fanta

manifestgen -i shs.yaml -c customizations-1.yaml -o shs-cust-1.yaml


ncn-m001:/mnt/developer/ram # cat shs-cust-1.yaml
apiVersion: manifests/v1beta1
metadata:
  name: cray-sysmgmt-health
spec:
  charts:
  - name: cray-sysmgmt-health
    namespace: sysmgmt-health
    values:
      cephExporter:
        endpoints:
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      cephNodeExporter:
        enabled: true
        endpoints:
        - 10.252.1.4
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      imageHost: registry.local
      prometheus-snmp-exporter:
        serviceMonitor:
          enabled: false
      victoria-metrics-k8s-stack:
        alertmanager:
          externalAuthority: alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net
          externalUrl: https://alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net/
        grafana:
          externalAuthority: grafana.cmn.fanta.hpc.amslabs.hpecorp.net
          plugins: ''
        kubeEtcd:
          endpoints:
          - 10.252.1.8
          - 10.252.1.9
          - 10.252.1.10
        prometheus-node-exporter:
          resources:
            limits:
              cpu: '6'
              memory: 2Gi
            requests:
              cpu: 10m
              memory: 64Mi
        vmagent:
          vmagentSpec:
            externalAuthority: vmagent.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmagent.cmn.fanta.hpc.amslabs.hpecorp.net/
        vmselect:
          vmselectSpec:
            externalAuthority: vmselect.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmselect.cmn.fanta.hpc.amslabs.hpecorp.net/
    version: 1.1.5

diff shs-cust-2.yaml shs-cust-1.yaml
ncn-m001:/mnt/developer/ram # cat shs-cust-2.yaml
apiVersion: manifests/v1beta1
metadata:
  name: cray-sysmgmt-health
spec:
  charts:
  - name: cray-sysmgmt-health
    namespace: sysmgmt-health
    values:
      cephExporter:
        endpoints:
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      cephNodeExporter:
        enabled: true
        endpoints:
        - 10.252.1.4
        - 10.252.1.5
        - 10.252.1.6
        - 10.252.1.7
      imageHost: registry.local
      prometheus-snmp-exporter:
        serviceMonitor:
          enabled: false
      victoria-metrics-k8s-stack:
        alertmanager:
          externalAuthority: alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net
          externalUrl: https://alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net/
        grafana:
          externalAuthority: grafana.cmn.fanta.hpc.amslabs.hpecorp.net
          plugins: ''
        kubeEtcd:
          endpoints:
          - 10.252.1.8
          - 10.252.1.9
          - 10.252.1.10
        prometheus-node-exporter:
          resources:
            limits:
              cpu: '6'
              memory: 2Gi
            requests:
              cpu: 10m
              memory: 64Mi
        vmagent:
          vmagentSpec:
            externalAuthority: vmagent.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmagent.cmn.fanta.hpc.amslabs.hpecorp.net/
        vmselect:
          vmselectSpec:
            externalAuthority: vmselect.cmn.fanta.hpc.amslabs.hpecorp.net
            externalUrl: https://vmselect.cmn.fanta.hpc.amslabs.hpecorp.net/
    version: 1.1.5

 loftsman ship --manifest-path ./shs-cust-2.yaml --charts-path .
2025-01-23T05:27:44Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2025-01-23T05:27:44Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2025-01-23T05:27:44Z INF Ensuring that the loftsman namespace exists command=ship
2025-01-23T05:27:44Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2025-01-23T05:27:44Z INF Running a release for the provided manifest at ./shs-cust-2.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-sysmgmt-health v1.1.5
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-01-23T05:27:46Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.5
  - 10.252.1.6
  - 10.252.1.7
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.4
  - 10.252.1.5
  - 10.252.1.6
  - 10.252.1.7
imageHost: registry.local
prometheus-snmp-exporter:
  serviceMonitor:
    enabled: false
victoria-metrics-k8s-stack:
  alertmanager:
    externalAuthority: alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net
    externalUrl: https://alertmanager.cmn.fanta.hpc.amslabs.hpecorp.net/
  grafana:
    externalAuthority: grafana.cmn.fanta.hpc.amslabs.hpecorp.net
    plugins: ""
  kubeEtcd:
    endpoints:
    - 10.252.1.8
    - 10.252.1.9
    - 10.252.1.10
  prometheus-node-exporter:
    resources:
      limits:
        cpu: "6"
        memory: 2Gi
      requests:
        cpu: 10m
        memory: 64Mi
  vmagent:
    vmagentSpec:
      externalAuthority: vmagent.cmn.fanta.hpc.amslabs.hpecorp.net
      externalUrl: https://vmagent.cmn.fanta.hpc.amslabs.hpecorp.net/
  vmselect:
    vmselectSpec:
      externalAuthority: vmselect.cmn.fanta.hpc.amslabs.hpecorp.net
      externalUrl: https://vmselect.cmn.fanta.hpc.amslabs.hpecorp.net/
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.1.5
2025-01-23T05:27:46Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-sysmgmt-health-1.1.5.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=1.1.5 -f /tmp/loftsman-1737610064/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.1.5
2025-01-23T05:28:50Z INF W0123 05:28:35.276400 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.280503 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.290632 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.294833 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.299091 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.306063 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.310523 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.315203 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0123 05:28:35.327157 3672619 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "cray-sysmgmt-health" has been upgraded. Happy Helming!
NAME: cray-sysmgmt-health
LAST DEPLOYED: Thu Jan 23 05:28:02 2025
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 3
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.1.5
2025-01-23T05:28:50Z INF Ship status: success. Recording status, manifest to configmap loftsman-cray-sysmgmt-health in namespace loftsman command=ship
2025-01-23T05:28:50Z INF Recording log data to configmap loftsman-cray-sysmgmt-health-ship-log in namespace loftsman command=ship

