### PR TITLE
CASMPET-7498: Rename MetalLB configInline to configInlineHistorical

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -120,6 +120,20 @@ yq4 -i eval ".spec.kubernetes.services[\"kyverno-policy\"].checkImagePolicy += (
 yq4 -i eval '.spec.kubernetes.services.["cray-hubble"].externalHostname = "hubble.cmn.{{ network.dns.external }}"' "$c"
 yq4 -i eval ".spec.proxiedWebAppExternalHostnames.customerManagement |= (. + [\"{{ kubernetes.services['cray-hubble'].externalHostname }}\"] | unique)" "$c"
 
+metallb_path='.spec.kubernetes.services."cray-metallb".metallb'
+config_inline_key='configInline'
+config_inline_new_key='configInlineHistorical'
+
+# Remove MetalLB configInline due to this feature being depracated in MetalLB upstream,
+# moving value to configInlineHistorical in case is needed to restore old configuration
+# information.
+if [ "$(yq4 eval "${metallb_path}.${config_inline_key}" "$c")" != "null" ]; then
+  # Copy the value from the old key to the new key
+  yq4 eval -i "${metallb_path}.${config_inline_new_key} = ${metallb_path}.${config_inline_key}" "$c"
+  # Delete the old key
+  yq4 eval -i "del(${metallb_path}.${config_inline_key})" "$c"
+fi
+
 if yq4 eval '.spec.network.metallb.peers' "$c" &> /dev/null; then
 
   # 1. Get SLS Authentication Token


### PR DESCRIPTION
# Description
In some upgrade cases, the `configInline` value was being passed to MetalLB via `customizations.yaml`. This feature was deprecated in MetalLB v0.13.0 and is no longer supported now that MetalLB has been upgraded to v0.14.9. This meant that, when that field was set in `customizations.yaml`

To solve this problem, this PR renames the `configInline` key to `configInlineHistorical`, which gets around the problem while keeping the values around in case they are needed to restore some old configuration information that was manually changed. 

Resolves: https://jira-pro.it.hpe.com:8443/browse/CASMPET-7498

# Testing
Confirm reproducing failure with this values.yaml file:
```
metallb:
  nameOverride: "metallb"
  fullnameOverride: metallb
  configInline:
    peers:
    - peer-address: 10.252.0.2
      peer-asn: 63533
      my-asn: 65533
```
Results in:
```
Error: UPGRADE FAILED: execution error at (cray-metallb/charts/metallb/templates/deprecated_configInline.yaml:2:4): Starting from v0.13.0 configInline is no longer supported. Please see https://metallb.universe.tf/#backward-compatibility
```

With the updated key, there is no failure:
```
metallb:
  nameOverride: "metallb"
  fullnameOverride: metallb
  configInlineHistorical:
    peers:
    - peer-address: 10.252.0.2
      peer-asn: 63533
      my-asn: 65533
```

Confirming the change actually takes place running `./update-customizations.yaml` using a file with this metallb section:
```
      cray-metallb:
        metallb:
          configInline:
            peers:
              - peer-address: 10.252.0.2
                peer-asn: 63533
                my-asn: 65533
```

Results in:
```
      cray-metallb:
        metallb:
          configInlineHistorical:
            peers:
              - peer-address: 10.252.0.2
                peer-asn: 63533
                my-asn: 65533
          speaker:
            resources:
              requests:
                cpu: 100m
                memory: 100Mi
              limits:
                cpu: '2'
                memory: 4Gi
          controller:
            resources:
              requests:
                cpu: 100m
                memory: 100Mi
              limits:
                cpu: '2'
                memory: 4Gi
```

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.