### PR TITLE
CASMINST-7125 add fix-postgres.sh to prerequisites.sh

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -585,6 +585,18 @@ fi
 
 do_upgrade_csm_chart cray-postgres-operator platform.yaml
 
+state_name="FIX_POSTGRES"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/util/fix-postgres.sh"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then

--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -e -o pipefail
+
+# After postgresql-operator upgrade, a few issues may happen:
+# - operator will try to perform rolling restart of all postgresql clusters to add new mount to each pod, by setting
+#   zalando-postgres-operator-rolling-update-required: true annotation onto sts, but this may fail due to PSP issue (CASMINST-6728).
+#   restarting operator pod clears this error.
+# - operator will perform rolling restart of all postgresql clusters to add new mount to each pod, but restart sequence
+#   may get stuck on pod trying to update it's own label (CASMINST-6728). We mitigate this by explicit rolling restart
+#   of all PostgreSQL stateful sets.
+#
+
+function postgres_operator_running() {
+  if [ "$(kubectl -n services get pod -l app.kubernetes.io/name=postgres-operator --no-headers | awk '{ print $2 ":" $3 }')" == "2/2:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_pods_running() {
+  if [ "$(kubectl get pod -l application=spilo -A --no-headers | awk '{ print $3 ":" $4 }' | sort -u)" == "3/3:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_clusters_running() {
+  if [ "$(kubectl get postgresql -A -o json | jq -r '.items[].status.PostgresClusterStatus' | sort -u)" == "Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function wait_for() {
+  local command="${1}"
+  local message="${2}"
+  local count=0
+  local total=120
+  local sleep=5
+  while true; do
+    if ${command}; then
+      echo "${message}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}'
+      break
+    else
+      if [ "${count}" -ge "${total}" ]; then
+        echo "ERROR: giving up for ${message} after ${total} attempts"
+        exit 1
+      fi
+      count=$((count + 1))
+      echo "Waiting for ${message}, sleeping for ${sleep} seconds and retry, attempt ${count}/${total} ..."
+      sleep ${sleep}
+    fi
+  done
+}
+
+echo "Waiting for 60 seconds for cray-postgres-operator pod to settle after upgrade ..."
+sleep 60
+wait_for postgres_operator_running "postgres-operator pod running"
+# Only restart postgres clusters in argo, services, spire namespaces - but wait for all clusters (such as sma) to be healthy, as
+# preflight checks at the end of prerequisites script will need all clusters anyway.
+kubectl get sts -A -l application=spilo -o json \
+  | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services") | (.metadata.namespace + ":" + .metadata.name)' \
+  | while IFS=: read -r namespace sts; do
+    echo "Rolling restart ${sts} in namespace ${namespace} ..."
+    kubectl rollout restart -n "${namespace}" statefulset "${sts}"
+  done
+# restart cray-spire-postgres, kubectl rollout restart does not work for this cluster
+echo "Restarting all cray-spire-postgres members"
+kubectl exec -n spire cray-spire-postgres-0 -c postgres -- patronictl restart cray-spire-postgres --force
+echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
+sleep 300
+wait_for postgres_pods_running "all postgres pods running"
+wait_for postgres_clusters_running "all postgres clusters in state Running"
+echo "State of postgres clusters after operator upgrade:"
+kubectl get postgresql -A

--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-set -e -o pipefail
+set -eo pipefail
 
 # After postgresql-operator upgrade, a few issues may happen:
 # - operator will try to perform rolling restart of all postgresql clusters to add new mount to each pod, by setting


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Intermittently, the PosgreSQL upgrade gets stuck with HTTP 403 in CSM 1.7 upgrade. This was also observed during the CSM 1.5 upgrade and was fixed by this ticket: [CASMINST-6728](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6728). This PR adds the `fix-postgres.sh` script to CSM 1.7 and runs it during prerequisites.sh. It performs a rollout restarts of all postgres clusters. Note, cray-spire-postgres is restarted via patronictl because rollout restart does not work on this cluster.

This was tested on a vShasta automated upgrade.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
