### PR TITLE
CASMHMS-6483: Document Antero/ParryPeak power capping limitations (1.7)

### DIFF
--- a/operations/power_management/Power_Control_Service/Node_Card_Power_Management.md
+++ b/operations/power_management/Power_Control_Service/Node_Card_Power_Management.md
@@ -299,10 +299,12 @@ cray power cap set --xnames XNAME_LIST --control CONTROL_NAME 0 --format json
 cray power cap describe TASK_ID --format json
 ```
 
-Reset the power limit to the default maximum. Alternatively, using the max
-value returned from power cap snapshot may also be used. Multiple controls
-can be set at the same time on multiple nodes, but all target nodes must
-have the same set of controls available, otherwise the call will fail.
+Reset the power limit to the default maximum by setting the limit to 0.
+Alternatively, using the max value returned from power cap snapshot may
+also be used. For `HPE Cray EX4252` Antero and `HPE Cray EX255a` Parry
+Peak hardware, the max value must be used. Multiple controls can be set
+at the same time on multiple nodes, but all target nodes must have the
+same set of controls available, otherwise the call will fail.
 
 ```console
 cray power cap set \
@@ -375,6 +377,12 @@ Example output:
 ```
 
 ## Enable and Disable Power Limiting
+
+_NOTE:
+Power limiting on `HPE Cray EX4252` (Antero) and `HPE Cray EX255a`
+(Parry Peak) hardware cannot be disabled.  To effectively accomplish
+the same thing, set the power limit value to the max value returned
+from power cap snapshot._
 
 ### Enable Power Limiting
 


### PR DESCRIPTION
# Description

Document Antero/ParryPeak power capping limitations in CSM 1.7 docs

* Resolves [CASMHMS-6483](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6483)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.