### PR TITLE
CASMTRIAGE-7927: Update portainer image based on CSM 1.7 Kubernetes v…

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -168,7 +168,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
     script:
-      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
       command: [bash]
       source: |
         function sync_item() {
@@ -303,7 +303,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     script:
-      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
       command: [bash]
       source: |
         s3_secret_name={{inputs.parameters.s3_credentials_secret_name}}

--- a/workflows/iuf/operations/managed-nodes/managed-nodes-rollout.yaml
+++ b/workflows/iuf/operations/managed-nodes/managed-nodes-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -157,7 +157,7 @@ spec:
             valueFrom:
               path: /tmp/sat_command.txt
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           #!/bin/bash

--- a/workflows/iuf/operations/nexus-setup/cleanup-nexus-admin-credential.yaml
+++ b/workflows/iuf/operations/nexus-setup/cleanup-nexus-admin-credential.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,7 @@ spec:
         parameters:
           - name: nexus_admin_credential_secret_name
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           nexus_secret_name={{inputs.parameters.nexus_admin_credential_secret_name}}

--- a/workflows/iuf/operations/nexus-setup/nexus-get-prerequisites-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-get-prerequisites-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -59,7 +59,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           function sync_item() {

--- a/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
+++ b/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -181,7 +181,7 @@ spec:
           path: /tmp/product-content
           default: "{\"component_versions\": {\"s3\": []}}"
     script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
       command: [bash]
       source: |
         PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')

--- a/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
+++ b/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -171,7 +171,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           function sync_item() {
@@ -287,7 +287,7 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           vcs_secret_name={{inputs.parameters.vcs_user_credentials_secret_name}}

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -177,7 +177,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           function sync_item() {
@@ -302,7 +302,7 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [bash]
         source: |
           vcs_secret_name={{inputs.parameters.vcs_user_credentials_secret_name}}

--- a/workflows/templates/after-all-hooks.yaml
+++ b/workflows/templates/after-all-hooks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ spec:
         - name: get-after-all-hooks
           inline:
             script:
-              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
               command: [sh]
               source: |
                 kubectl get hooks -n argo -l after-all=true -o jsonpath='{.items}' | jq -c 'map(.metadata.name)'

--- a/workflows/templates/after-each-hooks.yaml
+++ b/workflows/templates/after-each-hooks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ spec:
         - name: get-after-each-hooks
           inline:
             script:
-              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
               command: [sh]
               source: |
                 kubectl get hooks -n argo -l after-each=true -o jsonpath='{.items}' | jq -c 'map(.metadata.name)'

--- a/workflows/templates/base/kubectlAndCurl.template.argo.yaml
+++ b/workflows/templates/base/kubectlAndCurl.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@ spec:
       script:
         # use portainer/kubectl-shell that has:
         #  - kubectl, jq, curl and csi 
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
         command: [sh]
         source: |
           #!/bin/sh

--- a/workflows/templates/before-all-hooks.yaml
+++ b/workflows/templates/before-all-hooks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ spec:
         - name: get-before-all-hooks
           inline:
             script:
-              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
               command: [sh]
               source: |
                 kubectl get hooks -n argo -l before-all=true -o jsonpath='{.items}' | jq -c 'map(.metadata.name)'

--- a/workflows/templates/before-each-hooks.yaml
+++ b/workflows/templates/before-each-hooks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ spec:
         - name: get-before-each-hooks
           inline:
             script:
-              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+              image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:2.27.0
               command: [sh]
               source: |
                 kubectl get hooks -n argo -l before-each=true -o jsonpath='{.items}' | jq -c 'map(.metadata.name)'


### PR DESCRIPTION
# Description

[CASMTRIAGE-7927](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7927) : Update portainer image based on CSM 1.7 Kubernetes Version v1.32 and use latest cray-site-init version 1.36.8

container-images PR : https://github.com/Cray-HPE/container-images/pull/677
Spira Link: https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
