### PR TITLE
CASMINST-7329 fix syntax in management-m001-rollout

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -181,9 +181,11 @@ spec:
                       else
                         echo "INFO Successfully completed master node ncn-m001 bootparameters update" 
                         touch /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done
+                      fi
                     else
                       echo "INFO Skipping master node ncn-m001 bootparameters update. It has previously been completed"
                       echo "INFO Note: To Re-run master node ncn-m001 bootparameters update, run the command: 'rm -f /etc/cray/upgrade/csm/${CSM_REL_NAME}/ncn-m001-bootparameters-update.done' "
+                    fi
           - name: upgrade-m001
             dependencies:
               - update-bootparams-m001


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

There was a recent change to the management-nodes-rollout when rolling out ncn-m001. This PR fixes syntax errors that broke this management nodes rollout stage.

This has been tested on a vShasta upgrade.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
