### PR TITLE
CASMTRIAGE-7918: Source vars.sh to define missing env vars

### DIFF
--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -31,6 +31,7 @@ if [[ $rc -ne 0 ]]; then
   cloud-init init > /dev/null 2>&1
 fi
 
+source /srv/cray/resources/common/vars.sh
 source /srv/cray/scripts/metal/lib.sh
 #shellcheck disable=SC2155
 export KUBERNETES_VERSION="v$(cat /etc/cray/kubernetes/version)"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
CASMTRIAGE-7918: Source vars.sh to define missing env vars.

Need to source /srv/cray/resources/common/vars.sh in promote-initial-master.sh script to pick up K8S_IMAGE_REGISTRY, RESOLV_CONF, and CERTIFICATE_VALIDITY_PERIOD so that values are used when creating /etc/cray/kubernetes/kubeadm.yaml from template.

# Testing
Tested `kubeadm.yaml` creation from template on `molly` (CSM 1.7 with K8s 1.32) and `beau` (CSM 1.7).

On `molly` I had to add the `CERTIFICATE_VALIDITY_PERIOD` export to `/srv/cray/resources/common/vars.sh` since the node-image with the fix is currently building.

On `molly` before sourcing `vars.sh`:
```
---
apiVersion: kubeadm.k8s.io/v1beta4
kind: ClusterConfiguration
kubernetesVersion: "v1.32.0"
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controlPlaneEndpoint: "10.252.1.2:6442"
caCertificateValidityPeriod: ""
certificateValidityPeriod: ""
dns:
  imageRepository: "/coredns"
imageRepository: ""
networking:

<snip>

---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
cgroupDriver: systemd
resolvConf: ""
maxPods: 200
shutdownGracePeriod: 60s
shutdownGracePeriodCriticalPods: 20s
containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
runtimeRequestTimeout: 15m
```

On `molly`,  after sourcing `vars.sh`, CERTIFICATE_VALIDITY_PERIOD, K8S_IMAGE_REGISTRY and RESOLV_CONF are populated correctly:
```
---
apiVersion: kubeadm.k8s.io/v1beta4
kind: ClusterConfiguration
kubernetesVersion: "v1.32.0"
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controlPlaneEndpoint: "10.252.1.2:6442"
caCertificateValidityPeriod: "26280h0m0s"
certificateValidityPeriod: "26280h0m0s"
dns:
  imageRepository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns"
imageRepository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io"
networking:

<snip>

---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
cgroupDriver: systemd
resolvConf: "/etc/resolv.conf"
maxPods: 200
shutdownGracePeriod: 60s
shutdownGracePeriodCriticalPods: 20s
containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
runtimeRequestTimeout: 15m
```

On `beau` before sourcing `vars.sh`:
```
---
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
kubernetesVersion: "v1.24.17"
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controlPlaneEndpoint: "10.252.1.2:6442"
dns:
  imageRepository: "/coredns"
imageRepository: ""
networking:

<snip>

---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
cgroupDriver: systemd
resolvConf: ""
maxPods: 200
shutdownGracePeriod: 60s
shutdownGracePeriodCriticalPods: 20s
```

On `beau`,  after sourcing `vars.sh`, K8S_IMAGE_REGISTRY and RESOLV_CONF are populated correctly:
```
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
kubernetesVersion: "v1.24.17"
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controlPlaneEndpoint: "10.252.1.2:6442"
dns:
  imageRepository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns"
imageRepository: "artifactory.algol60.net/csm-docker/stable/registry.k8s.io"
networking:

<snip>

---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
cgroupDriver: systemd
resolvConf: "/etc/resolv.conf"
maxPods: 200
shutdownGracePeriod: 60s
shutdownGracePeriodCriticalPods: 20s
```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
