### PR TITLE
CASMHMS-6257: Remove reference to restarting hmcollector now that bug is fixed

### DIFF
--- a/operations/firmware/FAS_Paradise.md
+++ b/operations/firmware/FAS_Paradise.md
@@ -63,15 +63,6 @@ To update using a JSON file and the Cray CLI, use this example JSON file and fol
 }
 ```
 
-**IMPORTANT:** There is a known bug that causes the `hmcollector-poll` service to lose event subscriptions
-after BMC firmware is updated. After updating BMC firmware, the `hmcollector-poll` service must be restarted to
-work around this issue. After the update is complete, and you confirm the BMC has been rebooted, restart
-the `hmcollector-poll` service with this command:
-
-```bash
-kubectl -n services rollout restart deployment cray-hms-hmcollector-poll
-```
-
 ## Update Paradise `bios_active` procedure
 
 The nodes must be **OFF** before updating the BIOS


### PR DESCRIPTION
# Description

Removed reference to hmcollector workaround now that the bug is fixed.

* Resolves [CASMHMS-6257](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6257)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
