### PR TITLE
CASMINST-7245: Remove platform-utils from prerequisites.sh

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1087,7 +1087,7 @@ if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    rpm_list=(csm-testing hpe-csm-goss-package platform-utils goss-servers cray-cmstools-crayctldeploy)
+    rpm_list=(csm-testing hpe-csm-goss-package goss-servers cray-cmstools-crayctldeploy)
     url_list=()
     for rpm_name in "${rpm_list[@]}"; do
       rpm_path=$(find "${CSM_ARTI_DIR}"/rpm/cray/csm/ -name \*${rpm_name}\*.rpm | sort -V | tail -1)


### PR DESCRIPTION
Let `cloud-init` update it during node rebuild.

See full discussion here:
https://cray.slack.com/archives/G01GNSCG6KV/p1741935730817799

I am creating this PR to implement the change that @mtupitsyn  and @jpdavis-prof  discussed, and that Mikhail tested.