### PR TITLE
CASMCMS-8867: Check for CFS sessions before importing the data

### DIFF
--- a/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
+++ b/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
@@ -96,6 +96,13 @@ criteria listed above.
       /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh /tmp/cfs-export-20230410170613-Tg0nap.tgz
       ```
 
+   - If there are running or pending CFS sessions then the import will fail. In such cases, the import can be forced by using the
+     `--ignore-running-sessions` option.
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --ignore-running-sessions /tmp/cfs-export-20230410170613-Tg0nap.tgz
+      ```
+
    - If the CFS import is being done after a reinstall of CSM AND if VCS data from a prior CSM install has been imported, then
      invoke the tool with the `--clear-cfs` option. This is because the CFS data created during the reinstall of
      CSM will not match the re-imported VCS data.

--- a/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
+++ b/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
@@ -88,19 +88,15 @@ criteria listed above.
 1. (`ncn-mw#`) Run the following script to import the data from the archive file.
 
    > Modify the following example commands to specify the path to the output file from the automated export script.
+     The import tool will abort if it detects incomplete CFS sessions which could potentially be impacted
+     by the import; to override this behavior and import anyway, the `--ignore-running-sessions` argument
+     may be added when invoking the import script.
 
    - If this import is not happening after a reinstall of CSM, OR if VCS data was not imported from a previous CSM install,
      then invoke the tool as follows:
 
       ```bash
       /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh /tmp/cfs-export-20230410170613-Tg0nap.tgz
-      ```
-
-   - If there are running or pending CFS sessions then the import will fail. In such cases, the import can be forced by using the
-     `--ignore-running-sessions` option.
-
-      ```bash
-      /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --ignore-running-sessions /tmp/cfs-export-20230410170613-Tg0nap.tgz
       ```
 
    - If the CFS import is being done after a reinstall of CSM AND if VCS data from a prior CSM install has been imported, then

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -502,6 +502,8 @@ def main() -> None:
     current_cfs_data = load_cfs_data()
 
     if parsed_args.clear_cfs:
+        if not parsed_args.ignore_running_sessions:
+            check_for_running_cfs_sessions("CFS data")
         # Take a snapshot of the CFS data before clearing it
         print("Taking a snapshot of system CFS data before clearing it")
         snapshot_cfs_data()

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -459,7 +459,6 @@ def clear_cfs(current_cfs_data: CfsData) -> None:
         del current_cfs_data.sources[source_name]
 
 
-
 def check_for_running_cfs_sessions(resource_type: str) -> None:
     print(f"{resource_type} are being updated. Checking for running and pending CFS sessions...")
     cfs_sessions = []
@@ -470,9 +469,9 @@ def check_for_running_cfs_sessions(resource_type: str) -> None:
         cfs_sessions.extend(cfs.list_sessions(params=session_params))
 
     if cfs_sessions:
-        print(f"Following CFS sessions are running,aborting import. Run with --ignore-running-sessions to override.")
+        print(f"The following CFS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.")
         print(", ".join(session["name"] for session in cfs_sessions))
-        raise CfsError("There are running CFS sessions. Aborting import.")
+        raise CfsError("There are CFS sessions that are not complete. Aborting import.")
 
 
 def main() -> None:
@@ -491,7 +490,7 @@ def main() -> None:
     parser.add_argument(metavar="json_directory", type=json_data_from_directory, dest="json_data",
                         help=f"Directory containing {CMP_JSON}, {CFG_JSON}, and {OPT_JSON}")
     parser.add_argument("--ignore-running-sessions", action='store_true',
-                        help="Ignore running CFS sessions when importing CFS data")
+                        help="Ignore non-completed CFS sessions when importing CFS data")
     parsed_args = parser.parse_args()
 
     cfs_data_to_import = parsed_args.json_data
@@ -518,14 +517,14 @@ def main() -> None:
                                           current_cfs_data.components,
                                           current_cfs_data.configurations, configs_to_create)
 
-    # Check for running sessions if we have components to update
+    # Check for non-complete (pending or running) sessions if we have components to update
     if not parsed_args.ignore_running_sessions and comps_to_update:
         check_for_running_cfs_sessions("components")
 
     print("\nExamining CFS options...")
     options_to_change = get_options_to_change(cfs_data_to_import.options, current_cfs_data.options)
 
