### PR TITLE
CASMCMS-9299: Improve Gitea/VCS password change procedure; document known issue

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -248,6 +248,7 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
 - [Exporting and Importing CFS Data](configuration_management/Exporting_and_Importing_CFS_Data.md)
 - [CFS API Details](../api/cfs.md)
 - [Version Control Service \(VCS\)](configuration_management/Version_Control_Service_VCS.md)
+    - [VCS Administrative User](configuration_management/VCS_Administrative_User.md)
     - [Git Operations](configuration_management/Git_Operations.md)
     - [VCS Branching Strategy](configuration_management/VCS_Branching_Strategy.md)
     - [Customize Configuration Values](configuration_management/Customize_Configuration_Values.md)

--- a/operations/configuration_management/Create_and_Populate_a_VCS_Configuration_Repository.md
+++ b/operations/configuration_management/Create_and_Populate_a_VCS_Configuration_Repository.md
@@ -1,13 +1,12 @@
 # Create and Populate a VCS Configuration Repository
 
-Create a new repository in the VCS and populate it with content for site customizations in a custom Configuration Framework Service
-\(CFS\) configuration layer.
+Create a new repository in the Version Control Service (VCS) and populate it with content for site customizations in a custom
+Configuration Framework Service \(CFS\) configuration layer.
 
 ## Prerequisites
 
