### PR TITLE
CASMTRIAGE-7734: Removed comma from cray_nodeBMC_nodeAccUC.json FAS recipe - 1.4

### DIFF
--- a/scripts/operations/firmware/recipes/cray_nodeBMC_nodeAccUC.json
+++ b/scripts/operations/firmware/recipes/cray_nodeBMC_nodeAccUC.json
@@ -9,7 +9,7 @@
     },
     "targetFilter": {
         "targets": [
-          "Node0.AccUC",
+          "Node0.AccUC"
         ]
     },
     "command": {


### PR DESCRIPTION
# Description

Removed comma from cray_nodeBMC_nodeAccUC.json FAS recipe

CASMTRIAGE-7734

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