-    # Check for running sessions if options are being updated
+    # Check for non-complete (pending or running) sessions if options are being updated
     if not parsed_args.ignore_running_sessions and options_to_change:
         check_for_running_cfs_sessions("options")
 

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -430,10 +430,6 @@ def clear_cfs(current_cfs_data: CfsData) -> None:
     """
     Clear select CFS data
     """
-    for config_name in list(current_cfs_data.configurations):
-        print(f"Deleting configuration '{config_name}'")
-        cfs.delete_configuration(config_name)
-        del current_cfs_data.configurations[config_name]
 
     comp_clear_data = {"error_count": 0, "state": [], "desired_config": "", "tags": {}}
     for comp_sublist in chunk_list(list(current_cfs_data.components)):
@@ -443,6 +439,11 @@ def clear_cfs(current_cfs_data: CfsData) -> None:
                                                              update_data=comp_clear_data)
         for comp_id in updated_comp_response['component_ids']:
             current_cfs_data.components[comp_id].update(comp_clear_data)
+
+    for config_name in list(current_cfs_data.configurations):
+        print(f"Deleting configuration '{config_name}'")
+        cfs.delete_configuration(config_name)
+        del current_cfs_data.configurations[config_name]
 
     if current_cfs_data.sources:
         # No sources to clear

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -457,6 +457,23 @@ def clear_cfs(current_cfs_data: CfsData) -> None:
         cfs.delete_source(source_name)
         del current_cfs_data.sources[source_name]
 
