### PR TITLE
CASMTRIAGE-8015 WAR for cray-kafka-operator chart upgrade failure

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -39,6 +39,8 @@ vmstorage
 vmalert
 vmselect
 victoria
+RoleBinding
+ServiceAccount
 
 1.0.x
 1.2.x
@@ -256,6 +258,7 @@ Jetstack
 Jinja
 Jinja2
 Kafka
+cray-kafka-operator
 Kata
 Kea
 Keepalived
@@ -670,6 +673,7 @@ pre-uprade
 preboot
 prebuilt
 preempted
+Preemptive
 preemptively
 provisioners
 PXEboot

--- a/troubleshooting/known_issues/kafka_chart_upgrade_failure.md
+++ b/troubleshooting/known_issues/kafka_chart_upgrade_failure.md
@@ -2,13 +2,13 @@
 
 ## [Issue description](#issue-description)
 
-If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.0 or CSM 1.6.1 from CSM 1.5.x, the upgrade of the cray-kafka-operator helm chart would fail as part of the CSM services upgrade process.
+If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.x from CSM 1.5.x, the upgrade of the cray-kafka-operator helm chart would fail as part of the CSM services upgrade process.
 
 Note - This issue would not affect clusters that were freshly installed with CSM 1.4.x or CSM 1.5.x and are being upgraded to CSM 1.6.x version.
 
 ## [Error identification](#error-identification)
 
-CSM services upgrade fails when upgrading to CSM 1.6.x with the following error -
+CSM services upgrade fails when upgrading to CSM 1.6.x with the following error:
 
 ```text
 2025-03-27T13:50:50Z ERR  error="Some charts did not release successfully, see above and/or the output log file for more info" command=ship
@@ -22,7 +22,7 @@ CSM services upgrade fails when upgrading to CSM 1.6.x with the following error 
 2025-03-27T13:50:50Z ERR Error releasing chart cray-kafka-operator v1.2.1: Shell error: Error: UPGRADE FAILED: pre-upgrade hooks failed: timed out waiting for the condition chart=cray-kafka-operator command=ship namespace=operators version=1.2.1
 ```
 
-There would be failed Kubernetes jobs for Kafka as follows -
+There would be failed Kubernetes jobs for Kafka as follows:
 
 ```text
 ncn-m001:~/cray-kafka-operator # kubectl get job -A|grep kafka
@@ -64,13 +64,15 @@ Similar type of errors could be seen on other Strimzi CRDs too.
 
 (`ncn-mw#`) To resolve this issue, update the Strimzi CRDs on the cluster by removing references to the older versions - `v1alpha1` and `v1beta1`.
 After this update, the Strimzi CRDs (except `kafkatopics` and `kafkausers`) will retain only the latest supported version `v1beta2` which eliminates the upgrade failure.
-Run the following script to fix the issue -
+Run the following script to fix the issue:
 
-[`kafka_crd_fix.sh`](../scripts/kafka_crd_fix.sh)
+```bash
+/usr/share/doc/csm/troubleshooting/scripts/kafka_crd_fix.sh
+```
 
 Example output:
 
-```bash
+```console
 ncn-m001:~ # ./kafka_crd_fix.sh
 Checking for old kafka CRD versions
 old version present in kafkabridges.kafka.strimzi.io storedVersions: v1alpha1
@@ -134,7 +136,7 @@ serviceaccount "crd-updater" deleted
 
 Verify if the fix is applied as expected by re-running the script again.
 
-```bash
+```console
 ncn-m001:~ # ./kafka_crd_fix.sh
 Checking for old kafka CRD versions
 kafkabridges.kafka.strimzi.io: okay

