### PR TITLE
CASMTRIAGE-7214 Apply kdump fix from CASMTRIAGE-7232

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -175,6 +175,7 @@ documentation improvements. This page lists some of the highlights.
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
 * Fixed PowerDNS server TLD is missing NS delegation records for subdomains
 * Fixed an issue where FRU Tracking doesn't create a detected event after a removed event
+* Fixed an issue where `kdump` would freeze while writing the `vmcore` and other dump files
 
 ## Deprecations
 

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1100,8 +1100,11 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     # Loop through one at a time. If `--limit` isn't provided, we will error out on the 'Global' key.
     for ncn_xname in "${NCN_XNAMES[@]}"; do
 
+      # 's/crashkernel=360M/crashkernel=512M,high crashkernel=72M,low/g' is a catch-all for systems upgrading to 1.5
+      # from 1.5.0-1.5.2 or 1.4. It is not needed for 1.6 and up, but it is safe to run.
       params=$(cray bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[] |."params"' \
         | sed -E 's/ip=hsn[0-9]+:auto6//g' \
+        | sed -E 's/crashkernel=360M/crashkernel=512M,high crashkernel=72M,low/g' \
         | tr -d \")
 
       if ! cray bss bootparameters update --hosts "${ncn_xname}" \


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This ensures the kdump `crashkernel=360M` parameter is always removed and replaced with the new `crashkernel` parameters from CASMTRIAGE-7232.

This acts as a catch-all for users that have not ran the CASMTRIAGE-7232 hotfix in 1.5.0-1.5.2, or users coming from 1.4.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
