### PR TITLE
CASMTRIAGE-8116 - Known Issue improper permissions on console ssh key file.

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -83,6 +83,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [IMS Image Job Performance](../operations/image_management/Image_Job_Performance.md)
 * [Storage node `cloud-init` fails with 'Timed out waiting for device' error](./known_issues/storage_node_cloud_init_fails_with_timed_out.md)
+* [Console SSH Key Permissions](./known_issues/console_ssh_key_permissions.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/console_ssh_key_permissions.md
+++ b/troubleshooting/known_issues/console_ssh_key_permissions.md
@@ -1,0 +1,142 @@
+# Console SSH Key Permissions
+
+## Issue description
+
+Sometimes the permissions of the private key file used to connect with the Mountain nodes via SSH
+are not set correctly. This can cause the SSH connection to the node to fail. The log file will not
+contain the console output and interactive sessions will fail.
+
+## Error identification
+
+The console log file will contain an error message similar to the following:
+
+```text
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Permissions 0777 for '/var/log/console/conman.key' are too open.
+It is required that your private key files are NOT accessible by others.
+This private key will be ignored.
+Load key "/var/log/console/conman.key": bad permissions
+n0@x1000c5s5b0's password: 
+```
+
+## Fix procedure
+
+The workaround is to manually assign the correct permissions to the SSH private key file. This file is
+located on a shared volume mounted in the `cray-console-node` pods. Fixing the permissions of the file
+within one pod will resolve the issue for all pods.
+
+1. (`ncn-mw#`) Find the `cray-console-node` pod IDs.
+
+    ```bash
+    kubectl get pods -n services --no-headers -o wide | grep cray-console-node | awk '{print $1}'
+    ```
+
+   Example output:
+
+    ```text
+    cray-console-node-0
+    cray-console-node-1
+    ```
+
+1. (`ncn-mw#`) Log into one of the `cray-console-node` pods using their IDs.
+
+    ```bash
+    kubectl exec -n services -it CRAY-CONSOLE-NODE-POD-ID -- /bin/sh
+    ```
+
+1. (`pod#`) Find the permissions of the private key file.
+
+    ```bash
+    ls -la /var/log/console
+    ```
+
+    Example output:
+
+    ```text
+    total 3
+    drwxrwxrwx 2 nobody nobody    3 Feb 12 12:57 .
+    drwxrwxrwx 5 nobody nobody    4 Feb  7  2024 ..
+    -rwxrwxrwx 1 nobody nobody   20 Apr 22 16:23 TargetNodes.txt
+    -rwxrwxrwx 1 nobody nobody 1679 Feb 12 12:57 conman.key
+    -rwxrwxrwx 1 nobody nobody  381 Feb 12 12:57 conman.key.pub
+    ```
+
+1. (`pod#`) Correct the permissions of the private key file.
+
+    ```bash
+    chmod 600 /var/log/console/conman.key
+    ```
+
+1. (`pod#`) Verify that the permissions of the private key file are now correct.
+
+    ```bash
+    ls -la /var/log/console
+    ```
+
+    Example output:
+
+    ```text
+    total 3
+    drwxr-xr-x 2 nobody nobody    3 Feb 12 12:57 .
+    drwxr-xr-x 5 nobody nobody    4 Feb  7  2024 ..
+    -rwxrwxrwx 1 nobody nobody   20 Apr 22 16:23 TargetNodes.txt
+    -rw------- 1 nobody nobody 1679 Feb 12 12:57 conman.key
+    -rwxrwxrwx 1 nobody nobody  381 Feb 12 12:57 conman.key.pub
+    ```
+
+1. (`pod#`) Restart the `conmand` process.
+
+    In order for the new SSH key to be used, the `conmand` process must be restarted. This can be done
+    by sending a `SIGHUP` signal to the process.
+
+    1. Find the `conmand` process ID.
+
+        ```bash
+        ps -aux | grep conmand
+        ```
+
+        Example output:
+
+        ```text
+        nobody     88657  1.1  0.0 243624  4096 ?        Sl   21:37   0:03 conmand -F -v -c /etc/conman.conf
+        nobody     88716  0.0  0.0   5340  1024 pts/8    S+   21:42   0:00 grep conmand
+        ```
+
+        In this example, the conmand process ID is `88657`.
+
+    1. Send the `SIGHUP` signal to the conmand process.
+
+        ```bash
+        kill 88657
+        ```
+
+    1. Wait for the conmand process to restart. This can take a few seconds.
+
+        ```bash
+        ps -aux | grep conmand
+        ```
+
+        Example output:
+
+        ```text
+        nobody     88957  0.0  0.0 243624  4096 ?        Sl   21:37   0:03 conmand -F -v -c /etc/conman.conf
+        nobody     89116  0.0  0.0   5340  1024 pts/8    S+   21:42   0:00 grep conmand
+        ```
+
+        The conmand process ID will change to a new number.
+
+1. (`pod#`) Exit the pod.
+
+    ```bash
+    exit
+    ```
+
+1. (`ncn-mw#`) Restart the `conmand` process on the other `cray-console-node` pods.
+
+    The key file permissions are now correct for all pods, but the `conmand` process must be
+    restarted on the other pods as well. This can be done by sending a `SIGHUP` signal to the
+    `conmand` process on each pod.
+
+    Repeat the step 'Restart the `conmand` process' for each of the other `cray-console-node` pods.

--- a/upgrade/1.6.2/README.md
+++ b/upgrade/1.6.2/README.md
@@ -32,6 +32,7 @@ See [CSM 1.6.2 Release Notes](../../RELEASE_NOTES_1.6.2.md).
 1. [Verification](#verification)
 1. [Take Etcd manual backup](#take-etcd-manual-backup)
 1. [Complete upgrade](#complete-upgrade)
+1. [Relevant troubleshooting links for upgrade-related issues](#relevant-troubleshooting-links-for-upgrade-related-issues)
 
 ### Preparation
 
@@ -236,3 +237,13 @@ exit
 ```
 
 It is recommended to save the typescript file for later reference.
+
+### Relevant troubleshooting links for upgrade-related issues
+
+* Console Mountain SSH key permissions
+
+   Sometimes after the worker node rollout, the permissions of the private key file used to connect with the Mountain nodes via SSH
+   are not set correctly. This can cause the SSH connection to the node to fail. The log file will not
+   contain the console output and interactive sessions will fail.
+
+   To resolve this issue see [Console SSH Key Permissions](../../troubleshooting/known_issues/console_ssh_key_permissions.md).

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -186,3 +186,11 @@ The upgrade to CSM 1.6 is done through IUF. Follow one of the following two proc
    <line number> /usr/share/doc/csm/upgrade/scripts/upgrade/prerequisites.sh
    rsync -aq "${CSM_ARTI_DIR}"/chrony "${target_ncn}":/srv/cray/scripts/common/
    ```
+
+- Console Mountain SSH key permissions
+
+   Sometimes after the worker node rollout, the permissions of the private key file used to connect with the Mountain nodes via SSH
+   are not set correctly. This can cause the SSH connection to the node to fail. The log file will not
+   contain the console output and interactive sessions will fail.
+
+   To resolve this issue see [Console SSH Key Permissions](../troubleshooting/known_issues/console_ssh_key_permissions.md).


### PR DESCRIPTION
# Description

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8116

There is something in the upgrade process that is changing the permissions on the ssh private key file that is used to connect to the Mountain node consoles. This documents a manual workaround to resolve the issue.

This will be fixed in CSM-1.7.0, so this WAR is only needed in the release/1.6 documentation. 

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
