### PR TITLE
CASMCMS-9435/CASMCMS-9436/CASMCMS-9437: Update passwordless SSH documentation to discuss SSH configuration files

### DIFF
--- a/operations/CSM_product_management/Configure_the_root_Password_and_SSH_Keys_in_Vault.md
+++ b/operations/CSM_product_management/Configure_the_root_Password_and_SSH_Keys_in_Vault.md
@@ -29,6 +29,8 @@ Specifically, the `write_root_secrets_to_vault.py` script reads the following fr
 - The private SSH key from `/root/.ssh/id_rsa`.
 - The public SSH key from `/root/.ssh/id_rsa.pub`.
 
+For more information on this script, see [Update Root Secrets In Vault](../security_and_authentication/Update_Root_Secrets_In_Vault.md).
+
 This script can be run on any Kubernetes management NCN (master or worker). It only needs to be run once for
 the cluster, because the same Vault credentials are used for all management NCNs.
 
@@ -41,18 +43,9 @@ the cluster, because the same Vault credentials are used for all management NCNs
 /usr/share/doc/csm/scripts/operations/configuration/write_root_secrets_to_vault.py
 ```
 
-A successful execution will exit with return code 0 and will have output similar to the following:
+A successful execution will exit with return code 0 and will end with output similar to the following:
 
 ```text
