### PR TITLE
CASMTRIAGE-8077: IUF workflow does not start after the re-installation of Keycloak

### DIFF
--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -804,6 +804,28 @@ The following actions may be useful if errors are encountered when executing `iu
 - If an Argo step fails, Argo will attempt to re-execute the step. If the retry succeeds, the failed step will still be displayed, colored red, in the Argo UI alongside the successful retry step, colored green. Although the failed
   step is still displayed, it did not affect the success of the overall workflow and can be ignored.
 
+### 1. Specific scenarios
+
+1. IUF workflow does not start after the reinstallation of Keycloak.
+
+    - IUF stores the `client_id` and `client_secret` used to authorize with Keycloak during initialization of IUF backend. When Keycloak is reinstalled, the `client_secret` is regenerated and the `client_secret` stored by IUF is no longer valid.
+
+    - The following error is seen in `cray-nls` pod (IUF backend) when IUF uses the stored `client_id` and `client_secret` to authorize with Keycloak:
+
+        ```text
+        2025-04-14T06:25:58.143Z        ERROR   iuf/sessions_workflow_gen.go:210        Could not generate authToken Could not retrieve OIDC token:
+        Expected 200 response but instead got 401
+        {"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}
+        ```
+
+    - To start IUF workflows again, restart the `cray-nls` pods in `argo` namespace using the following command:
+
+        ```bash
+        kubectl rollout restart deployment cray-nls -n argo
+        ```
+
+    - After `cray-nls` pods are restarted, reissue the `iuf` command that was previously being attempted.
+
 ## Install and Upgrade Observability Framework
 
 The Install and Upgrade Observability Framework includes assertions for Goss health checks, as well as metrics and dashboards for health checks.


### PR DESCRIPTION
# Description

CASMTRIAGE-8077 IUF workflow does not start after the re-installation of Keycloak
backport https://github.com/Cray-HPE/docs-csm/pull/5934 to release/1.5

cray-nls not able to validate "admin-client" id with keycloak
Restart the cray-nls pods

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
