### PR TITLE
CASMINST-7102: Make master node upgrade backup and update bootparameter separate step

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -65,9 +65,26 @@ spec:
             templateRef:
               name: workflow-template-record-time-template
               template: record-time-template
-          - name: list-tar-files
+          - name: remove-previous-done-files
             dependencies:
               - start-operation
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
+                - name: scriptContent
+                  value: |
+                    . /etc/cray/upgrade/csm/myenv                    
+                    #Remove .done check files of previous activity at start of new activity
+                    rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/*.done
+          - name: list-tar-files
+            dependencies:
+              - remove-previous-done-files
             inline:
               script:
                 image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.13

--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -81,15 +81,7 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
-                    . /etc/cray/upgrade/csm/myenv
                     echo "NOTICE This workflow will rollout ncn-m001 upgrade."
-                    if [ -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done ] || [ -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done ]; then
-                      echo "WARNING "
-                      echo "WARNING Note: To Re-run master node ncn-m001 backup, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done' "
-                      echo "WARNING Note: To Re-run master node ncn-m001 bootparameters update, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done' "
-                      echo "WARNING This is not recommended and must be done only if the system is upgraded successfully and the existing backup and bootparameters update will not skip on Re-run management-m001-rollout"
-                      echo "WARNING "
-                    fi
           - name: verify-master-images-and-configuration
             dependencies:
               - INFO-to-read
@@ -136,7 +128,8 @@ spec:
                         touch /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done
                       fi
                     else
-                      echo "INFO Skipping master node ncn-m001 backup.It has previously been completed"
+                      echo "INFO Skipping master node ncn-m001 backup. It has previously been completed"
+                      echo "INFO Note: To Re-run master node ncn-m001 backup, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done' "
                     fi
           - name: update-bootparams-m001
             dependencies:
@@ -189,7 +182,8 @@ spec:
                         echo "INFO Successfully completed master node ncn-m001 bootparameters update" 
                         touch /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done
                     else
-                      echo "INFO Skipping master node ncn-m001 bootparameters update.It has previously been completed" 
+                      echo "INFO Skipping master node ncn-m001 bootparameters update. It has previously been completed"
+                      echo "INFO Note: To Re-run master node ncn-m001 bootparameters update, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done' "
           - name: upgrade-m001
             dependencies:
               - update-bootparams-m001
@@ -243,6 +237,10 @@ spec:
                     if [[ $? -ne 0 ]]; then
                         echo "ERROR master node ncn-m001 upgrade has failed"
                         exit 1
+                    else
+                        . /etc/cray/upgrade/csm/myenv
+                        rm /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done
+                        rm /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done
                     fi
           - name: end-operation
             dependencies:

--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -81,7 +81,15 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
+                    . /etc/cray/upgrade/csm/myenv
                     echo "NOTICE This workflow will rollout ncn-m001 upgrade."
+                    if [ -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done ] || [ -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done ]; then
+                      echo "WARNING "
+                      echo "WARNING Note: To Re-run master node ncn-m001 backup, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done' "
+                      echo "WARNING Note: To Re-run master node ncn-m001 bootparameters update, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done' "
+                      echo "WARNING This is not recommended and must be done only if the system is upgraded successfully and the existing backup and bootparameters update will not skip on Re-run management-m001-rollout"
+                      echo "WARNING "
+                    fi
           - name: verify-master-images-and-configuration
             dependencies:
               - INFO-to-read
@@ -110,46 +118,81 @@ spec:
                   value: 'ncn-m001'
                 - name: scriptContent
                   value: |
-                    BACKUP_TARFILE="csm_upgrade.pre_m001_reboot_artifacts.$(date +%Y%m%d_%H%M%S).tgz"
-                    ls -d \
-                        /root/apply_csm_configuration.* \
-                        /root/csm_upgrade.* \
-                        /root/output.log 2>/dev/null |
-                    sed 's_^/__' |
-                    xargs tar -C / -czvf "/root/${BACKUP_TARFILE}"
-                    cray artifacts create config-data "${BACKUP_TARFILE}" "/root/${BACKUP_TARFILE}"
-                    # Check for cray artifact create command result
-                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
-                    CFS_CONFIG_NAME=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
-                    IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
-                    XNAME=$(cat /etc/cray/xname)
-                    # Check for the XNAME variable
-                    echo "DEBUG Setting CFS config $config on ncn-m001 ($XNAME)"
-                    /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-                    --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames "${XNAME}" --no-enable --no-clear-err
-
-                    IMS_RESULTANT_IMAGE_ID=${IMAGE_ID}
-                    METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
-                       | awk -F 'metal.server=' '{print $2}' \
-                       | awk -F ' ' '{print $1}')
-                    echo "${METAL_SERVER}"
-
-                    S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
-                    echo "${S3_ARTIFACT_PATH}"
-                    NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
-                    echo "${NEW_METAL_SERVER}"
-                    PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-                    sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-                    tr -d \")
-                    echo "${PARAMS}"
-
-                    cray bss bootparameters update --hosts "${XNAME}" \
-                        --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
-                        --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
-                        --params "${PARAMS}"
-          - name: upgrade-m001
+                    . /etc/cray/upgrade/csm/myenv
+                    if [ ! -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done ]; then
+                      BACKUP_TARFILE="csm_upgrade.pre_m001_reboot_artifacts.$(date +%Y%m%d_%H%M%S).tgz"
+                      ls -d \
+                          /root/apply_csm_configuration.* \
+                          /root/csm_upgrade.* \
+                          /root/output.log 2>/dev/null |
+                      sed 's_^/__' |
+                      xargs tar -C / -czvf "/root/${BACKUP_TARFILE}"
+                      cray artifacts create config-data "${BACKUP_TARFILE}" "/root/${BACKUP_TARFILE}"
+                      if [[ $? -ne 0 ]]; then
+                        echo "ERROR master node ncn-m001 backup has failed"
+                        exit 1
+                      else
+                        echo "INFO Successfully completed master node ncn-m001 backup"
+                        touch /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-backup.done
+                      fi
+                    else
+                      echo "INFO Skipping master node ncn-m001 backup.It has previously been completed"
+                    fi
+          - name: update-bootparams-m001
             dependencies:
               - backup-m001
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: 'ncn-m001'
+                - name: scriptContent
+                  value: |
+                    . /etc/cray/upgrade/csm/myenv
+                    if [ ! -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done ]; then
+                      prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                      CFS_CONFIG_NAME=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
+                      IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                      XNAME=$(cat /etc/cray/xname)
+                      # Check for the XNAME variable
+                      echo "DEBUG Setting CFS config $config on ncn-m001 ($XNAME)"
+                      /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+                      --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames "${XNAME}" --no-enable --no-clear-err
+
+                      IMS_RESULTANT_IMAGE_ID=${IMAGE_ID}
+                      METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
+                        | awk -F 'metal.server=' '{print $2}' \
+                        | awk -F ' ' '{print $1}')
+                      echo "${METAL_SERVER}"
+
+                      S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
+                      echo "${S3_ARTIFACT_PATH}"
+                      NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+                      echo "${NEW_METAL_SERVER}"
+                      PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
+                      sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+                      tr -d \")
+                      echo "${PARAMS}"
+
+                      cray bss bootparameters update --hosts "${XNAME}" \
+                          --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
+                          --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
+                          --params "${PARAMS}"
+                      if [[ $? -ne 0 ]]; then
+                        echo "ERROR master node ncn-m001 bootparameters update has failed"
+                        exit 1
+                      else
+                        echo "INFO Successfully completed master node ncn-m001 bootparameters update" 
+                        touch /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done
+                    else
+                      echo "INFO Skipping master node ncn-m001 bootparameters update.It has previously been completed" 
+          - name: upgrade-m001
+            dependencies:
+              - update-bootparams-m001
             templateRef:
               name: ssh-template
               template: shell-script
@@ -195,8 +238,12 @@ spec:
                         echo "ERROR libcsm-latest.noarch.rpm RPM doesn't exists under /root directory"
                         exit 1
                     fi
-                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
 
+                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
+                    if [[ $? -ne 0 ]]; then
+                        echo "ERROR master node ncn-m001 upgrade has failed"
+                        exit 1
+                    fi
           - name: end-operation
             dependencies:
               - upgrade-m001


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

CASMINST-7102: Make master node upgrade backup and update bootparameters in a sepate task with additional checks to skip if Re-run workflow

Remove .done files in directory /etc/cray/upgrade/csm/${CSM_REL_NAME}  when starting new activity as initial step in process-media stage

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
