### PR TITLE
CASMCMS-9260: Document IMS image job performance reasons/remediations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -204,6 +204,8 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 
 ## Known issues
 
+* Image build and customization jobs generally take longer than they did in previous CSM versions. For more details, see
+  [Image Job Performance](operations/image_management/Image_Job_Performance.md).
 * [Firmware Action Service (FAS)](glossary.md#firmware-action-service-fas) Loader / HFP script `post-deliver-product.sh`
     * Loading firmware from Nexus using the FAS Loader will intermittently crash with HFP release 23.12 or later. Rerunning the FAS Loader will be required.
     * This affects the HFP script `post-deliver-product.sh` which will hang when the FAS Loader crashes. Rerunning the script will be required.

--- a/operations/README.md
+++ b/operations/README.md
@@ -72,6 +72,7 @@ Build and customize image recipes with the Image Management Service (IMS).
 
 - [Image Management](image_management/Image_Management.md)
 - [Image Management Workflows](image_management/Image_Management_Workflows.md)
+- [Image Job Performance](image_management/Image_Job_Performance.md)
 - [Upload and Register an Image Recipe](image_management/Upload_and_Register_an_Image_Recipe.md)
 - [Build a New UAN Image Using the Default Recipe](image_management/Build_a_New_UAN_Image_Using_the_Default_Recipe.md)
 - [Build an Image Using IMS REST Service](image_management/Build_an_Image_Using_IMS_REST_Service.md)
@@ -90,6 +91,7 @@ Build and customize image recipes with the Image Management Service (IMS).
 - [Troubleshoot Remote Build Node](image_management/Troubleshoot_Remote_Build_Node.md)
 - [Troubleshoot zypper interaction](image_management/Troubleshoot_zypper_interaction.md)
 - [IMS API](../api/ims.md)
+- [IMS known issues](../troubleshooting/README.md#image-management)
 
 ## Boot orchestration
 
@@ -149,6 +151,7 @@ Use the Boot Orchestration Service \(BOS\) to boot, configure, and shut down col
 - [Redeploy the iPXE and TFTP Services](boot_orchestration/Redeploy_the_IPXE_and_TFTP_Services.md)
 - [Upload Node Boot Information to Boot Script Service (BSS)](boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md)
 - [Hang Listing BOS V1 Sessions](../troubleshooting/known_issues/Hang_Listing_BOS_V1_Sessions.md)
+- [BOS known issues](../troubleshooting/README.md#booting)
 
 ## System power off procedures
 
@@ -265,6 +268,7 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
     - [Customize Configuration Values](configuration_management/Customize_Configuration_Values.md)
     - [Update the Privacy Settings for Gitea Configuration Content Repositories](configuration_management/Update_the_Privacy_Settings_for_Gitea_Configuration_Content_Repositories.md)
     - [Create and Populate a VCS Configuration Repository](configuration_management/Create_and_Populate_a_VCS_Configuration_Repository.md)
+- [CFS known issues](../troubleshooting/README.md#configuration-management)
 
 ## Kubernetes
 
@@ -308,6 +312,7 @@ As a result, the system's micro-services are modular, resilient, and can be upda
 - [TDS Lower CPU Requests](kubernetes/TDS_Lower_CPU_Requests.md)
 - [Fix `Failed to start etcd` on Master NCN](kubernetes/Fix_Failed_to_start_etcd_on_Master.md)
 - [Kubernetes and Bare Metal EtcD Certificate Renewal](kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md)
+- [Kubernetes known issues](../troubleshooting/README.md#kubernetes)
 
 ## Package repository management
 
@@ -386,6 +391,7 @@ Mechanisms used by the system to ensure the security and authentication of inter
 - [Audit Logs](security_and_authentication/Audit_Logs.md)
 - [Cray STS Token Generator API](../api/sts.md)
 - [Configure root user on HPE iLO BMCs](security_and_authentication/Configure_root_user_on_HPE_iLO_BMCs.md)
+- [Security and authentication known issues](../troubleshooting/README.md#security-and-authentication)
 
 ## Resiliency
 
@@ -415,6 +421,7 @@ troubleshooting node boot issues.
 - [Troubleshoot ConMan Asking for Password on SSH Connection](conman/Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
 - [Troubleshoot Console Node Pod Stuck in Terminating State](conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
 - [Complete Reset of the Console Services](conman/Complete_Reset_of_the_Console_Services.md)
+- [Console known issues](../troubleshooting/README.md#conman)
 
 ## Utility storage
 
@@ -458,6 +465,7 @@ services running on Kubernetes, as well as for telemetry data coming from the co
 - [Troubleshoot Insufficient Standby MDS Daemons Available](utility_storage/Troubleshoot_Insufficient_Standby_MDS_Daemons_Available.md)
 - [Troubleshoot S3FS Mount Issues](utility_storage/Troubleshoot_S3FS_Mounts.md)
 - [Fixing incorrect number of PG Issues](utility_storage/Troubleshoot_Pools_Have_Many_More_Objects_Per_Pg_Than_Average.md)
+- [Utility storage known issues](../troubleshooting/README.md#utility-storage)
 
 ## System management health
 
@@ -471,6 +479,7 @@ confident that a lack of issues indicates the system is operating normally.
 - [Configure Prometheus Email Alert Notifications](system_management_health/Configure_Prometheus_Email_Alert_Notifications.md)
 - [Grafana Dashboards by Component](system_management_health/Grafana_Dashboards_by_Component.md)
     - [Troubleshoot Grafana Dashboard](system_management_health/Troubleshoot_Grafana_Dashboard.md)
+    - [Grafana dashboards known issues](../troubleshooting/README.md#grafana-dashboards)
 - [Grafterm](system_management_health/Grafterm.md)
 - [Remove Kiali](system_management_health/Remove_Kiali.md)
 - [`prometheus-kafka-adapter` errors during installation](system_management_health/Prometheus_Kafka_Error.md)
@@ -619,6 +628,7 @@ Monitor and manage compute nodes (CNs) and non-compute nodes (NCNs) used in the 
 - [Update the HPE Node BIOS Time](node_management/Update_the_HPE_Node_BIOS_Time.md)
 - [Switch PXE Boot from Onboard NIC to PCIe](node_management/Switch_PXE_Boot_From_Onboard_NICs_to_PCIe.md)
 - [NCN NIC Replacement](node_management/NCN_NIC_Replacement.md)
+- [Node management known issues](../troubleshooting/README.md#node-management)
 
 ## Network
 
@@ -656,6 +666,7 @@ The customer accessible networks \(CMN/CAN/CHN\) provide access from outside the
 - [MetalLB Peering with Arista Edge Router](network/customer_accessible_networks/bi-can_arista_metallb_peering.md)
 - [CAN/CMN with Dual-Spine Configuration](network/customer_accessible_networks/Dual_Spine_Configuration.md)
 - [Troubleshoot CMN Issues](network/customer_accessible_networks/Troubleshoot_CMN_Issues.md)
+- [CMN known issues](../troubleshooting/README.md#customer-management-network-cmn)
 
 ### Dynamic Host Configuration Protocol (DHCP)
 
@@ -676,6 +687,7 @@ The central DNS infrastructure provides the structural networking hierarchy and 
 - [PowerDNS Migration Guide](network/dns/PowerDNS_migration.md)
 - [Troubleshoot Common DNS Issues](network/dns/Troubleshoot_Common_DNS_Issues.md)
 - [Troubleshoot PowerDNS](network/dns/Troubleshoot_PowerDNS.md)
+- [DNS known issues](../troubleshooting/README.md#domain-name-service-dns)
 
 ### External DNS
 
@@ -703,6 +715,7 @@ MetalLB can run in either `Layer2-mode` or `BGP-mode` for each address pool it m
 - [Check BGP Status and Reset Sessions](network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md)
 - [Troubleshoot Services without an Allocated IP Address](network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
 - [Troubleshoot BGP not Accepting Routes from MetalLB](network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
+- [MetalLB known issues](../troubleshooting/README.md#metallb)
 
 ## Spire
 
@@ -714,6 +727,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 - [Xname Validation](spire/xname_validation.md)
 - [Restore Missing Spire Meta-Data](spire/Restore_Missing_Spire_Metadata.md)
 - [Create a Backup of the Spire Postgres Database](spire/Create_a_backup_of_the_Spire_Postgres_Database.md)
+- [Spire known issues](../troubleshooting/README.md#spire)
 
 ## Update firmware with FAS
 
@@ -816,6 +830,7 @@ a User Access Instance \(UAI\) using the `cray` command. Users can also transfer
     - [Troubleshoot Common Mistakes when Creating a Custom End-User UAI Image](UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md)
     - [Troubleshoot Broker UAI SSSD Cannot Use `/etc/sssd/sssd.conf`](UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md)
     - [Troubleshoot UAS / CLI Authentication Issues](UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md)
+- [UAS known issues](../troubleshooting/README.md#user-access-service-uas)
 
 ## System Admin Toolkit (SAT)
 

--- a/operations/image_management/Image_Job_Performance.md
+++ b/operations/image_management/Image_Job_Performance.md
@@ -6,21 +6,25 @@ and a need to ensure that the default behavior will work on all systems. There a
 may use to reduce these durations in some cases. This document explains the reasons behind the longer durations,
 and includes options for speeding up the jobs.
 
-- [Different content](#different-content)
+- [Increased Ansible content](#increased-ansible-content)
 - [Emulation](#emulation)
 - [Remote build nodes](#remote-build-nodes)
 - [Kata](#kata)
 - [PVCs](#pvcs)
 
-## Different content
+## Increased Ansible content
+
+A large part of the reason that image customization jobs generally take longer in CSM 1.5 is because there is more content in many of
+the image customization Ansible playbooks (when compared to the corresponding Ansible playbooks in earlier CSM releases).
 
 Prior to CSM 1.5, there were some configuration tasks which could only be performed on a live node (not during image customization).
 These tasks would be run after the node booted by the
 [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) as part of the live node personalization.
-Because of improvements to IMS in CSM 1.5, many of these tasks are able to run during image customization. This leads to the image
-customization jobs taking longer to run. This is preferable to the previous behavior. Instead of every single node having to run those
-steps after they boot, the steps can be done just once to the image used by those nodes. This means that after the images are customized,
-the time required for a node to boot and begin doing work is usually significantly less than it was prior to CSM 1.5.
+Because of improvements to IMS in CSM 1.5, many of these tasks are able to run during image customization. Adding these tasks to the image
+customization plays leads to the image customization jobs taking longer to run. This is preferable to the previous behavior. Instead of
+every single node having to run those steps after they boot, the steps can be done just once to the image used by those nodes. This
+means that after the images are customized, the time required for a node to boot and begin doing work is usually significantly less than
+it was prior to CSM 1.5.
 
 ## Emulation
 

--- a/operations/image_management/Image_Job_Performance.md
+++ b/operations/image_management/Image_Job_Performance.md
@@ -1,0 +1,148 @@
+# Image Job Performance
+
+Starting in CSM 1.5, image build and customization jobs in the Image Management Service (IMS) generally have
+longer durations when compared to previous CSM releases. This is a consequence of intentional design choices,
+and a need to ensure that the default behavior will work on all systems. There are steps that administrators
+may use to reduce these durations in some cases. This document explains the reasons behind the longer durations,
+and includes options for speeding up the jobs.
+
+- [Different content](#different-content)
+- [Emulation](#emulation)
+- [Remote build nodes](#remote-build-nodes)
+- [Kata](#kata)
+- [PVCs](#pvcs)
+
+## Different content
+
+Prior to CSM 1.5, there were some configuration tasks which could only be performed on a live node (not during image customization).
+These tasks would be run after the node booted by the
+[Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs) as part of the live node personalization.
+Because of improvements to IMS in CSM 1.5, many of these tasks are able to run during image customization. This leads to the image
+customization jobs taking longer to run. This is preferable to the previous behavior. Instead of every single node having to run those
+steps after they boot, the steps can be done just once to the image used by those nodes. This means that after the images are customized,
+the time required for a node to boot and begin doing work is usually significantly less than it was prior to CSM 1.5.
+
+## Emulation
+
+In CSM 1.5, support for ARM (`aarch64`) hardware was added. Because the [worker NCNs](../../glossary.md#management-nodes)
+do not use ARM hardware, IMS by default uses an emulation environment when working with ARM images. This adds a significant performance
+penalty, and drastically increases the duration of the jobs. On systems that have ARM [compute nodes](../../glossary.md#compute-node-cn),
+IMS can be configured to use one of these nodes as a remote build node, avoiding the emulation layer. This bypasses the extreme
+performance penalties caused by running under emulation, and is strongly encouraged.
+
+See:
+
+- [Working With `aarch64` Images](Working_With_aarch64_Images.md)
+- [Configure a Remote Build Node](Configure_a_Remote_Build_Node.md)
+
+## Remote build nodes
+
+Even in cases where architecture emulation is not taking place, the use of a remote build node may offer a performance benefit.
+Administrators may wish to experiment with configuring an `x86` remote build node, to see if it offers performance improvements
+for `x86` IMS image builds and customizations.
+
+See [Configure a Remote Build Node](Configure_a_Remote_Build_Node.md).
+
+## Kata
+
+In order to provide a secure, isolated environment to work on images, IMS jobs run inside a Kata Container starting in CSM 1.5.
+This does incur a performance penalty, and it is possible to disable this behavior, but **this is not recommended**.
+For more information on Kata Containers, see the [Kata Containers home page](https://katacontainers.io/).
+
+Kata may be disabled by using the following procedure:
+
+1. (`ncn-mw#`) Edit the `cray-configmap-ims-v2-image-customize` Kubernetes ConfigMap in the `services` namespace.
+
+    > This will disable Kata for IMS image customization jobs. Skip this step in order to leave Kata enabled
+    > for image customizations.
+
+    ```bash
+    kubectl -n services edit cm cray-configmap-ims-v2-image-customize
+    ```
+
+    Edit it by commenting the following line:
+
+    ```yaml
+              runtimeClassName: $runtime_class
+    ```
+
+    After the edit, the line should be:
+
+    ```yaml
+              #runtimeClassName: $runtime_class
+    ```
+
+1. (`ncn-mw#`) Edit the `cray-configmap-ims-v2-image-create-kiwi-ng` Kubernetes ConfigMap in the `services` namespace.
+
+    > This will disable Kata for IMS image build jobs. Skip this step in order to leave Kata enabled
+    > for image builds.
+
+    ```bash
+    kubectl -n services edit cm cray-configmap-ims-v2-image-create-kiwi-ng
+    ```
+
+    Make the same edit as the previous step.
+
+1. (`ncn-mw#`) Restart IMS.
+
+    ```bash
+    kubectl -n services rollout restart deployment cray-ims && kubectl -n services rollout status deployment cray-ims
+    ```
+
+To re-enable Kata, perform the same procedure, but reverse the edits.
+
+## PVCs
+
+In order to reliably handle large images, in CSM 1.5, IMS pods started using Kubernetes Persistent Volume Claims (PVCs)
+for image storage, instead of in-memory volumes. This incurs a modest performance penalty, and it is possible to
+disable this behavior. However, doing so runs the risk of exhausting storage space on the worker NCNs, causing problems.
+As such, this is not recommended.
+
+The use of these PVCs may be disabled by using the following procedure:
+
+1. (`ncn-mw#`) Edit the `cray-configmap-ims-v2-image-customize` Kubernetes ConfigMap in the `services` namespace.
+
+    > This will disable PVCs for IMS image customization jobs. Skip this step in order to continue to use PVCs
+    > for image customizations.
+
+    ```bash
+    kubectl -n services edit cm cray-configmap-ims-v2-image-customize
+    ```
+
+    Edit the following section:
+
+    ```yaml
+          volumes:
+          - name: image-vol
+            persistentVolumeClaim:
+              claimName: cray-ims-$id-job-claim
+    ```
+
+    Edit it to be the following:
+
+    ```yaml
+          volumes:
+          - name: image-vol
+            emptyDir: {}
+            #persistentVolumeClaim:
+            #  claimName: cray-ims-$id-job-claim
+    ```
+
+1. (`ncn-mw#`) Edit the `cray-configmap-ims-v2-image-create-kiwi-ng` Kubernetes ConfigMap in the `services` namespace.
+
+    > This will disable PVCs for IMS image build jobs. Skip this step in order to continue to use PVCs
+    > for image builds.
+
+    ```bash
+    kubectl -n services edit cm cray-configmap-ims-v2-image-create-kiwi-ng
+    ```
+
+    Make the same edit as the previous step.
+
+1. (`ncn-mw#`) Restart IMS.
+
+    ```bash
+    kubectl -n services rollout restart deployment cray-ims && kubectl -n services rollout status deployment cray-ims
+    ```
+
+To re-enable PVCs, perform the same procedure, but reverse the edits.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -10,14 +10,15 @@ This document provides links to troubleshooting information for services and fun
 - [Configuration management](#configuration-management)
 - [ConMan](#conman)
 - [Customer Management Network (CMN)](#customer-management-network-cmn)
-- [Grafana dashboards](#grafana-dashboards)
 - [Domain Name Service (DNS)](#domain-name-service-dns)
+- [Grafana dashboards](#grafana-dashboards)
+- [Image management](#image-management)
 - [Kubernetes](#kubernetes)
 - [MetalLB](#metallb)
 - [Node management](#node-management)
 - [Security and authentication](#security-and-authentication)
 - [Spire](#spire)
-- [User Access service UAS](#user-access-service-uas)
+- [User Access Service UAS](#user-access-service-uas)
 - [Utility storage](#utility-storage)
 
 ## Helpful tips for navigating the CSM repository
@@ -78,6 +79,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [`cray-console-node` pods in `CrashLoopBackOff`](known_issues/cray-console-node_pods_in_CrashLoopBackOff.md)
 - [IMS Images Orphaned in S3](known_issues/ims_images_orphaned_in_s3.md)
 - [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
+- [IMS Image Job Performance](../operations/image_management/Image_Job_Performance.md)
 
 ## Booting
 
@@ -127,14 +129,25 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Troubleshoot BGP services without an allocated IP address](../operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
 - [Troubleshoot PXE boot](../install/troubleshooting_pxe_boot.md)
 
-## Grafana dashboards
-
-- [Grafana Dashboards](../operations/system_management_health/Troubleshoot_Grafana_Dashboard.md)
-
 ## Domain Name Service (DNS)
 
 - [Connectivity to Services with External IP addresses](../operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md)
 - [DNS Configuration Issues](../operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md)
+
+## Grafana dashboards
+
+- [Grafana Dashboards](../operations/system_management_health/Troubleshoot_Grafana_Dashboard.md)
+
+## Image management
+
+- [Image Job Performance](../operations/image_management/Image_Job_Performance.md)
+- [IMS image creation failure](known_issues/ims_image_creation_failure.md)
+- [Missing Binaries in aarch64 Images](known_issues/missing_binaries_in_aarch64_images.md)
+- [IMS image delete loses the `arch` information](known_issues/ims_image_delete_loses_arch.md)
+- [IMS Images Orphaned in S3](known_issues/ims_images_orphaned_in_s3.md)
+- [Troubleshoot Issues with Large Images](../operations/image_management/Troubleshoot_Large_Image.md)
+- [Troubleshoot Remote Build Node](../operations/image_management/Troubleshoot_Remote_Build_Node.md)
+- [Troubleshoot Interactions with zypper](../operations/image_management/Troubleshoot_zypper_interaction.md)
 
 ## Kubernetes
 
@@ -175,7 +188,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 - [Spire Database Cluster DNS Lookup Failure](known_issues/spire_database_lookup_error.md)
 - [Spire Failing to Start on NCNs](../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
 
-## User Access service UAS
+## User Access Service UAS
 
 **NOTE:** UAS and UAI are deprecated in CSM 1.5.2 and will be removed in CSM 1.6
 


### PR DESCRIPTION
Starting in CSM 1.5, customers began observing that their image jobs were taking longer than they expected (based on their experience in previous CSM versions).  Among others, this was documented in [CAST-37448](https://jira-pro.it.hpe.com:8443/browse/CAST-37448) and [CAST-37551](https://jira-pro.it.hpe.com:8443/browse/CAST-37551).

It turns out that the reasons for this are complicated, but not the result of bugs or a regression.

This PR primarily does the following:
1. Create a document which:
    1. States that the image job times are generally longer in CSM 1.5
    2. Explains the various causes of this
    3. Where applicable, gives options to improve the performance
2. Updates the release notes and known issues and operations index with pointers to this page, to ensure that customers find it.

I also did a little link cleanup and maintenance to the operations index and the troubleshooting index.

Backports (the backports to earlier CSM versions will just include the cleanup -- the backports to newer CSM versions will include all of it, except probably the link in the release notes)

1.6: https://github.com/Cray-HPE/docs-csm/pull/5830
1.7: https://github.com/Cray-HPE/docs-csm/pull/5831
1.4: https://github.com/Cray-HPE/docs-csm/pull/5832
1.3: https://github.com/Cray-HPE/docs-csm/pull/5833
1.2: https://github.com/Cray-HPE/docs-csm/pull/5834
1.0: https://github.com/Cray-HPE/docs-csm/pull/5835