--- a/troubleshooting/known_issues/kafka_chart_upgrade_failure.md
+++ b/troubleshooting/known_issues/kafka_chart_upgrade_failure.md
@@ -1,0 +1,151 @@
+# cray-kafka-operator chart failing to upgrade
+
+## [Issue description](#issue-description)
+
+If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.0 or CSM 1.6.1 from CSM 1.5.x, the upgrade of the cray-kafka-operator helm chart would fail as part of the CSM services upgrade process.
+
+Note - This issue would not affect clusters that were freshly installed with CSM 1.4.x or CSM 1.5.x and are being upgraded to CSM 1.6.x version.
+
+## [Error identification](#error-identification)
+
+CSM services upgrade fails when upgrading to CSM 1.6.x with the following error -
+
+```text
+2025-03-27T13:50:50Z ERR  error="Some charts did not release successfully, see above and/or the output log file for more info" command=ship
+120 /usr/share/doc/csm/upgrade/scripts/upgrade/csm-upgrade.sh
+./upgrade.sh
+
+[ERROR] - Unexpected errors, check logs: /root/output.log 
+```
+
+```text
+2025-03-27T13:50:50Z ERR Error releasing chart cray-kafka-operator v1.2.1: Shell error: Error: UPGRADE FAILED: pre-upgrade hooks failed: timed out waiting for the condition chart=cray-kafka-operator command=ship namespace=operators version=1.2.1
+```
+
+There would be failed Kubernetes jobs for Kafka as follows -
+
+```text
+ncn-m001:~/cray-kafka-operator # kubectl get job -A|grep kafka
+operators   cray-kafka-pre-upgrade-crd-hook   0/1   9m   9m
+
+ncn-m001:~/cray-kafka-operator # kubectl get po -n operators
+NAME                                    READY  STATUS   RESTARTS   AGE
+cray-kafka-pre-upgrade-crd-hook-7dtcx   0/1    Error    0          9m
+```
+
+The `/root/output.log` which stores the upgrade logs contains following type of errors related to Strimzi Kafka Custom Resource Definitions(CRDs) -
+
+```text
+Error from server (Invalid): error when applying patch:
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":<last_applied_configuration_values>
+to:
+Resource: "apiextensions.k8s.io/v1, Resource=customresourcedefinitions", GroupVersionKind: "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"
+Name: "kafkas.kafka.strimzi.io", Namespace: ""
+for: "/tmp/strimzi-crds-0.41.0.yaml": CustomResourceDefinition.apiextensions.k8s.io "kafkas.kafka.strimzi.io" is invalid: status.storedVersions[1]: Invalid value: "v1beta1": must appear in spec.versions
+
+Error from server (Invalid): error when applying patch:
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":<last_applied_configuration_values>
+to:
+Resource: "apiextensions.k8s.io/v1, Resource=customresourcedefinitions", GroupVersionKind: "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"
+Name: "kafkaconnects.kafka.strimzi.io", Namespace: ""
+for: "/tmp/strimzi-crds-0.41.0.yaml": CustomResourceDefinition.apiextensions.k8s.io "kafkaconnects.kafka.strimzi.io" is invalid: status.storedVersions[1]: Invalid value: "v1beta1": must appear in spec.versions
+
+Error from server (Invalid): error when applying patch:
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":<last_applied_configuration_values>
+to:
+Resource: "apiextensions.k8s.io/v1, Resource=customresourcedefinitions", GroupVersionKind: "apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"
+Name: "kafkarebalances.kafka.strimzi.io", Namespace: ""
+for: "/tmp/strimzi-crds-0.41.0.yaml": CustomResourceDefinition.apiextensions.k8s.io "kafkarebalances.kafka.strimzi.io" is invalid: status.storedVersions[1]: Invalid value: "v1alpha1": must appear in spec.versions
+```
+
+Similar type of errors could be seen on other Strimzi CRDs too.
+
+## [Workaround steps](#workaround-steps)
+
+(`ncn-mw#`) To resolve this issue, update the Strimzi CRDs on the cluster by removing references to the older versions - `v1alpha1` and `v1beta1`.
+After this update, the Strimzi CRDs (except `kafkatopics` and `kafkausers`) will retain only the latest supported version `v1beta2` which eliminates the upgrade failure.
+Run the following script to fix the issue -
+
+[`kafka_crd_fix.sh`](../scripts/kafka_crd_fix.sh)
+
+Example output:
+
+```bash
+ncn-m001:~ # ./kafka_crd_fix.sh
+Checking for old kafka CRD versions
+old version present in kafkabridges.kafka.strimzi.io storedVersions: v1alpha1
+old version present in kafkaconnectors.kafka.strimzi.io storedVersions: v1alpha1
+old version present in kafkaconnects.kafka.strimzi.io storedVersions: v1beta1
+old version present in kafkaconnects2is.kafka.strimzi.io storedVersions: v1beta1
+old version present in kafkamirrormaker2s.kafka.strimzi.io storedVersions: v1alpha1
+old version present in kafkamirrormakers.kafka.strimzi.io storedVersions: v1beta1
+old version present in kafkarebalances.kafka.strimzi.io storedVersions: v1alpha1
+old version present in kafkas.kafka.strimzi.io storedVersions: v1beta1
+kafkatopics.kafka.strimzi.io: okay
+kafkausers.kafka.strimzi.io: okay
+strimzipodsets.core.strimzi.io: okay
+Removing old kafka CRD versions
+serviceaccount/crd-updater created
+clusterrole.rbac.authorization.k8s.io/crd-update-access created
+clusterrolebinding.rbac.authorization.k8s.io/crd-update-binding created
+Using API Server: https://10.252.1.2:6442
+Processing CRD: kafkabridges.kafka.strimzi.io
+Patching CRD kafkabridges.kafka.strimzi.io status...
+Replacing CRD kafkabridges.kafka.strimzi.io
+CRD kafkabridges.kafka.strimzi.io updated successfully
+Processing CRD: kafkaconnectors.kafka.strimzi.io
+Patching CRD kafkaconnectors.kafka.strimzi.io status...
+Replacing CRD kafkaconnectors.kafka.strimzi.io
+CRD kafkaconnectors.kafka.strimzi.io updated successfully
+Processing CRD: kafkaconnects.kafka.strimzi.io
+Patching CRD kafkaconnects.kafka.strimzi.io status...
+Replacing CRD kafkaconnects.kafka.strimzi.io
+CRD kafkaconnects.kafka.strimzi.io updated successfully
+Processing CRD: kafkaconnects2is.kafka.strimzi.io
+Patching CRD kafkaconnects2is.kafka.strimzi.io status...
+Replacing CRD kafkaconnects2is.kafka.strimzi.io
+CRD kafkaconnects2is.kafka.strimzi.io updated successfully
+Processing CRD: kafkamirrormaker2s.kafka.strimzi.io
+Patching CRD kafkamirrormaker2s.kafka.strimzi.io status...
+Replacing CRD kafkamirrormaker2s.kafka.strimzi.io
+CRD kafkamirrormaker2s.kafka.strimzi.io updated successfully
+Processing CRD: kafkamirrormakers.kafka.strimzi.io
+Patching CRD kafkamirrormakers.kafka.strimzi.io status...
+Replacing CRD kafkamirrormakers.kafka.strimzi.io
+CRD kafkamirrormakers.kafka.strimzi.io updated successfully
+Processing CRD: kafkarebalances.kafka.strimzi.io
+Patching CRD kafkarebalances.kafka.strimzi.io status...
+Replacing CRD kafkarebalances.kafka.strimzi.io
+CRD kafkarebalances.kafka.strimzi.io updated successfully
+Processing CRD: kafkas.kafka.strimzi.io
+Patching CRD kafkas.kafka.strimzi.io status...
+Replacing CRD kafkas.kafka.strimzi.io
+CRD kafkas.kafka.strimzi.io updated successfully
+Skipping CRD: kafkatopics.kafka.strimzi.io
+Skipping CRD: kafkausers.kafka.strimzi.io
+Processing CRD: strimzipodsets.core.strimzi.io
+Patching CRD strimzipodsets.core.strimzi.io status...
+Replacing CRD strimzipodsets.core.strimzi.io
+CRD strimzipodsets.core.strimzi.io updated successfully
+clusterrolebinding.rbac.authorization.k8s.io "crd-update-binding" deleted
+clusterrole.rbac.authorization.k8s.io "crd-update-access" deleted
+serviceaccount "crd-updater" deleted
+```
+
+Verify if the fix is applied as expected by re-running the script again.
+
+```bash
+ncn-m001:~ # ./kafka_crd_fix.sh
+Checking for old kafka CRD versions
+kafkabridges.kafka.strimzi.io: okay
+kafkaconnectors.kafka.strimzi.io: okay
+kafkaconnects.kafka.strimzi.io: okay
+kafkaconnects2is.kafka.strimzi.io: okay
+kafkamirrormaker2s.kafka.strimzi.io: okay
+kafkamirrormakers.kafka.strimzi.io: okay
+kafkarebalances.kafka.strimzi.io: okay
+kafkas.kafka.strimzi.io: okay
+kafkatopics.kafka.strimzi.io: okay
+kafkausers.kafka.strimzi.io: okay
+strimzipodsets.core.strimzi.io: okay
+```

