### PR TITLE
CASMPET-7390: Istio and Kiali Upgrade

### DIFF
--- a/upgrade/scripts/upgrade/label-istio-resources.sh
+++ b/upgrade/scripts/upgrade/label-istio-resources.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# When upgrading from Istio 1.19.10 to 1.26.0, Istio Upstream recommends 
+# running the istioctl cli to translate charts from 1.19.10 to 1.26.0.
+# The command `istioctl manifest translate -f istiooperator.yaml` generates
+# two files : 
+#            install-base.sh
+#            install-pilot.sh
+# The script is a rearrangement of the two generated scripts to suit the CSM
+# cray-istio upgrade for CSM 1.7 release. This labels and annotates existing
+# Kubernetes resources to mark them as part of cray-istio-base, 
+# cray-istio-pilot and cray-istio-ingress Helm charts before the upgrade,
+# ensuring proper Helm management.
+
+set -x
+
+# Function to label/annotate resources for cray-istio-base chart
+label_cray_istio_base() {
+    echo "Labeling/Annotating resources for cray-istio-base chart..."
+    
+    # Label/Annotate resources to mark them a part of the Helm release.
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-reader-service-account meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istio-reader-service-account app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+    kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator app.kubernetes.io/managed-by=Helm
+}
+
+# Function to label/annotate resources for cray-istio-pilot chart
+label_cray_istio_pilot() {
+    echo "Labeling/Annotating resources for cray-istio-pilot chart..."
+    
+    # Label/Annotate resources to mark them a part of the Helm release.
+    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ConfigMap --namespace=istio-system istio meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ConfigMap --namespace=istio-system istio app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label Deployment.apps --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ConfigMap --namespace=istio-system istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ConfigMap --namespace=istio-system istio-sidecar-injector app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label PodDisruptionBudget.policy --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+    kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system app.kubernetes.io/managed-by=Helm
+}
+
+# Function to label/annotate resources for cray-istio-ingress chart
+label_cray_istio_ingress() {
+    echo "Labeling/Annotating resources for cray-istio-ingress chart..."
+
+    # Label/Annotate resources to mark them a part of the Helm release.
+    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+
+    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+
+    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+
+    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding app.kubernetes.io/managed-by=Helm
+
+    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl label Certificate --namespace=istio-system dvs-mqtt-cert app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Certificate --namespace=istio-system dvs-mqtt-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Certificate --namespace=istio-system ingress-gateway-cert app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Certificate --namespace=istio-system ingress-gateway-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl label PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl label DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl label Gateways.networking.istio.io --namespace=services customer-admin-gateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-admin-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Gateways.networking.istio.io --namespace=services customer-user-gateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-user-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Gateways.networking.istio.io --namespace=services hmn-gateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services hmn-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Gateways.networking.istio.io --namespace=services services-gateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services services-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-can meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway-can app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-chn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway-chn app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-cmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway-cmn app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-local meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label Service --namespace=istio-system istio-ingressgateway-local app.kubernetes.io/managed-by=Helm
+
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system cray-istio-jobs meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system cray-istio-jobs app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account app.kubernetes.io/managed-by=Helm
+    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-service-account app.kubernetes.io/managed-by=Helm
+}
+
+if [ $# -eq 0 ]; then
+    echo "Error: No chart name provided"
+    echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
+    exit 1
+fi
+
+case "$1" in
+    "cray-istio-base")
+        label_cray_istio_base
+        ;;
+    "cray-istio-pilot")
+        label_cray_istio_pilot
+        ;;
+    "cray-istio-ingress")
+        label_cray_istio_ingress
+        ;;
+    *)
+        echo "Error: Unknown chart name '$1'"
+        echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
+        exit 1
+        ;;
+esac
+
+echo "Completed labeling/annotating resources for $1"

--- a/upgrade/scripts/upgrade/label-istio-resources.sh
+++ b/upgrade/scripts/upgrade/label-istio-resources.sh
@@ -22,15 +22,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# When upgrading from Istio 1.19.10 to 1.26.0, Istio Upstream recommends 
+# When upgrading from Istio 1.19.10 to 1.26.0, Istio Upstream recommends
 # running the istioctl cli to translate charts from 1.19.10 to 1.26.0.
 # The command `istioctl manifest translate -f istiooperator.yaml` generates
-# two files : 
+# two files :
 #            install-base.sh
 #            install-pilot.sh
 # The script is a rearrangement of the two generated scripts to suit the CSM
 # cray-istio upgrade for CSM 1.7 release. This labels and annotates existing
