### PR TITLE
CASMPET-7441 exit if set-bss-images-cfs-config.yaml can't get image from IMS

### DIFF
--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -65,6 +65,10 @@ spec:
                     
                     # BELOW IS TEMPORARY UNTIL LIBCSM IS UPDATED
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
+                    if [[ -z $image_manifest_str ]]; then
+                      echo "ERROR IMS is not reachable or image: $IMAGE_ID does not exist. Exiting and will retry."
+                      exit 1
+                    fi
                     image_manifest_str=${image_manifest_str#*s3://}
                     bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
                     bucket_rm="${bucket}/"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

During a node upgrade, it is possible that IMS will not be reachable. This has only been seen intermitently on vShasta but causes issues with the upgrade. 

The error seen is below

```text
+++ cray ims images describe 5e084640-fe07-4b08-8156-4c0d0cee4779 --format json
+++ jq .link.path
Usage: cray ims images describe [OPTIONS] IMAGE_ID
Try 'cray ims images describe -h' for help.

Error: Error received from server: 503 Service Unavailable
++ image_manifest_str=
++ image_manifest_str=
+++ cut -d / -f 1
++ bucket=
++ bucket_rm=/
++ path=
++ path=
+++ echo 26682
+++ md5sum
+++ head -c 21
+++ echo
++ temp_file=/tmp/14635ca89855dab4a7311.json
++ cray artifacts get /tmp/14635ca89855dab4a7311.json
Usage: cray artifacts get [OPTIONS] BUCKET OBJECT FILEPATH
Try 'cray artifacts get -h' for help.

Error: Missing argument 'OBJECT'. 
```

This PR causes the workflow to exit if this is hit. The workflow will automatically retry after exiting and IMS may be up by then.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
