### PR TITLE
CASMTRIAGE-7705: Add Workaround Docs in CSM 1.5 for CASMTRIAGE-6941: ERR  Could not determine the media_dir

### DIFF
--- a/operations/iuf/workflows/managed_rollout.md
+++ b/operations/iuf/workflows/managed_rollout.md
@@ -74,7 +74,7 @@ Refer to the "Configure `OpenSearch`" section in the _HPE Cray EX System Monitor
 
    ```bash
    XNAME=x3000c0s29b1n0
-   iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout --limit-managed-rollout "${XNAME}" -mrs reboot
+   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout --limit-managed-rollout "${XNAME}" -mrs reboot
    ```
 
 1. Verify the canary node booted successfully with the desired image and CFS configuration.
@@ -92,7 +92,7 @@ Refer to the "Configure `OpenSearch`" section in the _HPE Cray EX System Monitor
         immediately reboot all compute nodes.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout -mrs reboot
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout -mrs reboot
         ```
 
    - If Slurm is the workload manager:
@@ -106,7 +106,7 @@ Refer to the "Configure `OpenSearch`" section in the _HPE Cray EX System Monitor
         add `-mrs reboot` to the `iuf run` command.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout
         ```
 
         **NOTE:** If the `-mrs reboot` option is used with Slurm, skip the following step.
@@ -184,7 +184,7 @@ Once this step has completed:
    (`ncn-m001#`) Execute the `post-install-check` stage.
 
     ```bash
-    iuf -a "${ACTIVITY_NAME}" run -r post-install-check
+    iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r post-install-check
     ```
 
 Once this step has completed:

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -71,7 +71,7 @@ Refer to that table and any corresponding product documents before continuing to
         ```
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ${STORAGE_CANARY}
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ${STORAGE_CANARY}
         ```
 
     1. (`ncn-m#`) Verify that the storage canary node booted successfully with the desired CFS configuration.
@@ -94,7 +94,7 @@ Refer to that table and any corresponding product documents before continuing to
         ```
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ${STORAGE_NODES}
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ${STORAGE_NODES}
         ```
 
     1. (`ncn-m001#`) Verify that all storage nodes configured successfully.
@@ -116,7 +116,7 @@ Refer to that table and any corresponding product documents before continuing to
         (`ncn-m001#`) Execute the `management-nodes-rollout` stage with `ncn-m002`.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ncn-m002
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ncn-m002
         ```
 
         > **`NOTE`** The `/etc/cray/kubernetes/encryption` directory should be restored if it was backed up. Once it is restored, the `kube-apiserver` on the rebuilt node should be restarted.
@@ -136,7 +136,7 @@ Refer to that table and any corresponding product documents before continuing to
         (`ncn-m001#`) Execute the `management-nodes-rollout` stage with `ncn-m003`.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ncn-m003
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ncn-m003
         ```
 
         > **`NOTE`** The `/etc/cray/kubernetes/encryption` directory should be restored if it was backed up. Once it is restored, the `kube-apiserver` on the rebuilt node should be restarted.
@@ -381,7 +381,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```
 
     ```bash
-    iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ${WORKER_CANARY}
+    iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ${WORKER_CANARY}
     ```
 
 1. Verify the canary node booted successfully with the desired image and CFS configuration.
@@ -415,7 +415,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     1. (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout Management_Worker
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout Management_Worker
         ```
 
     1. (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes. The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
@@ -426,7 +426,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
         ```
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout $WORKER_NODES
+        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout $WORKER_NODES
         ```
 
 1. (`ncn-m001#`) Use `kubectl` to remove the `iuf-prevent-rollout=true` label from the canary node.


### PR DESCRIPTION
CASMTRIAGE-7705: Add Workaround Documentation
for CASMTRIAGE-6941: ERR  Could not determine the media_dir

iuf commands fails without MEDIA_DIR if previous session has failed last_state is not updated and dict has None value for media_dir .

Adding  -m "${MEDIA_DIR}" argument to the stages where it currently missing . i.e  'update-vcs-config' , 'management-nodes-rollout' , 'managed-nodes-rollout' , 'post-install-check' .



- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
