### PR TITLE
CASMINST-6939 - Audit procedure does not update cloud-init data correctly

### DIFF
--- a/operations/security_and_authentication/Audit_Logs.md
+++ b/operations/security_and_authentication/Audit_Logs.md
@@ -101,7 +101,7 @@ ncn-mgmt-node-auditing-enabled: false
 1. Acquire an authentication token.
 
    ```console
-   TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client \
+   export TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client \
            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')  
    ```
@@ -157,4 +157,3 @@ documentation for more information.
    ```console
    craysys metadata get k8s-api-auditing-enabled
    ```
-  

--- a/operations/security_and_authentication/Audit_Logs.md
+++ b/operations/security_and_authentication/Audit_Logs.md
@@ -117,7 +117,7 @@ ncn-mgmt-node-auditing-enabled: false
    * Kubernetes API audit logging
 
      ```console
-     csi handoff bss-update-param --limit <mgmt-node-xname> --set k8s-api-auditing-enabled=true
+     csi handoff bss-update-cloud-init --set meta-data.k8s-api-auditing-enabled=true --limit Global
      ```
 
    Example output:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Fix to previous documentation update, the `csi` tool requires that the environment variable be exported.

Before change
```
ncn-m001:~ # TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client \
>            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
>            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
ncn-m001:~ # csi handoff bss-update-cloud-init --set meta-data.ncn-mgmt-node-auditing-enabled=false --limit Global
2025/03/10 11:09:29 Environment variable TOKEN can NOT be blank!
panic: Environment variable TOKEN can NOT be blank!


goroutine 1 [running]:
log.Panicln({0xc000731ae8?, 0xc?, 0x0?})
	/usr/local/go/src/log/log.go:446 +0x5a
github.com/Cray-HPE/cray-site-init/pkg/cli/handoff.checkToken(...)
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/pkg/cli/handoff/handoff.go:102
github.com/Cray-HPE/cray-site-init/pkg/cli/handoff.setupEnvs()
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/pkg/cli/handoff/handoff.go:112 +0x105
github.com/Cray-HPE/cray-site-init/pkg/cli/handoff.SetupClients()
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/pkg/cli/handoff/handoff.go:139 +0x17
github.com/Cray-HPE/cray-site-init/pkg/cli/handoff.setupCommon()
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/pkg/cli/handoff/handoff.go:158 +0x17
github.com/Cray-HPE/cray-site-init/pkg/cli/handoff.NewHandoffCloudInitCommand.func1(0xc0001f9800?, {0x2ab1aba?, 0x4?, 0x2ab19d6?})
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/pkg/cli/handoff/cloud-init.go:54 +0x1f
github.com/spf13/cobra.(*Command).execute(0xc000892908, {0xc000200b40, 0x4, 0x4})
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/vendor/github.com/spf13/cobra/command.go:989 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002db208)
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x182b6c7e0bff3db6?)
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/vendor/github.com/spf13/cobra/command.go:1041 +0x13
main.main()
	/home/jenkins/workspace/Cray-HPE_cray-site-init_v1.36.6/dist/rpmbuild/x86_64/BUILD/cray-site-init-1.36.6/cmd/csi/main.go:41 +0xc5
```
After change
```
ncn-m001:~ # export TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client \
>            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
>            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
ncn-m001:~ # csi handoff bss-update-cloud-init --set meta-data.ncn-mgmt-node-auditing-enabled=false --limit Global
2025/03/10 11:10:11 Getting management NCNs from SLS...
2025/03/10 11:10:11 Done getting management NCNs from SLS.
2025/03/10 11:10:11 Updating NCN cloud-init parameters...
2025/03/10 11:10:11 Successfully PUT BSS entry for Global
2025/03/10 11:10:11 Done updating NCN cloud-init parameters.
```

Also corrects the command to enable K8s auditing.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
