### PR TITLE
CASMPET-7409 add sleep after deploying postgres-operator crds in prerequisites.sh

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -568,8 +568,15 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
       echo "Error: failed to find cray-postgres-operator chart in ${CSM_ARTI_DIR}/helm."
       exit 1
     fi
-    # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
-    tar --extract --file="$postgres_chart_path" --to-stdout cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml | kubectl apply -f -
+    # check if file exists before applying crds, needed for backwards compatibility
+    if tar -tf "$postgres_chart_path" cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml > /dev/null 2>&1; then
+      # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
+      tar --extract --file="$postgres_chart_path" --to-stdout cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml | kubectl apply -f -
+      # 5 second sleep is necessary for cray-postgres-operator chart deploy. Chart fails with CRD error if no sleep
+      sleep 5
+    else
+      echo "File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in $postgres_chart_path"
+    fi
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

A sleep is necessary between deploying cray-postgres-operator CRDs and deploying the chart.

Without a sleep, the following failure is observed:

```text
ncn-m001:~ # cat /etc/cray/upgrade/csm/log/prerequisites-20250228050340.log
...
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-postgres-operator v1.10.1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-02-28T05:28:35Z INF Running helm install/upgrade with arguments: upgrade --install cray-postgres-operator /etc/cray/upgrade/csm/csm-1.7.0-alpha.7/tarball/csm-1.7.0-alpha.7/helm/cray-postgres-operator-1.10.1.tgz --namespace services --create-namespace --set global.chart.name=cray-postgres-operator --set global.chart.version=1.10.1 --timeout 10m chart=cray-postgres-operator command=ship namespace=services version=1.10.1
2025-02-28T05:28:36Z ERR Error releasing chart cray-postgres-operator v1.10.1: Shell error: Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(OperatorConfiguration.configuration): unknown field "enable_team_id_clustername_prefix" in 
...
```

This PR adds a sleep after deploying the crds. It also makes prerequisites.sh backwards compatible by checking if a the CRDs file exists before trying to deploy the CRDs.

## Testing

I reproduced the failure everytime I deployed the CRDs and did the cray-postgres-operator upgrade in quick succession.

```text
ncn-m001:~/leliasen/postgres # ./upgrade_postgres.sh
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do unchanged
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(OperatorConfiguration.configuration): unknown field "enable_team_id_clustername_prefix" in do.zalan.acid.v1.OperatorConfiguration.configuration, ValidationError(OperatorConfiguration.configuration.kubernetes): unknown field "enable_readiness_probe" in 
```

The cray-postgres-operator deployed successfully every time a 5 second sleep was added.

```text
ncn-m001:~/leliasen/postgres # ./upgrade_postgres_with_sleep.sh
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do unchanged

Sleeping 5 seconds

Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Fri Feb 28 21:53:45 2025
NAMESPACE: services
STATUS: deployed
REVISION: 7
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
```

I also tested the if statement added for checking if the CRDs file exists. This is for backwards compatibility.

When the file did **not** exist, the step succeeded with the following output.

```text
====> LINDSAY_TESTUPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in /etc/cray/upgrade/csm/csm-1.7.0-alpha.7/tarball/csm-1.7.0-alpha.7/helm/cray-postgres-operator-1.10.1.tgz
====> LINDSAY_TESTUPDATE_CRAY_POSTGRES_OPERATOR_CRDS has been completed
```

When the file **did** exist, the step succeeded with the following output.

```text
====> LINDSAY_TESTUPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do unchanged
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do unchanged
====> LINDSAY_TESTUPDATE_CRAY_POSTGRES_OPERATOR_CRDS has been completed
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