-* The Version Control Service \(VCS\) login credentials for the `crayvcs` user are set up.
-  See [VCS Administrative User](Version_Control_Service_VCS.md#vcs-administrative-user) in
-  [Version Control Service (VCS)](Version_Control_Service_VCS.md) for more information.
+* The VCS login credentials for the `crayvcs` user are set up.
+  See [VCS Administrative User](VCS_Administrative_User.md) for more information.
 
 ## Procedure
 

--- a/operations/configuration_management/Git_Operations.md
+++ b/operations/configuration_management/Git_Operations.md
@@ -2,9 +2,11 @@
 
 Use the `git` command to manage repository content in the Version Control Service \(VCS\).
 
-Once a repository is cloned, the git command line tool is available to interact with a repository from VCS. The `git` command is used for making commits, creating new branches, and pushing new branches, tags, and commits to the remote repository stored in VCS.
+Once a repository is cloned, the git command line tool is available to interact with a repository from VCS.
+The `git` command is used for making commits, creating new branches, and pushing new branches, tags, and commits to the remote repository stored in VCS.
 
-When pushing changes to the VCS server using the `crayvcs` user, input the password retrieved from the Kubernetes secret as the credentials. See the "VCS Administrative User" heading in [Version Control Service \(VCS\)](Version_Control_Service_VCS.md#vcs-administrative-user) for more information.
+When pushing changes to the VCS server using the `crayvcs` user, input the password retrieved from the Kubernetes secret as the credentials.
+See [VCS Administrative User](VCS_Administrative_User.md) for more information.
 
 ```bash
 git push

--- a/operations/configuration_management/VCS_Administrative_User.md
+++ b/operations/configuration_management/VCS_Administrative_User.md
@@ -1,0 +1,272 @@
+# VCS Administrative User
+
+> For additional information on the Version Control Service (VCS), see [Version Control Service (VCS)](Version_Control_Service_VCS.md).
+
+* [Administrative user credentials](#administrative-user-credentials)
+* [Retrieving password for administrative user](#retrieving-password-for-administrative-user)
+* [Change VCS administrative user password](#change-vcs-administrative-user-password)
+    1. [Prerequisites](#1-prerequisites)
+    1. [Change password in Keycloak](#2-change-password-in-keycloak)
+    1. [Change password in Gitea/VCS](#3-change-password-in-giteavcs)
+        * [Change password in Gitea/VCS using web interface](#change-password-in-giteavcs-using-web-interface)
+        * [Change password in Gitea/VCS using command line](#change-password-in-giteavcs-using-command-line)
+    1. [Change password in the `vcs-user-credentials` Kubernetes secret](#4-change-password-in-the-vcs-user-credentials-kubernetes-secret)
+
+The Cray System Management \(CSM\) product installation creates the administrative user `crayvcs` that is used by CSM and other product
+installers to import their configuration content into VCS.
+
+## Administrative user credentials
+
+The VCS login credentials for the `crayvcs` user are stored in three places:
+
+* `vcs-user-credentials` Kubernetes secret: This is used to initialize the other two locations, as well as providing a place where other users can query for the password.
+* VCS \(Gitea\): These credentials are used when pushing to Git using the default username and password. The password should be changed through the Gitea UI or command-line.
+* Keycloak: These credentials are used to access the VCS UI. They must be changed through Keycloak. For more information on accessing Keycloak, see
+  [Access the Keycloak User Management UI](../security_and_authentication/Access_the_Keycloak_User_Management_UI.md).
+
+> **WARNING:** These three sources of credentials are not synced by any mechanism. Changing the default password requires that is it changed in all three places. Changing only
+> one may result in difficulty determining the password at a later date, or may result in losing access to VCS altogether.
+
+## Retrieving password for administrative user
+
+(`ncn-mw#`) The following command retrieves and decodes the VCS administrative user password from the `vcs-user-credentials` secret.
+
+```bash
+kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
+```
+
+## Change VCS administrative user password
+
+The following procedure shows how to change the VCS password in all necessary locations.
+
+### 1. Prerequisites
+
+* Obtain the current VCS administrative user password. See [Retrieving password for administrative user](#retrieving-password-for-administrative user).
+  In this procedure, this password will be referred to as the "old" password.
+* Choose a new password. This password should follow the URL and filename safe base 64 alphabet: alphanumeric characters, dash/minus (`-`), and underscore (`_`).
+
+### 2. Change password in Keycloak
+
+> This procedure uses the Keycloak web interface to change the password. This can also be done on the command line. See the
+> [Update a Local Keycloak User Credential](../security_and_authentication/Keycloak_User_Management_with_Kcadm.md#update-a-local-keycloak-user-credential)
+> procedure in [Keycloak User Management with `Kcadm`](../security_and_authentication/Keycloak_User_Management_with_Kcadm.md).
+
+1. Log in to Keycloak with the default `admin` credentials.
+
+   See [Access the Keycloak User Management UI](../security_and_authentication/Access_the_Keycloak_User_Management_UI.md).
+
+1. Ensure the selected Realm is `Shasta` from the top-left dropdown in the left sidebar.
+
+1. From the left sidebar, under the `Manage` section, select `Users`.
+
+1. In the `Search...` textbox, type in `crayvcs` and click the search icon.
+
+1. In the filtered table below, click on the ID for the row that shows `crayvcs` in the `Username` column.
+
+1. Go to the `Credentials` tab and change the password.
+
+   Enter the new password in the `Reset Password` form. Ensure `Temporary` is switched **off**. Click on `Reset Password` button.
+
+### 3. Change password in Gitea/VCS
+
+This can be done either using the VCS web interface, or using the command line.
+
+#### Change password in Gitea/VCS using web interface
+
+1. Log in to Gitea with the default `admin` credentials.
+
+   Point the browser at `https://vcs.SHASTA_CLUSTER_DNS_NAME/vcs/user/settings/account`.
+
+   If presented with Keycloak login, use `crayvcs` as the username and the new VCS password. Wait to be redirected to the Gitea login page before continuing to the next step.
+
+1. Use the following Gitea login credentials:
+
+   * Username: `crayvcs`
+   * The old VCS password
+
+1. Enter the old password, new password, and confirmation, and then click `Update Password`.
+
+#### Change password in Gitea/VCS using command line
+
+1. (`ncn-mw#`) Identify the Gitea/VCS pod.
+
+    ```bash
+    POD=$(kubectl get pods -n services -l app.kubernetes.io/instance=gitea --no-headers | grep -w Running | awk '{ print $1 }') ; echo ${POD}
+    ```
+
+    Expected output should resemble the following:
+
+    ```text
+    gitea-vcs-6554bbd88f-fml62
+    ```
+
+1. (`ncn-mw#`) Open an interactive shell into the pod.
+
+    ```bash
+    kubectl exec -it -n services "${POD}" -- sh
+    ```
+
+1. (`pod#`) Update Gitea/VCS with the new password.
+
+    > `read -s` is used to read the password in order to prevent it from being echoed to the screen or saved in the shell history.
+
+    ```bash
+    USERNAME=crayvcs
+    cd /var/lib/gitea/custom
+    read -r -s -p "Enter new Gitea/VCS administrative password: " PW1 ; echo ; if [[ -z ${PW1} ]]; then
+        echo "ERROR: Password cannot be blank"
+    elif ! [[ $PW1 =~ ^[-_a-zA-Z0-9]+$ ]]; then
+        echo "ERROR: Password contains illegal characters. Must only contain alphanumeric, dash/minus, and underscores."
+    else
+        read -r -s -p "Enter again: " PW2
+        echo
+        if [[ ${PW1} != ${PW2} ]]; then
+            echo "ERROR: Passwords do not match"
+        else
+            echo "Changing password for '${USERNAME}'"
+            if /usr/local/bin/gitea admin user change-password --config /var/lib/gitea/app.ini --username "${USERNAME}" --password "${PW1}" ; then
+                echo "SUCCESS"
+            else
+                echo "ERROR" 1>&2
+            fi
+        fi
+    fi; unset PW1 PW2 USERNAME
+    ```
+
+    On success, the end of the output will resemble the following:
+
+    ```text
+    crayvcs's password has been successfully updated!
+    SUCCESS
+    ```
+
+1. (`pod#`) Exit the pod.
+
+    ```bash
+    exit
+    ```
+
+### 4. Change password in the `vcs-user-credentials` Kubernetes secret
+
+(`ncn-mw#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
+
+* Name of chart to be redeployed: `gitea`
+* Base name of manifest: `sysmgmt`
+* When reaching the step to update customizations, perform the following steps:
+
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
+
+    > This procedure gets a copy of the `shasta-cfg/stable/utils` directory from `github`. If this procedure is being followed when
+    > the PIT node or expanded CSM release tarball is still available, then this directory can copied from those instead.
+
+    1. Run `git clone https://github.com/Cray-HPE/csm.git -b release/1.7`.
+
+    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
+
+        ```bash
+        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        ```
+
+    1. Change the password in the `customizations.yaml` file.
+
+        The Gitea `crayvcs` password is stored in the `vcs-user-credentials` Kubernetes Secret in the `services` namespace.
+        This must be updated so that clients which need to make requests can authenticate with the new password.
+
+        > These commands make use of the `$CUSTOMIZATIONS` variable that is set earlier in the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure.
+
+        1. Delete the current Gitea sealed secret data from `customizations.yaml`.
+
+            ```bash
+            yq delete -i "${CUSTOMIZATIONS}" spec.kubernetes.sealed_secrets.gitea
+            ```
+
+        1. Verify that the Gitea sealed secret data is not present.
+
+            The following command should return no output.
+
+            ```bash
+            yq r "${CUSTOMIZATIONS}" spec.kubernetes.sealed_secrets.gitea
+            ```
+
+        1. Create a YAML file with the new password.
+
+            Create a file named `new_gitea_pw.yaml` with the following contents, replacing `my_secret_password` with the new Gitea password.
+
+            ```yaml
+            name: vcs-user-credentials
+            data:
+              - type: static
+                args:
+                  name: vcs_password
+                  value: my_secret_password
+              - type: static
+                args:
+                  name: vcs_username
+                  value: crayvcs
+            ```
+
+        1. Update `customizations.yaml` with the new password.
+
+            The following command should return no output.
+
+            ```bash
+            yq w -i "${CUSTOMIZATIONS}" -f new_gitea_pw.yaml spec.kubernetes.sealed_secrets.gitea.generate
+            ```
+
+        1. Verify that updates were successfully applied.
+
+            The following command should return the contents of the `new_gitea_pw.yaml` file.
+
+            ```bash
+            yq r "${CUSTOMIZATIONS}" spec.kubernetes.sealed_secrets.gitea.generate
+            ```
+
+        1. Delete `new_gitea_pw.yaml`.
+
+            ```bash
+            rm new_gitea_pw.yaml
+            ```
+
+    1. Encrypt the values after changing the `customizations.yaml` file.
+
+        > This command makes use of the `$CUSTOMIZATIONS` variable that is set earlier in the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure.
+
+        ```bash
+        ./utils/secrets-seed-customizations.sh "${CUSTOMIZATIONS}"
+        ```
+
+        If the above command complains that it cannot find `certs/sealed_secrets.crt`, then run the following commands to create it:
+
+        ```bash
+        mkdir -pv ./certs && ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ./certs/sealed_secrets.crt
+        ```
+
+* When reaching the step to validate that the redeploy was successful, perform the following steps:
+
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
+
+    1. Verify that the Secret has been updated.
+
+        Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
+
+        ```bash
+        kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
+        ```
+
+    1. Do a rolling restart of the Gitea/VCS service and wait for it to complete.
+
+        ```bash
+        kubectl rollout restart -n services deployment gitea-vcs && kubectl rollout status -n services deployment gitea-vcs && echo SUCCESS || echo ERROR
+        ```
+
+        On success, the output should end with `SUCCESS`.
+
+    1. Run a VCS health check.
+
+        ```bash
+        /usr/local/bin/cmsdev test -q vcs
+        ```
+
+        For more details on this test, including known issues and other command line options, see [Software Management Services health checks](../../troubleshooting/known_issues/sms_health_check.md).
+
+* **Make sure to perform the entire linked chart redeploy procedure, including the step to save the updated customizations.**

--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -2,8 +2,13 @@
 
 * [VCS web interface](#vcs-web-interface)
 * [Cloning a VCS repository](#cloning-a-vcs-repository)
-* [VCS administrative user](#vcs-administrative-user)
+* [Git Operations](Git_Operations.md)
+* [VCS Branching Strategy](VCS_Branching_Strategy.md)
+* [Create and Populate a VCS Configuration Repository](Create_and_Populate_a_VCS_Configuration_Repository.md)
+* [Update the Privacy Settings for Gitea Configuration Content Repositories](Update_the_Privacy_Settings_for_Gitea_Configuration_Content_Repositories.md)
+* [VCS Administrative User](VCS_Administrative_User.md)
 * [Access the `cray` Gitea organization](#access-the-cray-gitea-organization)
+* [Managing Sensitive Information in VCS](Secure_Sensitive_Information_in_VCS.md)
 * [Backup and restore data](#backup-and-restore-data)
     * [Automated backup and restore](#automated-backup-and-restore)
         * [Automated backup](#automated-backup)
@@ -38,17 +43,13 @@ Example output:
 ## Cloning a VCS repository
 
 On cluster nodes, the VCS service can be accessed through the gateway. VCS credentials for the `crayvcs` user are required before cloning a repository \(see
-[VCS administrative user](#vcs-administrative-user) below\).
+[VCS Administrative User](VCS_Administrative_User.md)\).
 
 (`ncn#`) To clone a repository in the `cray` organization, use the following command:
 
 ```bash
 git clone https://api-gw-service-nmn.local/vcs/cray/REPO_NAME.git
 ```
-
-## VCS administrative user
-
-See [VCS Administrative User](VCS_Administrative_User.md).
 
 ## Access the `cray` Gitea organization
 

--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -1,9 +1,8 @@
 # Version Control Service \(VCS\)
 
-* [VCS overview](#vcs-overview)
+* [VCS web interface](#vcs-web-interface)
 * [Cloning a VCS repository](#cloning-a-vcs-repository)
 * [VCS administrative user](#vcs-administrative-user)
-    * [Change VCS administrative user password](#change-vcs-administrative-user-password)
 * [Access the `cray` Gitea organization](#access-the-cray-gitea-organization)
 * [Backup and restore data](#backup-and-restore-data)
     * [Automated backup and restore](#automated-backup-and-restore)
@@ -18,7 +17,7 @@
         * [Alternative export method](#alternative-export-method)
         * [Alternative import method](#alternative-import-method)
 
-## VCS overview
+## VCS web interface
 
 The Version Control Service \(VCS\) includes a web interface for repository management, pull requests, and a visual view of all repositories and organizations. The following URL is for the VCS web interface:
 
@@ -49,153 +48,7 @@ git clone https://api-gw-service-nmn.local/vcs/cray/REPO_NAME.git
 
 ## VCS administrative user
 
-The Cray System Management \(CSM\) product installation creates the administrative user `crayvcs` that is used by CSM and other product installers to import their configuration
-content into VCS.
-
-(`ncn-mw#`) The initial VCS credentials for the `crayvcs` user are obtained with the following command:
-
-```bash
-kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
-```
-
-### Change VCS administrative user password
-
-The initial VCS login credentials for the `crayvcs` user are stored in three places:
-
-* `vcs-user-credentials` Kubernetes secret: This is used to initialize the other two locations, as well as providing a place where other users can query for the password.
-* VCS \(Gitea\): These credentials are used when pushing to Git using the default username and password. The password should be changed through the Gitea UI.
-* Keycloak: These credentials are used to access the VCS UI. They must be changed through Keycloak. For more information on accessing Keycloak, see
-  [Access the Keycloak User Management UI](../security_and_authentication/Access_the_Keycloak_User_Management_UI.md).
-
-> **WARNING:** These three sources of credentials are not synced by any mechanism. Changing the default password requires that is it changed in all three places. Changing only
-> one may result in difficulty determining the password at a later date, or may result in losing access to VCS altogether.
-
-To change the password in the `vcs-user-credentials` Kubernetes secret, use the following procedure:
-
-1. (`ncn-mw#`) Log in to Keycloak with the default `admin` credentials.
-
-   Point a browser at `https://auth.SYSTEM_DOMAIN_NAME/keycloak/admin`, replacing `SYSTEM_DOMAIN_NAME` with the actual NCN's DNS name.
-
-   The following is an example URL for a system: `https://auth.cmn.system1.us.cray.com/keycloak/admin`
-
-   Use the following `admin` login credentials:
-
-   * Username: `admin`
-   * The password can be obtained with the following command:
-
-     ```bash
-     kubectl get secret -n services keycloak-master-admin-auth \
-                  --template={{.data.password}} | base64 --decode
-     ```
-
-1. Ensure the selected Realm is `Shasta` from the top-left dropdown in the left sidebar.
-
-1. From the left sidebar, under the `Manage` section, select `Users`.
-
-1. In the `Search...` textbox, type in `crayvcs` and click the search icon.
-
-1. In the filtered table below, click on the ID for the row that shows `crayvcs` in the `Username` column.
-
-1. Go to the `Credentials` tab and change the password.
-
-   Enter the new password in the `Reset Password` form. Ensure `Temporary` is switched **off**. Click on `Reset Password` button.
-
-1. Log in to Gitea with the default `admin` credentials.
-
-   Point the browser at `https://vcs.SHASTA_CLUSTER_DNS_NAME/vcs/user/settings/account`.
-
-   If presented with Keycloak login, use `crayvcs` as the username and the new VCS password. Wait to be redirected to the Gitea login page before continuing to the next step.
-
-1. Use the following Gitea login credentials:
-
-   * Username: `crayvcs`
-   * (`ncn-mw#`) The old VCS password, which can be obtained with the following command:
-
-     ```bash
-     kubectl get secret -n services vcs-user-credentials \
-             --template={{.data.vcs_password}} | base64 --decode
-     ```
-
-1. Enter the existing password (from previous step), new password, and confirmation, and then click `Update Password`.
-
-1. SSH into `ncn-w001` or `ncn-m001`.
-
-1. (`ncn-mw#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
-
-   * Name of chart to be redeployed: `gitea`
-   * Base name of manifest: `sysmgmt`
-   * When reaching the step to update customizations, perform the following steps:
-
-      **Only follow these steps as part of the previously linked chart redeploy procedure.**
-
-      1. Run `git clone https://github.com/Cray-HPE/csm.git`.
-
-      1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
-
-         ```bash
-         cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
-         ```
-
-      1. Change the password in the `customizations.yaml` file.
-
-         The Gitea `crayvcs` password is stored in the `vcs-user-credentials` Kubernetes Secret in the `services` namespace. This must be updated so that clients which need to make requests can authenticate with the new password.
-
-         In the `customizations.yaml` file, set the values for the `gitea` keys in the `spec.kubernetes.sealed_secrets` field.
-         The value in the data element where the name is `password` needs to be changed to the new Gitea password. The section
-         below will replace the existing sealed secret data in the `customizations.yaml` file.
-
-         For example:
-
-         ```yaml
-         gitea:
-            generate:
-               name: vcs-user-credentials
-               data:
-                 - type: static
-                   args:
-                   name: vcs_password
-                   value: my_secret_password
-                 - type: static
-                   args:
-                   name: vcs_username
-                   value: crayvcs
-         ```
-
-      1. Encrypt the values after changing the `customizations.yaml` file.
-
-          > This command makes use of the `$CUSTOMIZATIONS` variable that is set earlier in the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure.
-
-          ```bash
-          ./utils/secrets-seed-customizations.sh "${CUSTOMIZATIONS}"
-          ```
-
-         If the above command complains that it cannot find `certs/sealed_secrets.crt`, then run the following commands to create it:
-
-          ```bash
-          mkdir -pv ./certs && ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ./certs/sealed_secrets.crt
-          ```
-
-   * When reaching the step to validate that the redeploy was successful, perform the following steps:
-
-      **Only follow these steps as part of the previously linked chart redeploy procedure.**
-
-      1. Verify that the Secret has been updated.
-
-         Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
-
-         ```bash
-         kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
-         ```
-
-      1. Run a VCS health check.
-
-         ```bash
-         /usr/local/bin/cmsdev test -q vcs
-         ```
-
-         For more details on this test, including known issues and other command line options, see [Software Management Services health checks](../../troubleshooting/known_issues/sms_health_check.md).
-
-   * **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
+See [VCS Administrative User](VCS_Administrative_User.md).
 
 ## Access the `cray` Gitea organization
 

--- a/operations/security_and_authentication/Manage_System_Passwords.md
+++ b/operations/security_and_authentication/Manage_System_Passwords.md
@@ -4,41 +4,62 @@ Many system services require login credentials to gain access to them. The infor
 
 Contact HPE Cray service in order to obtain the default usernames and passwords for any of these components or services.
 
+- [Keycloak](#keycloak)
+- [Gitea/VCS](#giteavcs)
+- [System Management Health Service](#system-management-health-service)
+- [Management network switches](#management-network-switches)
+    - [Liquid-cooled cabinet](#liquid-cooled-cabinet)
+    - [Air-cooled cabinet](#air-cooled-cabinet)
+    - [Coolant Distribution Unit (CDU)](#coolant-distribution-unit-cdu)
+    - [ClusterStor](#clusterstor)
+- [Redfish credentials](#redfish-credentials)
+    - [List accounts](#list-accounts)
+    - [Add accounts](#add-accounts)
+    - [Delete accounts](#delete-accounts)
+    - [Update passwords](#update-passwords)
+- [System controllers](#system-controllers)
+- [SNMP credentials](#snmp-credentials)
+- [HPE Cray EX liquid-cooled cabinet hardware](#hpe-cray-ex-liquid-cooled-cabinet-hardware)
+- [Gigabyte](#gigabyte)
+- [Passwords managed in other product streams](#passwords-managed-in-other-product-streams)
+    - [Cray Operating System (COS)](#cray-operating-system-cos)
+    - [User Access Node (UAN)](#user-access-node-uan)
+
 ## Keycloak
 
 Default Keycloak admin user login credentials:
 
-- Username: admin
+- Username: `admin`
 - The password can be obtained with the following command:
 
   ```bash
-  kubectl get secret -n services keycloak-master-admin-auth \
-  --template={{.data.password}} | base64 --decode
+  kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode
   ```
 
-To update the default password for the admin account, refer to [Change the Keycloak Admin Password](Change_the_Keycloak_Admin_Password.md).
+To update the default password for the `admin` account, refer to [Change the Keycloak Admin Password](Change_the_Keycloak_Admin_Password.md).
 
 To create new accounts, refer to [Create Internal User Accounts in the Keycloak Shasta Realm](Create_Internal_User_Accounts_in_the_Keycloak_Shasta_Realm.md).
 
-## Gitea
+## Gitea/VCS
 
-The default Gitea user credentials is `crayvcs`. The password is randomly generated at install time
-and can be found in the vcs-user-credentials secret.
+The default Gitea/VCS administrative user name is `crayvcs`.
+The password is randomly generated at install time and can be found in the `vcs-user-credentials` secret.
 
 ```bash
-kubectl get secret -n services vcs-user-credentials \
---template={{.data.vcs_password}} | base64 --decode
+kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
 ```
 
-For more information on Gitea, including how to change the password, see [Version Control Service VCS](../configuration_management/Version_Control_Service_VCS.md).
+For more information on Gitea/VCS, see [Version Control Service (VCS)](../configuration_management/Version_Control_Service_VCS.md).
+For information on the administrative user, including changing its password, see
+[VCS Administrative User](../configuration_management/VCS_Administrative_User.md).
 
 ## System Management Health Service
 
-The default username is admin.
+The default username is `admin`.
 
 > **`NOTE`** Contact HPE Cray service in order to obtain the default password for Grafana and Kiali.
 
-## Management Network Switches
+## Management network switches
 
 Each rack type includes a different set of passwords. During different stages of installation, these passwords are subject to change.
 
@@ -49,52 +70,49 @@ However, if the user gets locked out attempting to change the password or the co
 
 > **`NOTE`** IP addresses can be found from the generated SLS file.
 
-**Liquid-Cooled Cabinet:**
+### Liquid-cooled cabinet
 
-| Name        | Role          | Switch          | Login |
-|-------------|---------------|-----------------|-------|
-| sw-leaf-bmc | Leaf-BMC/Mgmt | Dell S3048-ON   | admin |
-| sw-spine    | Spine         | Mellanox SN2100 | admin |
-| sw-leaf-bmc | Leaf-BMC/Mgmt | Aruba 6300      | admin |
-| sw-spine    | Spine         | Aruba 8325      | admin |
-| sw-leaf     | Leaf          | Aruba 8325      | admin |
+| Name          | Role          | Switch          | Login   |
+|---------------|---------------|-----------------|---------|
+| `sw-leaf-bmc` | Leaf-BMC/Mgmt | Dell S3048-ON   | `admin` |
+| `sw-spine`    | Spine         | Mellanox SN2100 | `admin` |
+| `sw-leaf-bmc` | Leaf-BMC/Mgmt | Aruba 6300      | `admin` |
+| `sw-spine`    | Spine         | Aruba 8325      | `admin` |
+| `sw-leaf`     | Leaf          | Aruba 8325      | `admin` |
 
-**Air-Cooled Cabinet:**
+### Air-cooled cabinet
 
-| Name        | Role          | Switch        | Login |
-|-------------|---------------|---------------|-------|
-| sw-leaf-bmc | Leaf/Mgmt     | Dell S3048-ON | admin |
-| sw-leaf-bmc | Leaf-BMC/Mgmt | Aruba 6300    | admin |
+| Name          | Role          | Switch        | Login   |
+|---------------|---------------|---------------|---------|
+| `sw-leaf-bmc` | Leaf/Mgmt     | Dell S3048-ON | `admin` |
+| `sw-leaf-bmc` | Leaf-BMC/Mgmt | Aruba 6300    | `admin` |
 
-**Coolant Distribution Unit (CDU):**
+### Coolant Distribution Unit (CDU)
 
-| Name   | Role     | Switch         | Login |
-|--------|----------|----------------|-------|
-| sw-cdu | CDU/Leaf | Dell S4048T-ON | admin |
-| sw-cdu | CDU/Leaf | Aruba 8360     | admin |
+| Name     | Role     | Switch         | Login   |
+|----------|----------|----------------|---------|
+| `sw-cdu` | CDU/Leaf | Dell S4048T-ON | `admin` |
+| `sw-cdu` | CDU/Leaf | Aruba 8360     | `admin` |
 
-**ClusterStor:**
+### ClusterStor
 
-| Name     | Role                  | Switch         | IP Address    | Login |
-|----------|-----------------------|----------------|---------------|-------|
-| Arista   |                       | DCS-7060CX-32S | 172.16.249.10 | admin |
-| Sonexion | Entry point to Arista | CS-L300        | 172.30.49.178 | admin |
-| E1000    |                       | CS-E1000       |               | admin |
+| Name     | Role                  | Switch         | IP Address    | Login   |
+|----------|-----------------------|----------------|---------------|---------|
+| Arista   |                       | DCS-7060CX-32S | 172.16.249.10 | `admin` |
+| Sonexion | Entry point to Arista | CS-L300        | 172.30.49.178 | `admin` |
+| E1000    |                       | CS-E1000       |               | `admin` |
 
-## Redfish Credentials
+## Redfish credentials
 
 Redfish accounts are only valid with the Redfish API. They do not allow system logins via `ssh` or serial console.
 
 Three accounts are created by default:
 
-- Root - Administrative account
-  - Username: root
-
-- Operator - Power components on/off, read values, and configure accounts
-  - Username: operator
-
-- ReadOnly - Log in, configure self, and read values
-  - Username: guest
+| Username     | Authority    | Role                                                         |
+|--------------|--------------|--------------------------------------------------------------|
+| `root`       | `Root`       | Administrative account                                       |
+| `operator`   | `Operator`   | Power components on/off, read values, and configure accounts |
+| `guest`      | `ReadOnly`   | Log in, configure self, and read values                      |
 
 > **`NOTE`** Contact HPE Cray service in order to obtain the default passwords.
 
@@ -102,151 +120,144 @@ The System Configuration Service (SCSD) is used to set the credentials for Redfi
 Refer to [Set BMC Credentials](../system_configuration_service/Set_BMC_Credentials.md) for more information.
 
 The account database is automatically saved to the non-volatile settings partition
-\(/nvram/redfish/redfish-accounts\) any time an account or account policy is modified.
-The file is stored as a redis command dump and is replayed \(if it exists\) anytime the core Redfish
-schema is loaded via the init script. If default accounts must be restored,
-delete the redis command dump and reboot the controller.
+\(`/nvram/redfish/redfish-accounts`\) any time an account or account policy is modified.
+The file is stored as a `redis` command dump and is replayed \(if it exists\) anytime the core Redfish
+schema is loaded via the `init` script. If default accounts must be restored,
+delete the `redis` command dump and reboot the controller.
 
-**List accounts:**
+### List accounts
 
-Use the following API path to list all accounts:
+Use the following API path to list all accounts: `GET /redfish/v1/AccountService/Accounts`
 
-```bash
-GET /redfish/v1/AccountService/Accounts
+```json
+{
+"@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
+"@odata.etag": "W/\"1559675674\"",
+"@odata.id": "/redfish/v1/AccountService/Accounts",
+"@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+"Description": "Collection for Manager Accounts",
+"Members": [
+{
+    "@odata.id": "/redfish/v1/AccountService/Accounts/1"
+},
+{
+    "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+}
+],
+"Members@odata.count": 2,
+"Name": "Accounts Collection"
+}
+```
 
-    {
-        "@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
-        "@odata.etag": "W/\"1559675674\"",
-        "@odata.id": "/redfish/v1/AccountService/Accounts",
-        "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
-        "Description": "Collection for Manager Accounts",
-        "Members": [
-        {
-            "@odata.id": "/redfish/v1/AccountService/Accounts/1"
-        },
-        {
-            "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+Use the following API path to list a single account: `GET /redfish/v1/AccountService/Accounts/1`
+
+```json
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount(*)",
+    "@odata.etag": "W/"1559675272"",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/1",
+    "@odata.type": "#ManagerAccount.v1_1_1.ManagerAccount",
+    "Description": "Default Account",
+    "Enabled": true,
+    "Id": "1",
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
         }
-        ],
-        "Members@odata.count": 2,
-        "Name": "Accounts Collection"
-    }
-
+    },
+    "Locked": false,
+    "Name": "Default Account",
+    "RoleId": "Administrator",
+    "UserName": "root"
+}
 ```
 
-Use the following API path to list a single account:
-
-```bash
-GET /redfish/v1/AccountService/Accounts/1
-
-    {
-        "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount(*)",
-        "@odata.etag": "W/"1559675272"",
-        "@odata.id": "/redfish/v1/AccountService/Accounts/1",
-        "@odata.type": "#ManagerAccount.v1_1_1.ManagerAccount",
-        "Description": "Default Account",
-        "Enabled": true,
-        "Id": "1",
-        "Links": {
-            "Role": {
-                "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
-            }
-        },
-        "Locked": false,
-        "Name": "Default Account",
-        "RoleId": "Administrator",
-        "UserName": "root"
-    }
-```
-
-**Add accounts:**
+### Add accounts
 
 If an account is successfully created, then the account information data structure will be returned.
 The most important bit returned is the Id because it is part of the URL used for any further manipulation of the account.
 
-Use the following API path to add accounts:
+Use the following API path to add accounts: `POST /redfish/v1/AccountService/Accounts`
 
-```bash
-POST /redfish/v1/AccountService/Accounts
+Include a request body like the following:
 
-    Content-Type: application/json
-    {
-        "Name": "Test Account",
-        "RoleId": "Administrator",
-        "UserName": "test",
-        "Password": "test123",
-        "Locked": false,
-        "Enabled": true
-    }
-
-    Response:
-    {
-        "@odata.context": "/redfish/v1/$metadataAccountService/Members/Accounts",
-        "@odata.etag": "W/"1559679136"",
-        "@odata.id": "/redfish/v1/AccountService/Accounts",
-        "@odata.type": "#ManagerAccount.v1_1_1.ManagerAccount",
-        "Description": "Collection of Account Details",
-        "Id": "5",  **<<-- Note this value**
-        "Links": {
-            "Role": {
-                "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
-            }
-        },
-        "Enabled": true,
-        "Locked": false,
-        "Name": "Test",
-        "RoleId": "Administrator",
-        "UserName": "test"
-    }
+```json
+{
+    "Name": "Test Account",
+    "RoleId": "Administrator",
+    "UserName": "test",
+    "Password": "test123",
+    "Locked": false,
+    "Enabled": true
+}
 ```
 
-**Delete accounts:**
+Example response:
+
+```json
+{
+    "@odata.context": "/redfish/v1/$metadataAccountService/Members/Accounts",
+    "@odata.etag": "W/"1559679136"",
+    "@odata.id": "/redfish/v1/AccountService/Accounts",
+    "@odata.type": "#ManagerAccount.v1_1_1.ManagerAccount",
+    "Description": "Collection of Account Details",
+    "Id": "5",
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        }
+    },
+    "Enabled": true,
+    "Locked": false,
+    "Name": "Test",
+    "RoleId": "Administrator",
+    "UserName": "test"
+}
+```
+
+Be sure to note the `Id` value in the response (`5` in the above example).
+
+### Delete accounts
 
 Delete an account with the `curl` command:
 
 ```bash
-# curl -u root:xxx -X DELETE https://x0c0s0b0/redfish/v1/AccountService/Accounts/ACCOUNT_ID
+curl -u root:xxx -X DELETE https://x0c0s0b0/redfish/v1/AccountService/Accounts/ACCOUNT_ID
 ```
 
-**Update passwords:**
+### Update passwords
 
 Update the password for an account with the `curl` command:
 
 > **WARNING**: Changing Redfish credentials outside of Cray System Management (CSM) services may cause the Redfish device to be no longer manageable under CSM.
+
+```bash
+curl -u root:xxx -X PATCH -H 'Content-Type: application/json' -d '{"Name": "Test"}' https://x0c0s0b0/redfish/v1/AccountService/Accounts/ACCOUNT_ID
+```
+
 > If the credentials for other devices need to be changed, refer to the following device-specific credential changing procedures:
 >
-> - To change liquid-cooled BM≥C credentials, refer to [Change Cray EX Liquid-Cooled Cabinet Global Default Password](../security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md).
+> - To change liquid-cooled BMC credentials, refer to [Change Cray EX Liquid-Cooled Cabinet Global Default Password](../security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md).
 > - To change air-cooled node BMC credentials, refer to [Change Air-Cooled Node BMC Credentials](../security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md).
 > - To change Slingshot switch BMC credentials, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide (> 1.6.0)*.
 
-```bash
-# curl -u root:xxx -X PATCH \
--H 'Content-Type: application/json' \
--d '{"Name": "Test"}' \
-https://x0c0s0b0/redfish/v1/AccountService/Accounts/ACCOUNT_ID
-```
-
-## System Controllers
+## System controllers
 
 For SSH access, the system controllers have the following default credentials:
 
-- Node controller \(nC\)
-  - Username: root
-
-- Chassis controller \(cC\)
-  - Username: root
-
-- Switch controller \(sC\)
-  - Username: root
-
-- sC minimal recovery firmware image \(rec\)
-  - Username: root
+| Controller                                   | Username |
+|----------------------------------------------|----------|
+| Node controller \(nC\)                       | `root`   |
+| Chassis controller \(cC\)                    | `root`   |
+| Switch controller \(sC\)                     | `root`   |
+| sC minimal recovery firmware image \(`rec`\) | `root`   |
 
 > **`NOTE`** Contact HPE Cray service in order to obtain the default passwords.
 
-Passwords for nC, cC, and sC controllers are all managed with the following process. The cfgsh tool is a configuration shell that can be used interactively or scripted. Interactively, it may be used as follows after logging in as root via `ssh`:
+Passwords for nC, cC, and sC controllers are all managed with the following process.
+The `cfgsh` tool is a configuration shell that can be used interactively or scripted. Interactively, it may be used as follows after logging in as root via SSH:
 
-```bash
+```console
 config
 x0c1(conf)# CURRENT_PASSWORD root NEW_PASSWORD
 x0c1(conf)# exit
@@ -256,51 +267,57 @@ exit
 
 It may be used non-interactively as well. This is useful for separating out several of the commands used for the initial setup. The shell utility returns non-zero on error.
 
-```bash
-# cfgsh --config CURRENT_PASSWORD root NEW_PASSWORD
-# cfgsh copy running-config startup-config
+```console
+cfgsh --config CURRENT_PASSWORD root NEW_PASSWORD
+cfgsh copy running-config startup-config
 ```
 
-In both cases, a `running-config` must be saved out to non-volatile storage in a startup configuration file. If it is not, the password will revert to default on the next boot. This is the exact same behavior as standard managed Ethernet switches.
+In both cases, a `running-config` must be saved out to non-volatile storage in a startup configuration file.
+If it is not, the password will revert to default on the next boot. This is the exact same behavior as standard managed Ethernet switches.
 
-## SNMP Credentials
+## SNMP credentials
 
 To adjust the SNMP credentials, perform the following tasks:
 
-1. Update the default credentials specified in the customizations.yaml file.
+1. Update the default credentials specified in the `customizations.yaml` file.
 
-- See [Update Default Air-Cooled BMC and Leaf-BMC Switch SNMP Credentials](Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md)
+    See [Update Default Air-Cooled BMC and Leaf-BMC Switch SNMP Credentials](Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md)
 
 1. Update the credentials actively being used for existing leaf switches.
 
-- See For more information on SNMP credentials, see [Configuring SNMP in CSM]( ../../operations/network/management_network/configure_snmp.md)
+    For more information on SNMP credentials, see [Configuring SNMP in CSM]( ../../operations/network/management_network/configure_snmp.md)
 
-## HPE Cray EX Liquid-Cooled Cabinet Hardware
+## HPE Cray EX liquid-cooled cabinet hardware
 
-Change the global default credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs).
-The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.
+- Change the global default credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs).
 
-- See [Change EX Liquid-Cooled Cabinet Global Default Password](Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md)
+    The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.
 
-Provision a Glibc compatible SHA-512 administrative password hash to a cabinet environmental controller (CEC). This password becomes the Redfish default global credential to access the CMM controllers and node controllers (BMCs).
+    See [Change EX Liquid-Cooled Cabinet Global Default Password](Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md)
 
-- See [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md)
+- Provision a Glibc compatible SHA-512 administrative password hash to a cabinet environmental controller (CEC). This password becomes the Redfish default global credential to access the CMM controllers and node controllers (BMCs).
 
-Change the credential for HPE Cray EX liquid-cooled cabinet chassis controllers and node controller (BMCs) used by CSM services after the CECs have been set to a new global default credential.
+    See [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md)
 
-- See [Updating the Liquid-Cooled EX Cabinet CEC with Default Credentials after a CEC Password Change](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md)
+- Change the credential for HPE Cray EX liquid-cooled cabinet chassis controllers and node controller (BMCs) used by CSM services after the CECs have been set to a new global default credential.
+
+    See [Updating the Liquid-Cooled EX Cabinet CEC with Default Credentials after a CEC Password Change](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md)
 
 ## Gigabyte
 
-The default username is admin.
+The default username is `admin`.
 
 > **`NOTE`** Contact HPE Cray service in order to obtain the default password for Gigabyte.
 
-## Passwords Managed in Other Product Streams
+## Passwords managed in other product streams
 
 Refer to the following product stream documentation for detailed procedures about updating passwords for compute nodes and User Access Nodes (UANs).
 
-**Cray Operating System (COS):** To update the root password for compute nodes, refer to "Set Root Password for Compute Nodes" in the COS product stream documentation for more information.
+### Cray Operating System (COS)
 
-**User Access Node (UAN):** Refer to "Create UAN Boot Images" in the UAN product stream documentation for the steps required to change the password on UANs.
-The "uan_shadow" header in the "UAN Ansible Roles" section includes more context on setting the root password on UANS.
+To update the root password for compute nodes, refer to "Set Root Password for Compute Nodes" in the COS product stream documentation for more information.
+
+### User Access Node (UAN)
+
+Refer to "Create UAN Boot Images" in the UAN product stream documentation for the steps required to change the password on UANs.
+The `uan_shadow` header in the "UAN Ansible Roles" section includes more context on setting the root password on UANS.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -73,6 +73,8 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [CFS Component With Zero-Length ID](known_issues/CFS_Component_With_Zero_Length_ID.md)
 * [IMS Images Orphaned in S3](known_issues/ims_images_orphaned_in_s3.md)
 * [`cray-console-node` pods in `CrashLoopBackOff`](known_issues/cray-console-node_pods_in_CrashLoopBackOff.md)
+* [CFS-API pods in CLBO state](known_issues/cfs-api_pods_in_CLBO_state.md)
+* [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 
 ## Booting
 
@@ -94,6 +96,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md)
 * [Incrementally Configuring Images](incrementally_configuring_images.md)
 * [CFS-API pods in CLBO state](known_issues/cfs-api_pods_in_CLBO_state.md)
+* [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 
 ## ConMan
 
@@ -174,6 +177,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Common Vault Cluster Issues](../operations/security_and_authentication/Troubleshoot_Common_Vault_Cluster_Issues.md)
 * [Keycloak User Localization](../operations/security_and_authentication/Keycloak_User_Localization.md)
 * [Troubleshoot Kyverno configuration manually](../operations/security_and_authentication/Troubleshoot_Kyverno_Configuration_manually.md)
+* [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 
 ## Spire
 

--- a/troubleshooting/known_issues/VCS_Password_With_Illegal_Characters.md
+++ b/troubleshooting/known_issues/VCS_Password_With_Illegal_Characters.md
@@ -1,0 +1,60 @@
+# VCS Password With Illegal Characters
+
+In rare cases, a new CSM install will generate a VCS administrative password that contains illegal characters.
+
+* [Symptoms](#symptoms)
+    * [`csm-config-import` job failure](#csm-config-import-job-failure)
+    * [`cmsdev` VCS subtest failure](#cmsdev-vcs-subtest-failure)
+* [Remediation](#remediation)
+
+## Symptoms
+
+There are two ways that this problem is discovered.
+
+### `csm-config-import` job failure
+
+When this problem causes a `csm-config-import` job to fail, the Kubernetes pod log will end with an error
+similar to the following.
+
+```text
+2024-06-13 21:11:20,793 - cf-gitea-import - DEBUG - Cloning repository: csm-config-management
+Traceback (most recent call last):
+  File "/opt/csm/cf-gitea-import/./import.py", line 446, in <module>
+    git_repo = clone_repo(
+  File "/opt/csm/cf-gitea-import/./import.py", line 119, in clone_repo
+    return Repo.clone_from(clone_url, workdir, depth=1, multi_options=["--no-single-branch"])
+  File "/usr/lib/python3.9/site-packages/git/repo/base.py", line 1328, in clone_from
+    return cls._clone(
+  File "/usr/lib/python3.9/site-packages/git/repo/base.py", line 1237, in _clone
+    finalize_process(proc, stderr=stderr)
+  File "/usr/lib/python3.9/site-packages/git/util.py", line 453, in finalize_process
+    proc.wait(**kwargs)
+  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 600, in wait
+    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
+git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
+  cmdline: git clone -v --depth=1 --no-single-branch -- http://crayvcs:BPuN/M846JL5XKTTWVqcV2mhuZfzOC64nnZ/e54ri1M=@gitea-vcs/cray/csm-config-management.git /tmp/csm
+  stderr: 'Cloning into '/tmp/csm'...
+fatal: unable to access 'http://crayvcs:BPuN/M846JL5XKTTWVqcV2mhuZfzOC64nnZ/e54ri1M=@gitea-vcs/cray/csm-config-management.git/': URL rejected: Port number was not a decimal number between 0 and 65535
+```
+
+### `cmsdev` VCS subtest failure
+
+When this problem is present, the `cmsdev` VCS subtest will report an error that resembles the following:
+
+```text
+ERROR (run tag Xe9tC-vcs): Command failed
+```
+
+If the test is run in verbose mode, or the `cmsdev` log file is examined, a line similar to the following is found:
+
+```text
+fatal: unable to access 'https://crayvcs:BPuN/M846JL5XKTTWVqcV2mhuZfzOC64nnZ/e54ri1M=@api-gw-service-nmn.local/vcs/test-cmsdev-zvkEP50G/harf-zEK1SuiP.git/': URL using bad/illegal format or missing URL
+```
+
+See [Software Management Services health checks](sms_health_check.md) for more information on running the test and locating its log file.
+
+## Remediation
+
+The VCS administrative user password needs to be changed to a value that does not contain illegal characters.
+Legal passwords should only contain alphanumeric characters, dash/minus (`-`), and underscore (`_`). See
+[Change VCS administrative user password](../../operations/configuration_management/VCS_Administrative_User.md#change-vcs-administrative-user-password).

--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -5,6 +5,7 @@
 - [Known issues with SMS tests](#known-issues-with-sms-tests)
     - [Cray CLI](#cray-cli)
     - [Invalid CFS component](#invalid-cfs-component)
+    - [VCS subtest command failure](#vcs-subtest-command-failure)
 
 ## SMS test execution
 
@@ -52,6 +53,10 @@ Additional test execution details can be found in `/opt/cray/tests/install/logs/
 
 ## Known issues with SMS tests
 
+- [Cray CLI](#cray-cli)
+- [Invalid CFS component](#invalid-cfs-component)
+- [VCS subtest command failure](#vcs-subtest-command-failure)
+
 ### Cray CLI
 
 Some of the subtests may fail if the Cray CLI is not configured on the management NCN where `cmsdev` is executed.
@@ -88,3 +93,22 @@ CFS subtest to fail. The `cmsdev` test failure symptom will depend on the versio
     ```
 
 For details on how to correct this problem, see [CFS Component With Zero-Length ID](CFS_Component_With_Zero_Length_ID.md).
+
+### VCS subtest command failure
+
+If the VCS administrative password contains illegal characters, it can cause the VCS subtest to fail with an error
+message that resembles the following:
+
+```text
+ERROR (run tag Xe9tC-vcs): Command failed
+```
+
+If the test is run in verbose mode, or the `cmsdev` log file is examined, a line similar to the following is found:
+
+```text
+fatal: unable to access 'https://crayvcs:BPuN/M846JL5XKTTWVqcV2mhuZfzOC64nnZ/e54ri1M=@api-gw-service-nmn.local/vcs/test-cmsdev-zvkEP50G/harf-zEK1SuiP.git/': URL using bad/illegal format or missing URL
+```
+
+See [VCS Password With Illegal Characters](VCS_Password_With_Illegal_Characters.md) for more information on this problem, including
+remediation steps.
+See [SMS test execution](#sms-test-execution) for more information on running the test in verbose mode and locating its log file.


### PR DESCRIPTION
This PR does a few things:

1. Moves the information on the VCS administrative user out of the main VCS page, into its own page.
2. Updates the content of that new page to fill in gaps, make improvements, and correct problems that we observed when walking a customer through that procedure this week.
3. Documents the known issue reported in [CAST-37761](https://jira-pro.it.hpe.com:8443/browse/CAST-37761) and [CASMTRIAGE-7072](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7072)
4. Updates links on various other pages, to account for the above changes.
5. And obviously some linting.

We used the updated procedure with the customer, and I've done additional testing on `mug`.

This is not limited to a particular CSM version, so I intend to backport it as far back as I can. In some cases my backports may not preserve all of the changes, mainly in cases where I am unable to test things to ensure they are correct on the older CSM version.

Backports:

1.6: https://github.com/Cray-HPE/docs-csm/pull/5764
1.5: https://github.com/Cray-HPE/docs-csm/pull/5765
1.4: https://github.com/Cray-HPE/docs-csm/pull/5766
1.3: https://github.com/Cray-HPE/docs-csm/pull/5767
1.2: https://github.com/Cray-HPE/docs-csm/pull/5768
1.0: https://github.com/Cray-HPE/docs-csm/pull/5773 (limited backport of just some general doc improvements)