### PR TITLE
CASMTRIAGE-7880: Add new known issue for spire workload configmap typo

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -62,6 +62,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [NCN resource checks known issues](known_issues/ncn_resource_checks.md)
 * [Spire database connection pool configuration in an air*gapped environment](known_issues/spire_database_airgap_configuration.md)
 * [Spire Database Cluster DNS Lookup Failure](known_issues/spire_database_lookup_error.md)
+* [Enable Spire xname validation error](known_issues/spire_xname_validation_error.md)
 * [Postgres Database is in Recovery](known_issues/postgres_database_recovery.md)
 * [Test Failures Due To No Discovered Compute Nodes In HSM](known_issues/test_failures_no_discovered_computes_in_hsm.md)
 * [Velero Version Mismatch](known_issues/velero_version_mismatch.md)

--- a/troubleshooting/known_issues/spire_xname_validation_error.md
+++ b/troubleshooting/known_issues/spire_xname_validation_error.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-There is a known issue when the Spire servers are configured to use xname validation in CSM 1.6 where once validation is enabled the `request-ncn-join` pods enter a crash loop.
+There is a known issue when the Spire servers are configured to use xname validation in CSM 1.6, where once validation is enabled, the `request-ncn-join` pods enter a crash loop.
 
 There is a misconfiguration of the workloads configuration file that is used when xname validation is turned on. This leads to the Spire registration servers unable to give new
 tokens to any workload attempting to join spire.

--- a/troubleshooting/known_issues/spire_xname_validation_error.md
+++ b/troubleshooting/known_issues/spire_xname_validation_error.md
@@ -1,0 +1,710 @@
+# Enable Spire XName Validation Error
+
+## Description
+
+There is a known issue when the Spire servers are configured to use xname validation in CSM 1.6 where once validation is enabled the `request-ncn-join` pods enter a crash loop.
+
+There is a misconfiguration of the workloads configuration file that is used when xname validation is turned on. This leads to the Spire registration servers unable to give new
+tokens to any workload attempting to join spire.
+
+## Symptoms
+
+* The `request-ncn-join` pods may be in a `Init:CrashLoopBackOff` state.
+* Services may fail to acquire tokens from the `spire-server` or `cray-spire-server`.
+* The `cray-spire-server` pods contain the following error in the registration server container logs.
+
+  ```text
+  2025/02/24 03:19:55 Error: Error Reading Workloads Configuration file, Detail: yaml: line 187: did not find expected '-' indicator
+  ```
+
+## Solution
+
+### Apply workaround
+
+1. (`ncn-mw#`) Delete the `cray-spire-workloads` config map.
+
+  Command:
+
+  ```bash
+  kubectl delete cm -n spire cray-spire-workloads
+  ```
+
+  Output:
+
+  ```bash
+  configmap "cray-spire-workloads" deleted
+  ```
+
+1. (`ncn-mw#`) Apply a fixed `cray-spire-workloads` config map.
+
+  Command:
+
+  ```bash
+  cat <<EOF | kubectl apply --server-side -f -
+  apiVersion: v1
+  data:
+    compute.yaml: |-
+      ---
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cpsmount_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cps-utils/bin/cpsmount_helper
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/orca-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/ckdump_helper
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/wlm
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/wlm-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cos-config-helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cos-config-helper-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump_helper
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/wlm
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/wlm-spire-agent
+      - spiffeID: spiffe://shasta/compute/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
+    ncn.yaml: |-
+      ---
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cpsmount_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cps-utils/bin/cpsmount_helper
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/orca-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/sbps-marshal-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cos-config-helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cos-config-helper-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
+      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/sbps-marshal-spire-agent
+    storage.yaml: |-
+      ---
+      - spiffeID: spiffe://shasta/storage/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/storage/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/storage/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/storage/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/storage/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
+    uan.yaml: |-
+      ---
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cpsmount_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cps-utils/bin/cpsmount_helper
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/orca-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/ckdump_helper
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/usr/bin/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cpsmount
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cpsmount-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cos-config-helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cos-config-helper-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/orca
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/orca-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/ckdump_helper
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump_helper
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/ckdump
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/ckdump-spire-agent
+        jwtSVIDTTL: 864000
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/bos-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/bos-reporter-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/cfs-state-reporter
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/cfs-state-reporter-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/dvs-map
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-map-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/dvs-mqtt
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-mqtt-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/dvs-hmi
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/dvs-hmi-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/heartbeat
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/heartbeat-spire-agent
+      - spiffeID: spiffe://shasta/uan/XNAME/workload/tpm-provisioner
+        selectors:
+          - type: unix
+            value: uid:0
+          - type: unix
+            value: gid:0
+          - type: unix
+            value: path:/opt/cray/cray-spire/tpm-provisioner
+  kind: ConfigMap
+  metadata:
+    annotations:
+      meta.helm.sh/release-name: cray-spire
+      meta.helm.sh/release-namespace: spire
+    labels:
+      app.kubernetes.io/instance: cray-spire
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: cray-spire
+    name: cray-spire-workloads
+    namespace: spire
+  EOF
+  ```
+
+  Output:
+
+  ```bash
+  configmap/cray-spire-workloads serverside-applied
+  ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This adds a WAR for fixing an issue with spire when xname validation gets enabled. The bug has been fixed in csm 1.7 and is not present in csm 1.5 so no backporting is needed.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
