### PR TITLE
CASMTRIAGE-8077: IUF workflow does not start after the re-installation of Keycloak

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1149,13 +1149,3 @@ iscsi-sbps-targets-config
 
 - troubleshooting/debugging_with_hms_pprof_images.md
 mutexes
-
-- operations/iuf/IUF.md
-cray-product-catalog
-cray-nls
-client_id
-client_secret
-iuf
-keycloak
-unauthorized_client
-unexecuted

--- a/.spelling
+++ b/.spelling
@@ -1149,3 +1149,13 @@ iscsi-sbps-targets-config
 
 - troubleshooting/debugging_with_hms_pprof_images.md
 mutexes
+
+- operations/iuf/IUF.md
+cray-product-catalog
+cray-nls
+client_id
+client_secret
+iuf
+keycloak
+unauthorized_client
+unexecuted

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -856,23 +856,23 @@ The following actions may be useful if errors are encountered when executing `iu
 
  1. IUF workflow does not start after the reinstallation of Keycloak.
 
-    - IUF stores the client-id and client-secret used to authorize with keycloak during initialization of IUF backend. When keycloak is reinstalled, the `client_secret` is regenerated and the `client_secret` stored by IUF is no longer valid.
+    - IUF stores the `client_id` and `client_secret` used to authorize with Keycloak during initialization of IUF backend. When Keycloak is reinstalled, the `client_secret` is regenerated and the `client_secret` stored by IUF is no longer valid.
 
-    - The following error is seen in cray-nls pod (IUF backend) when IUF uses the stored `client_id` and `client_secret` to authorize with Keycloak:
+    - The following error is seen in `cray-nls` pod (IUF backend) when IUF uses the stored `client_id` and `client_secret` to authorize with Keycloak:
 
-         ```text
-         2025-04-14T06:25:58.143Z        ERROR   iuf/sessions_workflow_gen.go:210        Could not generate authToken Could not retrieve OIDC token:
-         Expected 200 response but instead got 401
-         {"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}
-         ```
+        ```text
+        2025-04-14T06:25:58.143Z        ERROR   iuf/sessions_workflow_gen.go:210        Could not generate authToken Could not retrieve OIDC token:
+        Expected 200 response but instead got 401
+        {"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}
+        ```
 
-    - To start IUF workflows again, restart the cray-nls pods in argo namespace using the following command:
+    - To start IUF workflows again, restart the `cray-nls` pods in `argo` namespace using the following command:
 
          ```bash
          kubectl rollout restart deployment cray-nls -n argo
          ```
 
-    - After cray-nls pods are restarted, reissue the iuf command that was previously being attempted.
+    - After `cray-nls` pods are restarted, reissue the `iuf` command that was previously being attempted.
 
 ## Install and Upgrade Observability Framework
 

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -840,21 +840,21 @@ The following actions may be useful if errors are encountered when executing `iu
 
 ### 4. Specific scenarios
 
- 1. IUF workflow may loop while rebuilding a management node.
+1. IUF workflow may loop while rebuilding a management node.
 
     - IUF loops while waiting for CFS to complete configuration of a management node. This step might not be completing because the CFS error count for the node has exceeded the maximum retry count for applying the configuration.
     - Look at the Ansible logs for the CFS configuration operation for that node and attempt to rectify the problem.
     - After resolving the problem, update the default error count in CFS using the below command. Run this command form a master or worker node. Set environment variable `XNAME` to be the xname of the node where the CFS configuration has failed.
 
-         ```bash
-         cray cfs components update --enabled true --state '[]' --error-count 0 --format json $XNAME
-         ```
+        ```bash
+        cray cfs components update --enabled true --state '[]' --error-count 0 --format json $XNAME
+        ```
 
     - Once the error count is reset, the CFS will restart configuration for the node. If it does not start within a few minutes,
-   check whether CFS is unable to start the configuration again for the node due to any other issue. Rectify the problem by referring to the
-   [CFS troubleshooting guide](../../operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md)
+      check whether CFS is unable to start the configuration again for the node due to any other issue. Rectify the problem by referring to the
+      [CFS troubleshooting guide](../../operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 
- 1. IUF workflow does not start after the reinstallation of Keycloak.
+1. IUF workflow does not start after the reinstallation of Keycloak.
 
     - IUF stores the `client_id` and `client_secret` used to authorize with Keycloak during initialization of IUF backend. When Keycloak is reinstalled, the `client_secret` is regenerated and the `client_secret` stored by IUF is no longer valid.
 
@@ -868,9 +868,9 @@ The following actions may be useful if errors are encountered when executing `iu
 
     - To start IUF workflows again, restart the `cray-nls` pods in `argo` namespace using the following command:
 
-         ```bash
-         kubectl rollout restart deployment cray-nls -n argo
-         ```
+        ```bash
+        kubectl rollout restart deployment cray-nls -n argo
+        ```
 
     - After `cray-nls` pods are restarted, reissue the `iuf` command that was previously being attempted.
 

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -854,6 +854,26 @@ The following actions may be useful if errors are encountered when executing `iu
    check whether CFS is unable to start the configuration again for the node due to any other issue. Rectify the problem by referring to the
    [CFS troubleshooting guide](../../operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 
+ 1. IUF workflow does not start after the reinstallation of Keycloak.
+
+    - IUF stores the client-id and client-secret used to authorize with keycloak during initialization of IUF backend. When keycloak is reinstalled, the `client_secret` is regenerated and the `client_secret` stored by IUF is no longer valid.
+
+    - The following error is seen in cray-nls pod (IUF backend) when IUF uses the stored `client_id` and `client_secret` to authorize with Keycloak:
+
+         ```text
+         2025-04-14T06:25:58.143Z        ERROR   iuf/sessions_workflow_gen.go:210        Could not generate authToken Could not retrieve OIDC token:
+         Expected 200 response but instead got 401
+         {"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}
+         ```
+
+    - To start IUF workflows again, restart the cray-nls pods in argo namespace using the following command:
+
+         ```bash
+         kubectl rollout restart deployment cray-nls -n argo
+         ```
+
+    - After cray-nls pods are restarted, reissue the iuf command that was previously being attempted.
+
 ## Install and Upgrade Observability Framework
 
 The Install and Upgrade Observability Framework includes assertions for Goss health checks, as well as metrics and dashboards for health checks.


### PR DESCRIPTION

# Description

CASMTRIAGE-8077 IUF workflow does not start after the re-installation of Keycloak

cray-nls not able to validate "admin-client" id with keycloak
Restart the cray-nls pods

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
