### PR TITLE
CASMPET-7329: remove cray-psp chart upgrade

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -939,7 +939,6 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
-do_upgrade_csm_chart cray-psp platform.yaml
 do_upgrade_csm_chart cray-postgres-operator platform.yaml
 do_upgrade_csm_chart cray-iuf platform.yaml
 do_upgrade_csm_chart cray-nls platform.yaml


### PR DESCRIPTION
 # Description

Update prerequisites.sh to remove the cray-psp chart upgrade, as the chart itself will not be present in CSM 1.7. This is because Kubernetes does not support pod security policies in Kubernetes 1.25+.

Relates to cray-hpe/csm#3925.

Jira ticket: [CASMPET-7329](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7329)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
