### PR TITLE
CASMCMS-9318 - add multi-tenancy to console services and create cray cli module for user interaction.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 
 ### Miscellaneous functionality
 
+* Console logs and interaction is now available and tenant aware through the cray cli, see [console](operations/conman/ConMan.md#console) for more information.
+
 ### New hardware support
 
 ### New software support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ### Miscellaneous functionality
 
-* Console logs and interaction is now available and tenant aware through the cray cli, see [console](operations/conman/ConMan.md#console) for more information.
+* Console logs and interaction is now available and tenant aware through the `cray` CLI, see [console](operations/conman/ConMan.md#console) for more information.
 
 ### New hardware support
 

--- a/api/console.md
+++ b/api/console.md
@@ -1,0 +1,223 @@
+<h1 id="console-service">Console Service v1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from
+the tabs above or the mobile navigation menu.
+
+The Console Service provides access to node console logs and interactive console sessions
+for nodes in the system. These are accessed via websocket connections.
+
+# Base URL
+
+* <a href="wss://api-gw-service-nmn.local/apis/console-operator/console-operator">wss://api-gw-service-nmn.local/apis/console-operator/console-operator</a>
+
+## Workflow: Opening an Interactive Console Session
+
+`GET /interact/{node_id}`
+
+*Interact with the console of `node_id`*
+
+A successful interaction will not return a response. Instead, the connection will be
+upgraded to a websocket connection. The client can then send and receive messages
+over the websocket connection.
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|Cray-Tenant-Name|header|[TenantName](#schematenantname)|false|Tenant name.|
+|Authorization|header|string|false|Bearer token for authentication.|
+|Connection|header|string|false|"Upgrade"|
+|Upgrade|header|string|false|"websocket"|
+
+> Example responses
+
+> 403 Forbidden Response
+
+This is typically returned when the user does not have permission to access the node.
+
+```json
+{
+  "message": "string"
+}
+
+
+> 404 Not Found Response
+
+This is typically returned when the node does not exist.
+
+```json
+{
+  "message": "string"
+}
+```
+
+## Workflow: Following Console Logs
+
+`GET /interact/{node_id}`
+
+*Interact with the console of `node_id`*
+
+A successful interaction will not return a response. Instead, the connection will be
+upgraded to a websocket connection. The client can then receive messages when content is
+written to the node's console.
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|Cray-Tenant-Name|header|[TenantName](#schematenantname)|false|Tenant name.|
+|Cray-Console-Lines|header|int|false|Number of previous lines to display|
+|Cray-Console-Follow|header|string|false|"Upgrade"|
+|Authorization|header|string|false|Bearer token for authentication.|
+|Connection|header|string|false|"Upgrade"|
+|Upgrade|header|string|false|"websocket"|
+
+> Example responses
+
+> 403 Forbidden Response
+
+This is typically returned when the user does not have permission to access the node.
+
+```json
+{
+  "message": "string"
+}
+
+> 404 Not Found Response
+
+This is typically returned when the node does not exist.
+
+```json
+{
+  "message": "string"
+}
+```
+
+## Code Samples
+
+Here is sample python code to create a websocket client for interacting with both console
+endpoints. This code uses the `websockets` library to create a websocket client and
+`aioconsole` to handle user input. The code is designed to be run in an asyncio event loop.
+
+```python
+import asyncio
+import websockets
+import aioconsole
+import json
+
+###########################################################################
+# helper function to run the websocket terminal interaction
+###########################################################################
+async def websocket_terminal_interaction(ctx, endpoint: str, headers: dict[str,str]) -> str:
+    # set up the return value
+    errMsg = ""
+    
+    # pull information from context
+    auth = ctx.obj["auth"]
+    tenant = ctx.get('core.tenant', "")
+
+    # add auth header
+    token = ""
+    if auth and auth.session and auth.session.access_token:
+        token = auth.session.access_token
+    if token != "":
+        headers["Authorization"] = f"Bearer {token}"
+
+    # add tenant header
+    if tenant:
+        headers["Cray-Tenant-Name"] = tenant
+
+    # build the uri from the hostname and endpoint - note secure websocket
+    uri = f"wss://api-gw-service-nmn.local/{endpoint}"
+
+    try:
+        # connect to the websocket
+        async with websockets.connect(uri, additional_headers=headers) as websocket:
+            print(f"Connected to {uri}")
+
+            async def send_messages():
+                while True:
+                    try:
+                        message = await aioconsole.ainput("")
+                        await websocket.send(message)
+                    except asyncio.CancelledError:
+                        break
+                    except Exception as e:
+                        print(f"Error sending message: {e}")
+                        break
+
+            async def receive_messages():
+                while True:
+                    try:
+                        message = await websocket.recv()
+                        print(f"{message}", end='', flush=True)
+                    except websockets.ConnectionClosed:
+                        print("Connection closed by the server.")
+                        break
+                    except Exception as e:
+                        print(f"Error receiving message: {e}")
+                        break
+
+            send_task = asyncio.create_task(send_messages())
+            receive_task = asyncio.create_task(receive_messages())
+
+            done, pending = await asyncio.wait(
+                [send_task, receive_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for task in pending:
+                task.cancel()
+    except websockets.InvalidStatus as e:
+        # Expect this to be an unauthorized tenant, try to pull details
+        # from the response body
+        errMsg = "Websocket connection failed"
+        body = e.response.body
+        if body:
+            data = json.loads(body.decode('utf-8'))
+            errMsg = f"{data.get('message', errMsg)}"
+    except websockets.ConnectionClosed as e:
+        # handle the connection getting closed
+        errMsg = f"Connection closed: {e}"
+        body = e.response.body
+        if body:
+            data = json.loads(body.decode('utf-8'))
+            errMsg = f"{data.get('message', errMsg)}"
+    except Exception as e:
+        # gracefully handle any other exceptions
+        errMsg = f"Error: {e}"
+
+    return errMsg
+
+###########################################################################
+# cray console interact
+###########################################################################
+def interact(ctx, xname):
+    """ Interact with the console. """
+    headers = {}
+    endpoint = f"apis/console-operator/console-operator/interact/{xname}"
+    errMsg = asyncio.run(websocket_terminal_interaction(ctx, endpoint, headers))
+
+    # if there was an error, print the help, then the error message
+    if errMsg:
+        print(f"\n\nERROR: {errMsg}")
+
+###########################################################################
+# cray console log
+###########################################################################
+def tail(ctx, xname, lines, follow):
+    """ Tail the console output. """
+
+    # pull out the options and load into the headers
+    headers = {}
+    if lines:
+        headers["Cray-Console-Lines"] = str(lines)
+    if follow:
+        headers["Cray-Console-Follow"] = str(follow)
+
+    # open the websocket
+    endpoint = f"apis/console-operator/console-operator/tail/{xname}"
+    errMsg = asyncio.run(websocket_terminal_interaction(ctx, endpoint, headers))
+
+    # if there was an error, print the help, then the error message
+    if errMsg:
+        print(f"\n\nERROR: {errMsg}")
+```

--- a/api/console.md
+++ b/api/console.md
@@ -35,6 +35,7 @@ over the websocket connection.
 {
   "message": "string"
 }
+```
 
 <h3 id="interact_get-responses">Responses</h3>
 
@@ -72,6 +73,7 @@ written to the node's console.
 {
   "message": "string"
 }
+```
 
 <h3 id="tail_get-responses">Responses</h3>
 

--- a/api/console.md
+++ b/api/console.md
@@ -31,29 +31,23 @@ over the websocket connection.
 
 > 403 Forbidden Response
 
-This is typically returned when the user does not have permission to access the node.
-
 ```json
 {
   "message": "string"
 }
 
+<h3 id="interact_get-responses">Responses</h3>
 
-> 404 Not Found Response
-
-This is typically returned when the node does not exist.
-
-```json
-{
-  "message": "string"
-}
-```
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|403|[Forbidden Response](https://tools.ietf.org/html/rfc7231#section-6.5.3)|User does not have permission to access the node.|Inline|
+|404|[Not Found Response](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The node does not exist.|Inline|
 
 ## Workflow: Following Console Logs
 
-`GET /interact/{node_id}`
+`GET /tail/{node_id}`
 
-*Interact with the console of `node_id`*
+*Tail the console's log file of `node_id`*
 
 A successful interaction will not return a response. Instead, the connection will be
 upgraded to a websocket connection. The client can then receive messages when content is
@@ -74,22 +68,35 @@ written to the node's console.
 
 > 403 Forbidden Response
 
-This is typically returned when the user does not have permission to access the node.
-
 ```json
 {
   "message": "string"
 }
 
-> 404 Not Found Response
+<h3 id="tail_get-responses">Responses</h3>
 
-This is typically returned when the node does not exist.
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|403|[Forbidden Response](https://tools.ietf.org/html/rfc7231#section-6.5.3)|User does not have permission to access the node.|Inline|
+|404|[Not Found Response](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The node does not exist.|Inline|
+
+<h2 id="schematenantname">V2TenantName</h2>
 
 ```json
-{
-  "message": "string"
-}
+"string"
+
 ```
+
+Name of the tenant that owns this resource. Only used in environments
+with multi-tenancy enabled. An empty string or null value means the resource
+is not owned by a tenant. The absence of this field from a resource indicates
+the same.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string¦null|false|read-only|Name of the tenant that owns this resource. Only used in environments<br>with multi-tenancy enabled. An empty string or null value means the resource<br>is not owned by a tenant. The absence of this field from a resource indicates<br>the same.|
 
 ## Code Samples
 

--- a/api/console.md
+++ b/api/console.md
@@ -82,7 +82,7 @@ written to the node's console.
 |403|[Forbidden Response](https://tools.ietf.org/html/rfc7231#section-6.5.3)|User does not have permission to access the node.|Inline|
 |404|[Not Found Response](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The node does not exist.|Inline|
 
-<h2 id="schematenantname">V2TenantName</h2>
+<h2 id="schematenantname">TenantName</h2>
 
 ```json
 "string"

--- a/api/console.md
+++ b/api/console.md
@@ -6,9 +6,11 @@ the tabs above or the mobile navigation menu.
 The Console Service provides access to node console logs and interactive console sessions
 for nodes in the system. These are accessed via websocket connections.
 
-# Base URL
+## Base URL
 
-* <a href="wss://api-gw-service-nmn.local/apis/console-operator/console-operator">wss://api-gw-service-nmn.local/apis/console-operator/console-operator</a>
+The Console Service is available at the following base URL:
+["wss://api-gw-service-nmn.local/apis/console-operator/console-operator"](wss://api-gw-service-nmn.local/apis/console-operator/console-operator)
+
 
 ## Workflow: Opening an Interactive Console Session
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -412,6 +412,7 @@ troubleshooting node boot issues.
 - [Troubleshoot Console Node Pod Stuck in Terminating State](conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
 - [Complete Reset of the Console Services](conman/Complete_Reset_of_the_Console_Services.md)
 - [Console known issues](../troubleshooting/README.md#conman)
+- [Console API](../api/console.md)
 
 ## Utility storage
 

--- a/operations/conman/Access_Compute_Node_Logs.md
+++ b/operations/conman/Access_Compute_Node_Logs.md
@@ -5,12 +5,12 @@ This procedure shows how the ConMan utility can be used to retrieve compute node
 ## Prerequisites
 
 * The Cray CLI is configured.
-  * See [Configure the Cray CLI](../configure_cray_cli.md).
+    * See [Configure the Cray CLI](../configure_cray_cli.md).
 
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* If the user is a member of a tenant only the logs for that tenant are available. 
+* If the user is a member of a tenant only the logs for that tenant are available.
 
 ## Procedure
 

--- a/operations/conman/Access_Compute_Node_Logs.md
+++ b/operations/conman/Access_Compute_Node_Logs.md
@@ -26,7 +26,7 @@ This procedure shows how the ConMan utility can be used to retrieve compute node
     cray console tail \
         --lines 20 \
         --follow \
-        XNAME
+        $XNAME
     ```
 
     Example output:

--- a/operations/conman/Access_Compute_Node_Logs.md
+++ b/operations/conman/Access_Compute_Node_Logs.md
@@ -10,7 +10,7 @@ This procedure shows how the ConMan utility can be used to retrieve compute node
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* If the user is a member of a tenant only the logs for that tenant are available.
+* If the user is a member of a tenant, then only the logs for that tenant are available.
 
 ## Procedure
 
@@ -20,10 +20,10 @@ This procedure shows how the ConMan utility can be used to retrieve compute node
 
 1. (`ncn-mw#`) Start tailing the console log.
 
-    Execute the `cray conman tail` command to start tailing the console log for a specific node.
+    Execute the `cray console tail` command to start tailing the console log for a specific node.
 
     ```bash
-    cray conman tail \
+    cray console tail \
         --lines 20 \
         --follow \
         XNAME

--- a/operations/conman/Access_Compute_Node_Logs.md
+++ b/operations/conman/Access_Compute_Node_Logs.md
@@ -4,59 +4,51 @@ This procedure shows how the ConMan utility can be used to retrieve compute node
 
 ## Prerequisites
 
-The user performing this procedure needs to have access permission to the `cray-console-operator` pod.
+* The Cray CLI is configured.
+  * See [Configure the Cray CLI](../configure_cray_cli.md).
 
 ## Limitations
 
-Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
+* Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
+* If the user is a member of a tenant only the logs for that tenant are available. 
 
 ## Procedure
 
-> **`NOTE`** this procedure has changed since the CSM 0.9 release.
+> **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
 1. Log on to a Kubernetes master or worker node.
 
-1. (`ncn-mw#`) Find the `cray-console-operator` pod.
+1. (`ncn-mw#`) Start tailing the console log.
+
+    Execute the `cray conman tail` command to start tailing the console log for a specific node.
 
     ```bash
-    OP_POD=$(kubectl get pods -n services \
-            -o wide|grep cray-console-operator|awk '{print $1}')
-    echo $OP_POD
+    cray conman tail \
+        --lines 20 \
+        --follow \
+        XNAME
     ```
 
     Example output:
 
     ```text
-    cray-console-operator-6cf89ff566-kfnjr
+    Connected to wss://api-gw-service-nmn.local/apis/console-operator/console-operator/tail/x3000c0s19b1n0
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 11:00:00 UTC.
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 12:00:00 UTC.
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 13:00:00 UTC.
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 14:00:00 UTC.
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 15:00:00 UTC.
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 16:00:00 UTC.
     ```
 
-1. (`ncn-mw#`) Log on to the pod.
+1. (`ncn-mw#`) Stop the tailing of the console log.
 
-    ```bash
-    kubectl exec -it -n services $OP_POD  -c cray-console-operator -- sh
-    ```
+    Press `Ctrl-C` twice to stop the tailing of the console log.
 
-1. The console log file for each node is labeled with the component name (xname) of that node.
+    Example output:
 
-    List the log directory contents.
-
-    ```bash
-    # ls -la /var/log/conman
-    total 44
-    -rw------- 1 root root 1415 Nov 30 20:00 console.XNAME
-    ...
-    ```
-
-    > The log directory is also accessible from the `cray-console-node` pods.
-
-1. The log files are plain text files which can be viewed with commands like `cat` or `tail`.
-
-    ```bash
-    tail /var/log/conman/console.XNAME
-    ```
-
-1. Exit out of the pod.
-
-    ```bash
-    exit
+    ```text
+    <ConMan> Console [x3000c0s19b1n0] log at 2025-04-22 15:00:00 UTC.
+    ^C^C
+    Aborted!
     ```

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -2,11 +2,13 @@
 
 ConMan is a tool used for connecting to remote consoles and collecting console logs. These node logs can then be used for various administrative purposes, such as troubleshooting node boot issues.
 
-ConMan runs on the system as a containerized service. It runs in a set of Docker containers within Kubernetes pods named `cray-console-operator` and `cray-console-node`.
-Node console logs are stored locally within the `cray-console-node` pods in the `/var/log/conman/` directory, as well as being collected by the System Monitoring Framework \(SMF\).
+ConMan runs on the system as a containerized service. It runs in a set of Docker containers within Kubernetes pods
+named `cray-console-operator` and `cray-console-node`.
+Node console logs are stored locally within the `cray-console-node` pods in the `/var/log/conman/` directory, as well as being collected by
+the System Monitoring Framework \(SMF\).
 
-In CSM versions 1.0 and later, the ConMan logs and interactive consoles are accessible through one of the `cray-console-node` pods.
-There are multiple `cray-console-node` pods, scaled to the size of the system.
+In CSM versions 1.7.0 and later, the ConMan logs and interactive consoles are accessible through the Cray CLI. The `cray conman` command
+provides a set of subcommands for managing the ConMan service and
 
 ## How to use
 

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -8,7 +8,7 @@ Node console logs are stored locally within the `cray-console-node` pods in the 
 the System Monitoring Framework \(SMF\).
 
 In CSM versions 1.7.0 and later, the ConMan logs and interactive consoles are accessible through the Cray CLI. The `cray console` command
-provides a set of subcommands for managing the ConMan service and
+provides a set of subcommands for accessing the logs and interactive consoles.
 
 ## How to use
 
@@ -28,3 +28,6 @@ provides a set of subcommands for managing the ConMan service and
 - [Troubleshoot ConMan Failing to Connect to a Console](Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
 - [Troubleshoot ConMan Node Pod Stuck in Terminating](Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
 - [Complete Reset of the Console Services](Complete_Reset_of_the_Console_Services.md)
+
+## Web Interface
+- [Accessing the Console Web Interface](../../api/console.md)

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -29,6 +29,6 @@ provides a set of subcommands for accessing the logs and interactive consoles.
 - [Troubleshoot ConMan Node Pod Stuck in Terminating](Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
 - [Complete Reset of the Console Services](Complete_Reset_of_the_Console_Services.md)
 
-## Web Interface
+## Web interface
 
 - [Accessing the Console Web Interface](../../api/console.md)

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -3,11 +3,11 @@
 ConMan is a tool used for connecting to remote consoles and collecting console logs. These node logs can then be used for various administrative purposes, such as troubleshooting node boot issues.
 
 ConMan runs on the system as a containerized service. It runs in a set of Docker containers within Kubernetes pods
-named `cray-console-operator` and `cray-console-node`.
+in the `services` namespace named `cray-console-operator` and `cray-console-node`.
 Node console logs are stored locally within the `cray-console-node` pods in the `/var/log/conman/` directory, as well as being collected by
 the System Monitoring Framework \(SMF\).
 
-In CSM versions 1.7.0 and later, the ConMan logs and interactive consoles are accessible through the Cray CLI. The `cray conman` command
+In CSM versions 1.7.0 and later, the ConMan logs and interactive consoles are accessible through the Cray CLI. The `cray console` command
 provides a set of subcommands for managing the ConMan service and
 
 ## How to use

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -30,4 +30,5 @@ provides a set of subcommands for accessing the logs and interactive consoles.
 - [Complete Reset of the Console Services](Complete_Reset_of_the_Console_Services.md)
 
 ## Web Interface
+
 - [Accessing the Console Web Interface](../../api/console.md)

--- a/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
+++ b/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
@@ -84,13 +84,13 @@ The user performing these procedures needs to have access permission to the `cra
 1. (`ncn-mw#`) Establish a serial console session with the desired NCN.
 
     ```bash
-    kubectl -n services exec -it $NODE_POD -c cray-console-node -- conman -j $XNAME
+    cray console interact $XNAME
     ```
 
     The console session log files for each NCN are located in a shared volume in the `cray-console-node` pods.
     In those pods, the log files are in the `/var/log/conman/` directory and are named `console.<xname>`.
 
-1. Exit the connection to the console by entering `&.`.
+1. Exit the connection to the console by entering `&.``[Enter]`.
 
 ## Evacuation procedure
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -5,12 +5,12 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 ## Prerequisites
 
 * The Cray CLI is configured.
-  * See [Configure the Cray CLI](../configure_cray_cli.md).
+    * See [Configure the Cray CLI](../configure_cray_cli.md).
 
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* If the user is a member of a tenant only the logs for that tenant are available. 
+* If the user is a member of a tenant only the logs for that tenant are available.
 
 ## Procedure
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -10,7 +10,7 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* If the user is a member of a tenant only the logs for that tenant are available.
+* If the user is a member of a tenant, then only the logs for that tenant are available.
 
 ## Procedure
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -4,59 +4,47 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 
 ## Prerequisites
 
-The user performing this procedure needs to have access permission to the `cray-console-operator` and `cray-console-node` pods.
+* The Cray CLI is configured.
+  * See [Configure the Cray CLI](../configure_cray_cli.md).
+
+## Limitations
+
+* Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
+* If the user is a member of a tenant only the logs for that tenant are available. 
 
 ## Procedure
 
-> **`NOTE`** this procedure has changed since the CSM 0.9 release.
+> **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
 1. Log on to a Kubernetes master or worker node.
 
-1. (`ncn-mw#`) Find the `cray-console-operator` pod.
+1. (`ncn-mw#`) Connect to the node's console.
 
     ```bash
-    OP_POD=$(kubectl get pods -n services -o wide|grep cray-console-operator|awk '{print $1}'); echo $OP_POD
+    cray console interact $XNAME
     ```
 
     Example output:
 
     ```text
-    cray-console-operator-6cf89ff566-kfnjr
-    ```
+    Connected to wss://api-gw-service-nmn.local/apis/console-operator/console-operator/interact/x3000c0s19b1n0
 
-1. (`ncn-mw#`) Set the `XNAME` variable to the component name (xname) of the node whose console is to be opened.
+    <ConMan> Connection to console [x3000c0s19b1n0] opened.
 
-    ```bash
-    XNAME=x123456789s0c0n0
-    ```
-
-1. (`ncn-mw#`) Find the `cray-console-node` pod that is connected to that node.
-
-    ```bash
-    NODEPOD=$(kubectl -n services exec $OP_POD -c cray-console-operator -- sh -c "/app/get-node $XNAME" | jq .podname | sed 's/"//g')
-    echo $NODEPOD
-    ```
-
-    Example output:
-
-    ```text
-    cray-console-node-1
-    ```
-
-1. (`ncn-mw#`) Connect to the node's console using ConMan on the `cray-console-node` pod which was found.
-
-    ```bash
-    kubectl exec -it -n services $NODEPOD -c cray-console-node -- conman -j $XNAME
-    ```
-
-    Example output:
-
-    ```text
-    <ConMan> Connection to console [x3000c0s25b1] opened.
-
-    nid000009 login:
+    nid000001 login:
     ```
 
     Using the command above, a user can also attach to an already active SOL session that is being used by another user, so both can access the node's SOL simultaneously.
 
-1. Exit the connection to the console with the `&.` command.
+1. Exit the connection to the console with the `&.``[Enter]` command.
+
+    Example output:
+
+    ```text
+    <ConMan> Connection to console [x3000c0s19b1n0] opened.
+
+    nid000001 login:&.
+    &.
+    <ConMan> Connection to console [x3000c0s19b1n0] closed.
+    Connection closed by the server.
+    ```

--- a/operations/conman/Manage_Node_Consoles.md
+++ b/operations/conman/Manage_Node_Consoles.md
@@ -1,6 +1,7 @@
 # Manage Node Consoles
 
-ConMan is used for connecting to remote consoles and collecting console logs. These node logs can then be used for various administrative purposes, such as troubleshooting node boot issues.
+ConMan is used for connecting to remote consoles and collecting console logs. These node logs can then be used for various
+administrative purposes, such as troubleshooting node boot issues.
 
 ConMan runs on the system in a set of containers within Kubernetes pods named `cray-console-operator` and `cray-console-node`.
 
@@ -17,74 +18,12 @@ See [ConMan](ConMan.md) for other procedures related to remote consoles and node
 This procedure can be run from any member of the Kubernetes cluster to verify node consoles are being managed
 by ConMan and to connect to a console.
 
-**`NOTE`** this procedure has changed since the CSM 0.9 release.
+**`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
-1. (`ncn-mw#`) Find the `cray-console-operator` pod.
+1. Follow a node's console logs.
 
-    ```bash
-    OP_POD=$(kubectl get pods -n services \
-            -o wide|grep cray-console-operator|awk '{print $1}')
-    echo $OP_POD
-    ```
+    Follow the procedure in [Access Compute Node Logs](Access_Compute_Node_Logs.md) to follow the console logs of a node.
 
-    Example output:
+1. Interact with a node through its console.
 
-    ```text
-    cray-console-operator-6cf89ff566-kfnjr
-    ```
-
-1. (`ncn-mw#`) Find the `cray-console-node` pod that is connected to the node.
-
-    Be sure to substitute the actual component name (xname) of the node in the command below.
-
-    ```bash
-    XNAME=<xname>
-    NODEPOD=$(kubectl -n services exec $OP_POD -c cray-console-operator -- sh -c "/app/get-node $XNAME" | jq .podname | sed 's/"//g')
-    echo $NODEPOD
-    ```
-
-    Example output:
-
-    ```text
-    cray-console-node-2
-    ```
-
-1. (`ncn-mw#`) Log into the `cray-console-node` container in this pod:
-
-    ```bash
-    kubectl exec -n services -it $NODEPOD -c cray-console-node -- bash
-    ```
-
-    Example output:
-
-    ```text
-    cray-console-node#
-    ```
-
-1. Check the list of nodes being monitored.
-
-    ```bash
-    conman -q
-    ```
-
-    Output looks similar to the following:
-
-    ```text
-    x9000c0s1b0n0
-    x9000c0s20b0n0
-    x9000c0s22b0n0
-    x9000c0s24b0n0
-    x9000c0s27b1n0
-    x9000c0s27b2n0
-    x9000c0s27b3n0
-    ```
-
-1. Compute nodes or UANs are automatically added to this list a short time after they are discovered.
-
-1. To access the node's console, run the following command from within the pod. Again, remember to substitute the actual component name (xname) of the node.
-
-    ```bash
-    conman -j <xname>
-    ```
-
-    > **`NOTE`** The console session can be exited by entering `&.`
+    Follow the procedure in [Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md) to interact with a node through its console.

--- a/operations/node_management/Update_the_Gigabyte_Node_BIOS_Time.md
+++ b/operations/node_management/Update_the_Gigabyte_Node_BIOS_Time.md
@@ -7,50 +7,9 @@ which causes the node boot to drop into the `dracut` emergency shell.
 
 ## Procedure
 
-1. (`ncn-mw#`) Retrieve the `cray-console-operator` pod ID.
+1. (`ncn-mw#`) Connect to the node's console.
 
-    ```bash
-    CONPOD=$(kubectl get pods -n services -o wide|grep cray-console-operator|awk '{print $1}'); echo ${CONPOD}
-    ```
-
-    Example output:
-
-    ```text
-    cray-console-operator-79bf95964-qpcpp
-    ```
-
-The following steps should be repeated for each Gigabyte node which needs to have its BIOS time reset.
-
-1. (`ncn-mw#`) Set the `XNAME` variable to the component name (xname) of the node whose console you wish to open.
-
-    ```bash
-    XNAME=x3001c0s24b1n0
-    ```
-
-1. (`ncn-mw#`) Find the `cray-console-node` pod that is connected to that node.
-
-    ```bash
-    NODEPOD=$(kubectl -n services exec "${CONPOD}" -c cray-console-operator -- \
-            sh -c "/app/get-node ${XNAME}" | jq .podname | sed 's/"//g') ; echo ${NODEPOD}
-    ```
-
-    Example output:
-
-    ```text
-    cray-console-node-1
-    ```
-
-1. (`ncn-mw#`) Connect to the node's console using ConMan on the identified `cray-console-node` pod.
-
-    ```bash
-    kubectl exec -it -n services "${NODEPOD}" -- conman -j "${XNAME}"
-    ```
-
-    Example output:
-
-    ```text
-    <ConMan> Connection to console [x3001c0s24b1] opened.
-    ```
+    Follow the steps in the [Log in to a Node Using ConMan](../conman/Log_in_to_a_Node_Using_ConMan.md) procedure to connect to the node's console.
 
 1. (`ncn-mw#`) In another terminal, boot the node to BIOS.
 
@@ -87,6 +46,6 @@ The following steps should be repeated for each Gigabyte node which needs to hav
 
 1. Enter the `F10` key followed by the `Enter` key to save the BIOS time.
 
-1. Exit the connection to the console by entering `&.`.
+1. Exit the connection to the console by entering `&.``[Enter]`.
 
 1. Repeat the above steps for other nodes which need their BIOS time reset.


### PR DESCRIPTION
# Description
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9033

Update the documentation for the new console services api. This is now available through the cray cli rather than needing to interact directly with the console pods in K8S. The tenancy of the user is also checked prior to allowing interaction with a console.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
