### PR TITLE
CASMCMS-9253 - known issue doc for orphaned S3 image files.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -900,6 +900,7 @@ zypper
 4xSFP
 4xSFP+
 4xSFP28
+5Gb
 500m
 50m
 550m

--- a/scripts/remove_orphaned_artifacts.py
+++ b/scripts/remove_orphaned_artifacts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+import argparse
+import json
+import requests
+import os
+import boto3
+
+class Artifact:
+
+    def __init__(self, obj):
+        self.key = obj['Key']
+        self.size = obj['Size']
+        self.id = None
+        self._is_ims = None
+
+    # determine if this is a non-deleted ims artifact
+    def is_active_ims_artifact(self) -> bool:
+        # if already computed, use it
+        if self._is_ims is not None:
+            return self._is_ims
+        
+        # we expect the first part of the key to be the IMS id which is a
+        # hash in in the format of 'fdca156c-19b2-4453-983d-45f8ee96fbcb'
+        self._is_ims = False
+        parts = self.key.split('/')
+        if len(parts) > 0 and len(parts[0])==36 and len(parts[0].split('-'))==5:
+            self._is_ims = True
+            self.id = parts[0]
+
+        return self._is_ims        
+        
+
+def get_token() -> str:
+    token_file = os.getenv("CRAY_CREDENTIALS")
+    token = None
+    if token_file is None:
+        print("CRAY_CREDENTIALS environment variable must be set prior to use.")
+        exit(1)
+    with open(token_file) as token_file_json:
+        contents = json.load(token_file_json)
+        token = contents['access_token']
+    if token is None:
+        print(f"Unable to read access token from {token_file}")
+        exit(1)
+    return token
+
+def get_ims_images(token):
+    images_url = "https://api-gw-service-nmn.local/apis/ims/images"
+    headers = {"Authorization" : f"Bearer {token}"}
+    r = requests.get(images_url, headers=headers)
+    ims_image_ids = []
+    for image in r.json():
+        ims_image_ids.append(image['id'])
+    r.close()
+    return ims_image_ids
+
+def get_s3_client(token):
+    # get the S3 creds / information and create the boto3 client
+    s3_info_url = "https://api-gw-service-nmn.local/apis/sts/token"
+    s3_info_header = {"Authorization" : f"Bearer {token}", "Accept":"application/json"}
+    r = requests.put(s3_info_url, headers=s3_info_header)
+    s3_info_json = r.json()
+    s3_client_kwargs = {
+        'aws_access_key_id':s3_info_json['Credentials']['AccessKeyId'],
+        'aws_secret_access_key':s3_info_json['Credentials']['SecretAccessKey'],
+        'aws_session_token':s3_info_json['Credentials']['SessionToken'],
+        'endpoint_url':s3_info_json['Credentials']['EndpointURL']
+    }
+    r.close()
+    return boto3.client('s3', **s3_client_kwargs), boto3.resource('s3', **s3_client_kwargs)
+
+def get_s3_artifacts(s3_client):
+    s3_r = s3_client.list_objects_v2(Bucket='boot-images')
+    artifacts = []
+    if s3_r['KeyCount'] > 0:
+        for artifact in s3_r['Contents']:
+           artifacts.append(Artifact(artifact)) 
+    page=1
+    while s3_r['IsTruncated']:
+        page+=1
+        s3_r = s3_client.list_objects_v2(Bucket='boot-images', ContinuationToken=s3_r['NextContinuationToken'])
+        
+        if s3_r['KeyCount'] > 0:
+            for artifact in s3_r['Contents']:
+               artifacts.append(Artifact(artifact)) 
+    return artifacts
+
+# https://stackoverflow.com/a/15485265
+def sizeof_fmt(num):
+    """
+    Given a number of bytes, returns a human-friendly string
+    representation of the size.
+    """
+    suffix="b"
+    for unit in ("", "K", "M", "G", "T"):
+        if abs(num) < 1024.0:
+            return f"{num:3.3f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.3f} peta{suffix}"
+
+def options():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', required=False, help="Only find orphans, don't delete them", action='store_true')
+    args = parser.parse_args()
+    return args
+
+def main():
+    # read any command line arguments
+    args = options()
+    
+    # get the auth token
+    token = get_token()
+
+    # get the defined images in IMS and set up a lookup table with the ids
+    ims_image_ids = get_ims_images(token)
+    
+    # get the boto3 client to interact with S3
+    s3_client, s3_resource = get_s3_client(token)
+        
+    # get the items in the S3 'boot-images' bucket
+    artifacts = get_s3_artifacts(s3_client)
+
+    # process the artifacts to find the ones that don't belong to an IMS record
+    byte_count = 0
+    for artifact in artifacts:
+        if artifact.is_active_ims_artifact() and not artifact.id in ims_image_ids:
+            byte_count += artifact.size
+            action = ""
+            if args.dry_run is True:
+                action = "Found"
+            else:
+                action = "Deleted"
+                s3_resource.Object('boot-images', artifact.key).delete()
+            
+            print(f"{action}: {artifact.key}, size: {sizeof_fmt(artifact.size)}")
+    
+    print(f"Total orphaned: {sizeof_fmt(byte_count)}")
+
+if __name__ == '__main__':
+    main()

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -74,6 +74,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [CFS Component With Zero-Length ID](known_issues/CFS_Component_With_Zero_Length_ID.md)
 * [IUF CLI reports false error that `management-nodes-rollout` failed](known_issues/iuf_cli_false_error_management_rollout_failed.md)
 * [`cray-console-node` pods in `CrashLoopBackOff`](known_issues/cray-console-node_pods_in_CrashLoopBackOff.md)
