### PR TITLE
CASMINST-7139: Update SAT bootprep known issue for 1.5.3

### DIFF
--- a/operations/iuf/workflows/image_preparation.md
+++ b/operations/iuf/workflows/image_preparation.md
@@ -29,9 +29,9 @@ Refer to that table and any corresponding product documents before continuing to
     iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run --site-vars "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r update-cfs-config prepare-images
     ```
 
-    **`NOTE`:** If it is necessary to execute a `sat bootprep` command directly from management
-    nodes on CSM 1.5.2 systems to debug a failure, an error may occur during image customization.
-    To fix this issue, see the workaround documented in [`sat bootprep` image customization error](../../../troubleshooting/known_issues/sat_bootprep_image_customization_error.md)
+    **`NOTE`:** On CSM 1.5 systems running CSM 1.5.2 or higher, if it is necessary to execute a `sat bootprep` command directly from management
+    nodes to debug a failure, then an error may occur during image customization. For details and workaround, see
+    [`sat bootprep` image customization error](../../../troubleshooting/known_issues/sat_bootprep_image_customization_error.md)
 
 1. Inspect the newly-created management NCN and managed node images, CFS configurations, and BOS session templates to ensure they are correct before continuing with the next steps of the workflow. The artifacts can be identified
 by examining the output from `iuf run` or by examining the Kubernetes ConfigMap associated with the activity. See the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation for

--- a/operations/sat/sat_in_csm.md
+++ b/operations/sat/sat_in_csm.md
@@ -60,7 +60,9 @@ refer to **SAT Uninstall and Downgrade** in the SAT documentation.
 
 ## Known issues
 
+The following are known issues with SAT in CSM 1.5:
+
 - In CSM 1.5.0, SAT status may give CFS errors on large systems. For more information, see
-[CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
-- In CSM 1.5.2, `sat bootprep` will encounter an error during image customization.
-To overcome this issue, see [`sat bootprep` image customization error](../../troubleshooting/known_issues/sat_bootprep_image_customization_error.md).
+  [CFS V2 Failures On Large Systems](../../troubleshooting/known_issues/CFS_V2_Failures_On_Large_Systems.md).
+- In CSM 1.5.2 or higher, `sat bootprep` may encounter an error during image customization. For details and workaround, see
+  [`sat bootprep` image customization error](../../troubleshooting/known_issues/sat_bootprep_image_customization_error.md).

--- a/troubleshooting/known_issues/sat_bootprep_image_customization_error.md
+++ b/troubleshooting/known_issues/sat_bootprep_image_customization_error.md
@@ -1,6 +1,9 @@
 # `sat bootprep` image customization error
 
-On CSM 1.5.2 systems, the following error occurs when you try to customize an image using the `sat bootprep` command directly from management nodes:
+## Symptom
+
+On CSM 1.5 systems running version CSM 1.5.2 or higher, the following error may occur
+when you try to customize an image using the `sat bootprep` command directly from management nodes:
 
 ```text
 Traceback (most recent call last):
@@ -26,8 +29,10 @@ Traceback (most recent call last):
     self.begin_image_configure()
   File "/sat/venv/lib/python3.9/site-packages/sat/cli/bootprep/input/image.py", line 405, in begin_image_configure
     self.image_configure_session = self.cfs_client.create_image_customization_session(
-TypeError: create_image_customization_session() missing 1 required positional argument: 'image_name' 
+TypeError: create_image_customization_session() missing 1 required positional argument: 'image_name'
 ```
+
+## Scope
 
 This affects versions 3.25.14 and 3.25.15 of the `sat` CLI. The version of the `sat` CLI can be
 viewed with `sat --version`. These versions of the `sat` CLI were included in SAT product versions
@@ -35,10 +40,31 @@ viewed with `sat --version`. These versions of the `sat` CLI were included in SA
 
 ## Workaround
 
-Set the environment variable `SAT_IMAGE` to point at the older version of
-`cray-sat` provided by CSM 1.5.2 instead of the version from the newer SAT product stream.
-Do this only for `sat bootprep` commands. For example,
+Set the environment variable `SAT_IMAGE` to point at different version of `cray-sat` that does not
+have this problem. Do this only for `sat bootprep` commands.
 
-```bash
-SAT_IMAGE="registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat:3.25.11" sat bootprep run
-```
+1. (`ncn-mw#`) List and sort the available `cray-sat` versions, omitting those with this error.
+
+    ```bash
+    podman search --no-trunc --list-tags registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat |
+        awk '{ print $NF }' |
+        grep -Ev '^3[.]25[.]1[45]$' |
+        grep -E '^[0-9]+[.][0-9]+[.][0-9]+' |
+        sort -V
+    ```
+
+    Example output:
+
+    ```text
+    3.25.11
+    3.25.16
+    ```
+
+1. (`ncn-mw#`) Run the `sat bootprep` command with the `SAT_IMAGE` environment variable set to the latest version
+   listed in the previous step.
+
+    For example:
+
+    ```bash
+    SAT_IMAGE="registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat:3.25.16" sat bootprep run
+    ```


### PR DESCRIPTION
There is a known SAT issue in CSM 1.5.2 that is also possible to hit in CSM 1.5.3. This PR updates the relevant workaround procedure and references to the procedure to account for the fact that it is present in both patch releases. The workaround remains essentially the same, and we tested the updated version on hela.

No backports needed -- this is unique to CSM 1.5.

The diff for the workaround procedure looks so huge because the version checked into the repository had Windows newlines, and they got stripped by git when I checked it in.