### PR TITLE
CASMINST-7274: Create 1.6.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ documentation improvements. This page lists some of the highlights.
 This is the release notes page for CSM 1.6.0. Each patch for CSM 1.6 has its own release notes, detailing what
 changes it includes.
 
+* [CSM 1.6.2 Release Notes](RELEASE_NOTES_1.6.2.md)
 * [CSM 1.6.1 Release Notes](RELEASE_NOTES_1.6.1.md)
 
 ## Features
@@ -26,13 +27,14 @@ changes it includes.
 * iSCSI
     * See [iSCSI SBPS](operations/iscsi_sbps/iscsi_sbps.md) for
       details on iSCSI based boot content projection for `rootfs` and `PE` images.
-* Multi-Tenancy
-* Bonded HSN interfaces supporting Slingshot resiliency
-* HPE Cray OS 24.2
+* [Multi-Tenancy](operations/multi-tenancy/Overview.md)
+* Bonded [High Speed Network (HSN)](glossary.md#high-speed-network-hsn) interfaces supporting [Slingshot](glossary.md#slingshot) resiliency
+* [HPE Cray OS (COS)](glossary.md#cray-operating-system-cos) 24.2
 * SLES 15 SP6
-* SHS 11.1
-* CSM can now be upgraded with IUF. See [Upgrade CSM](upgrade/README.md) for more details.
-* The [BOS](glossary.md#boot-orchestration-service-bos) API now enforces limits that previously had
+* [Slingshot Host Software (SHS)](glossary.md#slingshot-host-software-shs) 11.1
+* CSM can now be upgraded with the [Install and Upgrade Framework (IUF)](glossary.md#install-and-upgrade-framework-iuf).
+    * See [Upgrade CSM](upgrade/README.md) for more details.
+* The [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos) API now enforces limits that previously had
   only been recommended. When updating to CSM 1.6, BOS data is migrated to be in compliance with the
   API specification. See [BOS data notice](upgrade/README.md#bos-data-notice) for more details.
 * The [System Admin Toolkit (SAT)](glossary.md#system-admin-toolkit-sat) is fully included in CSM.
@@ -97,7 +99,7 @@ information, see [SAT in CSM](operations/system_admin_toolkit/about_sat/SAT_in_C
 
 ### Scale
 
-* Performance improvements in BOS and CFS on large scale systems.
+* Performance improvements in BOS and the [Configuration Framework Service (CFS)](glossary.md#configuration-framework-service-cfs) on large scale systems.
 
 ### Security
 
@@ -129,13 +131,13 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * CSM 1.6.0 does not support servers with NVIDIA CPUs and GPUs.
     * Systems with these servers should not be upgraded to CSM 1.6.0.
     * CSM 1.6.1 and later support servers with NVIDIA CPUs and GPUs.
-* CSM 1.5.4 included fixes to `BSS` and `cfs-trust` to allow large scale parallel boots of compute nodes.
+* CSM 1.5.4 included fixes to the [Boot Script Service (BSS)](glossary.md#boot-script-service-bss) and `cfs-trust` to allow large scale parallel boots of compute nodes.
   These changes did not make it into CSM 1.6.0 or CSM 1.6.1, but will be present in CSM 1.6.2 and CSM 1.7.0.
   Workarounds until then include:
     * Boot in smaller sets of compute nodes
     * Disable debug logging in BSS by changing `BSS_DEBUG` from "true" to "false" in the `cray-bss` deployment.
       This may allow slightly larger sets of compute nodes to boot in parallel.
-* After updating Paradise BMC firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
+* After updating Paradise [BMC](glossary.md#baseboard-management-controller-bmc) firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
     * See [Updating Foxconn Paradise Nodes with FAS](operations/firmware/FAS_Paradise.md) for details on how to do this
 * `cfs-api` pods in CLBO state during CSM install.
     * When installing CSM 1.6, `cray-shared-kafka-kafka-` pods in the services namespace fail to come up which results in `cfs-api` pods in CLBO state.
@@ -148,14 +150,16 @@ see [Removals](introduction/deprecated_features/README.md#removals)
     * A workaround is presented in [IUF does not run the next stage for an activity](troubleshooting/known_issues/iuf_unable_to_run_next_stage.md)
 * iSCSI based boot content projection may fail if the image to be projected does not have an `etag`
     * A workaround is presented in [iSCSI SBPS boot failure](troubleshooting/known_issues/SBPS_boot_fail.md)
-* CANU 1.8.0 and later is known to cause a brief NMN network outage.
+* [CSM Automatic Network Utility (CANU)](glossary.md#csm-automatic-network-utility-canu) 1.8.0 and later is known to cause a brief
+  [Node Management Network (NMN)](glossary.md#node-management-network-nmn) network outage.
     * CANU 1.8.0 and later introduce a separation of administrative traffic and user traffic on the management network
       via addition of a new VRF and OSPF area. Until all switches are updated and new routes are propagated, there is a
       brief NMN network outage. IP addressing does not change, but NMN traffic will flow over a new isolated VRF
       channel. The length of the outage is dependent on the time to apply new switch configurations to all management
       network switches - OSPF will propagate routes within seconds. As this affects liquid-cooled Mountain cabinets,
       running jobs may be affected. A dedicated outage window is highly recommended for applying these changes.
-* SMA 1.10.15 and later includes an upgraded LDMS that introduces an incompatibility with configuration files used in prior versions.
+* [System Monitoring Application (SMA)](glossary.md#system-monitoring-application-sma) 1.10.15 and later includes an upgraded LDMS that introduces an incompatibility with
+  configuration files used in prior versions.
     * When upgrading from an older SMA version to a version with this new LDMS, the administrator must change the configuration files.
     * A workaround is presented as an Action in the deliver-product stage in the **IUF Stage Details for SMA** section of the _HPE Cray Supercomputing EX System Monitoring Application Installation Guide_.
 * Services that use PostgreSQL may fail when a Kubernetes master node is rebooted or rebuilt.
@@ -164,6 +168,8 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * There are resource leaks in several HMS services ([PCS](glossary.md#power-control-service-pcs), [SMD](glossary.md#hardware-state-manager-smd), hmcollector, and [FAS](glossary.md#firmware-action-service-fas))
     * This issue is partially resolved by a hotfix for the CSM 1.5.2 release and fully resolved in the CSM 1.5.3 and 1.6.1 releases
     * For more information, including a workaround, see [HMS Resource Leaks](troubleshooting/known_issues/HMS_Resource_Leaks.md).
+
+For a full list of known issues, see [Known issues](troubleshooting/README.md#known-issues).
 
 ## Resolved CASTs
 

--- a/RELEASE_NOTES_1.6.1.md
+++ b/RELEASE_NOTES_1.6.1.md
@@ -3,7 +3,8 @@
 This page documents the changes introduced by this patch, compared to the previous patch
 version of CSM.
 
-For the main CSM 1.6 release notes page, see [CSM 1.6 release notes](RELEASE_NOTES.md).
+For the main CSM 1.6 release notes page, including links to other patch release notes,
+see [CSM 1.6 release notes](RELEASE_NOTES.md).
 
 * [Additions and improvements](#additions-and-improvements)
 * [Bug fixes](#bug-fixes)
@@ -21,27 +22,33 @@ For the main CSM 1.6 release notes page, see [CSM 1.6 release notes](RELEASE_NOT
 * Update `cray-keycloak` for new `JobConditionType` `SuccessCriteriaMet`
 * Avoid infinite loop while uploading artifacts with `cray-nexus-setup` image
 * Allow customization of `ipxe` debug options
-* Make BOS migration pod more polite
-* TESTS: `cmsdev`: Add explicit check for blank CFS ID field
-* Update CFS API spec to reject invalid component creation/update requests
-* Bypass needless work in some CFS queries
-* Make CFS Options class thread-safe and more performant
-* Add ability to create CFS source and specify secret name instead of username/password
-* Update CFS API spec with actual status code for successful source restore
-* Improve CFS config delete performance on scale systems
-* Add context managers around BOS requests/sessions; enable paging of BOS components
-* PCS/TRS: Mitigate resource leaks / heavy usage
+* [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
+    * Make BOS migration pod more polite
+    * Add context managers around BOS requests/sessions; enable paging of BOS components
+* [Configuration Framework Service (CFS)](glossary.md#configuration-framework-service-cfs)
+    * Update CFS API spec to reject invalid component creation/update requests
+    * Bypass needless work in some CFS queries
+    * Make CFS Options class thread-safe and more performant
+    * Add ability to create CFS source and specify secret name instead of username/password
+    * Update CFS API spec with actual status code for successful source restore
+    * Improve CFS config delete performance on scale systems
+* [Power Control Service (PCS)](glossary.md#power-control-service-pcs)/TRS: Mitigate resource leaks / heavy usage
 * Cleanup previous/old SquashFS images during upgrade
-* Update `customization.yaml` for SMA Victoria metrics PVC size
-* Update "sat bootprep" to support CFS v2 or v3
-* Update "sat bootsys" to support CFS v2 or v3
-* SAT: Add ability to sort reports by multiple fields
+* Update `customization.yaml` for [System Monitoring Application (SMA)](glossary.md#system-monitoring-application-sma) Victoria metrics PVC size
+* [System Admin Toolkit (SAT)](glossary.md#system-admin-toolkit-sat)
+    * Update "sat bootprep" to support CFS v2 or v3
+    * Update "sat bootsys" to support CFS v2 or v3
+    * SAT: Add ability to sort reports by multiple fields
 
 ### Security
 
 * Remove `sshd` from `cray-console-operator` image
-* Fix CVEs in `artifactory.algol60.net/csm-docker/stable/cray-firmware-action:1.34.0`
-* Fix CANU generated switch configuration security concern
+* Fix CVEs in [Firmware Action Service (FAS)](glossary.md#firmware-action-service-fas) image `artifactory.algol60.net/csm-docker/stable/cray-firmware-action:1.34.0`
+* Fix [CSM Automatic Network Utility (CANU)](glossary.md#csm-automatic-network-utility-canu) generated switch configuration security concern
+
+### Tests
+
+* [`cmsdev`](troubleshooting/known_issues/sms_health_check.md): Add explicit check for blank CFS ID field
 
 ## Customer-requested
 
@@ -146,12 +153,12 @@ For the main CSM 1.6 release notes page, see [CSM 1.6 release notes](RELEASE_NOT
 
 ## Known issues
 
-* CSM 1.5.4 included fixes to `BSS` and `cfs-trust` to allow large scale parallel boots of compute nodes.
+* CSM 1.5.4 included fixes to the [Boot Script Service (BSS)](glossary.md#boot-script-service-bss) and `cfs-trust` to allow large scale parallel boots of compute nodes.
   These changes did not make it into CSM 1.6.1 but will be present in CSM 1.6.2 and CSM 1.7.0. Workarounds until then include:
     * Boot in smaller sets of compute nodes
     * Disable debug logging in BSS by changing `BSS_DEBUG` from "true" to "false" in the `cray-bss` deployment.
       This may allow slightly larger sets of compute nodes to boot in parallel.
-* After updating Paradise BMC firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
+* After updating Paradise [BMC](glossary.md#baseboard-management-controller-bmc) firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
     * See [Updating Foxconn Paradise Nodes with FAS](operations/firmware/FAS_Paradise.md) for details on how to do this
 * `cfs-api` pods in CLBO state during CSM install.
     * When installing CSM 1.6, `cray-shared-kafka-kafka-` pods in the services namespace fail to come up which results in `cfs-api` pods in CLBO state.
@@ -159,12 +166,12 @@ For the main CSM 1.6 release notes page, see [CSM 1.6 release notes](RELEASE_NOT
 * `istio-proxy` containers fail with too many open files.
     * This may happen when any pod with `istio injection` enabled is started.
     * A workaround is presented in [Istio-Proxy failing with too many open files](troubleshooting/known_issues/Istio-Proxy_failing_with_too_many_open_files.md)
-* IUF does not run the next stage for an activity
+* [Install and Upgrade Framework (IUF)](glossary.md#install-and-upgrade-framework-iuf) does not run the next stage for an activity
     * During CSM upgrade, IUF reports that multiple sessions are in progress for an activity.
     * A workaround is presented in [IUF does not run the next stage for an activity](troubleshooting/known_issues/iuf_unable_to_run_next_stage.md)
 * iSCSI based boot content projection may fail if the image to be projected does not have an `etag`
     * A workaround is presented in [iSCSI SBPS boot failure](troubleshooting/known_issues/SBPS_boot_fail.md)
-* CANU 1.8.0 and later is known to cause a brief NMN network outage.
+* CANU 1.8.0 and later is known to cause a brief [Node Management Network (NMN)](glossary.md#node-management-network-nmn) network outage.
     * CANU 1.8.0 and later introduce a separation of administrative traffic and user traffic on the management network
       via addition of a new VRF and OSPF area. Until all switches are updated and new routes are propagated, there is a
       brief NMN network outage. IP addressing does not change, but NMN traffic will flow over a new isolated VRF
@@ -177,3 +184,5 @@ For the main CSM 1.6 release notes page, see [CSM 1.6 release notes](RELEASE_NOT
 * Services that use PostgreSQL may fail when a Kubernetes master node is rebooted or rebuilt.
     * A PostgreSQL database may fail over without clients reconnecting to the new cluster leader.
     * A workaround is presented in [PostgreSQL Database is in Recovery](troubleshooting/known_issues/postgres_database_recovery.md)
+
+For a full list of known issues, see [Known issues](troubleshooting/README.md#known-issues).

--- a/RELEASE_NOTES_1.6.2.md
+++ b/RELEASE_NOTES_1.6.2.md
@@ -1,0 +1,66 @@
+# Cray System Management (CSM) 1.6.2 Release Notes
+
+This page documents the changes introduced by this patch, compared to the previous patch
+version of CSM.
+
+For the main CSM 1.6 release notes page, including links to other patch release notes,
+see [CSM 1.6 release notes](RELEASE_NOTES.md).
+
+* [Additions and improvements](#additions-and-improvements)
+* [Bug fixes](#bug-fixes)
+* [Known issues](#known-issues)
+
+## Additions and improvements
+
+### General
+
+* [Configuration Framework Service (CFS)](glossary.md#configuration-framework-service-cfs): Add bulk component update option to [Cray CLI](glossary.md#cray-cli-cray)
+    * For more information, see [Managing many components](operations/configuration_management/CFS_Commands_Cheat_Sheet.md#managing-many-components)
+
+### Security
+
+* Fixed CVEs in [the `cmsdev` test tool](troubleshooting/known_issues/sms_health_check.md), `cray-console-node`, and `cray-console-operator`
+
+### Test
+
+* Add CFS node personalization to the [Barebones Image Boot Test](troubleshooting/cms_barebones_image_boot.md)
+
+## Bug fixes
+
+* Fixes to the [Boot Script Service (BSS)](glossary.md#boot-script-service-bss) and `cfs-trust` to allow large scale parallel boots of compute nodes
+* Fix bug preventing [CFS batcher](operations/configuration_management/Automatic_Configuration_Management.md#cfs-batcher-scheduling)
+  from starting sessions on very large scale systems
+* [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos): Gracefully handle requests to validate session templates which do not exist
+
+## Known issues
+
+* After updating Paradise [BMC](glossary.md#baseboard-management-controller-bmc) firmware, the `hmcollector-poll` service will lose event subscriptions and must be restarted
+    * See [Updating Foxconn Paradise Nodes with FAS](operations/firmware/FAS_Paradise.md) for details on how to do this
+* `cfs-api` pods in CLBO state during CSM install.
+    * When installing CSM 1.6, `cray-shared-kafka-kafka-` pods in the services namespace fail to come up which results in `cfs-api` pods in CLBO state.
+    * A workaround is presented in [CFS API pods in CLBO](troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md).
+* `istio-proxy` containers fail with too many open files.
+    * This may happen when any pod with `istio injection` enabled is started.
+    * A workaround is presented in [Istio-Proxy failing with too many open files](troubleshooting/known_issues/Istio-Proxy_failing_with_too_many_open_files.md)
+* [Install and Upgrade Framework (IUF)](glossary.md#install-and-upgrade-framework-iuf) does not run the next stage for an activity
+    * During CSM upgrade, IUF reports that multiple sessions are in progress for an activity.
+    * A workaround is presented in [IUF does not run the next stage for an activity](troubleshooting/known_issues/iuf_unable_to_run_next_stage.md)
+* iSCSI based boot content projection may fail if the image to be projected does not have an `etag`
+    * A workaround is presented in [iSCSI SBPS boot failure](troubleshooting/known_issues/SBPS_boot_fail.md)
+* [CSM Automatic Network Utility (CANU)](glossary.md#csm-automatic-network-utility-canu) 1.8.0 and later is known to cause a brief
+  [Node Management Network (NMN)](glossary.md#node-management-network-nmn) network outage.
+    * CANU 1.8.0 and later introduce a separation of administrative traffic and user traffic on the management network
+      via addition of a new VRF and OSPF area. Until all switches are updated and new routes are propagated, there is a
+      brief NMN network outage. IP addressing does not change, but NMN traffic will flow over a new isolated VRF
+      channel. The length of the outage is dependent on the time to apply new switch configurations to all management
+      network switches - OSPF will propagate routes within seconds. As this affects liquid-cooled Mountain cabinets,
+      running jobs may be affected. A dedicated outage window is highly recommended for applying these changes.
+* [System Monitoring Application (SMA)](glossary.md#system-monitoring-application-sma) 1.10.15 and later includes an upgraded LDMS that introduces an incompatibility with
+  configuration files used in prior versions.
+    * When upgrading from an older SMA version to a version with this new LDMS, the administrator must change the configuration files.
+    * A workaround is presented as an Action in the deliver-product stage in the **IUF Stage Details for SMA** section of the *HPE Cray Supercomputing EX System Monitoring Application Installation Guide*.
+* Services that use PostgreSQL may fail when a Kubernetes master node is rebooted or rebuilt.
+    * A PostgreSQL database may fail over without clients reconnecting to the new cluster leader.
+    * A workaround is presented in [PostgreSQL Database is in Recovery](troubleshooting/known_issues/postgres_database_recovery.md)
+
+For a full list of known issues, see [Known issues](troubleshooting/README.md#known-issues).


### PR DESCRIPTION
This creates the 1.6.2 release notes page (as well as some light linting of the existing release notes pages).

I have updated it with the content that I am familiar with in CSM 1.6.2. Looking at the list of tickets that went into the release, I see some which may merit callouts in the release notes. I will be opening additional tickets and assigning them to the people who did that work, so they can update the release notes if needed. But that will happen in separate PRs, so no need to hold off merging this one in anticipation of those.

I am going to "backport" just one part of this PR -- adding the link from the release notes page to the main CSM known issues page.