### PR TITLE
CASMCMS-9359/CASMCMS-9361: RELEASE NOTES: Document fix for CASMTRIAGE-8072/CASMCMS-9355 and CASMCMS-9357

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,11 @@
 
 ## Bug fixes
 
+* The [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
+  [`session-setup` operator](operations/boot_orchestration/BOS_Services.md#session-setup) now ignores invalid
+  [xnames](glossary.md#xname) referenced by [session templates](operations/boot_orchestration/Session_Templates.md),
+  fixing a bug that caused BOS [sessions](operations/boot_orchestration/Sessions.md) to be stuck in `pending` state.
+
 ## Deprecations
 
 For more details and a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,8 @@
   [`session-setup` operator](operations/boot_orchestration/BOS_Services.md#session-setup) now ignores invalid
   [xnames](glossary.md#xname) referenced by [session templates](operations/boot_orchestration/Session_Templates.md),
   fixing a bug that caused BOS [sessions](operations/boot_orchestration/Sessions.md) to be stuck in `pending` state.
+* BOS logging is significantly more memory efficient, fixing a problem where logging on large scale systems
+  could cause [BOS operator](operations/boot_orchestration/BOS_Services.md#bos-operators) Kubernetes pods to be `OOMKilled`.
 
 ## Deprecations
 


### PR DESCRIPTION
This is the counterpart to the BOS known issues documented in https://github.com/Cray-HPE/docs-csm/pull/5960 and its backports.

This PR updates the 1.7 release notes to report the bugs are fixed in CSM 1.7.

No backports.