### PR TITLE
CASMPET-7440 update fix-postgres.sh so that spire-postgres and cray-spire-postgres get restarted

### DIFF
--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -86,14 +86,11 @@ wait_for postgres_operator_running "postgres-operator pod running"
 # Only restart postgres clusters in argo, services, spire namespaces - but wait for all clusters (such as sma) to be healthy, as
 # preflight checks at the end of prerequisites script will need all clusters anyway.
 kubectl get sts -A -l application=spilo -o json \
-  | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services") | (.metadata.namespace + ":" + .metadata.name)' \
+  | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services" or .metadata.namespace == "spire") | (.metadata.namespace + ":" + .metadata.name)' \
   | while IFS=: read -r namespace sts; do
     echo "Rolling restart ${sts} in namespace ${namespace} ..."
     kubectl rollout restart -n "${namespace}" statefulset "${sts}"
   done
-# restart cray-spire-postgres, kubectl rollout restart does not work for this cluster
-echo "Restarting all cray-spire-postgres members"
-kubectl exec -n spire cray-spire-postgres-0 -c postgres -- patronictl restart cray-spire-postgres --force
 echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
 sleep 300
 wait_for postgres_pods_running "all postgres pods running"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Spire-postgres and cray-spire-postgres need to be restarted via `kubectl rollout restart` during prerequisistes.sh. I had previously thought a different mechanism was needed to restart these pods however rollout restart works and is the best way to do this.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
