### PR TITLE
CASMTRIAGE-7901: Update WAR for xname validation on CSM-1.6

### DIFF
--- a/troubleshooting/known_issues/spire_xname_validation_error.md
+++ b/troubleshooting/known_issues/spire_xname_validation_error.md
@@ -338,7 +338,7 @@ tokens to any workload attempting to join spire.
             value: gid:0
           - type: unix
             value: path:/usr/bin/heartbeat-spire-agent
-      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/sbps-marshal
         selectors:
           - type: unix
             value: uid:0
@@ -443,7 +443,7 @@ tokens to any workload attempting to join spire.
             value: gid:0
           - type: unix
             value: path:/opt/cray/cray-spire/tpm-provisioner
-      - spiffeID: spiffe://shasta/ncn/workload/sbps-marshal
+      - spiffeID: spiffe://shasta/ncn/XNAME/workload/sbps-marshal
         selectors:
           - type: unix
             value: uid:0
@@ -707,4 +707,18 @@ tokens to any workload attempting to join spire.
 
   ```bash
   configmap/cray-spire-workloads serverside-applied
+  ```
+
+1. Restart the `cray-spire-server` stateful set.
+
+  Command:
+
+  ```bash
+  kubectl rollout restart sts -n spire cray-spire-server
+  ```
+
+  Output:
+
+  ```bash
+  statefulset.apps/cray-spire-server restarted
   ```

--- a/troubleshooting/known_issues/spire_xname_validation_error.md
+++ b/troubleshooting/known_issues/spire_xname_validation_error.md
@@ -719,6 +719,6 @@ tokens to any workload attempting to join spire.
 
   Output:
 
-  ```bash
+  ```text
   statefulset.apps/cray-spire-server restarted
   ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This fixes the WAR to also include the change in the workloads to have XNAME validation actually enabled.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