-# Kubernetes resources to mark them as part of cray-istio-base, 
+# Kubernetes resources to mark them as part of cray-istio-base,
 # cray-istio-pilot and cray-istio-ingress Helm charts before the upgrade,
 # ensuring proper Helm management.
 
@@ -38,207 +38,207 @@ set -x
 
 # Function to label/annotate resources for cray-istio-base chart
 label_cray_istio_base() {
-    echo "Labeling/Annotating resources for cray-istio-base chart..."
-    
-    # Label/Annotate resources to mark them a part of the Helm release.
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-reader-service-account meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istio-reader-service-account app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
-    kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator app.kubernetes.io/managed-by=Helm
+  echo "Labeling/Annotating resources for cray-istio-base chart..."
+
+  # Label/Annotate resources to mark them a part of the Helm release.
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io wasmplugins.extensions.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io destinationrules.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io envoyfilters.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io gateways.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io proxyconfigs.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io serviceentries.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io sidecars.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io virtualservices.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadentries.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io workloadgroups.networking.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io authorizationpolicies.security.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io peerauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io requestauthentications.security.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label CustomResourceDefinition.apiextensions.k8s.io telemetries.telemetry.istio.io app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-reader-service-account meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istio-reader-service-account app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator meta.helm.sh/release-name=cray-istio-base meta.helm.sh/release-namespace=istio-system
+  kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istiod-default-validator app.kubernetes.io/managed-by=Helm
 }
 
 # Function to label/annotate resources for cray-istio-pilot chart
 label_cray_istio_pilot() {
-    echo "Labeling/Annotating resources for cray-istio-pilot chart..."
-    
-    # Label/Annotate resources to mark them a part of the Helm release.
-    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ConfigMap --namespace=istio-system istio meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ConfigMap --namespace=istio-system istio app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label Deployment.apps --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ConfigMap --namespace=istio-system istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ConfigMap --namespace=istio-system istio-sidecar-injector app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label PodDisruptionBudget.policy --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
-    kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system app.kubernetes.io/managed-by=Helm
+  echo "Labeling/Annotating resources for cray-istio-pilot chart..."
+
+  # Label/Annotate resources to mark them a part of the Helm release.
+  kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRole.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRole.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istiod-gateway-controller-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ConfigMap --namespace=istio-system istio meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ConfigMap --namespace=istio-system istio app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Deployment.apps --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label Deployment.apps --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ConfigMap --namespace=istio-system istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ConfigMap --namespace=istio-system istio-sidecar-injector app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label MutatingWebhookConfiguration.admissionregistration.k8s.io istio-sidecar-injector app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label PodDisruptionBudget.policy --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRole.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRoleBinding.rbac.authorization.k8s.io istio-reader-clusterrole-istio-system app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istiod meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istiod app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system meta.helm.sh/release-name=cray-istio-pilot meta.helm.sh/release-namespace=istio-system
+  kubectl label ValidatingWebhookConfiguration.admissionregistration.k8s.io istio-validator-istio-system app.kubernetes.io/managed-by=Helm
 }
 
 # Function to label/annotate resources for cray-istio-ingress chart
 label_cray_istio_ingress() {
-    echo "Labeling/Annotating resources for cray-istio-ingress chart..."
+  echo "Labeling/Annotating resources for cray-istio-ingress chart..."
 
-    # Label/Annotate resources to mark them a part of the Helm release.
-    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+  # Label/Annotate resources to mark them a part of the Helm release.
+  kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label HorizontalPodAutoscaler.autoscaling --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
 
-    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Deployment.apps --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Deployment.apps --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
 
-    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-admin app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-customer-user app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label PodDisruptionBudget.policy --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
 
-    kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRole.rbac.authorization.k8s.io cray-istio-jobs-role app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ClusterRoleBinding.rbac.authorization.k8s.io cray-istio-jobs-role-binding app.kubernetes.io/managed-by=Helm
 
-    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Role.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-admin-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-customer-user-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-hmn-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite RoleBinding.rbac.authorization.k8s.io --namespace=istio-system istio-ingressgateway-sds meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl label Certificate --namespace=istio-system dvs-mqtt-cert app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Certificate --namespace=istio-system dvs-mqtt-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Certificate --namespace=istio-system ingress-gateway-cert app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Certificate --namespace=istio-system ingress-gateway-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Certificate --namespace=istio-system dvs-mqtt-cert app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Certificate --namespace=istio-system dvs-mqtt-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Certificate --namespace=istio-system ingress-gateway-cert app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Certificate --namespace=istio-system ingress-gateway-cert meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl label PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite PeerAuthentication.security.istio.io --namespace=istio-system istio-ingressgateway-authn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl label DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=istio-system cluster-kafka-bootstrap-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite DestinationRule.networking.istio.io --namespace=services cluster-kafka-brokers-rule meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl label Gateways.networking.istio.io --namespace=services customer-admin-gateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-admin-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Gateways.networking.istio.io --namespace=services customer-user-gateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-user-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Gateways.networking.istio.io --namespace=services hmn-gateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services hmn-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Gateways.networking.istio.io --namespace=services services-gateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services services-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Gateways.networking.istio.io --namespace=services customer-admin-gateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-admin-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Gateways.networking.istio.io --namespace=services customer-user-gateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services customer-user-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Gateways.networking.istio.io --namespace=services hmn-gateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services hmn-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Gateways.networking.istio.io --namespace=services services-gateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Gateways.networking.istio.io --namespace=services services-gateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
 
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-can meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway-can app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-chn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway-chn app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-cmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway-cmn app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-local meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label Service --namespace=istio-system istio-ingressgateway-local app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-can meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway-can app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-chn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway-chn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-cmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway-cmn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-hmn meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway-hmn app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite Service --namespace=istio-system istio-ingressgateway-local meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label Service --namespace=istio-system istio-ingressgateway-local app.kubernetes.io/managed-by=Helm
 
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system cray-istio-jobs meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system cray-istio-jobs app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account app.kubernetes.io/managed-by=Helm
-    kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
-    kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-service-account app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system cray-istio-jobs meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system cray-istio-jobs app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-admin-service-account app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-customer-user-service-account app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-hmn-service-account app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite ServiceAccount --namespace=istio-system istio-ingressgateway-service-account meta.helm.sh/release-name=cray-istio-ingress meta.helm.sh/release-namespace=istio-system
+  kubectl label ServiceAccount --namespace=istio-system istio-ingressgateway-service-account app.kubernetes.io/managed-by=Helm
 }
 
 if [ $# -eq 0 ]; then
-    echo "Error: No chart name provided"
-    echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
-    exit 1
+  echo "Error: No chart name provided"
+  echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
+  exit 1
 fi
 
 case "$1" in
-    "cray-istio-base")
-        label_cray_istio_base
-        ;;
-    "cray-istio-pilot")
-        label_cray_istio_pilot
-        ;;
-    "cray-istio-ingress")
-        label_cray_istio_ingress
-        ;;
-    *)
-        echo "Error: Unknown chart name '$1'"
-        echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
-        exit 1
-        ;;
+  "cray-istio-base")
+    label_cray_istio_base
+    ;;
+  "cray-istio-pilot")
+    label_cray_istio_pilot
+    ;;
+  "cray-istio-ingress")
+    label_cray_istio_ingress
+    ;;
+  *)
+    echo "Error: Unknown chart name '$1'"
+    echo "Available charts: cray-istio-base, cray-istio-pilot, cray-istio-ingress"
+    exit 1
+    ;;
 esac
 
 echo "Completed labeling/annotating resources for $1"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -650,15 +650,15 @@ do_upgrade_csm_chart cray-kiali platform.yaml
 function delete_helm_secrets() {
   local chart_name secrets
   chart_name="$1"
-  
+
   # Find all secrets matching the Helm release pattern for the given chart across all namespaces
   secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$")
-  
-  if [[ -z "$secrets" ]]; then
+
+  if [[ -z $secrets ]]; then
     echo "No Helm secrets found for chart '$chart_name' in any namespace"
     return 0
   fi
-  
+
   # Delete each secret
   while read -r namespace secret_name; do
     echo "Deleting Helm secret: $secret_name in namespace: $namespace"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -558,6 +558,130 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Pre-cache images needed for istio upgrade. As soon as cray-istio-pilot is upgraded, network
+# connection to nexus will be broken, due to istio proxy and istiod versions mismatch. Upgrade of
+# cray-istio will fix that, but images must be pre-cached for it to succeed.
+state_name="PRECACHE_ISTIO_IMAGES"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  # Grab istio and docker-kubectl images from cacheImages list, remove duplicates.
+  {
+    istio_images=$(yq r -j "${CSM_MANIFESTS_DIR}/platform.yaml" 'spec.charts.(name==cray-precache-images).values.cacheImages' | jq -r '.[] | select( . | (contains("istio", "docker-kubectl")))' | sort | uniq)
+    worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u)
+    while read -r istio_image; do
+      while read -r worker_node; do
+        echo "Pre-caching image ${istio_image} on node ${worker_node}"
+        ssh -n "${worker_node}" "crictl pull ${istio_image}"
+      done <<< "${worker_nodes}"
+    done <<< "${istio_images}"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+# Undeploy the chart if it exists on the system.
+# Use this if a chart has been removed from a manifest and needs
+# to be removed from the system as part of an upgrade.
+function undeploy() {
+  # Check if the chart exists by running helm status
+  # If the chart is missing (rc==1), return success.
+  helm status "$@" || return 0
+  # Remove the chart completely without keeping history.
+  helm uninstall "$@"
+}
+
+# Undeploy Istio charts if they exist
+# cray-istio-operator and cray-istio-deploy are removed with upgrade to Istio 1.26.0
+undeploy -n istio-system cray-istio-operator
+undeploy -n istio-system cray-istio-deploy
+
+# Apply labels to Istio Base Resources
+# Running the label-istio-resources script to apply necessary labels to cray-istio-base chart resources.
+state_name="LABEL_ISTIO_BASE_RESOURCES"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/label-istio-resources.sh" cray-istio-base
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+do_upgrade_csm_chart cray-istio-base platform.yaml
+
+# Apply labels to Istio Pilot Resources
+# Running the label-istio-resources script to apply necessary labels to cray-istio-pilot chart resources.
+state_name="LABEL_ISTIO_PILOT_RESOURCES"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/label-istio-resources.sh" cray-istio-pilot
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+do_upgrade_csm_chart cray-istio-pilot platform.yaml
+
+# Apply labels to Istio Ingress Resources
+# Running the label-istio-resources script to apply necessary labels to cray-istio-ingress chart resources.
+state_name="LABEL_ISTIO_INGRESS_RESOURCES"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/label-istio-resources.sh" cray-istio-ingress
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+do_upgrade_csm_chart cray-istio-ingress platform.yaml
+do_upgrade_csm_chart cray-kiali platform.yaml
+
+# Delete all Helm secrets for a given chart across all namespaces and versions
+function delete_helm_secrets() {
+  local chart_name secrets
+  chart_name="$1"
+  
+  # Find all secrets matching the Helm release pattern for the given chart across all namespaces
+  secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$")
+  
+  if [[ -z "$secrets" ]]; then
+    echo "No Helm secrets found for chart '$chart_name' in any namespace"
+    return 0
+  fi
+  
+  # Delete each secret
+  while read -r namespace secret_name; do
+    echo "Deleting Helm secret: $secret_name in namespace: $namespace"
+    kubectl delete secret -n "$namespace" "$secret_name"
+  done <<< "$secrets"
+}
+
+delete_helm_secrets cray-istio
+
+# Restart vault pods because pods were having the older proxyv2 image version.
+# Running the rollout restart script to restart the required resources in istio-injection=enabled namespaces.
+state_name="RESTART_SERVICES_REFRESH_ISTIO"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/rollout-restart.sh"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="UPDATE_CRAY_POSTGRES_OPERATOR_CRDS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then

--- a/upgrade/scripts/upgrade/rollout-restart.sh
+++ b/upgrade/scripts/upgrade/rollout-restart.sh
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,17 +22,26 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# When upgrading from Istio 1.11.8 to 1.19.10 we need to rollout-restart because
+# When upgrading from Istio 1.19.10 to 1.26.0, we need to rollout-restart because
 # the istio-injection enabled namespaces doesn't get the latest image of istio.
 #
 
 set -x
 
-# This part of script is to delete the pods on vault namespace which do not have proxyv2:1.19.10
+# Define the Istio version
+ISTIO_VERSION="1.26.0"
+ISTIO_PROXYV2_IMAGE="istio/proxyv2:${ISTIO_VERSION}"
+ISTIO_PILOT_IMAGE="istio/pilot:${ISTIO_VERSION}"
+
+# Define wait times in seconds
+VAULT_PODS_WAIT_TIME=120
+RESOURCE_RESTART_WAIT_TIME=180
+
+# This part of script is to delete the pods on vault namespace which do not have the correct proxyv2 version
 # This is done because the vault is not updated in CSM1.6, this restart of vault may not be needed in future
 
 NAMESPACE="vault"
-CORRECT_VERSION="proxyv2:1.19.10"
+CORRECT_VERSION="${ISTIO_PROXYV2_IMAGE}"
 pods_deleted=false
 
 # Get all pods in the namespace
@@ -57,8 +66,8 @@ done
 
 # Wait for 2 minutes if any pods were deleted
 if [ "$pods_deleted" = true ]; then
-  echo "Waiting for 2 minutes for pods to restart..."
-  sleep 120
+  echo "Waiting for $(($VAULT_PODS_WAIT_TIME / 60)) minutes for pods to restart..."
+  sleep $VAULT_PODS_WAIT_TIME
 
   # Check the status of the pods after restart
   new_pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}')
