### PR TITLE
CASMCMS-9279 -- 1.6

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -524,6 +524,8 @@ For additional details and troubleshooting information, see
 
 ### 5.1 Run the test script
 
+> Note: In CSM 1.6.0, a known issue causes a [Barebones Boot Test Failure](../troubleshooting/known_issues/barebones_boot_test_failure.md). This issue has been resolved in CSM 1.6.1.
+
 This test can be run on any master or worker NCN, but not the PIT node.
 
 (`ncn-mw#`) The script is executable and can be run without any arguments. It returns zero on success and

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -34,6 +34,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 
 ## Known issues
 
+* [Barebones Boot Test Failure](known_issues/barebones_boot_test_failure.md)
 * [SAT/HSM/CAPMC/PCS Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
 * [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
 * [SSL Certificate Validation Issues](known_issues/ssl_certificate_validation_issues.md)

--- a/troubleshooting/cms_barebones_image_boot.md
+++ b/troubleshooting/cms_barebones_image_boot.md
@@ -8,18 +8,18 @@ PXE boot from the cluster.
 This page gives some information about the CSM barebones image and describes how the test script works.
 
 * [Notes on the CSM barebones images](#notes-on-the-csm-barebones-images)
-  * [Compute barebones images](#compute-barebones-images)
-  * [Minimal barebones image](#minimal-barebones-image)
+    * [Compute barebones images](#compute-barebones-images)
+    * [Minimal barebones image](#minimal-barebones-image)
 * [Test prerequisites](#test-prerequisites)
 * [Test overview](#test-overview)
 * [Test options](#test-options)
-  * [Controlling which node is used](#controlling-which-node-is-used)
-  * [Controlling which image is used](#controlling-which-image-is-used)
-  * [Controlling how the image is customized](#controlling-how-the-image-is-customized)
-  * [Controlling which product catalog entry is used](#controlling-which-product-catalog-entry-is-used)
-  * [Controlling which architecture is used](#controlling-which-architecture-is-used)
-  * [Controlling test script output level](#controlling-test-script-output-level)
-  * [Preventing resource deletion](#preventing-resource-deletion)
+    * [Controlling which node is used](#controlling-which-node-is-used)
+    * [Controlling which image is used](#controlling-which-image-is-used)
+    * [Controlling how the image is customized](#controlling-how-the-image-is-customized)
+    * [Controlling which product catalog entry is used](#controlling-which-product-catalog-entry-is-used)
+    * [Controlling which architecture is used](#controlling-which-architecture-is-used)
+    * [Controlling test script output level](#controlling-test-script-output-level)
+    * [Preventing resource deletion](#preventing-resource-deletion)
 
 ## Notes on the CSM barebones images
 
@@ -91,6 +91,8 @@ COS product stream is installed on the system.
 * The test script is installed as part of the `cray-cmstools-crayctldeploy` RPM.
 
 ## Test overview
+
+> Note: In CSM 1.6.0, a known issue causes a [Barebones Boot Test Failure](known_issues/barebones_boot_test_failure.md). This issue has been resolved in CSM 1.6.1.
 
 The script file location is `/opt/cray/tests/integration/csm/barebones_image_test`.
 Review the [Test prerequisites](#test-prerequisites) before proceeding.

--- a/troubleshooting/known_issues/barebones_boot_test_failure.md
+++ b/troubleshooting/known_issues/barebones_boot_test_failure.md
@@ -1,0 +1,56 @@
+# Barebones Boot Test Failure
+
+`/opt/cray/tests/integration/csm/barebones_image_test` returns "Failure of barebones image boot test".
+
+In CSM 1.6.0, the barebones boot image test fails with output similar to the following:
+
+```text
+cray.barebones-boot-test: INFO     Barebones image boot test starting
+cray.barebones-boot-test: INFO       For complete logs look in the file /opt/cray/tests/integration/logs/csm/barebones_image_test/20250211112322.log
+cray.barebones-boot-test: INFO     No architecture, node, or image specified; using default arch: x86
+cray.barebones-boot-test: INFO     Latest CSM version found in Product Catalog: 1.6.0
+cray.barebones-boot-test: INFO     Querying HSM to find an enabled compute node with 'x86' arch
+cray.barebones-boot-test: INFO     Found compute node 'x3000c0s17b3n0' with architecture 'x86'
+cray.barebones-boot-test: INFO     Found barebones image in product catalog: 'compute-csm-1.6-6.2.25-x86_64': {'id': '361c1121-0b03-4bb1-b707-d14ff8bd5b2f'}
+cray.barebones-boot-test: INFO     Base IMS image '361c1121-0b03-4bb1-b707-d14ff8bd5b2f' from the product catalog has arch 'x86'
+cray.barebones-boot-test: INFO     Creating CFS configuration 'example-session'
+cray.barebones-boot-test: INFO     Created CFS configuration 'example-session'
+cray.barebones-boot-test: INFO     Creating CFS session 'example-session' to customize IMS image '361c1121-0b03-4bb1-b707-d14ff8bd5b2f' with CFS configuration 'example-session'
+cray.barebones-boot-test: INFO     Created CFS session 'example-session'
+cray.barebones-boot-test: INFO     Waiting for CFS session 'example-session' to complete
+cray.barebones-boot-test: INFO     CFS session 'example-session' 'status' field is 'pending'
+cray.barebones-boot-test: INFO     CFS session 'example-session' 'status' field is now 'running'
+cray.barebones-boot-test: INFO     CFS session 'example-session' 'status' field is now 'complete'
+cray.barebones-boot-test: INFO     CFS session 'example-session' 'succeeded' field is now 'true'
+cray.barebones-boot-test: INFO     CFS session 'example-session' completed successfully
+cray.barebones-boot-test: INFO     Created IMS image '92045173-0735-4d3c-99fc-a198aa72bb29'
+cray.barebones-boot-test: INFO     CFS session 'example-session' created customized IMS image '92045173-0735-4d3c-99fc-a198aa72bb29'
+cray.barebones-boot-test: INFO     Creating BOS session template 'example-session'
+cray.barebones-boot-test: INFO     Created BOS session template 'example-session'
+cray.barebones-boot-test: INFO     Creating BOS session 'example-session' with BOS session template 'example-session' on node 'x3000c0s17b3n0'
+cray.barebones-boot-test: INFO     Created BOS session 'example-session'
+cray.barebones-boot-test: INFO     Waiting for BOS session 'example-session' to complete
+cray.barebones-boot-test: INFO     BOS session 'example-session' 'status' field is 'pending'
+cray.barebones-boot-test: INFO     BOS session 'example-session' 'status' field is now 'running'
+cray.barebones-boot-test: ERROR    BOS session 'example-session' has not completed even after 30 minutes
+cray.barebones-boot-test: ERROR    Failure of barebones image boot test.
+cray.barebones-boot-test: INFO     For troubleshooting information and manual steps, see https://github.com/Cray-HPE/docs-csm/blob/release/1.6/troubleshooting/cms_barebones_image_boot.md 
+```
+
+The test failure is attributed to incorrect network configuration, which causes the node to appear as though it has not booted. In most cases, the node has successfully booted but is inaccessible via the network.
+
+## Fix
+
+There is no fix for the barebones image in CSM 1.6.0. The problem exists in the barebones image as indicated above and has been patched in CSM 1.6.1 and later.
+
+Accessing the node may be done through the use of Cray Console.
+
+1. Find the node xname in the test output.
+
+    Look for text similar to the following in the test output:
+
+    ```text
+    Found compute node 'x3000c0s17b3n0' with architecture 'x86'
+    ```
+
+1. Follow the [Log in to a Node Using ConMan](../../operations/conman/Log_in_to_a_Node_Using_ConMan.md) procedure, using the xname identified in the previous step.

--- a/upgrade/Validate_CSM_Health_During_Upgrade.md
+++ b/upgrade/Validate_CSM_Health_During_Upgrade.md
@@ -3,8 +3,8 @@
 - Before performing the health validation, be sure that at least 15 minutes have elapsed
   since the CSM services were upgraded. This allows the various Kubernetes resources to
   initialize and start.
-- Although it is not recommended, the [Booting CSM `barebones` image](../operations/validate_csm_health.md#5-booting-csm-barebones-image)
-  test may be skipped if all compute nodes are active running application workloads.
+- The [Booting CSM `barebones` image](../operations/validate_csm_health.md#5-booting-csm-barebones-image)
+  > This test is broken in CSM 1.6.0 and should be skipped for that release. For more information, see the known issue, [Barebones Boot Test Failure](../troubleshooting/known_issues/barebones_boot_test_failure.md).
 
 1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
 


### PR DESCRIPTION
# Description

CSM compute barebones image boot test failure in CSM 1.6.0
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9279


- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.