### PR TITLE
CASMTRIAGE-7986 - pre-upgrade-status.sh incorrectly handles --hsn-not-required flag

### DIFF
--- a/upgrade/scripts/upgrade/util/pre-upgrade-status.sh
+++ b/upgrade/scripts/upgrade/util/pre-upgrade-status.sh
@@ -144,6 +144,11 @@ function sat_status() {
 
 function hsn_status() {
   echo "---- Recording HSN Status ----"
+  if [[ ${HSN_REQUIRED} == N ]]; then
+    msg="Skipping HSN status checks due to --hsn-not-required flag."
+    echo "WARNING ${msg}"
+    return
+  fi
   if [[ -n $(kubectl get pods -A | grep slingshot-fabric-manager | awk '{print $2}') ]]; then
     execute "kubectl exec -it -n services $(kubectl get pods -A | grep slingshot-fabric-manager | awk '{print $2}') -c slingshot-fabric-manager -- fmn_status" "fmn.show.status"
     execute "kubectl exec -it -n services $(kubectl get pods -A | grep slingshot-fabric-manager | awk '{print $2}') -c slingshot-fabric-manager -- fmn_status --details" "fmn.show.status.detail"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Add check to make the `--hsn-not-required` flag behave as expected and not attempt to gather HSN data if set.

Tested on `starlord`, script no longer attempt to gather HSN data if `--hsn-not-required` is supplied.
```
ncn-m001:~ # /usr/share/doc/csm/upgrade/scripts/upgrade/util/pre-upgrade-status.sh -o /root/pre-upgrade-out --hsn-not-required --sdu-not-required
...
---- Recording HSN Status ----
WARNING Skipping HSN status checks due to --hsn-not-required flag.
---- Recording Ceph Status ----
```

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
