### PR TITLE
CASMINST-7351: Remove UAS/UAI references; remove BOS etcd references

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -617,8 +617,7 @@ For more information, see [SOPS Introduction](operations/security_and_authentica
 ## Service/IO Cabinet
 
 An Air-Cooled service/IO cabinet houses a cluster of [NCNs](#non-compute-node-ncn), [Slingshot ToR switches](#slingshot-top-of-rack-tor-switch),
-and management network ToR switches to support the managed ecosystem storage,
-network, user access services (UAS), and other IO services such as LNet and gateways.
+and management network ToR switches to support the managed ecosystem storage, network, and other IO services such as LNet and gateways.
 
 ## Shasta Cabling Diagram (SHCD)
 

--- a/introduction/csm_overview.md
+++ b/introduction/csm_overview.md
@@ -25,38 +25,37 @@ The HPE Cray EX system has two types of nodes:
 `nidXXXXXX`, that is, `nid` followed by six digits. These six digits will be padded with zeroes at the beginning.
 All other nodes provide supporting functions to these compute nodes.
 * **Non-Compute Nodes (NCNs)**, which carry out system functions and come in many types:
-  * Management nodes in a Kubernetes cluster which host system services.
-    * Kubernetes master nodes, with names in the form of `ncn-mXXX`. Every system has three or more master nodes.
-    * Kubernetes worker nodes, with names in the form of `ncn-wXXX`. Every system has three or more worker nodes.
-    * Utility Storage nodes providing Ceph storage to Kubernetes nodes, with names in the form of `ncn-sXXX`. Every system has three or more storage nodes.
-  * Application nodes (ANs) which are not part of the Kubernetes management cluster
-    * User Access Nodes (UANs), known by some as login or front-end nodes
-    * Other site-defined types:
-      * Gateway nodes
-      * Data Mover nodes
-      * Visualization nodes
+    * Management nodes in a Kubernetes cluster which host system services.
+        * Kubernetes master nodes, with names in the form of `ncn-mXXX`. Every system has three or more master nodes.
+        * Kubernetes worker nodes, with names in the form of `ncn-wXXX`. Every system has three or more worker nodes.
+        * Utility Storage nodes providing Ceph storage to Kubernetes nodes, with names in the form of `ncn-sXXX`. Every system has three or more storage nodes.
+    * Application nodes (ANs) which are not part of the Kubernetes management cluster
+        * User Access Nodes (UANs), known by some as login or front-end nodes
+        * Other site-defined types:
+            * Gateway nodes
+            * Data Mover nodes
+            * Visualization nodes
 
 The following system networks connect the devices listed:
 
 * Networks external to the system:
-  * Customer Network (Data Center)
-    * `ncn-m001` BMC is connected by the customer network switch to the customer management network
-    * ClusterStor System Management Unit (SMU) interfaces
-    * User Access Nodes (UANs)
+    * Customer Network (Data Center)
+        * `ncn-m001` BMC is connected by the customer network switch to the customer management network
+        * ClusterStor System Management Unit (SMU) interfaces
+        * User Access Nodes (UANs)
 * System networks:
-  * Hardware Management Network (HMN)
-    * BMCs for Admin tasks
-    * Power distribution units (PDU)
-    * Keyboard/video/mouse (KVM)
-  * Node Management Network (NMN)
-    * All NCNs and compute nodes
-  * ClusterStor Management Network
-    * ClusterStor controller management interfaces of all ClusterStor components (SMU, Metadata
-Management Unit (MMU), and Scalable Storage Unit (SSU))
-  * High-Speed Network (HSN), which connects the following devices:
-    * Kubernetes worker nodes
-    * UANs
-    * ClusterStor controller data interfaces of all ClusterStor components (SMU, MMU, and SSU)
+    * Hardware Management Network (HMN)
+        * BMCs for Admin tasks
+        * Power distribution units (PDU)
+        * Keyboard/video/mouse (KVM)
+    * Node Management Network (NMN)
+        * All NCNs and compute nodes
+    * ClusterStor Management Network
+        * ClusterStor controller management interfaces of all ClusterStor components (SMU, Metadata Management Unit (MMU), and Scalable Storage Unit (SSU))
+    * High-Speed Network (HSN), which connects the following devices:
+        * Kubernetes worker nodes
+        * UANs
+        * ClusterStor controller data interfaces of all ClusterStor components (SMU, MMU, and SSU)
 
 During initial installation, several of those networks are created with default IP address ranges. See
 [Default IP Address Ranges](#2-default-ip-address-ranges)
@@ -130,8 +129,8 @@ There are several network values and other pieces of system information that are
 
   For more information on the CMN, see [Customer Accessible Networks](../operations/network/customer_accessible_networks/Customer_Accessible_Networks.md).
 
-  * Subnet for the MetalLB static address pool (`cmn-static-pool`), which is used for services that need to be pinned to the same IP address, such as the system DNS service.
-  * Subnet for the MetalLB dynamic address pool (`cmn-dynamic-pool`), which is used for services such as Prometheus and Nexus that can be reached by DNS.
+    * Subnet for the MetalLB static address pool (`cmn-static-pool`), which is used for services that need to be pinned to the same IP address, such as the system DNS service.
+    * Subnet for the MetalLB dynamic address pool (`cmn-dynamic-pool`), which is used for services such as Prometheus and Nexus that can be reached by DNS.
 * HPE Cray EX Domain: The value of the subdomain that is used to access externally exposed services.
   For example, if the system is named `TestSystem`, and the site is `example.com`, the HPE Cray EX domain
   would be `testsystem.example.com`. Central DNS would need to be configured to delegate requests for

--- a/introduction/csm_overview.md
+++ b/introduction/csm_overview.md
@@ -68,7 +68,7 @@ and an IP subnet.
 The low-level network management components (switch, DHCP service, ARP service) of the management nodes and
 ClusterStor interfaces are configured to serve one particular network (the "supported network") on the high-speed
 fabric. As part of the initial installation, the supported network is created to include all of the compute nodes,
-thereby enabling those compute nodes to access the gateway, user access services, and ClusterStor devices.
+thereby enabling those compute nodes to access the gateway and ClusterStor devices.
 
 A site may create other networks as well, but it is only the supported network that is served by those devices.
 

--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -100,7 +100,6 @@ required for initial installation scenarios.
         - Enable CAN, LDAP, and set MOTD
         - Move DVS and LNet settings to USS branch
         - Set the UAN root password in HashiCorp Vault
-        - Enable UAIs on UAN
     - SLURM Configuration
         - CSM Diags
             - Update CSM Diags network attachment definition

--- a/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
+++ b/operations/kubernetes/Backups_for_Etcd_Clusters_Running_in_Kubernetes.md
@@ -19,7 +19,6 @@ The following services are backed up daily \(one week of backups retained\) as p
 - Heartbeat Tracking Daemon \(HBTD\)
 - HMS Notification Fanout Daemon \(HMNFD\)
 - Power Control Service \(PCS\)
-- User Access Service \(UAS\)
 
 ## Test for recent etcd cluster backups
 
@@ -60,9 +59,6 @@ PASS: backup found less than 24 hours old.
 PASS: backup found less than 24 hours old.
 
 -- cray-power-control -- backups
-PASS: backup found less than 24 hours old.
-
--- cray-uas-mgr -- backups
 PASS: backup found less than 24 hours old.
  --- PASSED --- 
 ```
@@ -117,7 +113,6 @@ cray-fox/db-2024-09-30_23-00
 cray-hbtd/db-2024-09-30_23-00
 cray-hmnfd/db-2024-09-30_23-01
 cray-power-control/db-2024-09-30_23-00
-cray-uas-mgr/db-2024-09-30_23-00
 cray-bos/db-2024-10-01_23-00
 cray-bss/db-2024-10-01_23-00
 cray-fas/db-2024-10-01_23-00

--- a/operations/kubernetes/Check_for_and_Clear_etcd_Cluster_Alarms.md
+++ b/operations/kubernetes/Check_for_and_Clear_etcd_Cluster_Alarms.md
@@ -28,9 +28,6 @@ For example, a cluster's database `NOSPACE` alarm is set when database storage s
 
     === Check if any "alarms" are set for any of the Etcd Clusters in all Namespaces. ===
     === An empty list is returned if no alarms are set ===
-    ### cray-bos-bitnami-etcd-1 Alarms Set: ###
-    ### cray-bos-bitnami-etcd-2 Alarms Set: ###
-    ### cray-bos-bitnami-etcd-0 Alarms Set: ###
     ### cray-bss-bitnami-etcd-1 Alarms Set: ###
     ### cray-bss-bitnami-etcd-2 Alarms Set: ###
     ### cray-bss-bitnami-etcd-0 Alarms Set: ###
@@ -53,9 +50,6 @@ For example, a cluster's database `NOSPACE` alarm is set when database storage s
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 Disarmed Alarms: ###
-        ### cray-bos-bitnami-etcd-1 Disarmed Alarms: ###
-        ### cray-bos-bitnami-etcd-2 Disarmed Alarms: ###
         ### cray-bss-bitnami-etcd-0 Disarmed Alarms: ###
         ### cray-bss-bitnami-etcd-1 Disarmed Alarms: ###
         ### cray-bss-bitnami-etcd-2 Disarmed Alarms: ###
@@ -66,16 +60,16 @@ For example, a cluster's database `NOSPACE` alarm is set when database storage s
     - Clear all alarms in one particular etcd cluster.
 
         ```bash
-        /opt/cray/platform-utils/etcd/etcd-util.sh clear_alarms cray-bos
+        /opt/cray/platform-utils/etcd/etcd-util.sh clear_alarms cray-bss
         ```
 
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-0 Disarmed Alarms: ###
         memberID:14039380531903955557 alarm:NOSPACE
         memberID:10060051157615504224 alarm:NOSPACE
         memberID:9418794810465807950 alarm:NOSPACE
-        ### cray-bos-bitnami-etcd-1 Disarmed Alarms: ###
-        ### cray-bos-bitnami-etcd-2 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-1 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-2 Disarmed Alarms: ###
         ```

--- a/operations/kubernetes/Check_the_Health_of_etcd_Clusters.md
+++ b/operations/kubernetes/Check_the_Health_of_etcd_Clusters.md
@@ -25,11 +25,11 @@ This procedure requires root privileges.
     === Check the Health of the Etcd Clusters in all Namespaces. ===
     === Verify a "healthy" Report for Each Etcd Pod. ===
     Fri 10 Mar 2023 07:52:09 PM UTC
-    ### cray-bos-bitnami-etcd-0 ###
+    ### cray-bss-bitnami-etcd-0 ###
     127.0.0.1:2379 is healthy: successfully committed proposal: took = 4.166761ms
-    ### cray-bos-bitnami-etcd-1 ###
+    ### cray-bss-bitnami-etcd-1 ###
     127.0.0.1:2379 is healthy: successfully committed proposal: took = 4.697124ms
-    ### cray-bos-bitnami-etcd-2 ###
+    ### cray-bss-bitnami-etcd-2 ###
     127.0.0.1:2379 is healthy: successfully committed proposal: took = 4.119712ms
     [...]
      --- PASSED ---
@@ -54,9 +54,9 @@ This procedure requires root privileges.
     === Each cluster should contain at least three pods, but may contain more. ===
     === Ensure that no two pods in a given cluster exist on the same worker node. ===
     Fri 10 Mar 2023 07:54:22 PM UTC
-    cray-bos-bitnami-etcd-0                                           2/2     Running     0          22h     10.32.0.76    ncn-w002   <none>           <none>
-    cray-bos-bitnami-etcd-1                                           2/2     Running     0          22h     10.40.0.8     ncn-w003   <none>           <none>
-    cray-bos-bitnami-etcd-2                                           2/2     Running     0          22h     10.44.0.58    ncn-w001   <none>           <none>
+    cray-bss-bitnami-etcd-0                                           2/2     Running     0          22h     10.32.0.76    ncn-w002   <none>           <none>
+    cray-bss-bitnami-etcd-1                                           2/2     Running     0          22h     10.40.0.8     ncn-w003   <none>           <none>
+    cray-bss-bitnami-etcd-2                                           2/2     Running     0          22h     10.44.0.58    ncn-w001   <none>           <none>
     [...]
      --- PASSED ---
     ```
@@ -76,11 +76,11 @@ This procedure requires root privileges.
 
    === Check the health of Etcd Cluster's database in the Services Namespace. ===
    === PASS or FAIL status returned. ===
-   ### cray-bos-bitnami-etcd-0 Etcd Database Check: ###
+   ### cray-bss-bitnami-etcd-0 Etcd Database Check: ###
    PASS: OK foo fooCheck 1
-   ### cray-bos-bitnami-etcd-1 Etcd Database Check: ###
+   ### cray-bss-bitnami-etcd-1 Etcd Database Check: ###
    PASS: OK foo fooCheck 1
-   ### cray-bos-bitnami-etcd-2 Etcd Database Check: ###
+   ### cray-bss-bitnami-etcd-2 Etcd Database Check: ###
    PASS: OK foo fooCheck 1
    [...]
     --- PASSED ---

--- a/operations/kubernetes/Clear_Space_in_an_etcd_Cluster_Database.md
+++ b/operations/kubernetes/Clear_Space_in_an_etcd_Cluster_Database.md
@@ -26,13 +26,13 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
 
         === Check the health of Etcd Cluster's database in the Services Namespace. ===
         === PASS or FAIL status returned. ===
-        ### cray-bos-bitnami-etcd-0 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-0 Etcd Database Check: ###
         FAILED DATABASE CHECK - EXPECTED: OK foo fooCheck 1
         {"level":"warn","ts":"2020-10-23T23:56:48.408Z","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-208534eb-2ab4-4c58-8853-58bff088c394/127.0.0.1:2379","attempt":0,"error":"rpc error: code = ResourceExhausted desc = etcdserver: mvcc: database space exceeded"}
         Error: etcdserver: mvcc: database space exceeded
-        ### cray-bos-bitnami-etcd-1 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-1 Etcd Database Check: ###
         PASS: OK foo fooCheck 1
-        ### cray-bos-bitnami-etcd-2 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-2 Etcd Database Check: ###
         PASS: OK foo fooCheck 1
          --- PASSED ---
         ```
@@ -46,15 +46,15 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-0 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd14   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-1 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-1 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd11   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-2 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-2 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd10   7.8G   123M   7.7G   2%   /bitnami/etcd
         ```
@@ -68,12 +68,12 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
        Example output:
 
        ```text
-       ### cray-bos-bitnami-etcd-0 Disarmed Alarms: ###
+       ### cray-bss-bitnami-etcd-0 Disarmed Alarms: ###
        memberID:6004340417806974740 alarm:NOSPACE
        memberID:10618826089438871005 alarm:NOSPACE
        memberID:6927946043724325475 alarm:NOSPACE
-       ### cray-bos-bitnami-etcd-1 Disarmed Alarms: ###
-       ### cray-bos-bitnami-etcd-2 Disarmed Alarms: ###
+       ### cray-bss-bitnami-etcd-1 Disarmed Alarms: ###
+       ### cray-bss-bitnami-etcd-2 Disarmed Alarms: ###
        ```
 
     1. Verify that a new key-value can now be successfully stored.
@@ -89,11 +89,11 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         
         === Check the health of Etcd Cluster's database in the Services Namespace. ===
         === PASS or FAIL status returned. ===
-        ### cray-bos-bitnami-etcd-0 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-0 Etcd Database Check: ###
         PASS: OK foo fooCheck 1
-        ### cray-bos-bitnami-etcd-1 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-1 Etcd Database Check: ###
         PASS: OK foo fooCheck 1
-        ### cray-bos-bitnami-etcd-2 Etcd Database Check: ###
+        ### cray-bss-bitnami-etcd-2 Etcd Database Check: ###
         PASS: OK foo fooCheck 1
          --- PASSED ---
         ```
@@ -109,15 +109,15 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-0 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd14   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-1 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-1 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd11   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-2 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-2 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd10   7.8G   123M   7.7G   2%   /bitnami/etcd
         ```
@@ -165,9 +165,9 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         Running etcd defrag for: all
         Skip defrag for: cray-hbtd-etcd
         Skipping defrag for: cray-hbtd-etcd
-        Defragging cray-bos-bitnami-etcd-0
-        Defragging cray-bos-bitnami-etcd-1
-        Defragging cray-bos-bitnami-etcd-2
+        Defragging cray-bss-bitnami-etcd-0
+        Defragging cray-bss-bitnami-etcd-1
+        Defragging cray-bss-bitnami-etcd-2
 
         [...]
         ```
@@ -181,15 +181,15 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-0 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd14   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-1 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-1 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd11   7.8G   123M   7.7G   2%   /bitnami/etcd
 
-        ### cray-bos-bitnami-etcd-2 PVC Usage: ###
+        ### cray-bss-bitnami-etcd-2 PVC Usage: ###
         Filesystem   Size   Used   Avail   Use%   Mounted   on
         /dev/rbd10   7.8G   123M   7.7G   2%   /bitnami/etcd
         ```
@@ -203,10 +203,10 @@ Defragging the database cluster and clearing the etcd cluster `NOSPACE` alarm wi
         Example output:
 
         ```text
-        ### cray-bos-bitnami-etcd-0 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-0 Disarmed Alarms: ###
         memberID:6004340417806974740 alarm:NOSPACE
         memberID:10618826089438871005 alarm:NOSPACE
         memberID:6927946043724325475 alarm:NOSPACE
-        ### cray-bos-bitnami-etcd-1 Disarmed Alarms: ###
-        ### cray-bos-bitnami-etcd-2 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-1 Disarmed Alarms: ###
+        ### cray-bss-bitnami-etcd-2 Disarmed Alarms: ###
         ```

--- a/operations/kubernetes/Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md
+++ b/operations/kubernetes/Create_a_Manual_Backup_of_a_Healthy_etcd_Cluster.md
@@ -14,31 +14,31 @@ A healthy etcd cluster is available on the system. See [Check the Health of etcd
 
 1. Create a backup for the desired etcd cluster.
 
-    The example below is backing up the etcd cluster for the Boot Orchestration Service \(BOS\) named `wednesday-manual-backup`.
+    The example below is backing up the etcd cluster for the Boot Script Service \(BSS\) named `wednesday-manual-backup`.
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd-util.sh create_backup cray-bos wednesday-manual-backup
+    /opt/cray/platform-utils/etcd/etcd-util.sh create_backup cray-bss wednesday-manual-backup
     ```
 
     Example output:
 
     ```text
-    Taking snapshot from cray-bos-bitnami-etcd-0...
-    Pushing newly created snapshot /snapshots/cray-bos-bitnami-etcd/db-2023-03-10_23-38 to S3 as wednesday-manual-backup for cray-bos
-    upload: snapshots/cray-bos-bitnami-etcd/db-2023-03-10_23-38 to s3://etcd-backup/cray-bos/wednesday-manual-backup
+    Taking snapshot from cray-bss-bitnami-etcd-0...
+    Pushing newly created snapshot /snapshots/cray-bss-bitnami-etcd/db-2023-03-10_23-38 to S3 as wednesday-manual-backup for cray-bss
+    upload: snapshots/cray-bss-bitnami-etcd/db-2023-03-10_23-38 to s3://etcd-backup/cray-bss/wednesday-manual-backup
     ```
 
 1. Verify the newly created backup is available in S3:
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd-util.sh list_backups cray-bos
+    /opt/cray/platform-utils/etcd/etcd-util.sh list_backups cray-bss
     ```
 
     Example output:
 
     ```text
-    cray-bos/db-2023-03-10_21-00
-    cray-bos/db-2023-03-10_22-00
-    cray-bos/db-2023-03-10_23-00
-    cray-bos/wednesday-manual-backup
+    cray-bss/db-2023-03-10_21-00
+    cray-bss/db-2023-03-10_22-00
+    cray-bss/db-2023-03-10_23-00
+    cray-bss/wednesday-manual-backup
     ```

--- a/operations/kubernetes/Increase_PVC_size_in_an_etcd_Cluster_Database.md
+++ b/operations/kubernetes/Increase_PVC_size_in_an_etcd_Cluster_Database.md
@@ -11,7 +11,7 @@ This procedure will detail how to increase the size of the Persistent Volume Cla
 
 ## Procedure
 
-NOTE: The examples below use `cray-power-control` as the example etcd cluster. If inspecting another cluster, replace the cluster name with the appropriate cluster name (`cray-bos`, `cray-bss`, etc..).
+NOTE: The examples below use `cray-power-control` as the example etcd cluster. If inspecting another cluster, replace the cluster name with the appropriate cluster name (`cray-bss`, `cray-fas`, etc..).
 
 1. (`ncn-mw#`) Check the current PVC usage in the running pods. Note that the following script will only report usage for pods that are running,
 so it may be necessary to run this command multiple times in order to catch the pod(s) while they are briefly up and trying to start.

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -20,13 +20,13 @@ The automated script will restore the cluster from a backup if it finds a backup
 * (`ncn-mw#`) Rebuild/restore a single cluster
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bos
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bss
     ```
 
 * (`ncn-mw#`) Rebuild/restore multiple clusters
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-bss
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bss,cray-fas
     ```
 
 * (`ncn-mw#`) Rebuild/restore all clusters
@@ -38,7 +38,7 @@ The automated script will restore the cluster from a backup if it finds a backup
 ### Example command and output
 
 ```bash
-/opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bos
+/opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bss
 ```
 
 Example output:
@@ -46,7 +46,7 @@ Example output:
 ```text
 The following etcd clusters will be restored/rebuilt:
 
-cray-bos
+cray-bss
 
 You will be accepting responsibility for any missing data if there is a
 restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
@@ -55,23 +55,23 @@ yes
 
 Proceeding: restoring/rebuilding etcd clusters.
 The following etcd clusters did not have backups so they will need to be rebuilt:
-cray-bos
+cray-bss
 Would you like to proceed rebuilding all of these etcd clusters? (yes/no)
 yes
 
 
- ----- Rebuilding cray-bos -----
-statefulset.apps/cray-bos-bitnami-etcd scaled
+ ----- Rebuilding cray-bss -----
+statefulset.apps/cray-bss-bitnami-etcd scaled
 Waiting for statefulset spec update to be observed...
-statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-6977fdd4b7...
+statefulset rolling update complete 0 pods at revision cray-bss-bitnami-etcd-6977fdd4b7...
 Deleting existing PVC's...
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
-Setting cluster state for cray-bos to 'new'
-statefulset.apps/cray-bos-bitnami-etcd env updated
-statefulset.apps/cray-bos-bitnami-etcd scaled
-waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-747d7d97b4...
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-0" deleted
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-1" deleted
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-2" deleted
+Setting cluster state for cray-bss to 'new'
+statefulset.apps/cray-bss-bitnami-etcd env updated
+statefulset.apps/cray-bss-bitnami-etcd scaled
+waiting for statefulset rolling update to complete 0 pods at revision cray-bss-bitnami-etcd-747d7d97b4...
 Waiting for 1 pods to be ready...
 Waiting for 2 pods to be ready...
 Waiting for 3 pods to be ready...
@@ -79,11 +79,11 @@ Waiting for 3 pods to be ready...
 Waiting for 3 pods to be ready...
 Waiting for 2 pods to be ready...
 Waiting for 1 pods to be ready...
-statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-747d7d97b4...
-Setting cluster state for cray-bos to 'existing'
-statefulset.apps/cray-bos-bitnami-etcd env updated
+statefulset rolling update complete 3 pods at revision cray-bss-bitnami-etcd-747d7d97b4...
+Setting cluster state for cray-bss to 'existing'
+statefulset.apps/cray-bss-bitnami-etcd env updated
 Checking endpoint health.
-cray-bos etcd cluster health verified from cray-bos-bitnami-etcd-0
+cray-bss etcd cluster health verified from cray-bss-bitnami-etcd-0
 ```
 
 ## Final checks

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -26,7 +26,7 @@ The automated script will restore the cluster from a backup if it finds a backup
 * (`ncn-mw#`) Rebuild/restore multiple clusters
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-uas-mgr
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-bss
     ```
 
 * (`ncn-mw#`) Rebuild/restore all clusters

--- a/operations/kubernetes/Report_the_Endpoint_Status_for_etcd_Clusters.md
+++ b/operations/kubernetes/Report_the_Endpoint_Status_for_etcd_Clusters.md
@@ -20,19 +20,19 @@ This procedure provides the ability to view the etcd cluster endpoint status.
     Example output:
 
     ```text
-    ### cray-bos-bitnami-etcd-1 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-1 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     | 127.0.0.1:2379 | 6a95fcc74f1f8616 |   3.5.7 |   25 kB |     false |      false |         7 |        420 |                420 |        |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
-    ### cray-bos-bitnami-etcd-2 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-2 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     | 127.0.0.1:2379 | 2b4984dc5c79bd55 |   3.5.7 |   25 kB |      true |      false |         7 |        424 |                424 |        |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
-    ### cray-bos-bitnami-etcd-0 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-0 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
@@ -45,25 +45,25 @@ This procedure provides the ability to view the etcd cluster endpoint status.
 1. Report the endpoint status for a singe etcd cluster.
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd-util.sh endpoint_status cray-bos
+    /opt/cray/platform-utils/etcd/etcd-util.sh endpoint_status cray-bss
     ```
 
     Example output:
 
     ```text
-    ### cray-bos-bitnami-etcd-1 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-1 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     | 127.0.0.1:2379 | 6a95fcc74f1f8616 |   3.5.7 |   25 kB |     false |      false |         7 |        420 |                420 |        |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
-    ### cray-bos-bitnami-etcd-2 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-2 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     | 127.0.0.1:2379 | 2b4984dc5c79bd55 |   3.5.7 |   25 kB |      true |      false |         7 |        424 |                424 |        |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
-    ### cray-bos-bitnami-etcd-0 Endpoint Status: ###
+    ### cray-bss-bitnami-etcd-0 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
     +----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -21,13 +21,13 @@ If it does not discover a backup within the last 7 days, it will ask the user if
 * (`ncn-mw#`) Rebuild/restore a single cluster
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bos
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bss
     ```
 
 * (`ncn-mw#`) Rebuild/restore multiple clusters
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-bss
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bss,cray-fas
     ```
 
 * (`ncn-mw#`) Rebuild/restore all clusters
@@ -47,7 +47,7 @@ Example output:
 ```text
 The following etcd clusters will be restored/rebuilt:
 
-cray-bos
+cray-bss
 
 You will be accepting responsibility for any missing data if there is a
 restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
@@ -56,31 +56,31 @@ yes
 
 Proceeding: restoring/rebuilding etcd clusters.
 
- ----- Restoring from cray-bos/db-2023-03-13_20-00 -----
+ ----- Restoring from cray-bss/db-2025-05-28_20-00 -----
 Scaling etcd statefulset down to zero...
-statefulset.apps/cray-bos-bitnami-etcd scaled
-Waiting for statefulset spec update to be observed...
-statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-5f899db6df...
-Setting cluster state for cray-bos to 'new' and to start from snapshot
-statefulset.apps/cray-bos-bitnami-etcd env updated
+statefulset.apps/cray-bss-bitnami-etcd scaled
+statefulset rolling update complete 0 pods at revision cray-bss-bitnami-etcd-7ccc4dd5cc...
+Setting cluster state for cray-bss to 'new' and to start from snapshot
+statefulset.apps/cray-bss-bitnami-etcd env updated
 Deleting existing PVC's...
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
-persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-0" deleted
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-1" deleted
+persistentvolumeclaim "data-cray-bss-bitnami-etcd-2" deleted
 Scaling etcd statefulset back up to three members...
-statefulset.apps/cray-bos-bitnami-etcd scaled
-waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-5b59844585...
+statefulset.apps/cray-bss-bitnami-etcd scaled
+waiting for statefulset rolling update to complete 0 pods at revision cray-bss-bitnami-etcd-c766d98bf...
 Waiting for 1 pods to be ready...
 Waiting for 2 pods to be ready...
 Waiting for 3 pods to be ready...
 Waiting for 3 pods to be ready...
 Waiting for 3 pods to be ready...
+Waiting for 3 pods to be ready...
 Waiting for 2 pods to be ready...
 Waiting for 1 pods to be ready...
-statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-5b59844585...
-Setting cluster state for cray-bos to back to 'existing'
-statefulset.apps/cray-bos-bitnami-etcd env updated
+statefulset rolling update complete 3 pods at revision cray-bss-bitnami-etcd-c766d98bf...
+Setting cluster state for cray-bss to back to 'existing'
+statefulset.apps/cray-bss-bitnami-etcd env updated
 
 Checking endpoint health.
-cray-bos etcd cluster health verified from cray-bos-bitnami-etcd-1
+cray-bss etcd cluster health verified from cray-bss-bitnami-etcd-1
 ```

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -27,7 +27,7 @@ If it does not discover a backup within the last 7 days, it will ask the user if
 * (`ncn-mw#`) Rebuild/restore multiple clusters
 
     ```bash
-    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-uas-mgr
+    /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -m cray-bos,cray-bss
     ```
 
 * (`ncn-mw#`) Rebuild/restore all clusters

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -263,7 +263,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 ### Verify Access to External File Systems
 
-If the worker nodes host User Access Instance (UAI) pods or normally mount the external Lustre or Spectrum Scale (GPFS) file systems,
+If the worker nodes normally mount the external Lustre or Spectrum Scale (GPFS) file systems,
 then verify that the external file system is ready to be mounted by the worker nodes.
 
 Some systems are configured with lazy mounts that do not have this requirement for the worker nodes.

--- a/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Managed_Nodes.md
@@ -140,22 +140,6 @@ to ensure that the file system and its quorum nodes are quiesced before shutting
       +----------------+------+----------+--------+------+---------+------+-----------+-------------+-----------+----------+
       ```
 
-1. Check for User Access Instance (UAI) pods and remove them.
-
-   > Not all systems have been configured to use the containerized user environment (UAI) on worker nodes, but if they are in use, they should be stopped now.
-
-   1. (`ncn-m#`) Check for any UAI pods. This will show the username for each pod.
-
-   ```bash
-   cray uas uais list
-   ```
-
-   1. (`ncn-m#`) Remove any UAI pods using the usernames found in the previous step.
-
-   ```bash
-   cray uas uais delete --username USERNAME
-   ```
-
 1. If any external filesystems are mounted on the worker nodes, unmount them.
 
    Lustre, Spectrum Scale (GPFS), and NFS filesystems are usually defined in VCS cos-config-management in the `group_vars`

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -103,15 +103,6 @@ The `sat bootsys` command automates the shutdown of Ceph and the Kubernetes mana
    pdsh -w ncn-m001,$MASTERS,$WORKERS 'zypper -n install psmisc'
    ```
 
-1. If the worker nodes have been supporting the containerized User Access Instance (UAI) pods, then the DVS mounted
-   Cray Programming Environment (CPE) filesystems should be unmounted.
-
-   1. (`ncn-m001#`) Unmount the CPE content on the worker nodes.
-
-      ```bash
-      pdsh -w $WORKERS bash /etc/cray-pe.d/pe_cleanup.sh | dshbak -c
-      ```
-
 1. (`ncn-m001#`) Shut down platform services.
 
    > NOTE: There are some interactive questions which need answers before the shutdown process can progress.

--- a/operations/security_and_authentication/Create_Internal_User_Accounts_in_the_Keycloak_Shasta_Realm.md
+++ b/operations/security_and_authentication/Create_Internal_User_Accounts_in_the_Keycloak_Shasta_Realm.md
@@ -40,7 +40,7 @@ kubectl get secret -n services keycloak-master-admin-auth --template={{.data.pas
 
 1. Create a user and group ID for this user.
 
-    The User Access Service \(UAS\) requires these attributes. In the `Attributes` tab, performing the following steps for both the `uid` and `gid` attributes:
+    In the `Attributes` tab, performing the following steps for both the `uid` and `gid` attributes:
 
     1. Add the attribute name to the `Key` column and its value to the `Value` column.
 


### PR DESCRIPTION
UAS/UAI were removed in CSM 1.6
BOS no longer has an etcd cluster as of CSM 1.6

This PR updates the docs to reflect both of these facts.

CSM 1.6 backport:
https://github.com/Cray-HPE/docs-csm/pull/5993