### PR TITLE
CASMPET-7553: If helm status is 'uninstalled' return success

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -165,8 +165,13 @@ function deploy() {
 # Use this if a chart has been removed from a manifest and needs
 # to be removed from the system as part of an upgrade.
 function undeploy() {
-  # If the chart is missing (rc==1) just return success.
+  # Now that we're using --keep-history, helm status will return with a STATUS
+  # of "uninstalled" if the chart has already been uninstalled.
+  # If the chart is missing (rc==1) or if uninstalled, return success.
   helm status "$@" || return 0
+  if [ "$(helm status "$@" | grep STATUS | awk '{print $2}')" = "uninstalled" ]; then
+    return 0
+  fi
   # Remove the chart.
   helm uninstall "$@" --keep-history
 }
@@ -178,7 +183,7 @@ if [ ${k8s_minor_version} -gt 24 ]; then
 fi
 
 # If there are post-upgrade-*-<k8s_version>.yaml files, deploy charts in those files.
-manifests_dir="${CSM_ARTI_DIR}/manifests"
+manifests_dir="${CSM_ARTI_DIR}/build/manifests"
 find "${manifests_dir}/" -name "post-upgrade-*-${k8s_version}.yaml" | sort | while read -r manifest; do
   echo "INFO Deploying ${manifest} ..."
   deploy "${manifest}"


### PR DESCRIPTION
# Description
CASMPET-7553: Because we are now using the `--keep-history` flag with `helm uninstall`, the `helm status` call will return successfully on uninstalled charts. Add a check in the `undeploy` function, if helm status STATUS  is 'uninstalled' return success.

CASMPET-7552: In upgrade_control_plane.sh, use manifests in CSM_ARTI_DIR/build/manifests directory that have gone through manifestgen.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
