### PR TITLE
CASMTRIAGE-7975 add step to CSM 1.6 prerequisites to check coredns image

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1593,6 +1593,26 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     kubectl apply -f ${locOfScript}/postgres-pod.yaml
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+  echo
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+# the coredns container image needs to be verified. Once nodes are upgraded, k8s.gcr.io/coredns:v1.8.4 will not be available
+# coredns needs to be using k8s.gcr.io/coredns/coredns:v1.8.4 before node upgrades
+state_name="CHECK_COREDNS_CONTAINER_IMAGE"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    if [[ -n $(kubectl get deployment -n kube-system coredns -o yaml | grep "k8s.gcr.io/coredns:v1.8.4") ]]; then
+      echo 'Setting coredns deployment to use image: "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4"'
+      kubectl set image deployment coredns -n kube-system coredns=artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
+    else
+      echo "Coredns is using the correct contianer image. Nothing to do."
+    fi
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
   echo


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

If a system has been upgraded from CSM 1.4 to CSM 1.5, coredns uses the container image "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:v1.8.4". When nodes are later upgraded to CSM 1.6, this container image is not available. Before the CSM 1.6 node upgrade is done, coredns should start using the image "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4". 

This PR adds a step to prerequisites.sh to check that coredns is using the correct container image. If it is not, then the correct image is set for the coredns deployment.

Testing:

I ran the prerequisites.sh script with all steps commented out except CHECK_COREDNS_CONTAINER_IMAGE.

1. When the correct image is running, the following behavior is seen

```text
====> CHECK_COREDNS_CONTAINER_IMAGE ...
====> CHECK_COREDNS_CONTAINER_IMAGE has been completed

ncn-m001: # cat /root/output.log | tail -5
Total Duration: 9.870s
Count: 28, Failed: 0, Skipped: 0
====> CHECK_COREDNS_CONTAINER_IMAGE ...
Coredns is using the correct contianer image. Nothing to do.
====> CHECK_COREDNS_CONTAINER_IMAGE has been completed
``` 

2. When the incorrect image is running, the following behavior is seen

```text
LOG_FILE is not specified; use default location: /root/output.log

====> CHECK_COREDNS_CONTAINER_IMAGE ...
====> CHECK_COREDNS_CONTAINER_IMAGE has been completed

ncn-m001:/etc/cray/upgrade/csm/csm-1.6.0/ncn-m001 # cat /root/output.log | tail -4

====> CHECK_COREDNS_CONTAINER_IMAGE ...
Setting coredns deployment to use image: "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4"
deployment.apps/coredns image updated
====> CHECK_COREDNS_CONTAINER_IMAGE has been completed
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
