### PR TITLE
CASMINST-7342 hardcode kubectl-shell:2.27.0 to use with workflowTemplates in CSM 1.7

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -127,6 +127,11 @@ for THIS_IMAGE in $(get_list_of_images_to_update); do
     THIS_IMAGE=$(update_cray_sat_image $THIS_IMAGE)
   fi
   LATEST_TAG=$(get_latest_tag_for_image $THIS_IMAGE)
+  if [[ ${THIS_IMAGE} == *"kubectl-shell" ]]; then
+    # The sorting function does not work for kubectl-shell so hardcode the correct image
+    # 2.27.0 is the image that should be used in CSM 1.7
+    LATEST_TAG="2.27.0"
+  fi
   # CASMTRIAGE-6188 retry for up to 60 seconds if LATEST_TAG is empty
   i=1
   while [[ -z ${LATEST_TAG} ]]; do

--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The update_tags.sh script is used to make sure the latest container images are used in workflowTemplates used by argo. However, the script does not sort the `kubectl-shell` image correctly. It uses the old image with tag `latest-v1.21.1-amd64` instead of the new image with tag `2.27.0`. 

This PR hardcodes the new image tag into update_tags.sh so that the correct image is used.

This was tested on a vShasta upgrade.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