@@ -92,13 +101,13 @@ else
   echo "No pods were deleted. Skipping wait."
 fi
 
-# The fuctionality of the script is:
+# The functionality of the script is:
 # This script is to restart the vault pods separately.
 # Because vault was not upgraded in this release that is why we need this script.
 # Get all istio-injection=enabled namespaces.
 # For each namespace we are keeping the record of the sts/deploys/ds which we need to restart by following way:
 #   Get all the pods in the namespace, and check istio image version.
-#   if image is not in 1.19.10 then
+#   if image is not correct version then
 #       Keep the name of the corresponding ds/sts/deploy in a list.
 #   Else move to another pod.
 # After iterating over all the namespaces we will have the list of sts/ds/deploys that needs to be restarted.
@@ -113,7 +122,7 @@ check_pod_istio_versions() {
   images=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.spec.containers[*].image}")
 
   # Check if any of the images is the latest Istio version
-  if echo "$images" | grep -q -e "istio/pilot:1.19.10" -e "istio/proxyv2:1.19.10"; then
+  if echo "$images" | grep -q -e "${ISTIO_PILOT_IMAGE}" -e "${ISTIO_PROXYV2_IMAGE}"; then
     return 0 # Pod has the latest Istio versions
   else
     return 1 # Pod does not have the latest Istio versions