--- a/troubleshooting/scripts/kafka_crd_fix.sh
+++ b/troubleshooting/scripts/kafka_crd_fix.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This script removes old kafka CRD versions from the storedVersions
+# so that an upgrade of the CRDs will succeed.
+
+trap 'delete_auth' EXIT
+
+delete_auth() {
+  kubectl delete --ignore-not-found clusterrolebinding crd-update-binding
+  kubectl delete --ignore-not-found clusterrole crd-update-access
+  kubectl delete --ignore-not-found serviceaccount crd-updater
+}
+
+create_auth() {
+  kubectl apply -f - << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crd-updater
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-update-access
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch","update","patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-update-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-update-access
+subjects:
+  - kind: ServiceAccount
+    name: crd-updater
+    namespace: default
+EOF
+}
+
+have_old_kakfa_crd() {
+  have_old_crd_version=false
+
+  for crd in $(kubectl get crd -l app=strimzi -o jsonpath='{.items[*].metadata.name}'); do
+    if [ "${crd}" = kafkatopics.kafka.strimzi.io ] || [ "${crd}" = kafkausers.kafka.strimzi.io ]; then
+      echo "${crd}: okay"
+      continue
+    fi
+
+    stored_versions=""
+    stored_versions=$(kubectl get crd "${crd}" -o jsonpath='{.status.storedVersions[*]}')
+    old_stored_versions=""
+    for version in ${stored_versions}; do
+      # Check if "v1alpha1" or "v1beta1" are present as part of storedVersions
+      if [ "${version}" != "v1beta2" ]; then
+        old_stored_versions="${old_stored_versions},${version}"
+      fi
+    done
+    if [ "${old_stored_versions}" != "" ]; then
+      echo "old version present in ${crd} storedVersions: ${old_stored_versions#,}"
+      have_old_crd_version=true
+    else
+      echo "${crd}: okay"
+    fi
+  done
+  if ${have_old_crd_version}; then
+    return 0
+  fi
+  return 1
+}
+
+remove_old_crd_versions() {
+  strimzi_kafka_crd_list=$(kubectl get crd -l app=strimzi -o custom-columns=":metadata.name")
+
+  # Grab the Kubernetes API server URL from your current kubeconfig
+  apiserver=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+  echo "Using API Server: ${apiserver}"
+
+  # Get the service account token from crd-updater
+  secret_name=$(kubectl get sa crd-updater -n default -o jsonpath='{.secrets[0].name}')
+  token=$(kubectl get secret "${secret_name}" -n default -o jsonpath='{.data.token}' | base64 -d)
+
+  for crd in ${strimzi_kafka_crd_list}; do
+    if [ "${crd}" = kafkatopics.kafka.strimzi.io ] || [ "${crd}" = kafkausers.kafka.strimzi.io ]; then
+      echo "Skipping CRD: ${crd}"
+      continue
+    fi
+
+    echo "Processing CRD: ${crd}"
+
+    # Patch status.storedVersions to only include v1beta2
+    echo "Patching CRD ${crd} status..."
+    if ! curl -s -o /dev/null --cacert /etc/kubernetes/pki/ca.crt -X PATCH \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/merge-patch+json" \
+      "${apiserver}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/${crd}/status" \
+      -d '{"status": {"storedVersions": ["v1beta2"]}}'; then
+      echo "Failed to patch CRD ${crd} status"
+    fi
+
+    crd_json=$(kubectl get crd "${crd}" -o json)
+
+    # Update the "served" and "storage" fields to true for the version v1beta2 and also Remove all versions except v1beta2 from spec.versions
+    modified_spec=$(echo "${crd_json}" | jq '
+      (.spec.versions[] | select(.name == "v1beta2")) |= (.served = true | .storage = true)
+      | .spec.versions |= map(select(.name == "v1beta2"))
+    ')
+
+    # Replace the CRD spec
+    echo "Replacing CRD ${crd}"
+    if echo "${modified_spec}" | kubectl replace --raw "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/${crd}" -f - > /dev/null; then
+      echo "CRD ${crd} updated successfully"
+    else
+      echo "Failed to update CRD ${crd}"
+    fi
+  done
+}
+
+echo "Checking for old kafka CRD versions"
+if have_old_kakfa_crd; then
+  echo "Removing old kafka CRD versions"
+  create_auth
+  remove_old_crd_versions
+fi

--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -20,12 +20,13 @@ completes its upgrade, then quorum would be lost.
 
 1. [Start typescript](#1-start-typescript)
 1. [Ensure latest documentation installed](#2-ensure-latest-documentation-is-installed)
-1. [Export Nexus data](#3-export-nexus-data)
-1. [Adding switch admin password to Vault](#4-adding-switch-admin-password-to-vault)
-1. [Ensure SNMP is configured on the management network switches](#5-ensure-snmp-is-configured-on-the-management-network-switches)
-1. [Running sessions](#6-running-sessions)
-1. [Health validation](#7-health-validation)
-1. [Stop typescript](#8-stop-typescript)
+1. [Fix Kafka CRD issue](#3-fix-kafka-crd-issue)
+1. [Export Nexus data](#4-export-nexus-data)
+1. [Adding switch admin password to Vault](#5-adding-switch-admin-password-to-vault)
+1. [Ensure SNMP is configured on the management network switches](#6-ensure-snmp-is-configured-on-the-management-network-switches)
+1. [Running sessions](#7-running-sessions)
+1. [Health validation](#8-health-validation)
+1. [Stop typescript](#9-stop-typescript)
 
 ### 1. Start typescript
 
@@ -50,7 +51,19 @@ CSM version on the system -- not the target version of the upgrade.
 
 See [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation) for instructions.
 
-### 3. Export Nexus data
+### 3. Fix Kafka CRD issue
+
+If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.0 or CSM 1.6.1 from CSM 1.5.x, the upgrade of the `cray-kafka-operator` helm chart would fail as part of the CSM services upgrade process.
+
+**Note:**  This issue would not affect clusters that were freshly installed with CSM 1.4.x or CSM 1.5.x and are being upgraded to CSM 1.6.x versions.
+
+If the cluster has followed the upgrade path mentioned above, run the following script to apply the fix -
+
+[`kafka_crd_fix.sh`](../troubleshooting/scripts/kafka_crd_fix.sh)
+
+Reference [cray-kafka-operator chart upgrade failure](../troubleshooting/known_issues/kafka_chart_upgrade_failure.md) workaround document for additional details.
+
+### 4. Export Nexus data
 
 **Warning:** This process can take multiple hours where Nexus is unavailable and should be done
 during scheduled maintenance periods.
@@ -62,13 +75,13 @@ If there is no maintenance period available, then skip this step until after the
 Reference [Nexus Export and Restore Procedure](../operations/package_repository_management/Nexus_Export_and_Restore.md)
 for details.
 
-### 4. Adding switch admin password to Vault
+### 5. Adding switch admin password to Vault
 
 If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
 See [Adding switch admin password to Vault](../operations/network/management_network/README.md#adding-switch-admin-password-to-vault).
 
-### 5. Ensure SNMP is configured on the management network switches
+### 6. Ensure SNMP is configured on the management network switches
 <!-- snmp-authentication-tag -->
 <!-- When updating this information, search the docs for the snmp-authentication-tag to find related content -->
 <!-- These comments can be removed once we adopt HTTP/lw-dita/Generated docs with re-usable snippets -->
@@ -106,7 +119,7 @@ contains the following relevant information:
 
 Return here after verifying that SNMP is properly configured on the management network switches.
 
-### 6. Running sessions
+### 7. Running sessions
 
 [Boot Orchestration Service (BOS)](../glossary.md#boot-orchestration-service-bos),
 [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs),
@@ -144,7 +157,7 @@ Return here after verifying that SNMP is properly configured on the management n
    There is currently no method to prevent new sessions from being created as long as the service
    APIs are accessible on the API gateway.
 
-### 7. Health validation
+### 8. Health validation
 
 1. Validate CSM health.
 
@@ -159,6 +172,6 @@ Return here after verifying that SNMP is properly configured on the management n
    If a Lustre file system is being used, then see the ClusterStor documentation for details on how
    to validate Lustre health.
 
-### 8. Stop typescript
+### 9. Stop typescript
 
 For any typescripts that were started during this preparation stage, stop them with the `exit` command.

--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -53,13 +53,15 @@ See [Check for latest documentation](../update_product_stream/README.md#check-fo
 
 ### 3. Fix Kafka CRD issue
 
-If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.0 or CSM 1.6.1 from CSM 1.5.x, the upgrade of the `cray-kafka-operator` helm chart would fail as part of the CSM services upgrade process.
+If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.x from CSM 1.5.x, the upgrade of the cray-kafka-operator helm chart would fail as part of the CSM services upgrade process.
 
 **Note:**  This issue would not affect clusters that were freshly installed with CSM 1.4.x or CSM 1.5.x and are being upgraded to CSM 1.6.x versions.
 
-If the cluster has followed the upgrade path mentioned above, run the following script to apply the fix -
+If the cluster has followed the upgrade path mentioned above, run the following script to apply the fix:
 
-[`kafka_crd_fix.sh`](../troubleshooting/scripts/kafka_crd_fix.sh)
+```bash
+/usr/share/doc/csm/troubleshooting/scripts/kafka_crd_fix.sh
+```
 
 Reference [cray-kafka-operator chart upgrade failure](../troubleshooting/known_issues/kafka_chart_upgrade_failure.md) workaround document for additional details.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
CASMTRIAGE-8015 Baldar esr-2025 upgrade - management-nodes-rollout failure, error releasing chart cray-kafka-operator

Adding WAR document to address the above issue.
Issue detail - If a cluster which was initially installed with CSM 1.3 or earlier, and is now getting upgraded to CSM 1.6.0 or CSM 1.6.1 from CSM 1.5.x, the upgrade of the `cray-kafka-operator` helm chart would fail as part of the CSM services upgrade process. 

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
