### PR TITLE
CASMPET-7389: Remove 'batch.kubernetes.io/controller-uid' label

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -98,6 +98,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
    SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=cray-spire-update-bss -o name)
    kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
        | jq 'del(.spec.template.metadata.labels."controller-uid")' \
+       | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' \
        | kubectl replace --force -f -
    ```
 

--- a/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
@@ -152,7 +152,7 @@ automatic backup created by the `cray-smd-postgresql-db-backup` Kubernetes cronj
 1. (`ncn#`) Re-run the HSM loader job.
 
     ```bash
-    kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | kubectl replace --force -f -
+    kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
     ```
 
     Wait for the job to complete:

--- a/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
@@ -28,7 +28,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 1. Re-run the HSM loader job.
 
     ```bash
-    kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | kubectl replace --force -f -
+    kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
     ```
 
     Wait for the job to complete:

--- a/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
+++ b/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
@@ -99,7 +99,7 @@ by the `cray-sls-postgresql-db-backup` Kubernetes cronjob.
 3. (`ncn-mw#`) Re-run the SLS loader job:
 
     ```bash
-    kubectl -n services get job cray-sls-init-load -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | kubectl replace --force -f -
+    kubectl -n services get job cray-sls-init-load -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
     ```
 
     Wait for the job to complete:


### PR DESCRIPTION
# Description
K8s 1.32 jobs that use apiVersion `batch/v1` automatically get the label `batch.kubernetes.io/controller-uid` in addition to the `controller-uid` label.  When restarting these jobs, we need to remove both labels.

Resolves [CASMPET-7389](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7389)

# Testing
Tested the modified statements on `molly` running k8s 1.32 and on `beau` running k8s 1.24.

Labels on `molly`:
```
pit:~/studenym # cat cray-smd-init.yaml | grep controller-uid
      batch.kubernetes.io/controller-uid: 7b4dd848-0c0b-497f-a230-f3ee94249783
        batch.kubernetes.io/controller-uid: 7b4dd848-0c0b-497f-a230-f3ee94249783
        controller-uid: 7b4dd848-0c0b-497f-a230-f3ee94249783
pit:~/studenym #
```

Labels on `beau`:
```
pit:~/studenym # cat cray-smd-init.yaml | grep controller-uid
      controller-uid: 370cf3c0-fafa-43aa-8a09-7d5ad911e5f0
        controller-uid: 370cf3c0-fafa-43aa-8a09-7d5ad911e5f0
pit:~/studenym #
```

`beau` and `molly` testing output looks the same:
```
pit:~/studenym # SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=cray-spire-update-bss -o name)
pit:~/studenym #    kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
>        | jq 'del(.spec.template.metadata.labels."controller-uid")' \
>        | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' \
>        | kubectl replace --force -f -
job.batch "cray-spire-update-bss-1" deleted
job.batch/cray-spire-update-bss-1 replaced
pit:~/studenym # kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m
job.batch/cray-spire-update-bss-1 condition met
pit:~/studenym #     kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
job.batch "cray-smd-init" deleted
job.batch/cray-smd-init replaced
pit:~/studenym # kubectl wait -n services job cray-smd-init --for=condition=complete --timeout=5m
job.batch/cray-smd-init condition met
pit:~/studenym # kubectl -n services get job cray-smd-init -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
job.batch "cray-smd-init" deleted
job.batch/cray-smd-init replaced
pit:~/studenym # kubectl wait -n services job cray-smd-init --for=condition=complete --timeout=5m
job.batch/cray-smd-init condition met
pit:~/studenym # kubectl -n services get job cray-sls-init-load -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.spec.template.metadata.labels."batch.kubernetes.io/controller-uid")' | kubectl replace --force -f -
job.batch "cray-sls-init-load" deleted
job.batch/cray-sls-init-load replaced
pit:~/studenym # kubectl wait -n services job cray-sls-init-load --for=condition=complete --timeout=5m
job.batch/cray-sls-init-load condition met
pit:~/studenym #
```

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
