### PR TITLE
CASMTRIAGE-8008 - ncn-gateway-test.sh failing

### DIFF
--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -34,6 +34,7 @@ import yaml
 import base64
 import subprocess
 import os.path
+import socket
 
 try:
   from kubernetes import client, config
@@ -66,13 +67,15 @@ def resolvable(service):
         return True
 
 def reachable(service):
-    ret = os.system("ping -q -c 3 {} >/dev/null".format(service))
-    if ret != 0:
-        print("{} is NOT reachable".format(service))
-        return False
-    else:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    try:
+        sock.connect((service, 443))
         print("{} is reachable".format(service))
         return True
+    except:
+        print("{} is NOT reachable".format(service))
+        return False
 
 def get_admin_secret(k8sClientApi):
     """


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Under Cilium services do not respond to ICMP so the gateway tests fail when using `ping` to determine whether the service is reachable.

Use a simple python socket connection to determine whether a given service is reachable.

Tested on `fanta` the test now passes as expected.
```
ncn-m001:~ # /usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh
System domain is fanta.hpc.amslabs.hpecorp.net

Running tests on the NCN
auth.cmn.fanta.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.fanta.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

Reachable networks: ['can', 'nmnlb', 'hmnlb', 'cmn']

Getting token for hmnlb
auth.hmnlb.fanta.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.hmnlb.fanta.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.fanta.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.fanta.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/bos/v2/sessions - 404
PASS - [cray-bss]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/cfs/v3/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
SKIP - [nmdv2-service]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.hmnlb.fanta.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found
--snip--
Overall Gateway Test Status:  PASS
```

Tested the external version of the test from `csmpit` which also now passes.
```
csm-remote-pit:~ # /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py fanta.hpc.amslabs.hpecorp.net outside
auth.cmn.fanta.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.fanta.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

Reachable networks: ['can', 'cmn']

Getting token for hmnlb
auth.hmnlb.fanta.hpc.amslabs.hpecorp.net is NOT reachable
Could not retrieve token for hmnlb (expected)

Getting token for nmnlb
auth.nmnlb.fanta.hpc.amslabs.hpecorp.net is NOT reachable
Could not retrieve token for nmnlb (expected)

Getting token for cmn
auth.cmn.fanta.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.fanta.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.fanta.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.fanta.hpc.amslabs.hpecorp.net is NOT reachable
hmnlb is not reachable (expected)

------------- api.nmnlb.fanta.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.fanta.hpc.amslabs.hpecorp.net is NOT reachable
nmnlb is not reachable (expected)

------------- api.cmn.fanta.hpc.amslabs.hpecorp.net -------------------
api.cmn.fanta.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 204
PASS - [cray-bos]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/bos/v2/sessions - 200
PASS - [cray-bss]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200
PASS - [cray-cfs-api]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/cfs/v3/sessions - 200
PASS - [cray-console-data]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 204
PASS - [cray-console-operator]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 204
SKIP - [cray-cps]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/v2/cps/contents
PASS - [cray-fas]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 200
PASS - [cray-hbtd]: https://api.cmn.fanta.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 200
--snip--
Overall Gateway Test Status:  PASS
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
