### PR TITLE
CASMCMS-8867: Check for CFS sessions before importing the data

### DIFF
--- a/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
+++ b/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
@@ -67,6 +67,9 @@ criteria listed above.
 1. (`ncn-mw#`) Run the following script to import the data from the archive file.
 
    > Modify the following example commands to specify the path to the output file from the automated export script.
+     The import tool will abort if it detects incomplete CFS sessions which could potentially be impacted
+     by the import; to override this behavior and import anyway, the `--ignore-running-sessions` argument
+     may be added when invoking the import script.
 
    - If this import is not happening after a reinstall of CSM, OR if VCS data was not imported from a previous CSM install,
      then invoke the tool as follows:

--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -325,6 +325,21 @@ def update_components(comps_map: NameObjectMap, comp_ids_to_update: List[str]) -
         print(f"Updating component {comp_id} to desired configuration '{desired_config_name}'")
         cfs.update_component_desired_config(comp_id, desired_config_name)
 
+def check_for_running_cfs_sessions(resource_type: str) -> None:
+    print(f"{resource_type} are being updated. Checking for running and pending CFS sessions...")
+    cfs_sessions = []
+    for status in ["pending", "running"]:
+        session_params = {
+            "status": status
+        }
+        cfs_sessions.extend(cfs.list_sessions(params=session_params))
+
+    if cfs_sessions:
+        print(f"The following CFS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.")
+        print(", ".join(session["name"] for session in cfs_sessions))
+        raise CfsError("There are CFS sessions that are not complete. Aborting import.")
+
+
 def main() -> None:
     """
     Parses the command line arguments, does the stuff.
@@ -339,6 +354,8 @@ def main() -> None:
     parser.add_argument("--clear-cfs", action='store_true', help="Delete CFS configurations and clear CFS components before importing")
     parser.add_argument(metavar="json_directory", type=json_data_from_directory, dest="json_data",
                         help=f"Directory containing {CMP_JSON}, {CFG_JSON}, and {OPT_JSON}")
+    parser.add_argument("--ignore-running-sessions", action='store_true',
+                        help="Ignore non-completed CFS sessions when importing CFS data")
     parsed_args = parser.parse_args()
 
     cfs_data_to_import = parsed_args.json_data
@@ -347,14 +364,11 @@ def main() -> None:
     current_cfs_data = load_cfs_data()
 
     if parsed_args.clear_cfs:
+        if not parsed_args.ignore_running_sessions:
+            check_for_running_cfs_sessions("CFS data")
         # Take a snapshot of the CFS data before clearing it
         print("Taking a snapshot of system CFS data before clearing it")
         snapshot_cfs_data()
-
-        for config_name in list(current_cfs_data.configurations):
-            print(f"Deleting configuration '{config_name}'")
-            cfs.delete_configuration(config_name)
-            del current_cfs_data.configurations[config_name]
 
         for comp_name, comp_data in list(current_cfs_data.components.items()):
             if "tags" in comp_data and comp_data["tags"]:
@@ -364,6 +378,11 @@ def main() -> None:
                 print(f"Clearing error count, desired configuration, and state for component '{comp_name}'")
                 updated_comp = cfs.update_component(comp_name, errorCount=0, state=[], desiredConfig="", tags={})
             current_cfs_data.components[comp_name] = updated_comp
+
+        for config_name in list(current_cfs_data.configurations):
+            print(f"Deleting configuration '{config_name}'")
+            cfs.delete_configuration(config_name)
+            del current_cfs_data.configurations[config_name]
 
     # Determine the necessary updates
     print("\nExamining CFS configurations...")
@@ -375,8 +394,16 @@ def main() -> None:
                                           current_cfs_data.components,
                                           current_cfs_data.configurations, configs_to_create)
 
+    # Check for non-complete (pending or running) sessions if we have components to update
+    if not parsed_args.ignore_running_sessions and comps_to_update:
+        check_for_running_cfs_sessions("components")
+
     print("\nExamining CFS options...")
     options_to_change = get_options_to_change(cfs_data_to_import.options, current_cfs_data.options)
+
+    # Check for non-complete (pending or running) sessions if options are being updated
+    if not parsed_args.ignore_running_sessions and options_to_change:
+        check_for_running_cfs_sessions("options")
 
     print("")
     # If there are no changes to make, we are already done

--- a/scripts/operations/configuration/import_cfs_data.sh
+++ b/scripts/operations/configuration/import_cfs_data.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@
 # the Python script completes, the expanded files from the archive are
 # cleaned up by this shell script, unless --no-cleanup is specified.
 #
-# Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>
+# Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] [--ignore-running-sessions] <CFS export file.tgz>
 #
 ################################################################################
 
@@ -41,6 +41,7 @@ CLEANUP=YES
 OUTPUT_DIR=""
 CLEAR_CFS=""
 ARCHIVE=""
+IGNORE_RUNNING_SESSIONS=""
 
 cleanup() {
   [[ $CLEANUP == YES ]] || return
@@ -59,7 +60,7 @@ err_exit() {
 }
 
 usage() {
-  echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>"
+  echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] [--ignore-running-sessions] <CFS export file.tgz>"
   echo
   err_exit "$@"
 }
@@ -76,6 +77,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     "--no-cleanup") CLEANUP="" ;;
     "--clear-cfs") CLEAR_CFS="$1" ;;
+    "--ignore-running-sessions") IGNORE_RUNNING_SESSIONS="$1" ;;
     *)
       [[ $# -eq 1 ]] || usage "Unrecognized argument: $1"
       ARCHIVE="$1"
@@ -113,8 +115,8 @@ for FNAME in configurations.json options.json; do
 done
 
 # Call the Python importer script on this directory
-# CLEAR_CFS is deliberately not quoted because if it is empty, we don't want to pass in an empty argument to the Python script
-run_cmd "${import_python_script}" ${CLEAR_CFS} "${JSON_DIR}"
+# CLEAR_CFS and IGNORE_RUNNING_SESSIONS are deliberately not quoted because if it is empty, we don't want to pass in an empty argument to the Python script
+run_cmd "${import_python_script}" ${CLEAR_CFS} ${IGNORE_RUNNING_SESSIONS} "${JSON_DIR}"
 
 # Call cleanup (which will clean up the output directory unless --no-cleanup was specified)
 cleanup

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -240,13 +240,15 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
         log_error_raise_exception("Response from CFS has unexpected format", exc)
     return json_object
 
-def list_sessions() -> List[JsonObject]:
+def list_sessions(params: Union[JsonDict, None]=None) -> List[JsonObject]:
     """
     Queries CFS to list all sessions, and returns the list.
     """
     request_kwargs = {"url": CFS_V2_SESSIONS_URL,
                       "add_api_token": True,
                       "expected_status_codes": {200}}
+    if params:
+        return api_requests.get_retry_validate_return_json(params=params, **request_kwargs)
     return api_requests.get_retry_validate_return_json(**request_kwargs)
 
 # CFS versions functions


### PR DESCRIPTION
backport PR of 1.7 https://github.com/Cray-HPE/docs-csm/pull/5862

Tests

Imports were run with/without cfs sessions

1) Import cfs data with active session

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh cfs-export-20250404150320-Vg2hM3.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250404150623-lVi'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS

Examining CFS configurations...
Configurations with the following names exist in CFS and will not be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'csm-barebones-boot-test-20250402190220', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The following components already have desired configurations set in CFS and will not be updated:
x3000c0s19b2n0
The desired configuration for the following components will be imported:
x3000c0s19b3n0
components are being updated. Checking for running and pending CFS sessions...
The following CFS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.
rahul-test-import18
ERROR: There are CFS sessions that are not complete. Aborting import.
ERROR: Command failed with return code 1: /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.py /tmp/cfs-import-20250404150623-lVi/cfs-export-20250404150320-Vg2
Removing directory '/tmp/cfs-import-20250404150623-lVi'
```

2) import cfs data with active session and --ignore-running-sessions option

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --ignore-running-sessions cfs-export-20250404150320-Vg2hM3.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250404150728-D4v'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS

Examining CFS configurations...
Configurations with the following names exist in CFS and will not be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'csm-barebones-boot-test-20250402190220', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The following components already have desired configurations set in CFS and will not be updated:
x3000c0s19b2n0
The desired configuration for the following components will be imported:
x3000c0s19b3n0

Examining CFS options...
The following options already have the value from the imported data and will not be updated:
additionalInventoryUrl, batchSize, batchWindow, batcherCheckInterval, batcherDisable, batcherMaxBackoff, batcherPendingTimeout, defaultAnsibleConfig, defaultBatcherRetryPolicy, defaultPlaybook, hardwareSyncInterval, loggingLevel, sessionTTL

Taking a snapshot of system CFS data before making changes
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V/sessions.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9V/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250404150729-A9VYhY.tgz

Updating component x3000c0s19b3n0 to desired configuration 'csm-barebones-boot-test-20250320193723'

Taking a snapshot of system CFS data after import
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz/sessions.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250404150734-ybz6Ai.tgz

SUCCESS
Removing directory '/tmp/cfs-import-20250404150728-D4v'
```

3) Import with --clear-cfs  during running cfs session

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --clear-cfs cfs-export-20250404150320-Vg2hM3.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250404150921-v1D'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
CFS data are being updated. Checking for running and pending CFS sessions...
The following CFS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.
rahul-test-import19
ERROR: There are CFS sessions that are not complete. Aborting import.
ERROR: Command failed with return code 1: /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.py --clear-cfs /tmp/cfs-import-20250404150921-v1D/cfs-export-20250404150320-Vg2
Removing directory '/tmp/cfs-import-20250404150921-v1D'
```

4) Import with --clear-cfs and --ignore-running-sessions during running cfs session

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --clear-cfs --ignore-running-sessions cfs-export-20250404150320-Vg2hM3.tgz
Expanding archived CFS data into directory '/tmp/cfs-import-20250404150959-937'
Reading CFS component data from JSON file
Reading CFS configuration data from JSON file
Reading CFS option data from JSON file
Reading current data from CFS
Reading component data from CFS
Reading configuration data from CFS
Reading option data from CFS
Taking a snapshot of system CFS data before clearing it
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6/sessions.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250404151000-fT6PkS.tgz
Clearing error count, desired configuration, and state for component 'x3000c0s11b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s13b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s15b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s17b0n0'
Clearing error count, desired configuration, state, and tags for component 'x3000c0s19b1n0'
Clearing error count, desired configuration, state, and tags for component 'x3000c0s19b2n0'
Clearing error count, desired configuration, state, and tags for component 'x3000c0s19b3n0'
Clearing error count, desired configuration, and state for component 'x3000c0s19b4n0'
Clearing error count, desired configuration, and state for component 'x3000c0s1b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s26b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s28b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s32b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s34b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s36b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s38b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s3b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s5b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s7b0n0'
Clearing error count, desired configuration, and state for component 'x3000c0s9b0n0'
Clearing error count, desired configuration, and state for component 'x3001c0s31b0n0'
Clearing error count, desired configuration, and state for component 'x3001c0s33b0n0'
Clearing error count, desired configuration, and state for component 'x3001c0s35b0n0'
Clearing error count, desired configuration, and state for component 'x3001c0s37b0n0'
Clearing error count, desired configuration, and state for component 'x3001c0s39b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s10b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s10b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s11b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s11b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s12b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s12b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s13b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s13b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s14b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s14b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s15b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s15b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s16b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s16b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s17b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s17b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s18b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s18b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s19b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s19b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s1b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s1b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s20b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s20b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s21b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s21b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s24b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s24b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s2b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s2b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s31b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s31b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s33b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s33b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s34b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s34b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s35b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s35b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s36b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s36b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s38b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s38b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s39b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s39b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s3b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s3b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s40b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s40b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s43b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s43b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s47b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s47b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s48b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s48b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s4b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s4b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s5b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s5b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s6b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s6b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s7b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s7b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s8b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s8b0n1'
Clearing error count, desired configuration, and state for component 'x8000c0s9b0n0'
Clearing error count, desired configuration, and state for component 'x8000c0s9b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s12b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s12b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s17b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s17b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s1b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s1b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s23b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s23b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s27b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s27b0n1'
Clearing error count, desired configuration, and state for component 'x8000c1s5b0n0'
Clearing error count, desired configuration, and state for component 'x8000c1s5b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s26b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s26b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s27b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s27b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s28b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s28b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s29b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s29b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s31b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s31b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s32b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s32b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s33b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s33b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s34b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s34b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s35b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s35b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s36b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s36b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s37b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s37b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s38b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s38b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s39b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s39b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s40b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s40b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s41b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s41b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s42b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s42b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s43b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s43b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s44b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s44b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s45b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s45b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s46b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s46b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s48b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s48b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s49b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s49b0n1'
Clearing error count, desired configuration, and state for component 'x8000c7s50b0n0'
Clearing error count, desired configuration, and state for component 'x8000c7s50b0n1'
Clearing error count, desired configuration, and state for component 'x8001c1s32b0n0'
Clearing error count, desired configuration, and state for component 'x8001c1s32b0n1'
Clearing error count, desired configuration, and state for component 'x8001c1s50b0n0'
Clearing error count, desired configuration, and state for component 'x8001c1s50b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s12b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s12b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s14b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s14b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s18b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s18b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s22b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s22b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s2b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s2b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s33b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s33b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s38b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s38b0n1'
Clearing error count, desired configuration, and state for component 'x8002c2s45b0n0'
Clearing error count, desired configuration, and state for component 'x8002c2s45b0n1'
Clearing error count, desired configuration, and state for component 'x8002c3s39b0n0'
Clearing error count, desired configuration, and state for component 'x8002c3s39b0n1'
Clearing error count, desired configuration, and state for component 'x8002c3s43b0n0'
Clearing error count, desired configuration, and state for component 'x8002c3s43b0n1'
Clearing error count, desired configuration, and state for component 'x8002c3s46b0n0'
Clearing error count, desired configuration, and state for component 'x8002c3s46b0n1'
Clearing error count, desired configuration, and state for component 'x8002c3s48b0n0'
Clearing error count, desired configuration, and state for component 'x8002c3s48b0n1'
Deleting configuration 'csm-barebones-boot-test-20250320193723'
Deleting configuration 'csm-barebones-boot-test-20250320203505'
Deleting configuration 'csm-barebones-boot-test-20250320210649'
Deleting configuration 'csm-barebones-boot-test-20250320212632'
Deleting configuration 'csm-barebones-boot-test-20250326020611'
Deleting configuration 'csm-barebones-boot-test-20250327194949'
Deleting configuration 'csm-barebones-boot-test-20250328021920'
Deleting configuration 'csm-barebones-boot-test-20250328162628'
Deleting configuration 'csm-barebones-boot-test-20250402190220'
Deleting configuration 'mitch-test'
Deleting configuration 'mitch-test-2'
Deleting configuration 'mitch3'
Deleting configuration 'rbak-test'
Deleting configuration 'sleep'

Examining CFS configurations...
The following configurations will be imported:
'csm-barebones-boot-test-20250320193723', 'csm-barebones-boot-test-20250320203505', 'csm-barebones-boot-test-20250320210649', 'csm-barebones-boot-test-20250320212632', 'csm-barebones-boot-test-20250326020611', 'csm-barebones-boot-test-20250327194949', 'csm-barebones-boot-test-20250328021920', 'csm-barebones-boot-test-20250328162628', 'csm-barebones-boot-test-20250402190220', 'mitch-test', 'mitch-test-2', 'mitch3', 'rbak-test', 'sleep'

Examining CFS components...
The following components have no desired configurations set in the import data and will not be updated:
x3000c0s11b0n0, x3000c0s13b0n0, x3000c0s15b0n0, x3000c0s17b0n0, x3000c0s19b1n0, x3000c0s19b4n0, x3000c0s1b0n0, x3000c0s26b0n0, x3000c0s28b0n0, x3000c0s32b0n0, x3000c0s34b0n0, x3000c0s36b0n0, x3000c0s38b0n0, x3000c0s3b0n0, x3000c0s5b0n0, x3000c0s7b0n0, x3000c0s9b0n0, x3001c0s31b0n0, x3001c0s33b0n0, x3001c0s35b0n0, x3001c0s37b0n0, x3001c0s39b0n0, x8000c0s10b0n0, x8000c0s10b0n1, x8000c0s11b0n0, x8000c0s11b0n1, x8000c0s12b0n0, x8000c0s12b0n1, x8000c0s13b0n0, x8000c0s13b0n1, x8000c0s14b0n0, x8000c0s14b0n1, x8000c0s15b0n0, x8000c0s15b0n1, x8000c0s16b0n0, x8000c0s16b0n1, x8000c0s17b0n0, x8000c0s17b0n1, x8000c0s18b0n0, x8000c0s18b0n1, x8000c0s19b0n0, x8000c0s19b0n1, x8000c0s1b0n0, x8000c0s1b0n1, x8000c0s20b0n0, x8000c0s20b0n1, x8000c0s21b0n0, x8000c0s21b0n1, x8000c0s24b0n0, x8000c0s24b0n1, x8000c0s2b0n0, x8000c0s2b0n1, x8000c0s31b0n0, x8000c0s31b0n1, x8000c0s33b0n0, x8000c0s33b0n1, x8000c0s34b0n0, x8000c0s34b0n1, x8000c0s35b0n0, x8000c0s35b0n1, x8000c0s36b0n0, x8000c0s36b0n1, x8000c0s38b0n0, x8000c0s38b0n1, x8000c0s39b0n0, x8000c0s39b0n1, x8000c0s3b0n0, x8000c0s3b0n1, x8000c0s40b0n0, x8000c0s40b0n1, x8000c0s43b0n0, x8000c0s43b0n1, x8000c0s47b0n0, x8000c0s47b0n1, x8000c0s48b0n0, x8000c0s48b0n1, x8000c0s4b0n0, x8000c0s4b0n1, x8000c0s5b0n0, x8000c0s5b0n1, x8000c0s6b0n0, x8000c0s6b0n1, x8000c0s7b0n0, x8000c0s7b0n1, x8000c0s8b0n0, x8000c0s8b0n1, x8000c0s9b0n0, x8000c0s9b0n1, x8000c1s12b0n0, x8000c1s12b0n1, x8000c1s17b0n0, x8000c1s17b0n1, x8000c1s1b0n0, x8000c1s1b0n1, x8000c1s23b0n0, x8000c1s23b0n1, x8000c1s27b0n0, x8000c1s27b0n1, x8000c1s5b0n0, x8000c1s5b0n1, x8000c7s26b0n0, x8000c7s26b0n1, x8000c7s27b0n0, x8000c7s27b0n1, x8000c7s28b0n0, x8000c7s28b0n1, x8000c7s29b0n0, x8000c7s29b0n1, x8000c7s31b0n0, x8000c7s31b0n1, x8000c7s32b0n0, x8000c7s32b0n1, x8000c7s33b0n0, x8000c7s33b0n1, x8000c7s34b0n0, x8000c7s34b0n1, x8000c7s35b0n0, x8000c7s35b0n1, x8000c7s36b0n0, x8000c7s36b0n1, x8000c7s37b0n0, x8000c7s37b0n1, x8000c7s38b0n0, x8000c7s38b0n1, x8000c7s39b0n0, x8000c7s39b0n1, x8000c7s40b0n0, x8000c7s40b0n1, x8000c7s41b0n0, x8000c7s41b0n1, x8000c7s42b0n0, x8000c7s42b0n1, x8000c7s43b0n0, x8000c7s43b0n1, x8000c7s44b0n0, x8000c7s44b0n1, x8000c7s45b0n0, x8000c7s45b0n1, x8000c7s46b0n0, x8000c7s46b0n1, x8000c7s48b0n0, x8000c7s48b0n1, x8000c7s49b0n0, x8000c7s49b0n1, x8000c7s50b0n0, x8000c7s50b0n1, x8001c1s32b0n0, x8001c1s32b0n1, x8001c1s50b0n0, x8001c1s50b0n1, x8002c2s12b0n0, x8002c2s12b0n1, x8002c2s14b0n0, x8002c2s14b0n1, x8002c2s18b0n0, x8002c2s18b0n1, x8002c2s22b0n0, x8002c2s22b0n1, x8002c2s2b0n0, x8002c2s2b0n1, x8002c2s33b0n0, x8002c2s33b0n1, x8002c2s38b0n0, x8002c2s38b0n1, x8002c2s45b0n0, x8002c2s45b0n1, x8002c3s39b0n0, x8002c3s39b0n1, x8002c3s43b0n0, x8002c3s43b0n1, x8002c3s46b0n0, x8002c3s46b0n1, x8002c3s48b0n0, x8002c3s48b0n1
The desired configuration for the following components will be imported:
x3000c0s19b2n0, x3000c0s19b3n0

Examining CFS options...
The following options already have the value from the imported data and will not be updated:
additionalInventoryUrl, batchSize, batchWindow, batcherCheckInterval, batcherDisable, batcherMaxBackoff, batcherPendingTimeout, defaultAnsibleConfig, defaultBatcherRetryPolicy, defaultPlaybook, hardwareSyncInterval, loggingLevel, sessionTTL


Importing configuration 'csm-barebones-boot-test-20250320193723'
Importing configuration 'csm-barebones-boot-test-20250320203505'
Importing configuration 'csm-barebones-boot-test-20250320210649'
Importing configuration 'csm-barebones-boot-test-20250320212632'
Importing configuration 'csm-barebones-boot-test-20250326020611'
Importing configuration 'csm-barebones-boot-test-20250327194949'
Importing configuration 'csm-barebones-boot-test-20250328021920'
Importing configuration 'csm-barebones-boot-test-20250328162628'
Importing configuration 'csm-barebones-boot-test-20250402190220'
Importing configuration 'mitch-test'
Importing configuration 'mitch-test-2'
Importing configuration 'mitch3'
Importing configuration 'rbak-test'
Importing configuration 'sleep'

Updating component x3000c0s19b2n0 to desired configuration 'csm-barebones-boot-test-20250320193723'
Updating component x3000c0s19b3n0 to desired configuration 'csm-barebones-boot-test-20250320193723'

Taking a snapshot of system CFS data after import
Writing CFS data to following directory: /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1
Reading components data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1/components.json
Reading configurations data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1/configurations.json
Reading options data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1/options.json
Reading sessions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1/sessions.json
Reading versions data from CFS
Writing data to /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1/versions.json
Successfully completed writing CFS data to JSON files
Creating compressed archive of exported data...
SUCCESS: CFS data stored in file: /root/rahul/repo/docs-csm/backup/cfs-export-20250404151044-eb1qIC.tgz

SUCCESS
Removing directory '/tmp/cfs-import-20250404150959-937'
```