### PR TITLE
CASM-5267: Make CURL_MAX_TIME,CURL_CONNECT_TIMEOUT configurable for nexus uploads

### DIFF
--- a/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -193,6 +193,10 @@ spec:
           secretKeyRef:
             name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: password
+      - name: CURL_MAX_TIME
+        value: "1800"
+      - name: CURL_CONNECT_TIMEOUT
+        value: "600"
       volumeMounts:
       - name: image
         mountPath: /images

--- a/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -194,6 +194,10 @@ spec:
           secretKeyRef:
             name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: password
+      - name: CURL_MAX_TIME
+        value: "1800"
+      - name: CURL_CONNECT_TIMEOUT
+        value: "600"
       volumeMounts:
       - name: product
         mountPath: /product

--- a/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -177,6 +177,10 @@ spec:
           secretKeyRef:
             name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: password
+      - name: CURL_MAX_TIME
+        value: "1800"
+      - name: CURL_CONNECT_TIMEOUT
+        value: "600"
       volumeMounts:
       - name: product
         mountPath: /images

--- a/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -196,6 +196,10 @@ spec:
           secretKeyRef:
             name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: password
+      - name: CURL_MAX_TIME
+        value: "1800"
+      - name: CURL_CONNECT_TIMEOUT
+        value: "600"
       volumeMounts:
       - name: products
         mountPath: /products


### PR DESCRIPTION
CASM-5267 Make CURL_MAX_TIME,CURL_CONNECT_TIMEOUT configurable for nexus uploads

CASMTRIAGE-7735 rpm stuck uploading during deliver-product

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
