### PR TITLE
CASMINST-7163: IUF: Force CFS v2 for SAT if needed to avoid CASMCMS-8966

### DIFF
--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,6 +79,19 @@ spec:
                       echo "INFO Using bootprep file $BOOTPREP_FILE_PATH for preparing images on managed nodes" 1>&2
                     fi
 
+                    # Determine CFS version, to avoid CASMTRIAGE-7760
+                    SAT_CFS_ARGS=""
+                    CFS_VERSION=$(curl -s -k -H "Authorization: Bearer {{inputs.parameters.auth_token}}" https://api-gw-service-nmn.local/apis/cfs/versions | \
+                                  python -c "import json, sys; c = json.load(sys.stdin); print('.'.join([ c['major'], c['minor'], c['patch']]))")
+                    if [[ -z "$CFS_VERSION" ]]; then
+                      echo "WARNING Cannot determine CFS service version. Will not specify CFS version for SAT command" 1>&2
+                    elif [[ "$CFS_VERSION" =~ ^1\.18\.[0-4]$ ]]; then
+                      echo "INFO CFS service version is $CFS_VERSION. Forcing SAT to use CFS v2" 1>&2
+                      SAT_CFS_ARGS="--cfs-version v2"
+                    else
+                      echo "INFO CFS service version is $CFS_VERSION. Will not specify CFS version for SAT command" 1>&2
+                    fi
+
                     VARS_FILE_PATH=$(mktemp)
                     cat > $VARS_FILE_PATH <<- 'EOF'
                       {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
@@ -89,11 +102,12 @@ spec:
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
                       --bos-version v2 \
+                      $SAT_CFS_ARGS \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
                     rc=$?
                     if [ $rc -ne 0 ]; then
                       echo "ERROR Bootprep for managed nodes failed. Please refer to the operations > configuration_management > Accessing_Sat_Bootprep_Files section of the CSM documentation and then re-run the 'prepare-images' stage" 1>&2
-                      echo -e "ERROR <sat bootprep run --limit images --limit session_templates --overwrite-images --overwrite-templates --vars-file "$VARS_FILE_PATH" --format json --bos-version v2 $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
+                      echo -e "ERROR <sat bootprep run --limit images --limit session_templates --overwrite-images --overwrite-templates --vars-file $VARS_FILE_PATH --format json --bos-version v2 $SAT_CFS_ARGS $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
                       exit $rc
                     fi
         - - name: end-operation

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,6 +79,19 @@ spec:
                       echo "INFO Using bootprep file $BOOTPREP_FILE_PATH for preparing images on management nodes" 1>&2
                     fi
 
+                    # Determine CFS version, to avoid CASMTRIAGE-7760
+                    SAT_CFS_ARGS=""
+                    CFS_VERSION=$(curl -s -k -H "Authorization: Bearer {{inputs.parameters.auth_token}}" https://api-gw-service-nmn.local/apis/cfs/versions | \
+                                  python -c "import json, sys; c = json.load(sys.stdin); print('.'.join([ c['major'], c['minor'], c['patch']]))")
+                    if [[ -z "$CFS_VERSION" ]]; then
+                      echo "WARNING Cannot determine CFS service version. Will not specify CFS version for SAT command" 1>&2
+                    elif [[ "$CFS_VERSION" =~ ^1\.18\.[0-4]$ ]]; then
+                      echo "INFO CFS service version is $CFS_VERSION. Forcing SAT to use CFS v2" 1>&2
+                      SAT_CFS_ARGS="--cfs-version v2"
+                    else
+                      echo "INFO CFS service version is $CFS_VERSION. Will not specify CFS version for SAT command" 1>&2
+                    fi
+
                     VARS_FILE_PATH=$(mktemp)
                     cat > $VARS_FILE_PATH <<- 'EOF'
                       {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
@@ -89,11 +102,12 @@ spec:
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
                       --bos-version v2 \
+                      $SAT_CFS_ARGS \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
                     rc=$?
                     if [ $rc -ne 0 ]; then
                       echo "ERROR Bootprep for management nodes failed. Please refer to the operations > configuration_management > Accessing_Sat_Bootprep_Files section of the CSM documentation and then re-run the 'prepare-images' stage" 1>&2
-                      echo "ERROR <sat bootprep run --limit images --limit session_templates --overwrite-images --overwrite-templates --vars-file "$VARS_FILE_PATH" --format json --bos-version v2 $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
+                      echo "ERROR <sat bootprep run --limit images --limit session_templates --overwrite-images --overwrite-templates --vars-file $VARS_FILE_PATH --format json --bos-version v2 $SAT_CFS_ARGS $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
                       exit $rc
                     fi
         - - name: end-operation

--- a/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,6 +79,19 @@ spec:
                       echo "INFO Using bootprep config file $BOOTPREP_FILE_PATH for updating CFS config on managed nodes" 1>&2
                     fi
 
+                    # Determine CFS version, to avoid CASMTRIAGE-7760
+                    SAT_CFS_ARGS=""
+                    CFS_VERSION=$(curl -s -k -H "Authorization: Bearer {{inputs.parameters.auth_token}}" https://api-gw-service-nmn.local/apis/cfs/versions | \
+                                  python -c "import json, sys; c = json.load(sys.stdin); print('.'.join([ c['major'], c['minor'], c['patch']]))")
+                    if [[ -z "$CFS_VERSION" ]]; then
+                      echo "WARNING Cannot determine CFS service version. Will not specify CFS version for SAT command" 1>&2
+                    elif [[ "$CFS_VERSION" =~ ^1\.18\.[0-4]$ ]]; then
+                      echo "INFO CFS service version is $CFS_VERSION. Forcing SAT to use CFS v2" 1>&2
+                      SAT_CFS_ARGS="--cfs-version v2"
+                    else
+                      echo "INFO CFS service version is $CFS_VERSION. Will not specify CFS version for SAT command" 1>&2
+                    fi
+
                     VARS_FILE_PATH=$(mktemp)
                     cat > $VARS_FILE_PATH <<- 'EOF'
                       {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
@@ -89,11 +102,12 @@ spec:
                       --overwrite-configs \
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
+                      $SAT_CFS_ARGS \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
                     rc=$?
                     if [ $rc -ne 0 ]; then
                       echo "ERROR Bootprep for managed nodes failed. Please refer to the operations > configuration_management > Accessing_Sat_Bootprep_Files section of the CSM documentation and then re-run the 'update-cfs-config' stage" 1>&2
-                      echo "ERROR <sat bootprep run --limit configurations --overwrite-configs --vars-file "$VARS_FILE_PATH" --format json $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
+                      echo "ERROR <sat bootprep run --limit configurations --overwrite-configs --vars-file $VARS_FILE_PATH --format json $SAT_CFS_ARGS $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
                       exit $rc
                     fi
         - - name: end-operation

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,6 +79,19 @@ spec:
                       echo "INFO Using bootprep config file $BOOTPREP_FILE_PATH for updating CFS config on management nodes" 1>&2
                     fi
 
+                    # Determine CFS version, to avoid CASMTRIAGE-7760
+                    SAT_CFS_ARGS=""
+                    CFS_VERSION=$(curl -s -k -H "Authorization: Bearer {{inputs.parameters.auth_token}}" https://api-gw-service-nmn.local/apis/cfs/versions | \
+                                  python -c "import json, sys; c = json.load(sys.stdin); print('.'.join([ c['major'], c['minor'], c['patch']]))")
+                    if [[ -z "$CFS_VERSION" ]]; then
+                      echo "WARNING Cannot determine CFS service version. Will not specify CFS version for SAT command" 1>&2
+                    elif [[ "$CFS_VERSION" =~ ^1\.18\.[0-4]$ ]]; then
+                      echo "INFO CFS service version is $CFS_VERSION. Forcing SAT to use CFS v2" 1>&2
+                      SAT_CFS_ARGS="--cfs-version v2"
+                    else
+                      echo "INFO CFS service version is $CFS_VERSION. Will not specify CFS version for SAT command" 1>&2
+                    fi
+
                     VARS_FILE_PATH=$(mktemp)
                     cat > $VARS_FILE_PATH <<- 'EOF'
                       {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
@@ -88,11 +101,12 @@ spec:
                       --overwrite-configs \
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
+                      $SAT_CFS_ARGS \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
                     rc=$?
                     if [ $rc -ne 0 ]; then
                       echo "ERROR Bootprep for management nodes failed. Please refer to the operations > configuration_management > Accessing_Sat_Bootprep_Files section of the CSM documentation and then re-run the 'update-cfs-config' stage" 1>&2
-                      echo "ERROR <sat bootprep run --limit configurations --overwrite-configs --vars-file "$VARS_FILE_PATH" --format json $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
+                      echo "ERROR <sat bootprep run --limit configurations --overwrite-configs --vars-file $VARS_FILE_PATH --format json $SAT_CFS_ARGS $MEDIA_DIR/$BOOTPREP_FILE_PATH> failed" 1>&2
                       exit $rc
                     fi
         - - name: end-operation


### PR DESCRIPTION
[CASMTRIAGE-7760](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7760) was opened because of a SAT bootprep failure during an upgrade from CSM 1.5.0 to CSM 1.6.1. This failure was caused by [CASMCMS-8966](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8966), a bug that exists in CFS v1.18.0 (the version of CFS that ships with CSM 1.5.0).

CSM 1.5.0 shipped with CFS v1.18.0. That CFS version had the bug documented in [CASMCMS-8966](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8966). That was fixed in CFS v1.18.5, which shipped with CSM 1.5.1.

When upgrading from from CSM 1.5.0 to CSM 1.6.x, IUF calls a SAT bootprep command that fails because of this bug. The workaround is to force SAT to use CFS v2 in that case (because the bug is specific to CFS v3).

If the starting version of the upgrade is CSM 1.5.1 or later, then it is running with a CFS version that does not have this issue.
This will also not be seen if upgrading from CSM 1.5.0 plus the BOS/CFS scale hotfix, as that pulls in a CFS version which has the fix for this.

This PR modifies the relevant IUF workflows so that they check the CFS version, and if it is >= 1.18.0 and < 1.18.5, then run SAT bootprep to run with the `--cfs-version v2` flag.

This change is only in `docs-csm` for CSM 1.6, since that is what will be installed on the system when this upgrade is running. No PRs needed to other branches.

This has been tested on starlord to verify that it works as expected.