### PR TITLE
CASMINST-6734: SW_ADMIN_PASSWORD variable is not required to be set for tests anymore

### DIFF
--- a/api/nls.md
+++ b/api/nls.md
@@ -88,7 +88,6 @@ func main() {
   "hosts": [
     "string"
   ],
-  "switchPassword": "string",
   "wipeOsd": true
 }
 ```
@@ -206,7 +205,6 @@ func main() {
     "property1": "string",
     "property2": "string"
   },
-  "switchPassword": "string",
   "workflowType": "string",
   "zapOsds": true
 }
@@ -699,7 +697,6 @@ bearerAuth
   "hosts": [
     "string"
   ],
-  "switchPassword": "string",
   "wipeOsd": true
 }
 
@@ -711,7 +708,6 @@ bearerAuth
 |---|---|---|---|---|
 |dryRun|boolean|false|none|none|
 |hosts|[string]|false|none|none|
-|switchPassword|string|false|none|none|
 |wipeOsd|boolean|false|none|none|
 
 <h2 id="tocS_models.CreateRebootWorkflowResponse">models.CreateRebootWorkflowResponse</h2>
@@ -757,7 +753,6 @@ bearerAuth
     "property1": "string",
     "property2": "string"
   },
-  "switchPassword": "string",
   "workflowType": "string",
   "zapOsds": true
 }
@@ -774,7 +769,6 @@ bearerAuth
 |imageId|string|false|none|none|
 |labels|object|false|none|none|
 |» **additionalProperties**|string|false|none|none|
-|switchPassword|string|false|none|none|
 |workflowType|string|false|none|used to determine storage rebuild vs upgrade|
 |zapOsds|boolean|false|none|this is necessary for storage rebuilds when unable to wipe the node prior to rebuild|
 

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -215,10 +215,6 @@ function createWorkflowPayload() {
 {
 "dryRun": ${dryRun},
 "hosts": ${jsonArray},
-"switchPassword": "$(kubectl -n vault exec -i cray-vault-0 -c vault -- env \
-      VAULT_TOKEN="$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' | base64 -d)" \
-      VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json \
-      vault kv get secret/net-creds/switch_admin | jq -r '.data.admin')",
 "imageId": "${imageId}",
 "bootTimeoutInSeconds": ${rebootTimeout},
 "desiredCfsConfig": "${desiredCfsConfig}"$(if [[ -n ${labels} ]]; then echo ", \"labels\": ${labels}"; fi)

--- a/workflows/ncn/worker/worker.reboot.yaml
+++ b/workflows/ncn/worker/worker.reboot.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -205,8 +205,6 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
-              - name: switchPassword
-                value: "{{$.SwitchPassword}}"
           {{- end }}
           - name: after-all
             dependencies:

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -211,8 +211,6 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
-              - name: switchPassword
-                value: "{{$.SwitchPassword}}"
           {{- end }}
           - name: after-all
             dependencies:

--- a/workflows/templates/post-rebuild-worker.yaml
+++ b/workflows/templates/post-rebuild-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/templates/post-rebuild-worker.yaml
+++ b/workflows/templates/post-rebuild-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,6 @@ spec:
         parameters:
           - name: targetNcn
           - name: dryRun
-          - name: switchPassword
       dag:
         tasks:
         - name: worker-ensure-testing-rpms
@@ -62,8 +61,7 @@ spec:
               - name: scriptContent
                 value: |
                   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{inputs.parameters.targetNcn}} \
-                    -t "SW_ADMIN_PASSWORD='{{inputs.parameters.switchPassword}}' \
-                        GOSS_BASE=/opt/cray/tests/install/ncn \
+                    -t "GOSS_BASE=/opt/cray/tests/install/ncn \
                         TARGET_NCN={{inputs.parameters.targetNcn}} \
                         goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-worker.yaml \
                           --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate \


### PR DESCRIPTION
## Summary and Scope

Goss tests no longer need the switch admin password set using an environment variable. The tests read the value directly from Vault now.

Rather than using commands which expose credentials to any user looking at the running processes.

It also removes the various places where this value is stored and exported in an environment variable, as this is no longer required for the test (the test reads it directly from Vault).

CASMINST-6734

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams