### PR TITLE
CASMPET-7385 add cleanup-live-images step before upgrading storage nodes

### DIFF
--- a/workflows/templates/storage.reboot.yaml
+++ b/workflows/templates/storage.reboot.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -93,9 +93,23 @@ spec:
                       bootscript_last_epoch=0
                       echo $bootscript_last_epoch
                     fi
-          - name: "pxe-boot-node"
+          - name: "cleanup-live-images"
             dependencies:
               - get-bootscript-last-access-timestamp
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{inputs.parameters.targetNcn}}
+                    ssh $TARGET_NCN '/srv/cray/scripts/metal/cleanup-live-images.sh -y -a -o'
+          - name: "pxe-boot-node"
+            dependencies:
+              - cleanup-live-images
             templateRef:
               name: ssh-template
               template: shell-script


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
This reverts the commit - "Revert "[CASMPET-7385](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7385) add cleanup-live-images step before upgrading storage nodes""
This reverts commit efb2bd44b11572e15050ed37712875836ea92e26.

With this PR, cleanup-live-images WILL run before upgrading storage nodes.

The original reason this was reverted was because it broke the vShasta upgrade pipeline. However, the vShasta upgrade has worked around this problem and now this change can go in without impacting vShasta.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
