### PR TITLE
USS-2317 Document Slurm VNI range settings

### DIFF
--- a/operations/multi-tenancy/Create_a_Tenant.md
+++ b/operations/multi-tenancy/Create_a_Tenant.md
@@ -281,10 +281,40 @@ spec:
           memory: 512Mi
 ```
 
- > **Note:**
- >
- > - Container versions must be customized to the versions installed on the system
- > - Please set `spec.munge.uid` to 498 and `spec.munge.gid` to 484 if using munger container version `cray/munge-munge:1.6.0`
+Container versions must be customized to the versions installed on the system.
+List the available versions with the following commands:
+
+```
+curl -s https://registry.local/v2/cray/cray-slurmctld/tags/list | jq -r .tags[]
+curl -s https://registry.local/v2/cray/cray-slurmdbd/tags/list | jq -r .tags[]
+curl -s https://registry.local/v2/cray/munge-munge/tags/list | jq -r .tags[]
+curl -s https://registry.local/v2/cray/cray-sssd/tags/list | jq -r .tags[]
+curl -s https://registry.local/v2/cray/cray-slurm-config/tags/list | jq -r .tags[]
+curl -s https://registry.local/v2/cray/cray-pxc/tags/list | jq -r .tags[]
+```
+
+Typically, the highest available version should be used.
+For the slurmctld and slurmdbd containers, use versions with a `-slurm` postfix
+if available. For example, use `cray/cray-slurmctld:1.8.0-slurm` rather than
+`cray/cray-slurmctld:1.8.0`.
+
+If using munge container version `cray/munge-munge:1.6.0`, set `spec.munge.uid`
+to 498 and `spec.munge.gid` to 484.
+
+## Configuring the VNI range
+
+If USS 1.3.0 or newer is installed, the Slingshot VNI range used for the tenant
+may be configured using these settings:
+
+- `spec.config.vniPartition` - Slingshot fabric manager VNI partition name for
+  this tenant. The Slingshot operator creates a partition when the
+  `SlingshotTenant` custom resource is applied.
+- `spec.config.vniRange` - VNI range to use for this tenant, in format
+  `start-end`. Must not overlap with any other tenant's VNI range.
+  If `vniPartition` is set, the partition's VNI range overrides this value.
+- `spec.config.vniPartitionCreate` - If true, create a new Slingshot fabric
+  manager VNI partition with name `vniPartition` and range `vniRange` if it
+  doesn't exist.
 
 ## Apply the `slurm` operator CR
 

--- a/operations/multi-tenancy/Create_a_Tenant.md
+++ b/operations/multi-tenancy/Create_a_Tenant.md
@@ -284,7 +284,7 @@ spec:
 Container versions must be customized to the versions installed on the system.
 List the available versions with the following commands:
 
-```
+```bash
 curl -s https://registry.local/v2/cray/cray-slurmctld/tags/list | jq -r .tags[]
 curl -s https://registry.local/v2/cray/cray-slurmdbd/tags/list | jq -r .tags[]
 curl -s https://registry.local/v2/cray/munge-munge/tags/list | jq -r .tags[]
@@ -294,9 +294,9 @@ curl -s https://registry.local/v2/cray/cray-pxc/tags/list | jq -r .tags[]
 ```
 
 Typically, the highest available version should be used.
-For the slurmctld and slurmdbd containers, use versions with a `-slurm` postfix
-if available. For example, use `cray/cray-slurmctld:1.8.0-slurm` rather than
-`cray/cray-slurmctld:1.8.0`.
+For the `slurmctld` and `slurmdbd` containers, use versions with a `-slurm`
+postfix if available. For example, use `cray/cray-slurmctld:1.8.0-slurm` rather
+than `cray/cray-slurmctld:1.8.0`.
 
 If using munge container version `cray/munge-munge:1.6.0`, set `spec.munge.uid`
 to 498 and `spec.munge.gid` to 484.

--- a/operations/multi-tenancy/Create_a_Tenant.md
+++ b/operations/multi-tenancy/Create_a_Tenant.md
@@ -303,17 +303,17 @@ to 498 and `spec.munge.gid` to 484.
 
 ## Configuring the Virtual Network Identifier (VNI) range
 
-If USS 1.3.0 or newer is installed, the Slingshot VNI range used for the tenant
+If USS 1.3.0 or newer is installed, the HPE Slingshot VNI range used for the tenant
 may be configured using these settings:
 
-- `spec.config.vniPartition` - Slingshot fabric manager VNI partition name for
-  this tenant. The Slingshot operator creates a partition when the
+- `spec.config.vniPartition` - HPE Slingshot Fabric Manager VNI partition name for
+  this tenant. The HPE Slingshot network operator creates a partition when the
   `SlingshotTenant` custom resource is applied.
 - `spec.config.vniRange` - VNI range to use for this tenant, in format
   `start-end`. Must not overlap with any other tenant's VNI range.
   If `vniPartition` is set, the partition's VNI range overrides this value.
-- `spec.config.vniPartitionCreate` - If true, create a new Slingshot fabric
-  manager VNI partition with name `vniPartition` and range `vniRange` if it
+- `spec.config.vniPartitionCreate` - If true, create a new HPE Slingshot Fabric
+  Manager VNI partition with name `vniPartition` and range `vniRange` if it
   does not exist.
 
 ## Apply the `slurm` operator CR

--- a/operations/multi-tenancy/Create_a_Tenant.md
+++ b/operations/multi-tenancy/Create_a_Tenant.md
@@ -301,7 +301,7 @@ than `cray/cray-slurmctld:1.8.0`.
 If using munge container version `cray/munge-munge:1.6.0`, set `spec.munge.uid`
 to 498 and `spec.munge.gid` to 484.
 
-## Configuring the VNI range
+## Configuring the Virtual Network Identifier (VNI) range
 
 If USS 1.3.0 or newer is installed, the Slingshot VNI range used for the tenant
 may be configured using these settings:
@@ -314,7 +314,7 @@ may be configured using these settings:
   If `vniPartition` is set, the partition's VNI range overrides this value.
 - `spec.config.vniPartitionCreate` - If true, create a new Slingshot fabric
   manager VNI partition with name `vniPartition` and range `vniRange` if it
-  doesn't exist.
+  does not exist.
 
 ## Apply the `slurm` operator CR
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Document the new Slurm operator VNI range settings which will be released in USS 1.3.0. Also, update the instructions to provide more guidance on how to choose the container versions used in the Slurm operator CRD.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
