### PR TITLE
CASMCMS-8866:Update BOS import tool to check for running sessions

### DIFF
--- a/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
+++ b/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
@@ -42,7 +42,7 @@ the automated export script.
    > Modify the following example commands to specify the path to the output file from the automated BOS export script.
      The file may be a JSON file or a `tgz` file, depending on when the backup was made, because the BOS export tools
      have had multiple versions. Any file produced by any version of these tools will work as input for this restore procedure.
-     The import tool will abort if it detects incomplete CFS sessions which could potentially be impacted
+     The import tool will abort if it detects incomplete BOS sessions which could potentially be impacted
      by the import; to override this behavior and import anyway, the `--ignore-running-sessions` argument
      may be added when invoking the import script.
 

--- a/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
+++ b/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
@@ -2,18 +2,18 @@
 
 - [Prerequisites](#prerequisites)
 - [Automated procedures](#automated-procedures)
-  - [Export](#automated-bos-data-export)
-  - [Import](#automated-bos-data-import)
+    - [Export](#automated-bos-data-export)
+    - [Import](#automated-bos-data-import)
 - [Manual procedures](#manual-procedures)
-  - [Export](#manually-export-bos-data)
-  - [Import](#manually-import-bos-data)
+    - [Export](#manually-export-bos-data)
+    - [Import](#manually-import-bos-data)
 
 ## Prerequisites
 
 - Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to system management services.
-  - See [Configure the Cray CLI](../configure_cray_cli.md).
+    - See [Configure the Cray CLI](../configure_cray_cli.md).
 - In order to use the automated procedures, the latest CSM documentation RPM must be installed on the node where the procedure is being performed.
-  - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+    - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 
 ## Automated procedures
 
@@ -40,8 +40,11 @@ the automated export script.
 1. (`ncn-mw#`) Import all BOS session templates and options.
 
    > Modify the following example commands to specify the path to the output file from the automated BOS export script.
-   > The file may be a JSON file or a `tgz` file, depending on when the backup was made, because the BOS export tools
-   > have had multiple versions. Any file produced by any version of these tools will work as input for this restore procedure.
+     The file may be a JSON file or a `tgz` file, depending on when the backup was made, because the BOS export tools
+     have had multiple versions. Any file produced by any version of these tools will work as input for this restore procedure.
+     The import tool will abort if it detects incomplete CFS sessions which could potentially be impacted
+     by the import; to override this behavior and import anyway, the `--ignore-running-sessions` argument
+     may be added when invoking the import script.
 
    ```bash
    /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.sh /root/bos-export-20230417181409-oK4WMw.tgz

--- a/scripts/operations/configuration/import_bos_data.py
+++ b/scripts/operations/configuration/import_bos_data.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -297,6 +297,15 @@ def delete_all_sessions_and_templates(current_template_map: SessionTemplateMap) 
     delete_all_sessions(session_ids)
     delete_all_templates(list(current_template_map))
 
+def check_for_running_bos_sessions(resource_type: str) -> None:
+    print(f"{resource_type} are being updated. Checking for running and pending BOS sessions...")
+    bos_sessions =  list_sessions()
+    active_bos_sessions = [session for session in bos_sessions if session["status"]["status"] != "complete"]
+    if active_bos_sessions:
+        print(f"The following BOS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.")
+        print(", ".join(session["name"] for session in active_bos_sessions))
+        raise BosError("There are BOS sessions that are not complete. Aborting import.")
+
 def main() -> None:
     """
     Parses the command line arguments, does the stuff.
@@ -333,6 +342,9 @@ def main() -> None:
     parser.add_argument("file_or_directory",
                         help="JSON file containing session templates or directory containing "
                              "such JSON files")
+    parser.add_argument("--ignore-running-sessions", action='store_true',
+                        help="Ignore non-completed BOS sessions when importing BOS data")
+
     parsed_args = parser.parse_args()
 
     exported_template_map = load_templates_from_import_data(parsed_args.file_or_directory)
@@ -345,6 +357,8 @@ def main() -> None:
         # Get current BOS options on system
         current_bos_options = list_options()
         options_to_change = get_options_to_change(imported_bos_options, current_bos_options)
+        if not parsed_args.ignore_running_sessions and options_to_change:
+            check_for_running_bos_sessions("options")
     else:
         options_to_change = None
 
@@ -352,6 +366,8 @@ def main() -> None:
     current_template_map = load_current_templates()
 
     if parsed_args.clear_bos:
+        if not parsed_args.ignore_running_sessions:
+            check_for_running_bos_sessions("BOS data")
         # Take a snapshot of the BOS data before we begin.
         print("Taking a snapshot of system BOS data before clearing BOS")
         snapshot_bos_data()
@@ -361,6 +377,8 @@ def main() -> None:
         current_template_map = {}
 
     template_import_map = get_templates_to_import(exported_template_map, current_template_map)
+    if not parsed_args.ignore_running_sessions and template_import_map:
+        check_for_running_bos_sessions("sessiontemplates")
 
     print("")
     # If there are no changes to make, we are already done

--- a/scripts/operations/configuration/import_bos_data.sh
+++ b/scripts/operations/configuration/import_bos_data.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,12 +42,16 @@
 # If the --clear-bos parameter is specified, then all BOS sessions and session
 # templates will be deleted before the import is performed.
 #
+# if the --ignore-running-sessions parameter is specified, Import will proceed
+# even if BOS sessions are running.
+#
 # Most of the work is done by a Python script. This shell script mostly just
 # handles the TGZ case, if needed.
 #
 ##################################################################################
 
 CLEAR_BOS=""
+IGNORE_RUNNING_SESSIONS=""
 
 err_exit() {
   echo "ERROR: $*" >&2
@@ -64,7 +68,7 @@ import_python_script="${basedir}/import_bos_data.py"
   || err_exit "File is not executable: '${import_python_script}'"
 
 usage() {
-  echo "Usage: $0 [--clear-bos] <JSON or TGZ file containing BOS data>"
+  echo "Usage: $0 [--clear-bos] [--ignore-running-sessions] <JSON or TGZ file containing BOS data>"
   exit 1
 }
 
@@ -79,6 +83,13 @@ if [[ $# -eq 1 ]]; then
 elif [[ $# -eq 2 && $1 == --clear-bos ]]; then
   CLEAR_BOS="--clear-bos"
   ARCHIVE=$2
+elif [[ $# -eq 2 && $1 == --ignore-running-sessions ]]; then
+  IGNORE_RUNNING_SESSIONS="--ignore-running-sessions"
+  ARCHIVE=$2
+elif [[ $# -eq 3 && $1 == --clear-bos && $2 == --ignore-running-sessions ]]; then
+  CLEAR_BOS="--clear-bos"
+  IGNORE_RUNNING_SESSIONS="--ignore-running-sessions"
+  ARCHIVE=$3
 else
   usage
 fi
@@ -104,13 +115,13 @@ if [[ ${ARCHIVE} =~ .*\.tgz$ ]]; then
     OPTIONS_JSON=$(echo "${TEMPLATES_JSON}" | sed 's#/v2/sessiontemplates.json$#/v2/options.json#')
     [[ -e ${OPTIONS_JSON} ]] || err_exit "${OPTIONS_JSON} not found"
     echo "Found options file in archive: '${OPTIONS_JSON}'"
-    run_import ${CLEAR_BOS} --options-file "${OPTIONS_JSON}" "${TEMPLATES_JSON}"
+    run_import ${CLEAR_BOS} ${IGNORE_RUNNING_SESSIONS} --options-file "${OPTIONS_JSON}" "${TEMPLATES_JSON}"
   elif [[ -z ${TEMPLATES_JSON} ]]; then
     # In this case, there should be a directory in the archive containing JSON files of the session templates
     TEMPLATES_JSON=$(find "${TMPDIR}" -type f -name \*.json -printf "%h" -quit)
     [[ -n ${TEMPLATES_JSON} ]] || err_exit "No JSON files found in archive"
     echo "Found sessiontemplates directory in archive: '${TEMPLATES_JSON}'"
-    run_import ${CLEAR_BOS} "${TEMPLATES_JSON}"
+    run_import ${CLEAR_BOS} ${IGNORE_RUNNING_SESSIONS} "${TEMPLATES_JSON}"
   fi
 
   # Clean up

--- a/scripts/operations/configuration/import_bos_data.sh
+++ b/scripts/operations/configuration/import_bos_data.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
CASMCMS-8866:Update BOS import tool to check for running sessions

Tests

Imports were run with/without BOS sessions

1) Import BOS data with active session

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.sh bos-export-20250404020040-G4css2.tgz
Unpacking 'bos-export-20250404020040-G4css2.tgz' to temporary directory '/tmp/tmp.7ihRh8mm5X'
bos-export-20250404020040-G4c/
bos-export-20250404020040-G4c/v2/
bos-export-20250404020040-G4c/v2/components.json
bos-export-20250404020040-G4c/v2/options.json
bos-export-20250404020040-G4c/v2/sessions.json
bos-export-20250404020040-G4c/v2/sessiontemplates.json
bos-export-20250404020040-G4c/v2/version.json
Found sessiontemplates list in archive: '/tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/sessiontemplates.json'
Found options file in archive: '/tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/options.json'
Running: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --options-file /tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading session templates from /tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading in BOS options from JSON file
Processing session template name='session_template_2_rahul' tenant=null
Processing session template name='csm-barebones-boot-test-20250328162628' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250328162628' tenant=null)
Processing session template name='csm-barebones-boot-test-20250325214822' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250325214822' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320212632' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320212632' tenant=null)
Processing session template name='csm-barebones-boot-test-20241112175740' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20241112175740' tenant=null)
Processing session template name='csm-barebones-boot-test-20250331185252' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250331185252' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320203505' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320203505' tenant=null)
Processing session template name='session_template_rahul' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='session_template_rahul' tenant=null)
Processing session template name='csm-barebones-boot-test-20250326020611' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250326020611' tenant=null)
Processing session template name='csm-barebones-boot-test-20241026154226' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20241026154226' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320210649' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320210649' tenant=null)
Processing session template name='session_template_1_rahul' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='session_template_1_rahul' tenant=null)
Processing session template name='csm-barebones-boot-test-20250325200717' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250325200717' tenant=null)
Processing session template name='bos-reporter-test' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='bos-reporter-test' tenant=null)
Processing session template name='csm-barebones-boot-test-20250328021920' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250328021920' tenant=null)
sessiontemplates are being updated. Checking for running and pending BOS sessions...
The following BOS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.
41c6af5a-c0fe-461d-9294-608e9ca29e5a
ERROR: There are BOS sessions that are not complete. Aborting import.
ERROR: Command failed: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --options-file /tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.7ihRh8mm5X/bos-export-20250404020040-G4c/v2/sessiontemplates.json
```

2) Import BOS data with active session and --clear-bos option

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.sh --clear-bos bos-export-20250404020040-G4css2.tgz
Unpacking 'bos-export-20250404020040-G4css2.tgz' to temporary directory '/tmp/tmp.GH1OjGA3t8'
bos-export-20250404020040-G4c/
bos-export-20250404020040-G4c/v2/
bos-export-20250404020040-G4c/v2/components.json
bos-export-20250404020040-G4c/v2/options.json
bos-export-20250404020040-G4c/v2/sessions.json
bos-export-20250404020040-G4c/v2/sessiontemplates.json
bos-export-20250404020040-G4c/v2/version.json
Found sessiontemplates list in archive: '/tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/sessiontemplates.json'
Found options file in archive: '/tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/options.json'
Running: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --clear-bos --options-file /tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading session templates from /tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading in BOS options from JSON file
BOS data are being updated. Checking for running and pending BOS sessions...
The following BOS sessions are not complete; aborting import. Run with --ignore-running-sessions to override.
41c6af5a-c0fe-461d-9294-608e9ca29e5a
ERROR: There are BOS sessions that are not complete. Aborting import.
ERROR: Command failed: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --clear-bos --options-file /tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.GH1OjGA3t8/bos-export-20250404020040-G4c/v2/sessiontemplates.json
```

3) Import BOS data with active session and --ignore-running-sessions & --clear-bos option

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.sh --ignore-running-sessions bos-export-20250404020040-G4css2.tgz
Unpacking 'bos-export-20250404020040-G4css2.tgz' to temporary directory '/tmp/tmp.ImwZqs0JnU'
bos-export-20250404020040-G4c/
bos-export-20250404020040-G4c/v2/
bos-export-20250404020040-G4c/v2/components.json
bos-export-20250404020040-G4c/v2/options.json
bos-export-20250404020040-G4c/v2/sessions.json
bos-export-20250404020040-G4c/v2/sessiontemplates.json
bos-export-20250404020040-G4c/v2/version.json
Found sessiontemplates list in archive: '/tmp/tmp.ImwZqs0JnU/bos-export-20250404020040-G4c/v2/sessiontemplates.json'
Found options file in archive: '/tmp/tmp.ImwZqs0JnU/bos-export-20250404020040-G4c/v2/options.json'
Running: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --ignore-running-sessions --options-file /tmp/tmp.ImwZqs0JnU/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.ImwZqs0JnU/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading session templates from /tmp/tmp.ImwZqs0JnU/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading in BOS options from JSON file
Processing session template name='session_template_2_rahul' tenant=null
Processing session template name='csm-barebones-boot-test-20250328162628' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250328162628' tenant=null)
Processing session template name='csm-barebones-boot-test-20250325214822' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250325214822' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320212632' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320212632' tenant=null)
Processing session template name='csm-barebones-boot-test-20241112175740' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20241112175740' tenant=null)
Processing session template name='csm-barebones-boot-test-20250331185252' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250331185252' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320203505' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320203505' tenant=null)
Processing session template name='session_template_rahul' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='session_template_rahul' tenant=null)
Processing session template name='csm-barebones-boot-test-20250326020611' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250326020611' tenant=null)
Processing session template name='csm-barebones-boot-test-20241026154226' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20241026154226' tenant=null)
Processing session template name='csm-barebones-boot-test-20250320210649' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250320210649' tenant=null)
Processing session template name='session_template_1_rahul' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='session_template_1_rahul' tenant=null)
Processing session template name='csm-barebones-boot-test-20250325200717' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250325200717' tenant=null)
Processing session template name='bos-reporter-test' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='bos-reporter-test' tenant=null)
Processing session template name='csm-barebones-boot-test-20250328021920' tenant=null
Session template with identical contents already exists in BOS -- skipping import (name='csm-barebones-boot-test-20250328021920' tenant=null)

Taking a snapshot of system BOS data before making changes
Exporting BOS v2 components...
Exporting BOS v2 options...
Exporting BOS v2 sessions...
Exporting BOS v2 sessiontemplates...
Exporting BOS v2 version...
Creating compressed archive of exported data...
SUCCESS: BOS data stored in file: /root/rahul/repo/docs-csm/backup/bos-export-20250404022621-oyAG2Z.tgz

Importing BOS v2 session template name='session_template_2_rahul' tenant=null

Taking a snapshot of system BOS data after import
Exporting BOS v2 components...
Exporting BOS v2 options...
Exporting BOS v2 sessions...
Exporting BOS v2 sessiontemplates...
Exporting BOS v2 version...
Creating compressed archive of exported data...
SUCCESS: BOS data stored in file: /root/rahul/repo/docs-csm/backup/bos-export-20250404022633-joyPNz.tgz

SUCCESS
```

4) 3) Import BOS data with active session and --ignore-running-sessions option and 

```
ncn-m001:~/rahul/repo/docs-csm/backup # /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.sh --clear-bos --ignore-running-sessions bos-export-20250404020040-G4css2.tgz
Unpacking 'bos-export-20250404020040-G4css2.tgz' to temporary directory '/tmp/tmp.G9AWRRvZW6'
bos-export-20250404020040-G4c/
bos-export-20250404020040-G4c/v2/
bos-export-20250404020040-G4c/v2/components.json
bos-export-20250404020040-G4c/v2/options.json
bos-export-20250404020040-G4c/v2/sessions.json
bos-export-20250404020040-G4c/v2/sessiontemplates.json
bos-export-20250404020040-G4c/v2/version.json
Found sessiontemplates list in archive: '/tmp/tmp.G9AWRRvZW6/bos-export-20250404020040-G4c/v2/sessiontemplates.json'
Found options file in archive: '/tmp/tmp.G9AWRRvZW6/bos-export-20250404020040-G4c/v2/options.json'
Running: /usr/share/doc/csm/scripts/operations/configuration/import_bos_data.py --clear-bos --ignore-running-sessions --options-file /tmp/tmp.G9AWRRvZW6/bos-export-20250404020040-G4c/v2/options.json /tmp/tmp.G9AWRRvZW6/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading session templates from /tmp/tmp.G9AWRRvZW6/bos-export-20250404020040-G4c/v2/sessiontemplates.json
Reading in BOS options from JSON file
Taking a snapshot of system BOS data before clearing BOS
Exporting BOS v2 components...
Exporting BOS v2 options...
Exporting BOS v2 sessions...
Exporting BOS v2 sessiontemplates...
Exporting BOS v2 version...
Creating compressed archive of exported data...
SUCCESS: BOS data stored in file: /root/rahul/repo/docs-csm/backup/bos-export-20250404022849-OS7Njc.tgz

Deleting all BOS sessions and session templates
Deleting session name='csm-barebones-boot-test-20250328162628' tenant=null
Deleting session name='csm-barebones-boot-test-20250331185252' tenant=null
Deleting session name='53c0304f-379f-43bb-8e31-1bbddfdf8fe7' tenant=null
Deleting session name='41c6af5a-c0fe-461d-9294-608e9ca29e5a' tenant=null
Deleting session name='csm-barebones-boot-test-20250328021920' tenant=null
Deleting session template name='session_template_2_rahul' tenant=null
Deleting session template name='csm-barebones-boot-test-20250328162628' tenant=null
Deleting session template name='csm-barebones-boot-test-20250325214822' tenant=null
Deleting session template name='csm-barebones-boot-test-20250320212632' tenant=null
Deleting session template name='csm-barebones-boot-test-20241112175740' tenant=null
Deleting session template name='csm-barebones-boot-test-20250331185252' tenant=null
Deleting session template name='csm-barebones-boot-test-20250320203505' tenant=null
Deleting session template name='session_template_rahul' tenant=null
Deleting session template name='csm-barebones-boot-test-20250326020611' tenant=null
Deleting session template name='csm-barebones-boot-test-20241026154226' tenant=null
Deleting session template name='csm-barebones-boot-test-20250320210649' tenant=null
Deleting session template name='session_template_1_rahul' tenant=null
Deleting session template name='csm-barebones-boot-test-20250325200717' tenant=null
Deleting session template name='bos-reporter-test' tenant=null
Deleting session template name='csm-barebones-boot-test-20250328021920' tenant=null
Processing session template name='session_template_2_rahul' tenant=null
Processing session template name='csm-barebones-boot-test-20250328162628' tenant=null
Processing session template name='csm-barebones-boot-test-20250325214822' tenant=null
Processing session template name='csm-barebones-boot-test-20250320212632' tenant=null
Processing session template name='csm-barebones-boot-test-20241112175740' tenant=null
Processing session template name='csm-barebones-boot-test-20250331185252' tenant=null
Processing session template name='csm-barebones-boot-test-20250320203505' tenant=null
Processing session template name='session_template_rahul' tenant=null
Processing session template name='csm-barebones-boot-test-20250326020611' tenant=null
Processing session template name='csm-barebones-boot-test-20241026154226' tenant=null
Processing session template name='csm-barebones-boot-test-20250320210649' tenant=null
Processing session template name='session_template_1_rahul' tenant=null
Processing session template name='csm-barebones-boot-test-20250325200717' tenant=null
Processing session template name='bos-reporter-test' tenant=null
Processing session template name='csm-barebones-boot-test-20250328021920' tenant=null

Importing BOS v2 session template name='session_template_2_rahul' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250328162628' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250325214822' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250320212632' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20241112175740' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250331185252' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250320203505' tenant=null
Importing BOS v2 session template name='session_template_rahul' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250326020611' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20241026154226' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250320210649' tenant=null
Importing BOS v2 session template name='session_template_1_rahul' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250325200717' tenant=null
Importing BOS v2 session template name='bos-reporter-test' tenant=null
Importing BOS v2 session template name='csm-barebones-boot-test-20250328021920' tenant=null

Taking a snapshot of system BOS data after import
Exporting BOS v2 components...
Exporting BOS v2 options...
Exporting BOS v2 sessions...
Exporting BOS v2 sessiontemplates...
Exporting BOS v2 version...
Creating compressed archive of exported data...
SUCCESS: BOS data stored in file: /root/rahul/repo/docs-csm/backup/bos-export-20250404022926-Skx3Ol.tgz

SUCCESS
```
