### PR TITLE
CASMHMS-6371 Updated Add_a_Standard_Rack_Node to remove quotes from NID - release/1.7

### DIFF
--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -66,7 +66,7 @@ For this procedure, a new object must be created in the SLS and modifications wi
         ```bash
         NID=1
         ALIAS=nid000001
-        jq -n --arg ALIAS "${ALIAS}" --arg NID "${NID}" '{
+        jq -n --arg ALIAS "${ALIAS}" --argjson NID "${NID}" '{
             Aliases:[$ALIAS],
             NID: $NID, 
             Role: "Compute"
@@ -80,7 +80,7 @@ For this procedure, a new object must be created in the SLS and modifications wi
           "Aliases": [
             "nid000001"
           ],
-          "NID": "1",
+          "NID": 1,
           "Role": "Compute"
         }
         ```


### PR DESCRIPTION
CASMHMS-6371 Updated Add_a_Standard_Rack_Node to remove quotes from NID - release/1.7

# Description

Command in Add_a_Standard_Rack_Node adds quotes around the NID value and causes strings to be created instead of ints.

CASMHMS-6371

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.