### PR TITLE
CASMPET-7293: Changing iuf image version iuf:v0.1.13

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,7 +70,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
+                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
                 command: [sh]
                 source: |
                   #!/bin/sh

--- a/workflows/templates/base/echo.template.argo.yaml
+++ b/workflows/templates/base/echo.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,7 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
+        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
         command: [sh]
         source: |
           #!/usr/bin/bash

--- a/workflows/templates/base/iufBase.template.argo.yaml
+++ b/workflows/templates/base/iufBase.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ spec:
          factor: "2"
          maxDuration: "1m"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
+        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13
         command: [sh]
         source: |
           #!/usr/bin/bash


### PR DESCRIPTION
# Description

CASMPET-7293 Changing base image to suse-15.6 as all the required modules are not present in 15.3 repository

Changing iuf image version iuf:v0.1.13

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