+* [IMS Images Orphaned in S3](known_issues/ims_images_orphaned_in_s3.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/ims_images_orphaned_in_s3.md
+++ b/troubleshooting/known_issues/ims_images_orphaned_in_s3.md
@@ -22,7 +22,7 @@ all of the artifacts in the `boot-images` bucket in S3 and finds the artifacts t
 a valid IMS image. There is a `--dry-run` option which will only list the artifacts found; without that
 option the script will delete the orphaned artifacts.
 
-1. (`ncn-mw#`) Run the script in `dry run` mode
+1. (`ncn-mw#`) Run the script in `dry run` mode.
 
   Running the script with `--dry-run` as an argument will list the files that
   it finds that are orphaned without deleting anything. Do this first to inspect
@@ -56,7 +56,7 @@ option the script will delete the orphaned artifacts.
   Total orphaned: 303.84Gb
   ```
 
-1. (`ncn-mw#`) Delete the orphaned artifacts
+1. (`ncn-mw#`) Delete the orphaned artifacts.
 
   NOTE: This step is not reversible so make sure none of the files listed in the
   previous step are incorrectly identified.

--- a/troubleshooting/known_issues/ims_images_orphaned_in_s3.md
+++ b/troubleshooting/known_issues/ims_images_orphaned_in_s3.md
@@ -1,0 +1,92 @@
+# Known Issue: IMS Images Orphaned in S3
+
+There was an issue where image files larger than 5Gb were not correctly deleted from S3 when the image
+was deleted through the IMS service. These artifacts are no longer referenced by IMS but are still
+left in the S3 `boot-images` bucket and need to be deleted manually.
+
+This issue is resolved in CSM 1.6.1 and 1.7.0 and will not produce additional orphaned artifacts
+after these versions, but orphaned artifacts may still exist on the system from previous versions if
+they have not been cleaned up.
+
+## Prerequisites
+
+- The latest CSM documentation RPM must be installed on the node where the procedure is being performed.
+    - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+- Ensure there is an environment variable `CRAY_CREDENTIALS` pointing to an authentication token.
+    - See [Authenticate an Account with the Command Line](../../operations/security_and_authentication/Authenticate_an_Account_with_the_Command_Line.md).
+
+## Fix
+
+These items can be deleted out of S3. There is a script defined here that will automatically look through
+all of the artifacts in the `boot-images` bucket in S3 and finds the artifacts that no longer belong to
+a valid IMS image. There is a `--dry-run` option which will only list the artifacts found; without that
+option the script will delete the orphaned artifacts.
+
+1. (`ncn-mw#`) Run the script in `dry run` mode
+
+  Running the script with `--dry-run` as an argument will list the files that
+  it finds that are orphaned without deleting anything. Do this first to inspect
+  what is present before they are removed permanently.
+
+  ```bash
+  /usr/share/doc/csm/scripts/remove_orphaned_artifacts.py --dry-run
+  ```
+
+  Expected output will look something like:
+
+  ```text
+  Found: 01643906-7fa2-4388-9dc6-c6f2f8c5589d/rootfs, size: 14.315Gb
+  Found: 01b880ec-940d-470a-9beb-dfdf5b562bec/rootfs, size: 19.675Gb
+  Found: 02aa48c9-4376-4758-8f4c-09a6f4d46c13/rootfs, size: 21.770Gb
+  Found: 02c4841d-3d0e-4af4-a869-1a542bf2bf39/rootfs, size: 19.955Gb
+  Found: 039689b3-a1e8-432e-a058-c7973e2036d9/rootfs, size: 13.996Gb
+  Found: 05b18508-387e-45c6-85c8-c2169ecac37f/rootfs, size: 19.689Gb
+  Found: 06a2e527-607b-4703-bf1b-54c32aee4fb8/rootfs, size: 20.777Gb
+  Found: 0773ed3f-9237-48f5-89b6-2e49855f6d76/rootfs, size: 21.643Gb
+  Found: 079f6bce-d902-438a-8db7-bcb06a21d3de/rootfs, size: 13.995Gb
+  Found: 09fb55d9-798e-41f7-b8d4-2f45a80c5e07/rootfs, size: 14.017Gb
+  Found: 0c8a0db2-2403-41c6-85e5-5783e9c471b6/rootfs, size: 18.972Gb
+  Found: 10a14e1c-4cbc-4197-9a5a-f133db5d3d25/rootfs, size: 21.643Gb
+  Found: 11bde47f-8a41-469d-a6d6-dabdd8ce470f/rootfs, size: 5.957Gb
+  Found: 12df4d6c-d5a1-4e4d-8973-64dedff63b98/rootfs, size: 12.100Gb
+  Found: 142b8bfe-7f56-4385-ab20-1d4c176a447f/rootfs, size: 13.995Gb
+  Found: 15387a19-f1b9-4e16-bd9f-17e229ef2360/rootfs, size: 14.419Gb
+  Found: 160ce9fb-63a3-476b-926e-0f2a7baad65d/rootfs, size: 16.184Gb
+  Found: 16a7f5cf-9c04-4396-84b7-13e0cd4674f1/rootfs, size: 20.740Gb
+  Total orphaned: 303.84Gb
+  ```
+
+1. (`ncn-mw#`) Delete the orphaned artifacts
+
+  NOTE: This step is not reversible so make sure none of the files listed in the
+  previous step are incorrectly identified.
+
+  Run the script without the `--dry-run` option to delete the artifacts:
+
+  ```bash
+  /usr/share/doc/csm/scripts/remove_orphaned_artifacts.py --dry-run
+  ```
+
+  Expected output will look something like:
+
+  ```text
+  Deleted: 01643906-7fa2-4388-9dc6-c6f2f8c5589d/rootfs, size: 14.315Gb
+  Deleted: 01b880ec-940d-470a-9beb-dfdf5b562bec/rootfs, size: 19.675Gb
+  Deleted: 02aa48c9-4376-4758-8f4c-09a6f4d46c13/rootfs, size: 21.770Gb
+  Deleted: 02c4841d-3d0e-4af4-a869-1a542bf2bf39/rootfs, size: 19.955Gb
+  Deleted: 039689b3-a1e8-432e-a058-c7973e2036d9/rootfs, size: 13.996Gb
+  Deleted: 05b18508-387e-45c6-85c8-c2169ecac37f/rootfs, size: 19.689Gb
+  Deleted: 06a2e527-607b-4703-bf1b-54c32aee4fb8/rootfs, size: 20.777Gb
+  Deleted: 0773ed3f-9237-48f5-89b6-2e49855f6d76/rootfs, size: 21.643Gb
+  Deleted: 079f6bce-d902-438a-8db7-bcb06a21d3de/rootfs, size: 13.995Gb
+  Deleted: 09fb55d9-798e-41f7-b8d4-2f45a80c5e07/rootfs, size: 14.017Gb
+  Deleted: 0c8a0db2-2403-41c6-85e5-5783e9c471b6/rootfs, size: 18.972Gb
+  Deleted: 10a14e1c-4cbc-4197-9a5a-f133db5d3d25/rootfs, size: 21.643Gb
+  Deleted: 11bde47f-8a41-469d-a6d6-dabdd8ce470f/rootfs, size: 5.957Gb
+  Deleted: 12df4d6c-d5a1-4e4d-8973-64dedff63b98/rootfs, size: 12.100Gb
+  Deleted: 142b8bfe-7f56-4385-ab20-1d4c176a447f/rootfs, size: 13.995Gb
+  Deleted: 15387a19-f1b9-4e16-bd9f-17e229ef2360/rootfs, size: 14.419Gb
+  Deleted: 160ce9fb-63a3-476b-926e-0f2a7baad65d/rootfs, size: 16.184Gb
+  Deleted: 16a7f5cf-9c04-4396-84b7-13e0cd4674f1/rootfs, size: 20.740Gb
+  Total orphaned: 303.84Gb
+  ```


### PR DESCRIPTION
# Description
Backport of https://github.com/Cray-HPE/docs-csm/pull/5735.

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9253

There is a known issue where image files larger than 5Gb are not correctly deleted from S3, leaving them behind and are never automatically cleaned up. This provides a script that will identify them and delete them.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.