### PR TITLE
CASMHMS-6512: Remove references to ORCA relative to HMNFD

### DIFF
--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -10,7 +10,6 @@ That data needs to be repopulated in order for the cluster to go back to a healt
         - [BOS](#bos)
         - [BSS](#bss)
         - [FAS](#fas)
-        - [HMNFD](#hmnfd)
 
 ## Applicable services
 
@@ -19,7 +18,6 @@ The following services need their data repopulated in the etcd cluster:
 - Boot Orchestration Service \(BOS\)
 - Boot Script Service \(BSS\)
 - Firmware Action Service \(FAS\)
-- HMS Notification Fanout Daemon \(HMNFD\)
 - Mountain Endpoint Discovery Service \(MEDS\)
 
 ## Prerequisites
@@ -31,7 +29,6 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 - [BOS](#bos)
 - [BSS](#bss)
 - [FAS](#fas)
-- [HMNFD](#hmnfd)
 
 ### BOS
 
@@ -57,24 +54,3 @@ Image data will be reloaded from Nexus.
 Any images that were loaded into FAS outside of Nexus will need to be reloaded using the `Load Firmware from RPM or ZIP file` section in
 [FAS Admin Procedures](../firmware/FAS_Admin_Procedures.md#load-firmware-from-rpm-or-zip-file).
 After images are reloaded, any running actions at time of failure will need to be recreated.
-
-### HMNFD
-
-Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
-
-1. (`ncn-m#`) Resubscribe all compute nodes.
-
-    ```bash
-    TMPFILE=$(mktemp)
-    sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > "${TMPFILE}"
-    pdsh -w ^"${TMPFILE}" "systemctl restart cray-orca"
-    rm -rf "${TMPFILE}"
-    ```
-
-1. (`ncn-m#`) Resubscribe all worker nodes.
-
-    **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker nodes in the system.
-
-    ```bash
-    pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
-    ```


### PR DESCRIPTION
# Description

ORCA no longer exists so removed references to it when describing how to recreate HMNFD subscriptions after etcd rebuilds

# Issues and Related PRs
Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.