-Reading in SSH private key from '/root/.ssh/id_rsa' file
-Reading in SSH public key from '/root/.ssh/id_rsa.pub' file
-Reading in file '/etc/shadow'
-Found root user line in /etc/shadow
-Initializing Kubernetes client
-Making GET request to http://10.22.183.206:8200/v1/secret/csm/users/root
-Writing updated CSM root secret to Vault
-Making POST request to http://10.22.183.206:8200/v1/secret/csm/users/root
-Making GET request to http://10.22.183.206:8200/v1/secret/csm/users/root
 Secrets read back from Vault match desired values
 SUCCESS
 ```

--- a/operations/CSM_product_management/Set_Up_Passwordless_SSH.md
+++ b/operations/CSM_product_management/Set_Up_Passwordless_SSH.md
@@ -1,5 +1,19 @@
 # Set up passwordless SSH
 
+- [Overview]
+- [Options to set SSH keys]
+    - [Option 1: Use the CSM-provided SSH keys](#option-1-use-the-csm-provided-ssh-keys)
+    - [Option 2: Provide custom SSH keys](#option-2-provide-custom-ssh-keys)
+    - [Option 3: Disable CSM-provided passwordless SSH](#option-3-disable-csm-provided-passwordless-ssh)
+    - [Option 4: Restore CSM-provided SSH keys](#option-4-restore-csm-provided-ssh-keys)
+- [SSH configuration files](#ssh-configuration-files)
+    - [Back up the SSH configuration to Vault](#back-up-the-ssh-configuration-to-vault)
+    - [Delete the SSH configuration from Vault](#delete-the-ssh-configuration-from-vault)
+    - [Restore the SSH configuration from Vault](#restore-the-ssh-configuration-from-vault)
+- [Apply configuration with CFS node personalization](#apply-configuration-with-cfs-node-personalization)
+
+## Overview
+
 This procedure sets up passwordless SSH from management nodes to other management nodes and from
 management nodes to managed nodes such as compute nodes running Cray Operating System (COS) software
 and User Access Nodes (UANs). This procedure **does not** configure passwordless SSH from managed
@@ -26,6 +40,8 @@ passwordless SSH works to either of these node types.
 > connections between nodes. CFS will continue to function if passwordless SSH is disabled between
 > as described in [Option 3: Disable CSM-provided passwordless SSH](#option-3-disable-csm-provided-passwordless-ssh)
 
+[SSH configuration files](#ssh-configuration-files) can be used to further simplify the process of using passwordless SSH.
+
 ## Options to set SSH keys
 
 There are four options to choose from to set up passwordless SSH. Choose only one
@@ -41,6 +57,8 @@ of the following options:
 The installation of CSM automatically provides an SSH keypair in a Kubernetes ConfigMap and secret,
 and the default CSM Ansible plays enable passwordless SSH. No further action is necessary to accept
 this CSM default.
+
+In order to make passwordless SSH more convenient, see [SSH configuration files](#ssh-configuration-files).
 
 ### Option 2: Provide custom SSH keys
 
@@ -101,7 +119,9 @@ runs on the management nodes.
 > **`NOTE`**: This keypair may be the same keypair used for the `root` user on management nodes, but
 > it is not required to be the same. Either option is valid.
 
-Proceed to [Apply configuration with CFS node personalization](#apply-configuration-with-cfs-node-personalization).
+In order to apply this change, see [Apply configuration with CFS node personalization](#apply-configuration-with-cfs-node-personalization).
+
+In order to make passwordless SSH more convenient, see [SSH configuration files](#ssh-configuration-files).
 
 ### Option 3: Disable CSM-provided passwordless SSH
 
@@ -179,6 +199,93 @@ Use this procedure if switching from custom keys to the default CSM SSH keys onl
         ```
 
 Proceed to [Apply configuration with CFS node personalization](#apply-configuration-with-cfs-node-personalization).
+
+## SSH configuration files
+
+(`ncn#`) Completing [Option 1](#option-1-use-the-csm-provided-ssh-keys) or [Option 2](#option-2-provide-custom-ssh-keys)
+allows commands like the following to work without having to specify a password:
+
+```bash
+ssh -i /root/.ssh/csm-ecdsa x3000c0s10b4n0
+```
+
+The path to the key file does not need to be specified if an appropriate SSH configuration file is created with
+path `/root/.ssh/config` on the NCNs from which the SSH commands will be run. Here is an example of possible contents
+of this file:
+
+```text
+Host nid*
+  IdentityFile /root/.ssh/csm-ecdsa
+  StrictHostKeyChecking no
+
+Host uan* 
+  IdentityFile /root/.ssh/csm-ecdsa
+  StrictHostKeyChecking no
+
+Host app*
+  IdentityFile /root/.ssh/csm-ecdsa
+  StrictHostKeyChecking no
+
+Host lnet*
+  IdentityFile /root/.ssh/csm-ecdsa
+  StrictHostKeyChecking no
+
+Host x*c?s*b?n?
+  IdentityFile /root/.ssh/csm-ecdsa
+  StrictHostKeyChecking no
+```
+
+This file must be manually created by administrators. Note that this file does not persist across node rebuilds.
+CSM provides some tools to help backup and restore the contents of this file.
+
+- [Back up the SSH configuration to Vault](#back-up-the-ssh-configuration-to-vault)
+- [Delete the SSH configuration from Vault](#delete-the-ssh-configuration-from-vault)
+- [Restore the SSH configuration from Vault](#restore-the-ssh-configuration-from-vault)
+
+### Back up the SSH configuration to Vault
+
+(`ncn#`) The contents of the root SSH configuration file can be written to Vault by running the following script:
+
+> The `docs-csm` RPM must be installed in order to use this script. See
+> [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)
+
+```bash
+/usr/share/doc/csm/scripts/operations/configuration/write_ssh_config_to_vault.py
+```
+
+By default the script will copy the contents of `/root/.ssh/config`. Run the script with the `--help` option for
+information on how to use a different file as the source. For more information on this and related tools, see
+[Update Root Secrets In Vault](../security_and_authentication/Update_Root_Secrets_In_Vault.md).
+
+Note that there is a single SSH configuration location in Vault for all management NCNs -- if this script is run on multiple NCNs,
+each will overwrite the data from the previous. The expectation is that all NCNs will use the same root SSH configuration file.
+
+### Delete the SSH configuration from Vault
+
+(`ncn#`) The contents of the root SSH configuration file can be deleted from Vault by running the following script:
+
+> The `docs-csm` RPM must be installed in order to use this script. See
+> [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)
+
+```bash
+/usr/share/doc/csm/scripts/operations/configuration/write_ssh_config_to_vault.py --delete
+```
+
+### Restore the SSH configuration from Vault
+
+(`ncn#`) The contents of the root SSH configuration file can be restored from Vault using the following script:
+
+> The `docs-csm` RPM must be installed in order to use this script. See
+> [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)
+
+```bash
+/usr/share/doc/csm/scripts/operations/configuration/restore_ssh_config_from_vault.py
+```
+
+By default, the script will do nothing and pass if the SSH configuration does not exist in Vault. If the configuration
+is in Vault, then by default it will be written to `/root/.ssh/config`, and will fail if that file already exists.
+Run the script with the `--help` option for information on how to change these default behaviors. For more information
+on this and related tools, see [Update Root Secrets In Vault](../security_and_authentication/Update_Root_Secrets_In_Vault.md).
 
 ## Apply configuration with CFS node personalization
 

--- a/operations/network/management_network/README.md
+++ b/operations/network/management_network/README.md
@@ -30,9 +30,9 @@ exactly match installed products.
 * [Minimum software version requirements](#minimum-software-version-requirements)
 * [Transceiver and cable guide](transceiver_cable_guide.md)
 * [Changes](#changes)
-  * [Enhancements](#enhancements-and-features)
-  * [Issues and workarounds](#issues-and-workarounds)
-  * [Security Bulletin Subscription Service](#security-bulletin-subscription-service)
+    * [Enhancements](#enhancements-and-features)
+    * [Issues and workarounds](#issues-and-workarounds)
+    * [Security Bulletin Subscription Service](#security-bulletin-subscription-service)
 
 ## Adding switch admin password to Vault
 
@@ -48,12 +48,9 @@ to verify that it was written correctly.
 /usr/share/doc/csm/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
 ```
 
-On success, the script will exit with return code 0 and have the following final lines
-of output:
+On success, the script will exit with return code 0 and have the following final line of output:
 
 ```text
-Writing switch admin password to Vault
-Password read from Vault matches what was written
 SUCCESS
 ```
 

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -5,6 +5,7 @@ or some other issue with the node has occurred that warrants rebuilding the node
 
 - [Prerequisites](#prerequisites)
 - [Procedure](#procedure)
+- [Restore manual configuration](#restore-manual-configuration)
 - [Validation](#validation)
 
 ## Prerequisites
@@ -130,6 +131,11 @@ Follow each step below:
 1. [Re-add Storage Node to Ceph](Re-add_Storage_Node_to_Ceph.md)
 1. [Validate Boot Loader](Validate_Boot_Loader.md)
 1. [Storage Node Validation](Post_Rebuild_Storage_Node_Validation.md)
+
+## Restore manual configuration
+
+Restore any configurations for the node that are not automatically performed by [CFS](../../../glossary.md#configuration-framework-service-cfs)
+live node personalization. For example, [SSH configuration files](../../CSM_product_management/Set_Up_Passwordless_SSH.md#ssh-configuration-files).
 
 ## Validation
 

--- a/operations/security_and_authentication/SSH_Keys.md
+++ b/operations/security_and_authentication/SSH_Keys.md
@@ -26,49 +26,9 @@ skip any updates.
 
    Use `ssh-keygen` to generate a new pair or stage an existing pair, as per site security policies and procedures.
 
-1. (`ncn-mw#`) Get the [HashiCorp Vault](HashiCorp_Vault.md) root token.
-
-   ```bash
-   kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
-   ```
-
 1. Write the private and public halves of the key pair to the [HashiCorp Vault](HashiCorp_Vault.md).
 
-   > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
-   > `ssh_private_key` and `ssh_public_key` fields in the `secret/csm/users/root` secret are being updated,
-   > then any other desired fields are also included in the `write` command. For example the user's password hash.
-   > See [Update NCN Passwords](Update_NCN_Passwords.md).
-   > **Any fields omitted from the `write` command will be cleared from Vault.**
-
-   The path to the secret and the SSH key fields are configurable locations in
-   the CSM `csm.ssh_keys` Ansible role located in the CSM configuration
-   management Git repository that is in use. If not using the defaults as shown
-   in the command examples, ensure that the paths are consistent between Vault and
-   the values in the Ansible role. See `roles/csm.ssh_keys/README.md` in the
-   repository for more information.
-
-   1. (`ncn-mw#`) Open an interactive shell in the Vault Kubernetes pod.
-
-      ```bash
-      kubectl exec -itn vault cray-vault-0 -c vault -- sh
-      ```
-
-   1. (`cray-vault#`) Write the SSH keys to Vault.
-
-      * The `vault login` command will request the token value from the output of the previous step.
-      * Use the SSH keys from the earlier step.
-        * The `ssh_private_key` and `ssh_public_key` fields should contain the exact content from the
-          `id_rsa` and `id_rsa.pub` files (if using RSA key types).
-        * **`NOTE`**: It is important to enclose the key content in single quotes to preserve any special characters.
-      * The `vault read` command allows the administrator to verify that the contents of the secret were stored correctly.
-
-      ```bash
-      export VAULT_ADDR=http://cray-vault:8200
-      vault login
-      vault write secret/csm/users/root ssh_private_key='...' ssh_public_key='...' [... other fields (see warning below) ...]
-      vault read secret/csm/users/root
-      exit
-      ```
+    See [Update Root Secrets In Vault](Update_Root_Secrets_In_Vault.md).
 
 ## Procedure: Apply root SSH keys to NCNs (standalone)
 

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -51,47 +51,9 @@ location is `secret/csm/users/root password=...`.
    fi ; unset PW1 PW2
    ```
 
-1. (`ncn-mw#`) Get the [HashiCorp Vault](HashiCorp_Vault.md) root token.
-
-   ```bash
-   kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
-   ```
-
 1. Write the password hash to the [HashiCorp Vault](HashiCorp_Vault.md).
 
-   > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
-   > `password` field in the `secret/csm/users/root` secret is being updated,
-   > then any other desired fields are also included in the `write` command. For example the user's SSH keys.
-   > See [SSH keys](SSH_Keys.md).
-   > **Any fields omitted from the `write` command will be cleared from Vault.**
-
-   The path to the secret and the password field are configurable locations in
-   the CSM `csm.password` Ansible role located in the CSM configuration
-   management Git repository that is in use. If not using the defaults as shown
-   in the command examples, ensure that the paths are consistent between Vault and
-   the values in the Ansible role. See `roles/csm.password/README.md` in the
-   repository for more information.
-
-   1. (`ncn-mw#`) Open an interactive shell in the Vault Kubernetes pod.
-
-      ```bash
-      kubectl exec -itn vault cray-vault-0 -c vault -- sh
-      ```
-
-   1. (`cray-vault#`) Write the password hash to Vault.
-
-      * The `vault login` command will request the token value from the output of the previous step.
-      * Use the password hash generated in the earlier step.
-        * **`NOTE`**: It is important to enclose the hash in single quotes to preserve any special characters.
-      * The `vault read` command allows the administrator to verify that the contents of the secret were stored correctly.
-
-      ```bash
-      export VAULT_ADDR=http://cray-vault:8200
-      vault login
-      vault write secret/csm/users/root password='<INSERT HASH HERE>' [... other fields (see warning above) ...]
-      vault read secret/csm/users/root
-      exit
-      ```
+   See [Update Root Secrets In Vault](Update_Root_Secrets_In_Vault.md).
 
 ## Procedure: Apply `root` password to NCNs (standalone)
 

--- a/operations/security_and_authentication/Update_Root_Secrets_In_Vault.md
+++ b/operations/security_and_authentication/Update_Root_Secrets_In_Vault.md
@@ -1,0 +1,145 @@
+# Update Root Secrets In Vault
+
+* [Overview](#overview)
+* [Automated tools](#automated-tools)
+* [Manual procedures](#manual-procedures)
+
+## Overview
+
+Several CSM root user credentials are optionally stored in the [HashiCorp Vault](HashiCorp_Vault.md),
+acting as a secure backup and allowing them to be automatically configured by the
+[Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs).
+These credentials include:
+
+* Password hash
+* SSH public key
+* SSH private key
+* SSH configuration
+
+The path to the secret and the SSH key fields are configurable locations in the CSM `csm.ssh_keys`
+Ansible role located in the CSM configuration management Git repository that is in use.
+See `roles/csm.ssh_keys/README.md` in the repository for more information.
+
+The path to the secret and the password field are configurable locations in
+the CSM `csm.password` Ansible role located in the CSM configuration
+management Git repository that is in use. See `roles/csm.password/README.md` in the
+repository for more information.
+
+If the default path or keys have been changed, then CSM does not provide an automated way
+to update their values in Vault. In this case, the [Manual procedures](#manual-procedures) must be used.
+
+If the path and key fields are at their default values, then CSM provides [Automated tools](#automated-tools)
+to safely update the data in Vault.
+
+## Automated tools
+
+> The `docs-csm` RPM must be installed in order to use these tools. See
+> [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)
+
+### `write_root_secrets_to_vault.py`
+
+(`ncn-mw#`) The `/usr/share/doc/csm/scripts/operations/configuration/write_root_secrets_to_vault.py` script can be used to
+set the password, SSH keys, and/or SSH configuration for the root user. It can also be used to delete any of
+these values from Vault.  Run the script with the `--help` argument to see the different options.
+
+### `write_ssh_config_to_vault.py`
+
+(`ncn-mw#`) If only wanting to update or delete the root user SSH configuration, then the
+`/usr/share/doc/csm/scripts/operations/configuration/write_ssh_config_to_vault.py` script can be used. Run it with
+the `--help` option to see its usage.
+
+### `restore_ssh_config_from_vault.py`
+
+(`ncn-mw#`) The `/usr/share/doc/csm/scripts/operations/configuration/restore_ssh_config_from_vault.py` script
+copies the root SSH configuration out of Vault and into a file on the local system. Run it with the `--help` option to
+see its usage.
+
+### Related tools
+
+See [Adding switch admin password to Vault](../network/management_network/README.md#adding-switch-admin-password-to-Vault).
+
+## Manual procedures
+
+### Password hash
+
+The path to the secret and the password field are configurable locations in
+the CSM `csm.password` Ansible role located in the CSM configuration
+management Git repository that is in use.
+
+If not using the defaults as shown in the command examples, ensure that the paths are consistent between Vault and
+the values in the Ansible role. See `roles/csm.password/README.md` in the repository for more information.
+
+1. (`ncn-mw#`) Get the Vault root token.
+
+    ```bash
+    kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
+    ```
+
+1. (`ncn-mw#`) Open an interactive shell in the Vault Kubernetes pod.
+
+    ```bash
+    kubectl exec -itn vault cray-vault-0 -c vault -- sh
+    ```
+
+1. (`cray-vault#`) Write the password hash to Vault.
+
+   > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
+   > `password` field in the `secret/csm/users/root` secret is being updated,
+   > then any other desired fields are also included in the `write` command. For example the user's
+   > [SSH keys](#ssh-keys).
+   > **Any fields omitted from the `write` command will be cleared from Vault.**
+
+    * The `vault login` command will request the token value from the output of the previous step.
+    * **`NOTE`**: It is important to enclose the hash in single quotes to preserve any special characters.
+    * The `vault read` command allows the administrator to verify that the contents of the secret were stored correctly.
+
+    ```bash
+    export VAULT_ADDR=http://cray-vault:8200
+    vault login
+    vault write secret/csm/users/root password='<INSERT HASH HERE>' [... other fields (see warning above) ...]
+    vault read secret/csm/users/root
+    exit
+    ```
+
+### SSH keys
+
+The path to the secret and the SSH key fields are configurable locations in
+the CSM `csm.ssh_keys` Ansible role located in the CSM configuration
+management Git repository that is in use.
+
+If not using the defaults as shown in the command examples, ensure that the paths are consistent between Vault and
+the values in the Ansible role. See `roles/csm.ssh_keys/README.md` in the repository for more information.
+
+1. (`ncn-mw#`) Get the Vault root token.
+
+    ```bash
+    kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
+    ```
+
+1. (`ncn-mw#`) Open an interactive shell in the Vault Kubernetes pod.
+
+    ```bash
+    kubectl exec -itn vault cray-vault-0 -c vault -- sh
+    ```
+
+1. (`cray-vault#`) Write the SSH keys to Vault.
+
+   > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
+   > `ssh_private_key` and `ssh_public_key` fields in the `secret/csm/users/root` secret are being updated,
+   > then any other desired fields are also included in the `write` command. For example the user's
+   > [password hash](#password-hash).
+   > **Any fields omitted from the `write` command will be cleared from Vault.**
+
+    * The `vault login` command will request the token value from the output of the previous step.
+    * The `ssh_private_key` and `ssh_public_key` fields should contain the exact content from the
+      `id_rsa` and `id_rsa.pub` files (if using RSA key types).
+    * **`NOTE`**: It is important to enclose the key content in single quotes to preserve any special characters.
+    * The `vault read` command allows the administrator to verify that the contents of the secret were stored correctly.
+
+    ```bash
+    export VAULT_ADDR=http://cray-vault:8200
+    vault login
+    vault write secret/csm/users/root ssh_private_key='...' ssh_public_key='...' [... other fields (see warning above) ...]
+    vault read secret/csm/users/root
+    exit
+    ```

--- a/scripts/operations/configuration/python_lib/csm_root_secret.py
+++ b/scripts/operations/configuration/python_lib/csm_root_secret.py
@@ -1,0 +1,156 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: CSM Root Secret"""
+
+import logging
+import traceback
+from typing import NoReturn, Union
+from typing_extensions import Literal, TypedDict
+
+from . import common
+from . import k8s
+from . import vault
+
+
+class CsmUserSecretData(TypedDict, total=False):
+    password: str
+    ssh_config: str
+    ssh_private_key: str
+    ssh_public_key: str
+
+
+class CsmUserSecretUpdateData(TypedDict, total=False):
+    """
+    A value of None in the update dict means the field should be deleted
+    as part of the update
+    """
+    password: Union[str, None]
+    ssh_config: Union[str, None]
+    ssh_private_key: Union[str, None]
+    ssh_public_key: Union[str, None]
+
+
+CsmUserSecretFields = Literal['password', 'ssh_config', 'ssh_private_key', 'ssh_public_key']
+
+SSH_CONFIG_FIELD: CsmUserSecretFields = 'ssh_config'
+SSH_PRI_KEY_FIELD: CsmUserSecretFields = 'ssh_private_key'
+SSH_PUB_KEY_FIELD: CsmUserSecretFields = 'ssh_public_key'
+PW_FIELD: CsmUserSecretFields = 'password'
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> NoReturn:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+class CsmUserSecret:
+    """
+    Helper class for doing operations on the CSM root secret in Vault
+    """
+
+    CSM_USER_SECRET_PREFIX = "csm/users/"
+
+    def __init__(self, user: str, k8s_client: k8s.CoreV1API = None) -> None:
+        self.vault = vault.Vault(k8s_client=k8s_client)
+        self.secret_key = f"{self.CSM_USER_SECRET_PREFIX}{user}"
+
+    def delete(self, **delete_secret_kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to delete_secret()
+
+        If verify is set to True, after deleting, attempt to read the secret and
+        """
+        self.vault.delete_secret(secret_key=self.secret_key, **delete_secret_kwargs)
+
+    def get(self, **get_secret_kwargs) -> Union[CsmUserSecretData, None]:
+        """
+        Wrapper function that supplies the CSM root secret key to get_secret()
+        """
+        return self.vault.get_secret(secret_key=self.secret_key, **get_secret_kwargs)
+
+    def write(self, secret_data: CsmUserSecretData, **write_secret_kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to write_secret()
+        """
+        self.vault.write_secret(secret_key=self.secret_key, secret_data=secret_data,
+                                **write_secret_kwargs)
+
+    def update(self, secret_update_data: CsmUserSecretUpdateData, **write_secret_kwargs) -> None:
+        """
+        Because the CSM version of Vault does not support the PATCH operation, we have to
+        implement it ourselves.
+
+        Fields with values of None indicate that the field should be deleted from the secet in
+        Vault.
+
+        If the secret does not exist in Vault, just write the specified data.
+        Otherwise, reads the specified secret from Vault, patch the data fields,
+        and write it back.
+        Raises an exception if anything goes wrong.
+        """
+        if not secret_update_data:
+            logging.debug("No update data specified; returning")
+            return
+        root_secret = self.get(must_exist=False)
+        if root_secret is None:
+            new_root_secret = CsmUserSecretData()
+            # Get the update fields that are not set to None
+            for field, value in secret_update_data.items():
+                if value is not None:
+                    new_root_secret[field] = value
+            if not new_root_secret:
+                logging.debug("Secret does not exist in Vault, and no data specified to write")
+                return
+            self.write(new_root_secret, **write_secret_kwargs)
+            return
+
+        updated_root_secret = root_secret.copy()
+        for field, value in secret_update_data.items():
+            if value is None:
+                # Remove this field from the root secret, if it exists
+                updated_root_secret.pop(field, None)
+            else:
+                # Update the value of the field
+                updated_root_secret[field] = value
+
+        if updated_root_secret == root_secret:
+            logging.debug("Root secret in Vault already has specified updates")
+            return
+        self.write(updated_root_secret, **write_secret_kwargs)
+
+def csm_root_secret(k8s_client: k8s.CoreV1API = None) -> CsmUserSecret:
+    """
+    Return a CsmUserSecret for the root user
+    """
+    return CsmUserSecret(user="root", k8s_client=k8s_client)

--- a/scripts/operations/configuration/python_lib/root_ssh_config.py
+++ b/scripts/operations/configuration/python_lib/root_ssh_config.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Shared module used by scripts that need to access the root user SSH config
+"""
+
+import logging
+import os.path
+
+from python_lib import args
+
+
+# Default values
+CONFIG_DIR = "/root/.ssh"
+CONFIG_NAME = "config"
+CONFIG_PATH = os.path.join(CONFIG_DIR, CONFIG_NAME)
+
+
+def ssh_config_file(file_name: str) -> str:
+    """
+    Wrapper for args.get_text_file_contents with appropriate arguments for SSH config files.
+    """
+    logging.info("Reading in SSH config from '%s' file", file_name)
+    file_contents = args.get_text_file_contents(file_name=file_name)
+    logging.info("Read %d characters from '%s' file", len(file_contents), file_name)
+    return file_contents

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -26,7 +26,7 @@
 import base64
 import logging
 import traceback
-from typing import NoReturn
+from typing import Any, Dict, NoReturn
 
 from . import api_requests
 from . import common
@@ -37,10 +37,6 @@ from .types import JSONDecodeError, JsonObject
 K8S_NAMESPACE = "vault"
 K8S_SECRET_NAME = "cray-vault-unseal-keys"
 K8S_SERVICE_NAME = "cray-vault"
-
-CSM_ROOT_SECRET_KEY = "csm/users/root"
-SW_ADMIN_PW_KEY = "net-creds/switch_admin"
-SW_ADMIN_PW_FIELD = "admin"
 
 API_STATUS_OK_WITH_DATA = 200
 API_STATUS_OK_EMPTY = 204
@@ -139,7 +135,7 @@ def get_secret_data_from_response(api_response: api_requests.ApiResponse) -> Jso
             "Vault response to read secret request is not in expected format", exc)
 
 
-class Vault():
+class Vault:
     """
     Used as an interface into Vault.
     This object assumes that the Vault secret token is not
@@ -147,7 +143,7 @@ class Vault():
     will need to be made to handle it. The same is true of the service IP addresses and ports.
     """
 
-    def __init__(self, k8s_client: k8s.CoreV1API = None):
+    def __init__(self, k8s_client: k8s.CoreV1API = None) -> None:
         """
         Obtains and stores the Vault token from the Kubernetes secret.
         Obtains and stores the service IP address and port from Kubernetes, and saves
@@ -222,12 +218,18 @@ class Vault():
         request_headers = self.get_api_request_headers(additional_headers)
         return api_requests.post_retry_validate(headers=request_headers, **kwargs)
 
-    def delete_secret(self, secret_key: str) -> None:
+    def delete_secret(self, secret_key: str, verify:bool=False) -> None:
         """
         Deletes the specified secret key from Vault. This is also required in the case where the
         last field of data in a secret is being removed, because Vault does not allow for empty
         secrets.
+
         Raises an exception if anything goes wrong.
+        Note that the Vault API does not consider it an error to delete a secret that does not
+        exist, so no exception is raised in that case.
+
+        If verify is True, after the delete, attempt to read the secret from Vault, and
+        ensure that it is not found.
         """
         secret_url = self.get_secret_api_url(secret_key)
         logging.debug("%s secret URL = %s", secret_key, secret_url)
@@ -235,7 +237,15 @@ class Vault():
         self.api_delete(
             url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY)
 
-    def get_secret(self, secret_key: str, must_exist: bool = False) -> JsonObject:
+        if not verify:
+            return
+
+        if self.get_secret(secret_key, must_exist=False) is None:
+            return
+
+        log_error_raise_exception(f"Deleted {secret_key} from Vault, but it still exists")
+
+    def get_secret(self, secret_key: str, must_exist: bool = False) -> Dict[str, Any]:
         """
         Retrieves the Vault secret with the specified key and returns its contents.
         The must_exist argument governs whether a 404 response status code results
@@ -257,48 +267,80 @@ class Vault():
         if resp.status_code == API_STATUS_NOT_FOUND:
             # Since an exception was not raised, this must mean we are in the case where
             #  this is okay. So return None.
+            logging.debug("%s not found in Vault", secret_key)
             return None
         # Return the secret data from the response
         return get_secret_data_from_response(resp)
 
-    def write_secret(self, secret_key: str, secret_data: JsonObject) -> None:
+    def write_secret(self, secret_key: str, secret_data: Dict[str, Any],
+                     verify: bool=False) -> None:
         """
         Writes the specified secret data to Vault using the specified secret key.
         Raises an exception if anything goes wrong.
         """
+        if not secret_data:
+            # For Vault, writing an empty secret means deleting that secret
+            logging.info("Vault does not support writing empty secret data; deleting %s instead",
+                         secret_key)
+            self.delete_secret(secret_key, verify=verify)
+            return
         secret_url = self.get_secret_api_url(secret_key)
         logging.debug("%s secret URL = %s", secret_key, secret_url)
         logging.debug("Writing %s secret to Vault", secret_key)
         self.api_post(
             url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
 
-    def delete_csm_root_secret(self) -> None:
-        """
-        Wrapper function that supplies the CSM root secret key to delete_secret()
-        """
-        self.delete_secret(secret_key=CSM_ROOT_SECRET_KEY)
+        if not verify:
+            return
 
-    def get_csm_root_secret(self, **kwargs) -> JsonObject:
-        """
-        Wrapper function that supplies the CSM root secret key to get_secret()
-        """
-        return self.get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+        secret_data_after_write = self.get_secret(secret_key, must_exist=False)
+        if secret_data_after_write is None:
+            log_error_raise_exception(f"Wrote {secret_key}, but it still does not exist in Vault")
+        compare_secrets(secret_key, secret_written=secret_data,
+                        secret_read=secret_data_after_write)
 
-    def get_sw_admin_password(self) -> str:
-        """
-        Wrapper function that supplies the switch admin password key to get_secret(),
-        and extracts the SW_ADMIN_PW_FIELD field from the result
-        """
-        return self.get_secret(secret_key=SW_ADMIN_PW_KEY, must_exist=True)[SW_ADMIN_PW_FIELD]
 
-    def write_csm_root_secret(self, **kwargs) -> None:
-        """
-        Wrapper function that supplies the CSM root secret key to write_secret()
-        """
-        self.write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+def compare_secrets(secret_key: str, secret_written: Dict[str, Any],
+                    secret_read: Dict[str, Any]) -> None:
+    """
+    Compare the secret we wrote to what we read back. If there are any differences,
+    log them and raise an exception. Note that this assumes the two secrets
+    are simple shallow dicts.
+    """
+    secrets_match = True
 
-    def write_sw_admin_password(self, pw_string: str) -> None:
-        """
-        Wrapper function that supplies the switch admin password key to write_secret()
-        """
-        self.write_secret(secret_key=SW_ADMIN_PW_KEY, secret_data={ SW_ADMIN_PW_FIELD: pw_string })
+    # Validate that Vault values match what we wrote
+    logging.debug(
+        "Validating that Vault contents match what was written to %s", secret_key)
+
+    fields_not_written = secret_written.keys() - secret_read.keys()
+    extra_fields = secret_read.keys() - secret_written.keys()
+    common_fields = secret_read.keys() & secret_written.keys()
+
+    if fields_not_written:
+        secrets_match = False
+        logging.error("Fields were written to %s, but were not present when it was read back: %s",
+                      secret_key, fields_not_written)
+    else:
+        logging.debug("All written fields were present when %s was read back", secret_key)
+
+    if extra_fields:
+        secrets_match = False
+        logging.error("Fields were not written to %s, but were present when it was read back: %s",
+                      secret_key, extra_fields)
+    else:
+        logging.debug("All read fields in %s were present when written", secret_key)
+
+    for field in common_fields:
+        if secret_read[field] == secret_written[field]:
+            logging.debug("Vault value for %s in %s matches what was written", field, secret_key)
+        else:
+            secrets_match = False
+            logging.error("Vault value for %s in %s DOES NOT MATCH what was written", field,
+                          secret_key)
+
+    if not secrets_match:
+        raise common.ScriptException(
+            f"Secret {secret_key} read back from Vault does not match what was written")
+
+    logging.info("Secret %s read back from Vault matches desired values", secret_key)

--- a/scripts/operations/configuration/restore_ssh_config_from_vault.py
+++ b/scripts/operations/configuration/restore_ssh_config_from_vault.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Reads in the SSH configuration from Vault and writes it to /root/.ssh/config (or the
+user-specified path)
+"""
+
+import argparse
+import logging
+import os
+import os.path
+import sys
+from typing import NamedTuple, Union
+
+from python_lib import common
+from python_lib import logger
+from python_lib.csm_root_secret import csm_root_secret, SSH_CONFIG_FIELD
+from python_lib.root_ssh_config import CONFIG_DIR, CONFIG_NAME
+
+
+OVERWRITE_ARG = "--overwrite"
+IN_VAULT_ARG = "--fail-if-not-in-vault"
+
+class ScriptArgs(NamedTuple):
+    filename: str
+    overwrite: bool
+    must_be_in_vault: bool
+
+    @property
+    def filepath(self) -> str:
+        return os.path.join(CONFIG_DIR, self.filename)
+
+
+def file_basename(file_name: str) -> str:
+    """
+    Validate that the specified file_name is not empty, does not contain any '/' characters,
+    and contains at least one character that is not .
+    """
+    if not file_name:
+        raise argparse.ArgumentTypeError("File name may not be blank")
+    if '/' in file_name:
+        raise argparse.ArgumentTypeError("File name may not contain '/' characters")
+    if all(c == '.' for c in file_name):
+        raise argparse.ArgumentTypeError("File name must contain non-. character")
+    return file_name
+
+
+def write_ssh_config_file(args: ScriptArgs, ssh_config: str) -> None:
+    """
+    Validate that the target file and directory do not present any problems, either on
+    their own or due to the arguments we've been passed. If not, then write the config
+    to the file.
+    """
+    validate_target(args)
+    logging.info("Writing SSH configuration to %s", args.filepath)
+    with open(args.filepath, "wt") as configfile:
+        num_bytes = configfile.write(ssh_config)
+    logging.info("Wrote %d bytes to %s", num_bytes, args.filepath)
+    logging.info("Setting 644 file permissions to %s", args.filepath)
+    os.chmod(args.filepath, 0o644)
+    logging.info("Set 644 file permissions to %s", args.filepath)
+
+
+def validate_target(args: ScriptArgs):
+    """
+    Verify that:
+    1. CONFIG_DIR exists
+    2. CONFIG_DIR is a directory
+    3. If the target file exists, make sure it is a regular file and we are allowed to
+       overwrite it
+    """
+    if not os.path.exists(CONFIG_DIR):
+        common.log_error_raise_exception(f"Directory '{CONFIG_DIR}' does not exist")
+
+    # Make sure it is actually a directory
+    if not os.path.isdir(CONFIG_DIR):
+        common.log_error_raise_exception(f"'{CONFIG_DIR}' exists but is not a directory")
+
+    if not os.path.exists(args.filepath):
+        return
+
+    # It exists, so make sure it is a regular file
+    if not os.path.isfile(args.filepath):
+        common.log_error_raise_exception(f"'{args.filepath}' exists but is not a regular file")
+
+    # Finally, since it exists, make sure we are allowed to overwrite it
+    if args.overwrite:
+        return
+
+    common.log_error_raise_exception(f"File '{args.filepath}' already exists; call script with "
+                                     f"{OVERWRITE_ARG} to overwrite it")
+
+
+def get_ssh_config_from_vault(args: ScriptArgs) -> Union[str, None]:
+    """
+    Return the SSH config from Vault.
+    If it is not in Vault, return None, unless we were called with --fail-if-not-in-vault, in
+    which case reaise an Exception
+    """
+    root_secret = csm_root_secret().get(must_exist=False)
+    if root_secret is None:
+        # The CSM root secret is not in Vault
+        if not args.must_be_in_vault:
+            logging.info("CSM root secret is not in Vault")
+            return None
+        common.log_error_raise_exception("No CSM root secret in Vault, and script "
+                                         f"called with {IN_VAULT_ARG}")
+
+    try:
+        return root_secret[SSH_CONFIG_FIELD]
+    except KeyError as exc:
+        if not args.must_be_in_vault:
+            logging.info("No %s field in CSM root secret in Vault", SSH_CONFIG_FIELD)
+            return None
+        common.log_error_raise_exception(f"No {SSH_CONFIG_FIELD} field in CSM root secret in "
+                                         f"Vault, and script called with {IN_VAULT_ARG}", exc)
+
+
+def parse_args() -> ScriptArgs:
+    """
+    Parses the command line arguments.
+
+    [--file FILENAME] [--overwrite] [--fail-if-not-in-vault]
+    """
+    logging.debug("Command line arguments: %s", sys.argv)
+
+    parser = argparse.ArgumentParser(
+        description="Update root SSH config file from value in Vault")
+
+    parser.add_argument("--file", type=file_basename, metavar="filename", dest="filename",
+                        default=CONFIG_NAME, help=f"Name of file in {CONFIG_DIR} to write SSH "
+                                                  f"configuration into (default: {CONFIG_NAME})")
+    parser.add_argument(OVERWRITE_ARG, action='store_true', dest='overwrite', default=False,
+                        help="Overwrite the configuration file if it already exists "
+                             "(default: fail if it already exists)")
+    parser.add_argument(IN_VAULT_ARG, action='store_true', dest='must_be_in_vault',
+                        default=False, help="Fail if the SSH configuration is not found in Vault")
+    parsed_args = parser.parse_args()
+
+    return ScriptArgs(filename=parsed_args.filename,
+                      overwrite=parsed_args.overwrite,
+                      must_be_in_vault=parsed_args.must_be_in_vault)
+
+
+def main():
+    """
+    Parses the command line arguments, read the info from Vault, and write it to the target file
+    """
+    script_args = parse_args()
+    ssh_config = get_ssh_config_from_vault(script_args)
+    if ssh_config is None:
+        return
+    write_ssh_config_file(script_args, ssh_config)
+
+
+if __name__ == '__main__':
+    logger.configure_logging(
+        filename='/var/log/restore_ssh_config_from_vault.log')
+    try:
+        main()
+    except common.ScriptException as script_exc:
+        common.print_err_exit(f"{script_exc}")
+    print("SUCCESS", flush=True)

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -31,10 +31,11 @@ Reads in:
 
 Writes these to the secret/csm/users/root in Vault, and then
 reads them back to verify that they match what was written.
+
+The user can optionally include the SSH config file as well.
 """
 
 import argparse
-import copy
 import crypt
 import logging
 import sys
@@ -42,19 +43,18 @@ import sys
 from python_lib import args
 from python_lib import common
 from python_lib import logger
-from python_lib.types import JsonObject
-from python_lib.vault import Vault
-
+from python_lib.csm_root_secret import (csm_root_secret,
+                                        CsmUserSecretUpdateData,
+                                        PW_FIELD,
+                                        SSH_CONFIG_FIELD,
+                                        SSH_PRI_KEY_FIELD,
+                                        SSH_PUB_KEY_FIELD)
+from python_lib.root_ssh_config import CONFIG_PATH, ssh_config_file
 
 # Default values
 PRI_KEY_PATH = "/root/.ssh/id_rsa"
 PUB_KEY_PATH = "/root/.ssh/id_rsa.pub"
 MINIMUM_PW_LENGTH = 8
-
-# Constants
-PASSWORD_HASH_FIELD_NAME = "password"
-PRIVATE_KEY_FIELD_NAME = "ssh_private_key"
-PUBLIC_KEY_FIELD_NAME = "ssh_public_key"
 
 
 def root_hash_from_etc_shadow() -> str:
@@ -131,123 +131,7 @@ def pub_ssh_key_file(file_name: str) -> str:
         value_validator=lambda s: args.validate_string(s, min_length=256))
 
 
-def update_secret_fields(secret: JsonObject, field_changes: JsonObject) -> JsonObject:
-    """
-    Takes the current CSM root secret values (secret) and determines the desired new CSM root secret
-    values. Returns a dictionary of the new values.
-    """
-    updated_secret = copy.deepcopy(secret)
-    for field_name, new_field_value in field_changes.items():
-        if new_field_value is None:
-            # This means the field should be removed, if it is set
-            try:
-                del updated_secret[field_name]
-                logging.debug("CSM root secret %s in Vault will be deleted", field_name)
-            except KeyError:
-                # Not a problem, but let's note it for the log
-                logging.debug("Asked to delete CSM root secret %s in Vault, but it isn't set",
-                              field_name)
-            continue
-        # Record the new value
-        updated_secret[field_name] = new_field_value
-    return updated_secret
-
-
-def compare_root_secrets(secret_written: JsonObject, secret_read: JsonObject) -> None:
-    """
-    Compare the secret we wrote to what we read back. If there are any differences,
-    log them and raise an exception.
-    """
-    secrets_match = True
-
-    # Validate that Vault values match what we wrote
-    logging.debug("Validating that Vault contents match what was written to it")
-
-    fields_not_written = secret_written.keys() - secret_read.keys()
-    extra_fields = secret_read.keys() - secret_written.keys()
-    common_fields = secret_read.keys() & secret_written.keys()
-
-    if fields_not_written:
-        secrets_match = False
-        logging.error("Fields were written to the CSM root secret, but were not present"
-                      " when it was read back: %s", fields_not_written)
-    else:
-        logging.debug("All written secret fields were present when read back")
-
-    if extra_fields:
-        secrets_match = False
-        logging.error("Fields were not written to the CSM root secret, but were present"
-                      " when it was read back: %s", extra_fields)
-    else:
-        logging.debug("All read secret fields were present when written")
-
-    for field in common_fields:
-        if secret_read[field] == secret_written[field]:
-            logging.debug("Vault value for %s matches what was written", field)
-        else:
-            secrets_match = False
-            logging.error("Vault value for %s DOES NOT MATCH what was written", field)
-
-    if not secrets_match:
-        raise common.ScriptException(
-            "Secret read back from Vault does not match what was written")
-
-    logging.info("Secrets read back from Vault match desired values")
-
-
-def update_root_secret_in_vault(field_changes: JsonObject) -> None:
-    """
-    Write the SSH keys and passwords to the csm root secret in Vault.
-    If the result is that the secret no longer contains any data, it is deleted from Vault.
-    Then read secret the back to verify it matches what was written (or verify that it
-    no longer exists in Vault, if applicable).
-    """
-
-    vault = Vault()
-
-    # Get the current CSM root secrets from Vault. It is possible that the secret is not in Vault.
-    csm_root_secret_before = vault.get_csm_root_secret(must_exist=False)
-    if csm_root_secret_before is None:
-        logging.debug("CSM root secret does not currently exist in Vault")
-        csm_root_secret_before = dict()
-
-    # Generate the new desired root secret based on the current secret contents and the
-    # arguments to this function
-    csm_root_secret_to_write = update_secret_fields(secret=csm_root_secret_before,
-                                                    field_changes=field_changes)
-
-    if not csm_root_secret_to_write:
-        logging.info("Based on inputs, the desired CSM root secret is empty")
-        if not csm_root_secret_before:
-            logging.info(
-                "The CSM root secret in Vault is already empty, so nothing to do.")
-            return
-
-        # Vault does not allow empty secrets do be written. Instead, they must be deleted.
-        logging.info("Deleting CSM root secret from Vault")
-        vault.delete_csm_root_secret()
-
-        # Now attempt to read the CSM root secret from Vault.
-        csm_root_secret_after = vault.get_csm_root_secret(must_exist=False)
-        if csm_root_secret_after is not None:
-            common.log_error_raise_exception(
-                "CSM root secret appears to exist in Vault even after deleting it")
-        logging.info("CSM root secret deleted from Vault")
-        return
-
-    # We are left with the case where we are writing secret data to Vault
-    logging.info("Writing updated CSM root secret to Vault")
-    vault.write_csm_root_secret(secret_data=csm_root_secret_to_write)
-
-    # Read back CSM root secret from Vault. It should exist, since we just wrote it.
-    csm_root_secret_after = vault.get_csm_root_secret(must_exist=True)
-
-    # Compare what we wrote to what we read back
-    compare_root_secrets(csm_root_secret_to_write, csm_root_secret_after)
-    return
-
-
-def parse_args() -> JsonObject:
+def parse_args() -> CsmUserSecretUpdateData:
     """
     Parses the command line arguments.
     Returns a dictionary mapping secret field names to the value they should be
@@ -259,6 +143,7 @@ def parse_args() -> JsonObject:
      --pw-prompt | --pw-remove | --pw-sys]
     [--pri-key-file FILEPATH | --pri-key-no-change | --pri-key-remove]
     [--pub-key-file FILEPATH | --pub-key-no-change | --pub-key-remove]
+    [--config-file [FILEPATH] | --config-no-change | --config-remove]
     """
     logging.debug("Command line arguments: %s", sys.argv)
 
@@ -312,41 +197,63 @@ def parse_args() -> JsonObject:
                                dest='pub_key', default=argparse.SUPPRESS,
                                help="Remove saved public key (if any) from Vault")
 
+    # SSH config source arguments are mutually exclusive
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument("--config-no-change", action='store_const', const=NO_CHANGE,
+                              dest='ssh_config', default=NO_CHANGE,
+                              help="Do not change saved SSH config (if any) in Vault (default)")
+    config_group.add_argument("--config-file", nargs='?', type=ssh_config_file, const=CONFIG_PATH,
+                              default=argparse.SUPPRESS, metavar='ssh_config_file',
+                              dest='ssh_config',
+                              help=f"Read key from ssh_config_file or {CONFIG_PATH}")
+    config_group.add_argument("--config-remove", action='store_const', const=REMOVE,
+                              dest='ssh_config', default=argparse.SUPPRESS,
+                              help="Remove saved SSH config (if any) from Vault")
+
     parsed_args = parser.parse_args()
 
-    field_changes = dict()
+    field_changes = CsmUserSecretUpdateData()
 
     if parsed_args.pw_remove:
         # Clear the field in Vault, if it is set
-        field_changes[PASSWORD_HASH_FIELD_NAME] = None
+        field_changes[PW_FIELD] = None
     elif parsed_args.pw_hash_env_var is not None:
         # We have already read in the hashed value from the environment variable
-        field_changes[PASSWORD_HASH_FIELD_NAME] = parsed_args.pw_hash_env_var
+        field_changes[PW_FIELD] = parsed_args.pw_hash_env_var
     elif parsed_args.pw_env_var is not None:
         # Generate the hash
         logging.debug("Generating password hash")
-        field_changes[PASSWORD_HASH_FIELD_NAME] = crypt.crypt(
+        field_changes[PW_FIELD] = crypt.crypt(
             parsed_args.pw_env_var)
     elif parsed_args.pw_prompt is not None:
         # Generate the hash
         logging.debug("Generating password hash")
-        field_changes[PASSWORD_HASH_FIELD_NAME] = crypt.crypt(
+        field_changes[PW_FIELD] = crypt.crypt(
             parsed_args.pw_prompt)
     elif not parsed_args.pw_no_change:
         # Default is to read it from the system
-        field_changes[PASSWORD_HASH_FIELD_NAME] = root_hash_from_etc_shadow()
+        field_changes[PW_FIELD] = root_hash_from_etc_shadow()
 
     if parsed_args.pri_key is REMOVE:
         # Clear the field in Vault, if it is set
-        field_changes[PRIVATE_KEY_FIELD_NAME] = None
+        field_changes[SSH_PRI_KEY_FIELD] = None
     elif parsed_args.pri_key is not NO_CHANGE:
-        field_changes[PRIVATE_KEY_FIELD_NAME] = parsed_args.pri_key
+        # Use file contents
+        field_changes[SSH_PRI_KEY_FIELD] = parsed_args.pri_key
 
     if parsed_args.pub_key is REMOVE:
         # Clear the field in Vault, if it is set
-        field_changes[PUBLIC_KEY_FIELD_NAME] = None
+        field_changes[SSH_PUB_KEY_FIELD] = None
     elif parsed_args.pub_key is not NO_CHANGE:
-        field_changes[PUBLIC_KEY_FIELD_NAME] = parsed_args.pub_key
+        # Use file contents
+        field_changes[SSH_PUB_KEY_FIELD] = parsed_args.pub_key
+
+    if parsed_args.ssh_config is REMOVE:
+        # Clear the field in Vault, if it is set
+        field_changes[SSH_CONFIG_FIELD] = None
+    elif parsed_args.ssh_config is not NO_CHANGE:
+        # Use file contents
+        field_changes[SSH_CONFIG_FIELD] = parsed_args.ssh_config
 
     return field_changes
 
@@ -356,7 +263,7 @@ def main():
     Parses the command line arguments, read in the secrets, write them to Vault.
     """
     field_changes = parse_args()
-    update_root_secret_in_vault(field_changes)
+    csm_root_secret().update(field_changes, verify=True)
 
 
 if __name__ == '__main__':

--- a/scripts/operations/configuration/write_ssh_config_to_vault.py
+++ b/scripts/operations/configuration/write_ssh_config_to_vault.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Reads in the SSH configuration from /root/.ssh/config (or the user-specified path),
+writes it to secret csm/ssh-config/root in Vault, and then
+reads it back to verify that it matches what was written.
+"""
+
+import argparse
+import logging
+import sys
+
+from python_lib import common
+from python_lib import logger
+from python_lib.csm_root_secret import (csm_root_secret,
+                                        CsmUserSecretUpdateData,
+                                        SSH_CONFIG_FIELD)
+from python_lib.root_ssh_config import CONFIG_PATH, ssh_config_file
+
+
+def parse_args() -> CsmUserSecretUpdateData:
+    """
+    Parses the command line arguments.
+
+    [--file FILEPATH | --delete]
+    """
+    logging.debug("Command line arguments: %s", sys.argv)
+
+    parser = argparse.ArgumentParser(
+        description="Update or delete CSM root SSH config in Vault")
+
+    # Sentinel value
+    DELETE = object()
+
+    # The two possible arguments to this script are mutually exclusive
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--delete", action='store_const', dest='ssh_config', const=DELETE,
+                       default=argparse.SUPPRESS,
+                       help="Delete CSM root SSH config from Vault")
+    group.add_argument("--file", type=ssh_config_file, metavar="ssh-config-file",
+                       dest='ssh_config', default=CONFIG_PATH,
+                       help=f"Path to root SSH config file (default: {CONFIG_PATH})")
+    parsed_args = parser.parse_args()
+    update = CsmUserSecretUpdateData()
+    update[SSH_CONFIG_FIELD] = None if parsed_args.ssh_config is DELETE else parsed_args.ssh_config
+    return update
+
+
+def main():
+    """
+    Parses the command line arguments, read in the secrets, write them to Vault.
+    """
+    root_secret_update_data = parse_args()
+    csm_root_secret().update(root_secret_update_data, verify=True)
+
+
+if __name__ == '__main__':
+    logger.configure_logging(
+        filename='/var/log/write_ssh_config_to_vault.log')
+    try:
+        main()
+    except common.ScriptException as script_exc:
+        common.print_err_exit(f"{script_exc}")
+    print("SUCCESS", flush=True)

--- a/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
+++ b/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
@@ -37,29 +37,8 @@ from python_lib import common
 from python_lib import logger
 from python_lib.vault import Vault
 
-
-def update_password_in_vault(pw_string: str) -> None:
-    """
-    Writes the switch admin password to Vault.
-    Then read it back to verify it matches what was written
-    """
-
-    vault = Vault()
-
-    logging.info("Writing switch admin password to Vault")
-    vault.write_sw_admin_password(pw_string)
-
-    # Read back PW from Vault.
-    pw_from_vault = vault.get_sw_admin_password()
-
-    # Compare what we wrote to what we read back
-    if pw_string != pw_from_vault:
-        msg = "Password read back from Vault does NOT match what was written to Vault"
-        logging.error(msg)
-        raise common.ScriptException(msg)
-
-    logging.info("Password read from Vault matches what was written")
-    return
+SW_ADMIN_PW_KEY = "net-creds/switch_admin"
+SW_ADMIN_PW_FIELD = "admin"
 
 
 def prompt_user_for_password() -> str:
@@ -85,7 +64,10 @@ def main():
     Prompt the user for the password, write it to Vault.
     """
     admin_pw = prompt_user_for_password()
-    update_password_in_vault(admin_pw)
+    logging.info("Writing switch admin password to Vault")
+    Vault().write_secret(secret_key=SW_ADMIN_PW_KEY,
+                         secret_data={ SW_ADMIN_PW_FIELD: admin_pw },
+                         verify=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
> Note: I am intentionally making this PR against the branch for CASMCMS-9442, because I wanted to separate out the linting changes of that PR from the content changes in this one.

CASMCMS-9435: The current documentation for configuring passwordless SSH does not mention SSH configuration files. Without creating an appropriate SSH configuration file, passwordless SSH will only work if the path to the CSM key is specified to the SSH command.

This PR updates the documentation to remind administrators that they may want to create this file, give a basic example of its contents, and caution them that the file does not persist across image rebuilds. This also adds a reminder to the NCN rebuild documentation about restoring manual configurations (like SSH config files) post-rebuild.

CASMCMS-9436/CASMCMS-9437: Create scripts to backup and restore the SSH configuration from Vault (like what is done with the root secrets). Update the documentation to explain their usage.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/5979
1.5: https://github.com/Cray-HPE/docs-csm/pull/5980
1.4: https://github.com/Cray-HPE/docs-csm/pull/5981