### PR TITLE
CASMNET-2186 - Support Cilium upgrade with multus

### DIFF
--- a/workflows/templates/cilium.migrate.yaml
+++ b/workflows/templates/cilium.migrate.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/templates/cilium.migrate.yaml
+++ b/workflows/templates/cilium.migrate.yaml
@@ -69,9 +69,39 @@ spec:
                     echo "draining {{inputs.parameters.targetNcn}}"
                     kubectl drain --ignore-daemonsets --delete-emptydir-data {{inputs.parameters.targetNcn}}
                   fi
-        - name: promote-cilium 
+        - name: archive-weave-multus
           dependencies:
             - drain
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  ssh "${TARGET_NCN}" mv /etc/cni/net.d/10-weave.conflist /etc/cni/net.d/10-weave.conflist.cilium_bak
+        - name: migrate-multus-config
+          dependencies:
+            - drain
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  MULTUS_CONF=$(ssh "${TARGET_NCN}" cat /srv/cray/resources/common/multus/multus-cilium.conf)
+                  ssh "${TARGET_NCN}" "echo '{${MULTUS_CONF}'} > /etc/cni/net.d/00-multus.conf"
+        - name: promote-cilium
+          dependencies:
+            - archive-weave-multus
+            - migrate-multus-config
           templateRef:
             name: kubectl-and-curl-template
             template: shell-script

--- a/workflows/templates/cilium.post-migrate.yaml
+++ b/workflows/templates/cilium.post-migrate.yaml
@@ -51,9 +51,23 @@ spec:
                   fi
                   kubectl get netpol -A
                   rm -f /tmp/netpol-out.yaml
+        - name: update-multus-configmap
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  . /srv/cray/resources/common/vars.sh
+                  export MULTUS_CONF=$(cat /srv/cray/resources/common/multus/multus-cilium.conf)
+                  envsubst < /srv/cray/resources/common/multus/multus-daemonset.yml | yq4 'select(.kind=="ConfigMap")' | kubectl apply -f -
         - name: validate-cilium-content
           dependencies:
             - restore-network-policies
+            - update-multus-configmap
           templateRef:
             name: ssh-template
             template: shell-script


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

In order to support Cilium migration with Multus enabled the following needs to occur

* The `cni-exclusive` parameter must be set to false (see node-images PR)
* The `/etc/cni/net.d/10-weave.conflist` file needs to be moved to one side
* The `00-multus.conf` file needs to be updated for Cilium
* The `multus-cni-config` ConfigMap needs to be updated with the Cilium config.

Relates to:
- https://github.com/Cray-HPE/node-images/pull/1243

# Testing

Tested on vshasta

Verified that `cni-exclusive` is set to false in the final config.
```
ncn-m001:~ # kubectl -n kube-system get cm cilium-config -o yaml | yq4 '.data."cni-exclusive"'
false
```
Verified the `10-weave.conflist` configuration has been archived.
```
ncn-m001:~ # ls -1 /etc/cni/net.d/
00-multus.conf
05-cilium.conflist
10-weave.conflist.cilium_bak
99-loopback.conf.sample
multus.d
```

Verified that the Multus configuration put in place is for Cilium
```
ncn-m001:~ # jq . /etc/cni/net.d/00-multus.conf
{
  "name": "multus-cni-network",
  "cniVersion": "0.3.1",
  "type": "multus",
  "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
  "confDir": "/etc/cni/net.d",
  "clusterNetwork": "cilium",
  "systemNamespaces": [
    ""
  ]
}
```
Verified the `multus-cni-config` ConfigMap has been updated for Cilium.
```
ncn-m001:~ # kubectl -n kube-system get cm multus-cni-config  -o yaml
apiVersion: v1
data:
  00-multus.conf: |
    {
      "name": "multus-cni-network",
      "cniVersion": "0.3.1",
      "type": "multus",
      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
      "confDir": "/etc/cni/net.d",
      "clusterNetwork": "cilium",
      "systemNamespaces": [""]
    }
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"00-multus.conf":"{\n  \"name\": \"multus-cni-network\",\n  \"cniVersion\": \"0.3.1\",\n  \"type\": \"multus\",\n  \"kubeconfig\": \"/etc/cni/net.d/multus.d/multus.kubeconfig\",\n  \"confDir\": \"/etc/cni/net.d\",\n  \"clusterNetwork\": \"cilium\",\n  \"systemNamespaces\": [\"\"]\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"multus","tier":"node"},"name":"multus-cni-config","namespace":"kube-system"}}
  creationTimestamp: "2025-05-13T14:36:34Z"
  labels:
    app: multus
    tier: node
  name: multus-cni-config
  namespace: kube-system
  resourceVersion: "1568607"
  uid: 59d72f41-c494-45c6-bfe0-1f8dea3219b8
```


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
