### PR TITLE
CASMPET-7446: Update iSCSI SBPS doc with CASMPET-7445 WAR

### DIFF
--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -289,6 +289,9 @@ sanity checks on iSCSI targets.
 
 Refer to [GOSS tests for SBPS](https://github.com/Cray-HPE/sbps-marshal/blob/main/GOSS_tests_for_sbps.md) for the details.
 
+Verify the test log from goss tests and check whether all the DNS SRV and A records are listed. If NMN A records are not created, then please follow
+the steps in the WAR doc: [NMN records missing](https://github.com/Cray-HPE/docs-csm/tree/release/1.6/troubleshooting/known_issues/nmn_dns_a_records_missing.md)
+
 ### 3. Create BOS session template
 
 Once the node personalization is done and GOSS tests are run successfully, create BOS Session Template with SBPS boot parameters.


### PR DESCRIPTION
# Description
This to update the documentation of iSCSI SBPS with the WAR document created as part of  CASMPET-7445 where there are steps to be followed if NMN A (address) records are not created. https://github.com/Cray-HPE/docs-csm/pull/5844

Relates to:
https://github.com/Cray-HPE/docs-csm/pull/5844 - waiting for this PR to be merged to mainline. 

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [NA] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