@@ -175,8 +184,8 @@ restart_and_check_status() {
     fi
   done
 
-  echo "Waiting for 3 minutes..."
-  sleep 180
+  echo "Waiting for $(($RESOURCE_RESTART_WAIT_TIME / 60)) minutes..."
+  sleep $RESOURCE_RESTART_WAIT_TIME
 
   for resource in "${resources[@]}"; do
     resource_type=$(echo "$resource" | cut -d'/' -f1)
@@ -208,7 +217,7 @@ for ns in $namespaces; do
 
   for pod in $pods; do
     if ! check_pod_istio_versions "$ns" "$pod"; then
-      echo "Pod $pod in namespace $ns does not have the latest Istio version. Checking its controlling resource..."
+      echo "Pod $pod in namespace $ns does not have the latest Istio version ${ISTIO_VERSION}. Checking its controlling resource..."
       controlling_resource=$(get_controlling_resource "$ns" "$pod")
 
       # Extract resource type and name from controlling_resource
@@ -227,7 +236,7 @@ for ns in $namespaces; do
         echo "Skipping unknown or unhandled resource type: $controlling_resource for pod $pod"
       fi
     else
-      echo "Pod $pod in namespace $ns already has the latest Istio image versions"
+      echo "Pod $pod in namespace $ns already has the latest Istio image version ${ISTIO_VERSION}"
     fi
   done
 done

--- a/upgrade/scripts/upgrade/rollout-restart.sh
+++ b/upgrade/scripts/upgrade/rollout-restart.sh
@@ -66,7 +66,7 @@ done
 
 # Wait for 2 minutes if any pods were deleted
 if [ "$pods_deleted" = true ]; then
-  echo "Waiting for $(($VAULT_PODS_WAIT_TIME / 60)) minutes for pods to restart..."
+  echo "Waiting for $((VAULT_PODS_WAIT_TIME / 60)) minutes for pods to restart..."
   sleep $VAULT_PODS_WAIT_TIME
 
   # Check the status of the pods after restart
@@ -184,7 +184,7 @@ restart_and_check_status() {
     fi
   done
 
-  echo "Waiting for $(($RESOURCE_RESTART_WAIT_TIME / 60)) minutes..."
+  echo "Waiting for $((RESOURCE_RESTART_WAIT_TIME / 60)) minutes..."
   sleep $RESOURCE_RESTART_WAIT_TIME
 
   for resource in "${resources[@]}"; do


### PR DESCRIPTION
# Description
Upgrading `istio` involves some changes in upgrade workflow.  Since istio 1.26.0 version deprecates the istio-operator so we need to undeploy the charts `cray-istio-deploy` and `cray-istio-operator` before installing the new istio version, also we need to label the istio resources and at the end delete the helm secrets of old istio ingress chart.
Upgrade of istio compromises networking for most running services, because of `istio-proxy` container image version mismatch with `istiod`. Almost all services must be restarted to re-create `istio-proxy` sidecar containers with the right image. 

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