+
+
+def check_for_running_cfs_sessions(resource_type: str) -> None:
+    print(f"{resource_type} are being updated. Checking for running and pending CFS sessions...")
+    cfs_sessions = []
+    for status in ["pending", "running"]:
+        session_params = {
+            "status": status
+        }
+        cfs_sessions.extend(cfs.list_sessions(params=session_params))
+
+    if cfs_sessions:
+        print(f"Following CFS sessions are running,aborting import. Run with --ignore-running-sessions to override.")
+        print(", ".join(session["name"] for session in cfs_sessions))
+        raise CfsError("There are running CFS sessions. Aborting import.")
+
+
 def main() -> None:
     """
     Parses the command line arguments, does the stuff.
@@ -472,6 +489,8 @@ def main() -> None:
                         help="Delete CFS configurations and clear CFS components before importing")
     parser.add_argument(metavar="json_directory", type=json_data_from_directory, dest="json_data",
                         help=f"Directory containing {CMP_JSON}, {CFG_JSON}, and {OPT_JSON}")
+    parser.add_argument("--ignore-running-sessions", action='store_true',
+                        help="Ignore running CFS sessions when  importing CFS data")
     parsed_args = parser.parse_args()
 
     cfs_data_to_import = parsed_args.json_data
@@ -498,8 +517,16 @@ def main() -> None:
                                           current_cfs_data.components,
                                           current_cfs_data.configurations, configs_to_create)
 
+    # Check for running sessions if we have components to update
+    if not parsed_args.ignore_running_sessions and comps_to_update:
+        check_for_running_cfs_sessions("components")
+
     print("\nExamining CFS options...")
     options_to_change = get_options_to_change(cfs_data_to_import.options, current_cfs_data.options)
+
+    # Check for running sessions if options are being updated
+    if not parsed_args.ignore_running_sessions and options_to_change:
+        check_for_running_cfs_sessions("options")
 
     print("\nExamining CFS sources...")
     sources_to_restore = get_sources_to_restore(cfs_data_to_import.sources,

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -491,7 +491,7 @@ def main() -> None:
     parser.add_argument(metavar="json_directory", type=json_data_from_directory, dest="json_data",
                         help=f"Directory containing {CMP_JSON}, {CFG_JSON}, and {OPT_JSON}")
     parser.add_argument("--ignore-running-sessions", action='store_true',
-                        help="Ignore running CFS sessions when  importing CFS data")
+                        help="Ignore running CFS sessions when importing CFS data")
     parsed_args = parser.parse_args()
 
     cfs_data_to_import = parsed_args.json_data

--- a/scripts/operations/configuration/import_cfs_data.sh
+++ b/scripts/operations/configuration/import_cfs_data.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@
 # the Python script completes, the expanded files from the archive are
 # cleaned up by this shell script, unless --no-cleanup is specified.
 #
-# Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>
+# Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] [--ignore-running-sessions] <CFS export file.tgz>
 #
 ################################################################################
 
@@ -41,6 +41,7 @@ CLEANUP=YES
 OUTPUT_DIR=""
 CLEAR_CFS=""
 ARCHIVE=""
+IGNORE_RUNNING_SESSIONS=""
 
 cleanup() {
   [[ $CLEANUP == YES ]] || return
@@ -59,7 +60,7 @@ err_exit() {
 }
 
 usage() {
-  echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>"
+  echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] [--ignore-running-sessions] <CFS export file.tgz>"
   echo
   err_exit "$@"
 }
@@ -76,6 +77,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     "--no-cleanup") CLEANUP="" ;;
     "--clear-cfs") CLEAR_CFS="$1" ;;
+    "--ignore-running-sessions") IGNORE_RUNNING_SESSIONS="$1" ;;
     *)
       [[ $# -eq 1 ]] || usage "Unrecognized argument: $1"
       ARCHIVE="$1"
@@ -113,8 +115,8 @@ for FNAME in configurations.json options.json; do
 done
 
 # Call the Python importer script on this directory
-# CLEAR_CFS is deliberately not quoted because if it is empty, we don't want to pass in an empty argument to the Python script
-run_cmd "${import_python_script}" ${CLEAR_CFS} "${JSON_DIR}"
+# CLEAR_CFS and IGNORE_RUNNING_SESSIONS are deliberately not quoted because if it is empty, we don't want to pass in an empty argument to the Python script
+run_cmd "${import_python_script}" ${CLEAR_CFS} ${IGNORE_RUNNING_SESSIONS} "${JSON_DIR}"
 
 # Call cleanup (which will clean up the output directory unless --no-cleanup was specified)
 cleanup

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -331,11 +331,11 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
         log_error_raise_exception("Response from CFS has unexpected format", exc)
     return json_object
 
-def list_sessions() -> List[JsonObject]:
+def list_sessions(params: Union[JsonDict, None]=None) -> List[JsonObject]:
     """
     Queries CFS to list all sessions, and returns the list.
     """
-    return __list_and_merge("sessions", CFS_V3_SESSIONS_URL)
+    return __list_and_merge("sessions", CFS_V3_SESSIONS_URL, params=params)
 
 # CFS sources functions
 


### PR DESCRIPTION
CASMCMS-8867: Check for CFS sessions before importing the data
[CASMCMS-9336](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9336): importing cfs data fails with "--clear-cfs" option

1.3 backport PR https://github.com/Cray-HPE/docs-csm/pull/5871
1.4 backport PR https://github.com/Cray-HPE/docs-csm/pull/5870
1.5 backport PR https://github.com/Cray-HPE/docs-csm/pull/5869
1.6 backport PR https://github.com/Cray-HPE/docs-csm/pull/5868

Tests

Imports were run with/without cfs sessions

1) Import cfs data with active session

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh cfs-export-20250401173602-gpAjdY.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250401201611-zM9'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading CFS source data from JSON file
Checking CFS version on system
CFS version is 1.26.0
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
Reading source data from CFS

Examining CFS configurations...
configurations with the following names exist in CFS and will not be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The following components already have desired configurations set in CFS and will not be updated:
x3000c0s19b2n0
The desired configuration for the following components will be imported:
x3000c0s19b3n0
components are being updated. Checking for running and pending CFS sessions...
Following CFS sessions are running,aborting import. Run with --ignore-running-sessions to override.
rahul-test-import2
ERROR: There are running CFS sessions. Aborting import.
ERROR: Command failed with return code 1: /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.py /tmp/cfs-import-20250401201611-zM9/cfs-export-20250401173602-gpA
Removing directory '/tmp/cfs-import-20250401201611-zM9'
``` 

2) import cfs data with active session and `--ignore-running-sessions` option

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --ignore-running-sessions cfs-export-20250401173602-gpAjdY.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250401205138-yZt'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading CFS source data from JSON file
Checking CFS version on system
CFS version is 1.26.0
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
Reading source data from CFS

Examining CFS configurations...
configurations with the following names exist in CFS and will not be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The following components already have desired configurations set in CFS and will not be updated:
x3000c0s19b2n0
The desired configuration for the following components will be imported:
x3000c0s19b3n0

Examining CFS options...
The following options already have the value from the imported data and will not be updated:
additional_inventory_source, additional_inventory_url, batch_size, batch_window, batcher_check_interval, batcher_disable, batcher_max_backoff, batcher_pending_timeout, debug_wait_time, default_ansible_config, default_batcher_retry_policy, default_page_size, default_playbook, hardware_sync_interval, include_ara_links, logging_level, session_ttl

Examining CFS sources...

Taking a snapshot of system CFS data before making changes
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/sessions.json
Reading sources data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/sources.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3I/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250401205142-S3IFTD.tgz

Updating desired configuration to 'csm-barebones-boot-test-20250328162628' for components: ['x3000c0s19b3n0']

Taking a snapshot of system CFS data after import
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/sessions.json
Reading sources data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/sources.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CTh/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250401205147-CThdn6.tgz

SUCCESS
Removing directory '/tmp/cfs-import-20250401205138-yZt'
```

Here is session data which shows that it overlapped with import

```
ncn-m001:~ # cray cfs sessions describe rahul-test-import7
name = "rahul-test-import7"

[ansible]
config = "cfs-default-ansible-cfg"
verbosity = 0

[configuration]
limit = ""
name = "csm-barebones-boot-test-20250320193723"

[status]
artifacts = []

[tags]

[target]
definition = "spec"
image_map = []
[[target.groups]]
members = [ "x3000c0s19b3n0",]
name = "Compute"

[status.session]
completionTime = "2025-04-01T20:52:46"
job = "cfs-fdf6e21e-1ac2-4dfc-9cde-ca8f6794fadc"
startTime = "2025-04-01T20:51:07"
status = "complete"
succeeded = "true"
```

3) Import with --clear-cfs and --ignore-running-sessions

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --clear-cfs --ignore-running-sessions cfs-export-20250402214347-qcoWmS.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250402215557-xfW'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading CFS source data from JSON file
Checking CFS version on system
CFS version is 1.26.0
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
Reading source data from CFS
Taking a snapshot of system CFS data before clearing it
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/sessions.json
Reading sources data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/sources.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250402215602-N22Jvl.tgz
Clearing error count, desired configuration, state, and tags for components: '['x3000c0s11b0n0', 'x3000c0s13b0n0', 'x3000c0s15b0n0', 'x3000c0s17b0n0', 'x3000c0s19b1n0', 'x3000c0s19b2n0', 'x3000c0s19b3n0', 'x3000c0s19b4n0', 'x3000c0s1b0n0', 'x3000c0s26b0n0', 'x3000c0s28b0n0', 'x3000c0s32b0n0', 'x3000c0s34b0n0', 'x3000c0s36b0n0', 'x3000c0s38b0n0', 'x3000c0s3b0n0', 'x3000c0s5b0n0', 'x3000c0s7b0n0', 'x3000c0s9b0n0', 'x3001c0s31b0n0', 'x3001c0s33b0n0', 'x3001c0s35b0n0', 'x3001c0s37b0n0', 'x3001c0s39b0n0', 'x8000c0s10b0n0', 'x8000c0s10b0n1', 'x8000c0s11b0n0', 'x8000c0s11b0n1', 'x8000c0s12b0n0', 'x8000c0s12b0n1', 'x8000c0s13b0n0', 'x8000c0s13b0n1', 'x8000c0s14b0n0', 'x8000c0s14b0n1', 'x8000c0s15b0n0', 'x8000c0s15b0n1', 'x8000c0s16b0n0', 'x8000c0s16b0n1', 'x8000c0s17b0n0', 'x8000c0s17b0n1', 'x8000c0s18b0n0', 'x8000c0s18b0n1', 'x8000c0s19b0n0', 'x8000c0s19b0n1', 'x8000c0s1b0n0', 'x8000c0s1b0n1', 'x8000c0s20b0n0', 'x8000c0s20b0n1', 'x8000c0s21b0n0', 'x8000c0s21b0n1', 'x8000c0s24b0n0', 'x8000c0s24b0n1', 'x8000c0s2b0n0', 'x8000c0s2b0n1', 'x8000c0s31b0n0', 'x8000c0s31b0n1', 'x8000c0s33b0n0', 'x8000c0s33b0n1', 'x8000c0s34b0n0', 'x8000c0s34b0n1', 'x8000c0s35b0n0', 'x8000c0s35b0n1', 'x8000c0s36b0n0', 'x8000c0s36b0n1', 'x8000c0s38b0n0', 'x8000c0s38b0n1', 'x8000c0s39b0n0', 'x8000c0s39b0n1', 'x8000c0s3b0n0', 'x8000c0s3b0n1', 'x8000c0s40b0n0', 'x8000c0s40b0n1', 'x8000c0s43b0n0', 'x8000c0s43b0n1', 'x8000c0s47b0n0', 'x8000c0s47b0n1', 'x8000c0s48b0n0', 'x8000c0s48b0n1', 'x8000c0s4b0n0', 'x8000c0s4b0n1', 'x8000c0s5b0n0', 'x8000c0s5b0n1', 'x8000c0s6b0n0', 'x8000c0s6b0n1', 'x8000c0s7b0n0', 'x8000c0s7b0n1', 'x8000c0s8b0n0', 'x8000c0s8b0n1', 'x8000c0s9b0n0', 'x8000c0s9b0n1', 'x8000c1s12b0n0', 'x8000c1s12b0n1', 'x8000c1s17b0n0', 'x8000c1s17b0n1', 'x8000c1s1b0n0', 'x8000c1s1b0n1', 'x8000c1s23b0n0', 'x8000c1s23b0n1', 'x8000c1s27b0n0', 'x8000c1s27b0n1', 'x8000c1s5b0n0', 'x8000c1s5b0n1', 'x8000c7s26b0n0', 'x8000c7s26b0n1', 'x8000c7s27b0n0', 'x8000c7s27b0n1', 'x8000c7s28b0n0', 'x8000c7s28b0n1', 'x8000c7s29b0n0', 'x8000c7s29b0n1', 'x8000c7s31b0n0', 'x8000c7s31b0n1', 'x8000c7s32b0n0', 'x8000c7s32b0n1', 'x8000c7s33b0n0', 'x8000c7s33b0n1', 'x8000c7s34b0n0', 'x8000c7s34b0n1', 'x8000c7s35b0n0', 'x8000c7s35b0n1', 'x8000c7s36b0n0', 'x8000c7s36b0n1', 'x8000c7s37b0n0', 'x8000c7s37b0n1', 'x8000c7s38b0n0', 'x8000c7s38b0n1', 'x8000c7s39b0n0', 'x8000c7s39b0n1', 'x8000c7s40b0n0', 'x8000c7s40b0n1', 'x8000c7s41b0n0', 'x8000c7s41b0n1', 'x8000c7s42b0n0', 'x8000c7s42b0n1', 'x8000c7s43b0n0', 'x8000c7s43b0n1', 'x8000c7s44b0n0', 'x8000c7s44b0n1', 'x8000c7s45b0n0', 'x8000c7s45b0n1', 'x8000c7s46b0n0', 'x8000c7s46b0n1', 'x8000c7s48b0n0', 'x8000c7s48b0n1', 'x8000c7s49b0n0', 'x8000c7s49b0n1', 'x8000c7s50b0n0', 'x8000c7s50b0n1', 'x8001c1s32b0n0', 'x8001c1s32b0n1', 'x8001c1s50b0n0', 'x8001c1s50b0n1', 'x8002c2s12b0n0', 'x8002c2s12b0n1', 'x8002c2s14b0n0', 'x8002c2s14b0n1', 'x8002c2s18b0n0', 'x8002c2s18b0n1', 'x8002c2s22b0n0', 'x8002c2s22b0n1', 'x8002c2s2b0n0', 'x8002c2s2b0n1', 'x8002c2s33b0n0', 'x8002c2s33b0n1', 'x8002c2s38b0n0', 'x8002c2s38b0n1', 'x8002c2s45b0n0', 'x8002c2s45b0n1', 'x8002c3s39b0n0', 'x8002c3s39b0n1', 'x8002c3s43b0n0', 'x8002c3s43b0n1', 'x8002c3s46b0n0', 'x8002c3s46b0n1', 'x8002c3s48b0n0', 'x8002c3s48b0n1']'
Deleting configuration 'csm-barebones-boot-test-20250320193723'
Deleting configuration 'csm-barebones-boot-test-20250320203505'
Deleting configuration 'csm-barebones-boot-test-20250320210649'
Deleting configuration 'csm-barebones-boot-test-20250320212632'
Deleting configuration 'csm-barebones-boot-test-20250326020611'
Deleting configuration 'csm-barebones-boot-test-20250327194949'
Deleting configuration 'csm-barebones-boot-test-20250328021920'
Deleting configuration 'csm-barebones-boot-test-20250328162628'
Deleting configuration 'csm-barebones-boot-test-20250402190220'
Deleting configuration 'mitch-test'
Deleting configuration 'mitch-test-2'
Deleting configuration 'mitch3'
Deleting configuration 'rbak-test'
Deleting configuration 'sleep'

Examining CFS configurations...
The following configurations will be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'csm-barebones-boot-test-20250402190220', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The desired configuration for the following components will be imported:
x3000c0s19b2n0, x3000c0s19b3n0

Examining CFS options...
The following options already have the value from the imported data and will not be updated:
additional_inventory_source, additional_inventory_url, batch_size, batch_window, batcher_check_interval, batcher_disable, batcher_max_backoff, batcher_pending_timeout, debug_wait_time, default_ansible_config, default_batcher_retry_policy, default_page_size, default_playbook, hardware_sync_interval, include_ara_links, logging_level, session_ttl

Examining CFS sources...


Importing configuration 'csm-barebones-boot-test-20250320193723'
Importing configuration 'csm-barebones-boot-test-20250320203505'
Importing configuration 'csm-barebones-boot-test-20250320210649'
Importing configuration 'csm-barebones-boot-test-20250320212632'
Importing configuration 'csm-barebones-boot-test-20250326020611'
Importing configuration 'csm-barebones-boot-test-20250327194949'
Importing configuration 'csm-barebones-boot-test-20250328021920'
Importing configuration 'csm-barebones-boot-test-20250328162628'
Importing configuration 'csm-barebones-boot-test-20250402190220'
Importing configuration 'mitch-test'
Importing configuration 'mitch-test-2'
Importing configuration 'mitch3'
Importing configuration 'rbak-test'
Importing configuration 'sleep'

Updating desired configuration to 'csm-barebones-boot-test-20250320193723' for components: ['x3000c0s19b2n0']
Updating desired configuration to 'csm-barebones-boot-test-20250328162628' for components: ['x3000c0s19b3n0']

Taking a snapshot of system CFS data after import
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/sessions.json
Reading sources data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/sources.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38x/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250402215614-38xMXs.tgz

SUCCESS
Removing directory '/tmp/cfs-import-20250402215557-xfW'
ncn-m001:~/rahul/repo/docs-csm/backup #
```

4) Running with --clear-cfs while there were active sessions

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --clear-cfs cfs-export-20250403175103-xHn3I2.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250403180240-SBW'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading CFS source data from JSON file
Checking CFS version on system
CFS version is 1.26.0
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
Reading source data from CFS
CFS data are being updated. Checking for running and pending CFS sessions...
The following CFS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.
rahul-test-import15
ERROR: There are CFS sessions that are not complete. Aborting import.
ERROR: Command failed with return code 1: /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.py --clear-cfs /tmp/cfs-import-20250403180240-SBW/cfs-export-20250403175103-xHX
Removing directory '/tmp/cfs-import-20250403180240-SBW'
```