### PR TITLE
CASMCMS-9358/CASMCMS-9360: Document BOS known issues

### DIFF
--- a/operations/boot_orchestration/Manage_a_Session_Template.md
+++ b/operations/boot_orchestration/Manage_a_Session_Template.md
@@ -10,6 +10,7 @@ and the CLI will print the underlying call to the API in the output.
 * [List all session templates](#list-all-session-templates)
 * [View a session template](#view-a-session-template)
 * [Delete a session template](#delete-a-session-template)
+* [Modify a session template](#modify-a-session-template)
 
 ## Session template framework
 
@@ -131,3 +132,13 @@ Example output:
 ```bash
 cray bos v2 sessiontemplates delete <SESSION_TEMPLATE_NAME>
 ```
+
+## Modify a session template
+
+(`ncn-mw#`) The following command takes a JSON input file that contains the information required to modify the BOS session template.
+
+```bash
+cray bos v2 sessiontemplates update --file <INPUT_FILE> <TEMPLATE_NAME>
+```
+
+The format of this input file is the same as the one used to [Create a session template](#create-a-session-template).

--- a/operations/hardware_state_manager/Manage_Component_Groups.md
+++ b/operations/hardware_state_manager/Manage_Component_Groups.md
@@ -5,8 +5,8 @@ The creation, deletion, and modification of groups is enabled by the Hardware St
 * [Example group](#example-group)
 * [Prerequisites](#prerequisites)
 * [Create and modify a group](#create-and-modify-a-group)
-  * [Create a group](#create-a-group)
-  * [Modify a group](#modify-a-group)
+    * [Create a group](#create-a-group)
+    * [Modify a group](#modify-a-group)
 * [Retrieve a group](#retrieve-a-group)
 * [Delete a group](#delete-a-group)
 

--- a/operations/hardware_state_manager/Manage_Component_Groups.md
+++ b/operations/hardware_state_manager/Manage_Component_Groups.md
@@ -85,6 +85,12 @@ The following examples show different ways to create and modify a group.
     cray hsm groups members create --id XNAME GROUP_LABEL
     ```
 
+* (`ncn-mw#`) Remove a component from a group:
+
+    ```bash
+    cray hsm groups members delete XNAME GROUP_LABEL
+    ```
+
 ## Retrieve a group
 
 Retrieve the complete group object to learn more about a group. This is also submitted when the group is created, except it is up-to-date with any additions or deletions from the members set.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -82,10 +82,12 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Storage node `cloud-init` fails with 'Timed out waiting for device' error](known_issues/storage_node_cloud_init_fails_with_timed_out.md)
 * [Console SSH Key Permissions](known_issues/console_ssh_key_permissions.md)
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
+* [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
 
 ## Booting
 
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
+* [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
 
 ### UAN boot issues
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -79,10 +79,13 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [CFS-API pods in CLBO state](known_issues/cfs-api_pods_in_CLBO_state.md)
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [IMS Image Job Performance](../operations/image_management/Image_Job_Performance.md)
-* [Storage node `cloud-init` fails with 'Timed out waiting for device' error](./known_issues/storage_node_cloud_init_fails_with_timed_out.md)
-* [Console SSH Key Permissions](./known_issues/console_ssh_key_permissions.md)
+* [Storage node `cloud-init` fails with 'Timed out waiting for device' error](known_issues/storage_node_cloud_init_fails_with_timed_out.md)
+* [Console SSH Key Permissions](known_issues/console_ssh_key_permissions.md)
+* [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 
 ## Booting
+
+* [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 
 ### UAN boot issues
 
@@ -189,7 +192,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Interfaces with IP Address Issues](../operations/node_management/Troubleshoot_Interfaces_with_IP_Address_Issues.md)
 * [Loss of Console Connections and Logs on Gigabyte Nodes](../operations/node_management/Troubleshoot_Loss_of_Console_Connections_and_Logs_on_Gigabyte_Nodes.md)
 * [Manual NCN Upgrade](../upgrade/manual_ncn_upgrade.md)
-* [Storage node `cloud-init` fails with 'Timed out waiting for device' error](./known_issues/storage_node_cloud_init_fails_with_timed_out.md)
+* [Storage node `cloud-init` fails with 'Timed out waiting for device' error](known_issues/storage_node_cloud_init_fails_with_timed_out.md)
 
 ## Security and authentication
 

--- a/troubleshooting/known_issues/BOS_Operator_Pods_OOMKilled.md
+++ b/troubleshooting/known_issues/BOS_Operator_Pods_OOMKilled.md
@@ -11,17 +11,30 @@ On large scale systems with thousands of nodes, if the [Boot Orchestration Servi
 has debug logging enabled, then it is possible for some [BOS operator](../../operations/boot_orchestration/BOS_Services.md#bos-operators)
 Kubernetes pods to be `OOMKilled` when trying to log particularly large API responses.
 
+On large enough systems, it is possible for this to happen even without debug logging enabled.
+
 ## Details
 
 The BOS logging level is one of numerous [Options](../../operations/boot_orchestration/Options.md) that an administrator may customize.
 
 ## Workaround
 
-(`ncn-mw#`) The only workaround in this case is to set the BOS logging level to `INFO` or higher.
+(`ncn-mw#`) Use the following procedure to work around the problem.
+
+Check if debug logging is enabled.
 
 ```bash
-cray bos v2 options update --logging-level INFO
+cray bos v2 options list --format json
 ```
+
+* If debug logging is enabled, then the easiest workaround is to set the BOS logging level to `INFO` or higher.
+
+    ```bash
+    cray bos v2 options update --logging-level INFO
+    ```
+
+* If debug logging is not enabled, or if the problem persists after disabling it, then the only other option is to increase the
+  memory limits for the pods experiencing this problem. See [Increase Pod Resource Limits](../../operations/kubernetes/Increase_Pod_Resource_Limits.md).
 
 ## Fix
 

--- a/troubleshooting/known_issues/BOS_Operator_Pods_OOMKilled.md
+++ b/troubleshooting/known_issues/BOS_Operator_Pods_OOMKilled.md
@@ -1,0 +1,29 @@
+# BOS Operator Pods `OOMKilled`
+
+* [Summary](#summary)
+* [Details](#details)
+* [Workaround](#workaround)
+* [Fix](#fix)
+
+## Summary
+
+On large scale systems with thousands of nodes, if the [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos)
+has debug logging enabled, then it is possible for some [BOS operator](../../operations/boot_orchestration/BOS_Services.md#bos-operators)
+Kubernetes pods to be `OOMKilled` when trying to log particularly large API responses.
+
+## Details
+
+The BOS logging level is one of numerous [Options](../../operations/boot_orchestration/Options.md) that an administrator may customize.
+
+## Workaround
+
+(`ncn-mw#`) The only workaround in this case is to set the BOS logging level to `INFO` or higher.
+
+```bash
+cray bos v2 options update --logging-level INFO
+```
+
+## Fix
+
+This problem is fixed in CSM 1.7, by changing how BOS performs its debug logging. The fix is not backported to earlier CSM versions.
+Prior to CSM 1.7, the above [Workaround](#workaround) must be used if the issue is encountered.

--- a/troubleshooting/known_issues/BOS_Sessions_Stuck_Pending.md
+++ b/troubleshooting/known_issues/BOS_Sessions_Stuck_Pending.md
@@ -10,7 +10,7 @@
 
 If a [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) [Session](../../operations/boot_orchestration/Sessions.md)
 is created using a [Session Template](../../operations/boot_orchestration/Session_Templates.md) that indirectly refers to invalid
-xnames, then this can prevent the BOS [`session-setup` operator](../../operations/boot_orchestration/BOS_Services.md#session-setup)
+[xnames](../../glossary.md#xname), then this can prevent the BOS [`session-setup` operator](../../operations/boot_orchestration/BOS_Services.md#session-setup)
 from moving any sessions out of the `pending` state.
 
 ## Symptoms

--- a/troubleshooting/known_issues/BOS_Sessions_Stuck_Pending.md
+++ b/troubleshooting/known_issues/BOS_Sessions_Stuck_Pending.md
@@ -1,0 +1,74 @@
+# BOS Sessions Stuck Pending
+
+* [Summary](#summary)
+* [Symptoms](#symptoms)
+* [Details](#details)
+* [Remediation](#remediation)
+* [Fix](#fix)
+
+## Summary
+
+If a [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) [Session](../../operations/boot_orchestration/Sessions.md)
+is created using a [Session Template](../../operations/boot_orchestration/Session_Templates.md) that indirectly refers to invalid
+xnames, then this can prevent the BOS [`session-setup` operator](../../operations/boot_orchestration/BOS_Services.md#session-setup)
+from moving any sessions out of the `pending` state.
+
+## Symptoms
+
+The primary symptom is that new BOS sessions will remain in the `pending` state and never progress.
+If the `cray-bos-operator-session-setup` pod logs are viewed, it will repeatedly log errors, every time
+it tries to process sessions.
+
+## Details
+
+This can only happen when a session template is created that includes
+[Node groups](../../operations/boot_orchestration/Session_Templates.md#node-groups) in a boot set.
+Specifically, this problem happens if the session template specifies a
+[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm)
+[component group](../../operations/hardware_state_manager/Manage_Component_Groups.md)
+that contains xnames that do not exist as BOS [Components](../../operations/boot_orchestration/Components.md).
+
+## Remediation
+
+The solution is to delete the `pending` BOS sessions that are using these session templates, or to correct
+the session templates (or corresponding HSM groups).
+
+Once this has been done for all such sessions, then the problem is resolved and BOS sessions will proceed as normal.
+
+(`ncn-mw#`) Follow this procedure to identify and delete these sessions.
+
+1. List all `pending` BOS sessions.
+
+    ```bash
+    cray bos v2 sessions list --status pending --format json
+    ```
+
+1. For each listed session, describe its corresponding session template.
+
+    ```bash
+    cray bos v2 sessiontemplates describe <template_name> --format json
+    ```
+
+1. If the session template contains any boot sets with `node_groups` fields, list the members of the corresponding groups.
+
+    ```bash
+    cray hsm groups members list <group_label> --format json
+    ```
+
+1. For each xname listed, verify that the corresponding BOS component exists.
+
+    ```bash
+    cray bos v2 components describe <xname>
+    ```
+
+1. If any xname does not exist as a BOS component, then do one of the following:
+
+    * [Delete the BOS session](../../operations/boot_orchestration/Manage_a_BOS_Session.md#delete-a-session) which indirectly includes it.
+    * [Remove the invalid xname from the HSM group](../../operations/hardware_state_manager/Manage_Component_Groups.md#modify-a-group).
+    * [Modify the BOS session template](../../operations/boot_orchestration/Manage_a_Session_Template.md#modify-a-session-template)
+      to remove the reference to the HSM group.
+
+## Fix
+
+This problem is fixed in CSM 1.7, by modifying BOS to ignore any invalid xnames. The fix is not backported to earlier CSM versions.
+Prior to CSM 1.7, the above [Remediation](#remediation) must be used if the issue is encountered.


### PR DESCRIPTION
This documents as known issues the problem encountered in CASMTRIAGE-8072 and CASMCMS-9357.
It also updates the BOS session templates page to document how to modify a session template, and updates the HSM groups page to document how to remove members from a group.

The known issue part of this will be backported to CSM 1.5, 1.4, and (CASMTRIAGE-8072 only) 1.3.
The procedure updates will also be backported to CSM 1.7, 1.2, and 1.0.

Backports:
* 1.7: https://github.com/Cray-HPE/docs-csm/pull/5961
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/5962
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/5963
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/5964
* 1.2: https://github.com/Cray-HPE/docs-csm/pull/5966
* 1.0: https://github.com/Cray-HPE/docs-csm/pull/5967