### PR TITLE
CASMPET-7471: Add metallb device name and device network during upgrade

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -120,6 +120,51 @@ yq4 -i eval ".spec.kubernetes.services[\"kyverno-policy\"].checkImagePolicy += (
 yq4 -i eval '.spec.kubernetes.services.["cray-hubble"].externalHostname = "hubble.cmn.{{ network.dns.external }}"' "$c"
 yq4 -i eval ".spec.proxiedWebAppExternalHostnames.customerManagement |= (. + [\"{{ kubernetes.services['cray-hubble'].externalHostname }}\"] | unique)" "$c"
 
+if yq4 eval '.spec.network.metallb.peers' "$c" &> /dev/null; then
+
+    # 1. Get SLS Authentication Token
+    # shellcheck disable=SC2046,SC2155
+    export SLS_TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
+    # shellcheck disable=SC2166
+    if [ -z "${SLS_TOKEN}" -o "${SLS_TOKEN}" == "" -o "${SLS_TOKEN}" == "null" ]; then
+        echo >&2 "error: failed to obtain token from keycloak"
+        exit 1
+    fi
+
+    # 2. Fetch Network Data from SLS
+    SLS_NETWORKS_JSON=$(curl -s -k -H "Authorization: Bearer ${SLS_TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks)
+
+    # 3. Get the number of peers currently in customizations.yaml
+    num_peers=$(yq4 eval '.spec.network.metallb.peers | length' "$c")
+
+    for i in $(seq 0 $((num_peers - 1))); do
+        # 4. Get the peer-address for the current peer from the temp file
+        current_peer_ip=$(yq4 eval ".spec.network.metallb.peers[$i].\"peer-address\"" "$c")
+        [[ -z "$current_peer_ip" || "$current_peer_ip" == "null" ]] && continue
+
+        # 5. Search SLS data for the reservation matching the current_peer_ip
+        match_info=$(echo "$SLS_NETWORKS_JSON" | jq -c --arg ip "$current_peer_ip" '
+            first(
+                .[] | select(.ExtraProperties.Subnets) | . as $network |
+                .ExtraProperties.Subnets[] | select(.IPReservations and (.Name == "network_hardware" or .Name == "bootstrap_dhcp")) |
+                .IPReservations[] | select(.Name? and .IPAddress?) | select(.IPAddress == $ip) |
+                {deviceName: .Name, deviceNetwork: ($network.Name | ascii_downcase)}
+            )
+        ')
+
+        # 6. Extract device name and network
+        if [[ -n "$match_info" ]]; then
+            device_name=$(echo "$match_info" | jq -r '.deviceName')
+            device_network=$(echo "$match_info" | jq -r '.deviceNetwork')
+
+            # 7. Add the fields for the current peer index in the temp file
+            yq4 eval -i ".spec.network.metallb.peers[$i].\"device-name\" = \"${device_name}\"" "$c"
+            yq4 eval -i ".spec.network.metallb.peers[$i].\"device-network\" = \"${device_network}\"" "$c"
+        fi
+    done
+fi
+
 # lower cpu request for tds systems (4 workers)
 num_workers=$(kubectl get nodes | grep ncn-w | wc -l)
 if [ $num_workers -le 4 ]; then

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -122,29 +122,29 @@ yq4 -i eval ".spec.proxiedWebAppExternalHostnames.customerManagement |= (. + [\"
 
 if yq4 eval '.spec.network.metallb.peers' "$c" &> /dev/null; then
 
-    # 1. Get SLS Authentication Token
-    # shellcheck disable=SC2046,SC2155
-    export SLS_TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+  # 1. Get SLS Authentication Token
+  # shellcheck disable=SC2046,SC2155
+  export SLS_TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
 
-    # shellcheck disable=SC2166
-    if [ -z "${SLS_TOKEN}" -o "${SLS_TOKEN}" == "" -o "${SLS_TOKEN}" == "null" ]; then
-        echo >&2 "error: failed to obtain token from keycloak"
-        exit 1
-    fi
+  # shellcheck disable=SC2166
+  if [ -z "${SLS_TOKEN}" -o "${SLS_TOKEN}" == "" -o "${SLS_TOKEN}" == "null" ]; then
+    echo >&2 "error: failed to obtain token from keycloak"
+    exit 1
+  fi
 
-    # 2. Fetch Network Data from SLS
-    SLS_NETWORKS_JSON=$(curl -s -k -H "Authorization: Bearer ${SLS_TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks)
+  # 2. Fetch Network Data from SLS
+  SLS_NETWORKS_JSON=$(curl -s -k -H "Authorization: Bearer ${SLS_TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks)
 
-    # 3. Get the number of peers currently in customizations.yaml
-    num_peers=$(yq4 eval '.spec.network.metallb.peers | length' "$c")
+  # 3. Get the number of peers currently in customizations.yaml
+  num_peers=$(yq4 eval '.spec.network.metallb.peers | length' "$c")
 
-    for i in $(seq 0 $((num_peers - 1))); do
-        # 4. Get the peer-address for the current peer from the temp file
-        current_peer_ip=$(yq4 eval ".spec.network.metallb.peers[$i].\"peer-address\"" "$c")
-        [[ -z "$current_peer_ip" || "$current_peer_ip" == "null" ]] && continue
+  for i in $(seq 0 $((num_peers - 1))); do
+    # 4. Get the peer-address for the current peer from the temp file
+    current_peer_ip=$(yq4 eval ".spec.network.metallb.peers[$i].\"peer-address\"" "$c")
+    [[ -z $current_peer_ip || $current_peer_ip == "null" ]] && continue
 
-        # 5. Search SLS data for the reservation matching the current_peer_ip
-        match_info=$(echo "$SLS_NETWORKS_JSON" | jq -c --arg ip "$current_peer_ip" '
+    # 5. Search SLS data for the reservation matching the current_peer_ip
+    match_info=$(echo "$SLS_NETWORKS_JSON" | jq -c --arg ip "$current_peer_ip" '
             first(
                 .[] | select(.ExtraProperties.Subnets) | . as $network |
                 .ExtraProperties.Subnets[] | select(.IPReservations and (.Name == "network_hardware" or .Name == "bootstrap_dhcp")) |
@@ -153,16 +153,16 @@ if yq4 eval '.spec.network.metallb.peers' "$c" &> /dev/null; then
             )
         ')
 
-        # 6. Extract device name and network
-        if [[ -n "$match_info" ]]; then
-            device_name=$(echo "$match_info" | jq -r '.deviceName')
-            device_network=$(echo "$match_info" | jq -r '.deviceNetwork')
+    # 6. Extract device name and network
+    if [[ -n $match_info ]]; then
+      device_name=$(echo "$match_info" | jq -r '.deviceName')
+      device_network=$(echo "$match_info" | jq -r '.deviceNetwork')
 
-            # 7. Add the fields for the current peer index in the temp file
-            yq4 eval -i ".spec.network.metallb.peers[$i].\"device-name\" = \"${device_name}\"" "$c"
-            yq4 eval -i ".spec.network.metallb.peers[$i].\"device-network\" = \"${device_network}\"" "$c"
-        fi
-    done
+      # 7. Add the fields for the current peer index in the temp file
+      yq4 eval -i ".spec.network.metallb.peers[$i].\"device-name\" = \"${device_name}\"" "$c"
+      yq4 eval -i ".spec.network.metallb.peers[$i].\"device-network\" = \"${device_network}\"" "$c"
+    fi
+  done
 fi
 
 # lower cpu request for tds systems (4 workers)


### PR DESCRIPTION
# Description
This change modifies the `update_customizations.sh` script to add MetalLB `device-name` and `device-network` to `customizations.yaml` for each peer in the case of an upgrade. This is necessary because, due to a MetalLB upgrade that switches from using ConfigMaps to using CRDs, more information is needed to properly configure MetalLB. 

Relates to:
- Chart update: https://github.com/Cray-HPE/cray-metallb/pull/14
- cray-site-init update for fresh install: https://github.com/Cray-HPE/cray-site-init/pull/472

# Testing
Original customizations.yaml metallb content:
```yaml
    metallb:
      peers:
        - peer-address: 10.252.0.2
          peer-asn: 65533
          my-asn: 65531
        - peer-address: 10.252.0.3
          peer-asn: 65533
          my-asn: 65531
        - peer-address: 10.103.5.2
          peer-asn: 65533
          my-asn: 65532
        - peer-address: 10.103.5.3
          peer-asn: 65533
          my-asn: 65532
```
After running `./update-customizations.sh`:
```yaml
    metallb:
      peers:
        - peer-address: 10.252.0.2
          peer-asn: 65533
          my-asn: 65531
          device-name: sw-spine-001
          device-network: nmn
        - peer-address: 10.252.0.3
          peer-asn: 65533
          my-asn: 65531
          device-name: sw-spine-002
          device-network: nmn
        - peer-address: 10.103.5.2
          peer-asn: 65533
          my-asn: 65532
          device-name: sw-spine-001
          device-network: cmn
        - peer-address: 10.103.5.3
          peer-asn: 65533
          my-asn: 65532
          device-name: sw-spine-002
          device-network: cmn
```

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
