### PR TITLE
CASMPET-7452: Add in TPM node attestation documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1097,6 +1097,9 @@ SNMP-backed
 # To allow Site Init
 Init
 
+- operations/spire/Enable_TPM_node_attestation.md
+enrollment
+
 - operations/system_configuration_service/Set_BMC_Credentials.md
 # To allow System Admin Toolkit
 Admin

--- a/operations/README.md
+++ b/operations/README.md
@@ -719,6 +719,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 - [Update Spire Intermediate CA Certificate](spire/Update_Spire_Intermediate_CA_Certificate.md)
 - [Xname Validation](spire/xname_validation.md)
 - [Restore Missing Spire Meta-Data](spire/Restore_Missing_Spire_Metadata.md)
+- [Enable TPM node attestation](spire/Enable_TPM_node_attestation.md)
 - [Spire known issues](../troubleshooting/README.md#spire)
 
 ## Update firmware with FAS

--- a/operations/spire/Enable_TPM_node_attestation.md
+++ b/operations/spire/Enable_TPM_node_attestation.md
@@ -189,7 +189,7 @@ For each node that needs TPM node attestation:
 
    1. Example SAT Bootprep templates
 
-      ```text
+      ```yaml
       session_templates:
       - name: tpm-2.6.102-sles15sp5.x86_64
         image: tpm-2.6.102-sles15sp5.x86_64

--- a/operations/spire/Enable_TPM_node_attestation.md
+++ b/operations/spire/Enable_TPM_node_attestation.md
@@ -129,7 +129,7 @@ Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
 To disable the TPM attestation on management nodes the `spire-agent.conf`
 file must be returned to its original configuration on each node TPM attestation
 is turned on. Then a new join token must be created and the node then needs
-to be joined to spire.
+to be joined to Spire.
 
 On each node that you want to disable TPM attestation on:
 

--- a/operations/spire/Enable_TPM_node_attestation.md
+++ b/operations/spire/Enable_TPM_node_attestation.md
@@ -1,0 +1,231 @@
+# Enable TPM node attestation with Spire
+
+Spire supports node attestation with Trusted Platform Modules installed on CSM
+nodes. Currently there is support for all x86 based nodes. This support changes
+the way nodes are attested with spire to use the certificates that are created
+in the TPM. The Spire agent uses the TPM to join the Spire server instead of a
+join token.
+
+## Enable TPM node attestation
+
+To enable TPM node attestation on the mangement nodes there is a simple script
+that can enable it for all nodes that have a TPM. To reverse enabling TPM attestation
+for mangement nodes there is a manual process that needs to be run.
+
+To enable TPM node attestation on managed nodes there is a multi-step process requireing
+the node to be rebooted multiple times. During the attestation process on a managed
+node, the node will not be accessable until it has finished joining spire. Reversing
+the process requires another set of node reboots where the node is not accesable.
+
+### Enable TPM node attestation for Management nodes
+
+```bash
+/opt/cray/platform-utils/spire/spire-enable-tpm.sh
+```
+
+Example Output
+
+```bash
+ncn-m001:~ # /opt/cray/platform-utils/spire/spire-enable-tpm.sh
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+{"success":true}
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+2025/04/02 20:10:03 url: https://api-gw-service-nmn.local/apis/tpm-provisioner
+2025/04/02 20:10:03 xname: x3000c0s2b0n0
+2025/04/02 20:10:03 type: ncn
+2025/04/02 20:10:03 req: &{Method:GET URL:https://api-gw-service-nmn.local/apis/tpm-provisioner/authorize?xname=x3000c0s2b0n0&type=ncn Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:api-gw-service-nmn.local Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:{emptyCtx:{}}}
+time="2025-04-02T20:10:03Z" level=info msg="Reading EK certificate from NV index 01c00002"
+time="2025-04-02T20:10:04Z" level=info msg="Get Endorsement Key (RSA)"
+time="2025-04-02T20:10:04Z" level=info msg="Get Attestation Key (RSA)"
+time="2025-04-02T20:10:06Z" level=info msg="Get DevID (RSA)"
+time="2025-04-02T20:10:07Z" level=info msg="Certifying TPM-residency of keys"
+time="2025-04-02T20:10:07Z" level=info msg="CSR creation complete! [3]"
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+ncn-m002 is being joined to spire.
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+spire-tpm-conf.conf                                                                                                                                                                                                                                                                        100%  726     1.1MB/s   00:00
+Warning: Permanently added 'ncn-m002' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+{"success":true}
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+2025/04/02 20:10:15 url: https://api-gw-service-nmn.local/apis/tpm-provisioner
+2025/04/02 20:10:15 xname: x3000c0s7b0n0
+2025/04/02 20:10:15 type: ncn
+2025/04/02 20:10:15 req: &{Method:GET URL:https://api-gw-service-nmn.local/apis/tpm-provisioner/authorize?xname=x3000c0s7b0n0&type=ncn Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:api-gw-service-nmn.local Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:{emptyCtx:{}}}
+time="2025-04-02T20:10:15Z" level=info msg="Reading EK certificate from NV index 01c00002"
+time="2025-04-02T20:10:15Z" level=info msg="Get Endorsement Key (RSA)"
+time="2025-04-02T20:10:15Z" level=info msg="Get Attestation Key (RSA)"
+time="2025-04-02T20:10:23Z" level=info msg="Get DevID (RSA)"
+time="2025-04-02T20:10:23Z" level=info msg="Certifying TPM-residency of keys"
+time="2025-04-02T20:10:24Z" level=info msg="CSR creation complete! [3]"
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+ncn-w001 is being joined to spire.
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+spire-tpm-conf.conf                                                                                                                                                                                                                                                                        100%  726     1.3MB/s   00:00
+Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+{"success":true}
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+2025/04/02 20:10:31 url: https://api-gw-service-nmn.local/apis/tpm-provisioner
+2025/04/02 20:10:31 xname: x3000c0s8b0n0
+2025/04/02 20:10:31 type: ncn
+2025/04/02 20:10:31 req: &{Method:GET URL:https://api-gw-service-nmn.local/apis/tpm-provisioner/authorize?xname=x3000c0s8b0n0&type=ncn Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:api-gw-service-nmn.local Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:{emptyCtx:{}}}
+time="2025-04-02T20:10:31Z" level=info msg="Reading EK certificate from NV index 01c00002"
+time="2025-04-02T20:10:31Z" level=info msg="Get Endorsement Key (RSA)"
+time="2025-04-02T20:10:31Z" level=info msg="Get Attestation Key (RSA)"
+time="2025-04-02T20:11:02Z" level=info msg="Get DevID (RSA)"
+time="2025-04-02T20:11:03Z" level=info msg="Certifying TPM-residency of keys"
+time="2025-04-02T20:11:03Z" level=info msg="CSR creation complete! [3]"
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+ncn-w002 is being joined to spire.
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+spire-tpm-conf.conf                                                                                                                                                                                                                                                                        100%  726     1.8MB/s   00:00
+Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+{"success":true}
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+2025/04/02 20:11:11 url: https://api-gw-service-nmn.local/apis/tpm-provisioner
+2025/04/02 20:11:11 xname: x3000c0s9b0n0
+2025/04/02 20:11:11 type: ncn
+2025/04/02 20:11:11 req: &{Method:GET URL:https://api-gw-service-nmn.local/apis/tpm-provisioner/authorize?xname=x3000c0s9b0n0&type=ncn Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:api-gw-service-nmn.local Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:{emptyCtx:{}}}
+time="2025-04-02T20:11:11Z" level=info msg="Reading EK certificate from NV index 01c00002"
+time="2025-04-02T20:11:11Z" level=info msg="Get Endorsement Key (RSA)"
+time="2025-04-02T20:11:11Z" level=info msg="Get Attestation Key (RSA)"
+time="2025-04-02T20:11:20Z" level=info msg="Get DevID (RSA)"
+time="2025-04-02T20:11:20Z" level=info msg="Certifying TPM-residency of keys"
+time="2025-04-02T20:11:21Z" level=info msg="CSR creation complete! [3]"
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+ncn-w003 is being joined to spire.
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+spire-tpm-conf.conf                                                                                                                                                                                                                                                                        100%  726     1.3MB/s   00:00
+Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+{"success":true}
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+2025/04/02 20:11:26 url: https://api-gw-service-nmn.local/apis/tpm-provisioner
+2025/04/02 20:11:26 xname: x3000c0s10b0n0
+2025/04/02 20:11:26 type: ncn
+2025/04/02 20:11:26 req: &{Method:GET URL:https://api-gw-service-nmn.local/apis/tpm-provisioner/authorize?xname=x3000c0s10b0n0&type=ncn Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:api-gw-service-nmn.local Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:{emptyCtx:{}}}
+time="2025-04-02T20:11:26Z" level=info msg="Reading EK certificate from NV index 01c00002"
+time="2025-04-02T20:11:26Z" level=info msg="Get Endorsement Key (RSA)"
+time="2025-04-02T20:11:27Z" level=info msg="Get Attestation Key (RSA)"
+time="2025-04-02T20:11:32Z" level=info msg="Get DevID (RSA)"
+time="2025-04-02T20:11:33Z" level=info msg="Certifying TPM-residency of keys"
+time="2025-04-02T20:11:33Z" level=info msg="CSR creation complete! [3]"
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+ncn-w004 is being joined to spire.
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+spire-tpm-conf.conf                                                                                                                                                                                                                                                                        100%  726     1.7MB/s   00:00
+Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
+```
+
+### Disable TPM attestation on management nodes
+
+To disable the TPM attestation on managment nodes the `spire-agent.conf`
+file must be returned to its orignal configuration on each node TPM attestation
+is turned on. Then a new join token must be created and the node then needs
+to be joined to spire.
+
+On each node that you want to disable TPM attestation on:
+
+1. (ncn-mw#) Stop the `spire-agent` service
+   ```bash
+   systemctl stop spire-agent
+   ```
+
+1. (ncn-mw#) Remove old Spire data
+   ```bash
+   rm /var/lib/spire/conf/spire-agent.conf /var/lib/spire/data/keys.json /var/lib/spire/data/svid.key /var/lib/spire/bundle.der /var/lib/spire/agent_svid.der
+   ```
+
+1. (ncn-mw#) Restart the `request-ncn-join-token` Daemon Set
+   ```bash
+   kubectl rollout restart -n spire DaemonSet/request-ncn-join-token
+   ```
+
+1. (ncn-mw#) Restart the `spire-agent` service
+   ```bash
+   systemctl start spire-agent
+   ```
+
+### Enable TPM node attestation on manged nodes
+
+To enable TPM node attestation on managed nodes the node
+needs to be rebooted at least 2 times. This also requires making
+multiple BOS session templates and changing the session template
+each reboot so the node can attest with Spire properly.
+
+For each node that needs TPM node attestation:
+
+1. (ncn-mw#) Whitelist the nodes xname
+   ```bash
+   XNAME=x3000c0s19b1n0
+   KC_TOKEN=$(jq -r '.access_token' /root/.config/cray/tokens/api_gw_service_nmn_local.* | head -1)
+   curl -H "Authorization: Bearer $KC_TOKEN" -d "xname=$XNAME" https://api-gw-service-nmn.local/apis/tpm-provisioner/whitelist/add
+   ```
+
+1. (ncn-mw#) Create the bos templates with different kernel parameters
+   1. The enroll parameters:
+      ```text
+      kernel_parameters = "ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} tpm=enroll"
+      ```
+   1. The enable parameters:
+      ```text
+      kernel_parameters = "ip=dhcp quiet tpm=enable"
+      ```
+   1. Example SAT Bootprep templates
+      ```text
+      session_templates:
+      - name: tpm-2.6.102-sles15sp5.x86_64
+        image: tpm-2.6.102-sles15sp5.x86_64
+        configuration: tpm-config
+        bos_parameters:
+          boot_sets:
+            compute:
+              kernel_parameters: ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN}
+              node_roles_groups:
+              - Compute
+      - name: tpm-2.6.102-sles15sp5.x86_64-enroll
+        image: tpm-2.6.102-sles15sp5.x86_64
+        configuration: tpm-config
+        bos_parameters:
+          boot_sets:
+            compute:
+              kernel_parameters: ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} tpm=enroll
+              node_roles_groups:
+              - Compute
+      - name: tpm-2.6.102-sles15sp5.x86_64-enable
+        image: tpm-2.6.102-sles15sp5.x86_64
+        configuration: tpm-config
+        bos_parameters:
+          boot_sets:
+            compute:
+              kernel_parameters: ip=dhcp quiet tpm=enable
+              node_roles_groups:
+              - Compute
+        ```
+
+1. Reboot the node with the enroll parameters then wait for it to finish booting.
+   ```bash
+   cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enroll --operation reboot --limit $XNAME
+   ```
+
+1. Reboot the node with the enable.
+   ```bash
+   cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enable --operation reboot --limit $XNAME
+   ```
+
+1. Ensure the node has booted and is ready.
+
+### Disbable TPM node attestation on managed nodes
+
+1. Reboot the node with the standard kernel parameters
+   ```bash
+   cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64 --operation reboot --limit $XNAME
+   ```
+

--- a/operations/spire/Enable_TPM_node_attestation.md
+++ b/operations/spire/Enable_TPM_node_attestation.md
@@ -8,11 +8,11 @@ join token.
 
 ## Enable TPM node attestation
 
-To enable TPM node attestation on the management nodes there is a simple script
+To enable TPM node attestation on the management nodes, there is a simple script
 that can enable it for all nodes that have a TPM. To reverse enabling TPM attestation
-for management nodes there is a manual process that needs to be run.
+for management nodes, there is a manual process that needs to be run.
 
-To enable TPM node attestation on managed nodes there is a multi-step process requiring
+To enable TPM node attestation on managed nodes, there is a multi-step process requiring
 the node to be rebooted multiple times. During the attestation process on a managed
 node, the node will not be accessible until it has finished joining spire. Reversing
 the process requires another set of node reboots where the node is not accessible.
@@ -126,8 +126,8 @@ Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
 
 ### Disable TPM attestation on management nodes
 
-To disable the TPM attestation on management nodes the `spire-agent.conf`
-file must be returned to its original configuration on each node TPM attestation
+To disable the TPM attestation on management nodes, the `spire-agent.conf`
+file must be returned to its original configuration on each node where TPM attestation
 is turned on. Then a new join token must be created and the node then needs
 to be joined to Spire.
 
@@ -162,7 +162,7 @@ On each node that you want to disable TPM attestation on:
 To enable TPM node attestation on managed nodes the node
 needs to be rebooted at least 2 times. This also requires making
 multiple BOS session templates and changing the session template
-each reboot so the node can attest with Spire properly.
+during each reboot so the node can attest with Spire properly.
 
 For each node that needs TPM node attestation:
 
@@ -226,7 +226,7 @@ For each node that needs TPM node attestation:
    cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enroll --operation reboot --limit $XNAME
    ```
 
-1. Reboot the node with the enable.
+1. Reboot the node with TPM enabled.
 
    ```bash
    cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enable --operation reboot --limit $XNAME

--- a/operations/spire/Enable_TPM_node_attestation.md
+++ b/operations/spire/Enable_TPM_node_attestation.md
@@ -8,14 +8,14 @@ join token.
 
 ## Enable TPM node attestation
 
-To enable TPM node attestation on the mangement nodes there is a simple script
+To enable TPM node attestation on the management nodes there is a simple script
 that can enable it for all nodes that have a TPM. To reverse enabling TPM attestation
-for mangement nodes there is a manual process that needs to be run.
+for management nodes there is a manual process that needs to be run.
 
-To enable TPM node attestation on managed nodes there is a multi-step process requireing
+To enable TPM node attestation on managed nodes there is a multi-step process requiring
 the node to be rebooted multiple times. During the attestation process on a managed
-node, the node will not be accessable until it has finished joining spire. Reversing
-the process requires another set of node reboots where the node is not accesable.
+node, the node will not be accessible until it has finished joining spire. Reversing
+the process requires another set of node reboots where the node is not accessible.
 
 ### Enable TPM node attestation for Management nodes
 
@@ -126,34 +126,38 @@ Warning: Permanently added 'ncn-w004' (ED25519) to the list of known hosts.
 
 ### Disable TPM attestation on management nodes
 
-To disable the TPM attestation on managment nodes the `spire-agent.conf`
-file must be returned to its orignal configuration on each node TPM attestation
+To disable the TPM attestation on management nodes the `spire-agent.conf`
+file must be returned to its original configuration on each node TPM attestation
 is turned on. Then a new join token must be created and the node then needs
 to be joined to spire.
 
 On each node that you want to disable TPM attestation on:
 
-1. (ncn-mw#) Stop the `spire-agent` service
+1. (`ncn-mw#`) Stop the `spire-agent` service
+
    ```bash
    systemctl stop spire-agent
    ```
 
-1. (ncn-mw#) Remove old Spire data
+1. (`ncn-mw#`) Remove old Spire data
+
    ```bash
    rm /var/lib/spire/conf/spire-agent.conf /var/lib/spire/data/keys.json /var/lib/spire/data/svid.key /var/lib/spire/bundle.der /var/lib/spire/agent_svid.der
    ```
 
-1. (ncn-mw#) Restart the `request-ncn-join-token` Daemon Set
+1. (`ncn-mw#`) Restart the `request-ncn-join-token` Daemon Set
+
    ```bash
    kubectl rollout restart -n spire DaemonSet/request-ncn-join-token
    ```
 
-1. (ncn-mw#) Restart the `spire-agent` service
+1. (`ncn-mw#`) Restart the `spire-agent` service
+
    ```bash
    systemctl start spire-agent
    ```
 
-### Enable TPM node attestation on manged nodes
+### Enable TPM node attestation on managed nodes
 
 To enable TPM node attestation on managed nodes the node
 needs to be rebooted at least 2 times. This also requires making
@@ -162,23 +166,29 @@ each reboot so the node can attest with Spire properly.
 
 For each node that needs TPM node attestation:
 
-1. (ncn-mw#) Whitelist the nodes xname
+1. (`ncn-mw#`) Whitelist the nodes xname
+
    ```bash
    XNAME=x3000c0s19b1n0
    KC_TOKEN=$(jq -r '.access_token' /root/.config/cray/tokens/api_gw_service_nmn_local.* | head -1)
    curl -H "Authorization: Bearer $KC_TOKEN" -d "xname=$XNAME" https://api-gw-service-nmn.local/apis/tpm-provisioner/whitelist/add
    ```
 
-1. (ncn-mw#) Create the bos templates with different kernel parameters
-   1. The enroll parameters:
+1. (`ncn-mw#`) Create the BOS templates with different kernel parameters
+   1. The enrollment parameters:
+
       ```text
       kernel_parameters = "ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} tpm=enroll"
       ```
+
    1. The enable parameters:
+
       ```text
       kernel_parameters = "ip=dhcp quiet tpm=enable"
       ```
+
    1. Example SAT Bootprep templates
+
       ```text
       session_templates:
       - name: tpm-2.6.102-sles15sp5.x86_64
@@ -210,22 +220,24 @@ For each node that needs TPM node attestation:
               - Compute
         ```
 
-1. Reboot the node with the enroll parameters then wait for it to finish booting.
+1. Reboot the node with the enrollment parameters then wait for it to finish booting.
+
    ```bash
    cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enroll --operation reboot --limit $XNAME
    ```
 
 1. Reboot the node with the enable.
+
    ```bash
    cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64-enable --operation reboot --limit $XNAME
    ```
 
 1. Ensure the node has booted and is ready.
 
-### Disbable TPM node attestation on managed nodes
+### Disable TPM node attestation on managed nodes
 
 1. Reboot the node with the standard kernel parameters
+
    ```bash
    cray bos v2 sessions create --template-name tpm-2.6.102-sles15sp5.x86_64 --operation reboot --limit $XNAME
    ```
-


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This adds in documentation to turn on TPM node attestation in spire for both management and managed nodes.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
