### PR TITLE
CASMCMS-9449 Add support for *.md files in /api

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,6 +3,7 @@
  * [Boot Script Service v1](./bss.md)
  * [Cray Advanced Platform Monitoring and Control (CAPMC) v3](./capmc.md)
  * [Configuration Framework Service v1](./cfs.md)
+ * [Console Service v1](./console.md)
  * [Firmware Action Service v1](./firmware-action.md)
  * [Heartbeat Tracker Service v1](./hbtd.md)
  * [HMS Notification Fanout Daemon v1](./hmnfd.md)

--- a/api/console.md
+++ b/api/console.md
@@ -1,0 +1,230 @@
+<h1 id="console-service">Console Service v1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from
+the tabs above or the mobile navigation menu.
+
+The Console Service provides access to node console logs and interactive console sessions
+for nodes in the system. These are accessed via websocket connections.
+
+## Base URL
+
+The Console Service is available at the following base URL:
+["wss://api-gw-service-nmn.local/apis/console-operator/console-operator"](wss://api-gw-service-nmn.local/apis/console-operator/console-operator)
+
+
+## Workflow: Opening an Interactive Console Session
+
+`GET /interact/{node_id}`
+
+*Interact with the console of `node_id`*
+
+A successful interaction will not return a response. Instead, the connection will be
+upgraded to a websocket connection. The client can then send and receive messages
+over the websocket connection.
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|Cray-Tenant-Name|header|[TenantName](#schematenantname)|false|Tenant name.|
+|Authorization|header|string|false|Bearer token for authentication.|
+|Connection|header|string|false|"Upgrade"|
+|Upgrade|header|string|false|"websocket"|
+
+> Example responses
+> 403 Forbidden Response
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="interact_get-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|403|[Forbidden Response](https://tools.ietf.org/html/rfc7231#section-6.5.3)|User does not have permission to access the node.|Inline|
+|404|[Not Found Response](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The node does not exist.|Inline|
+
+## Workflow: Following Console Logs
+
+`GET /tail/{node_id}`
+
+*Tail the console's log file of `node_id`*
+
+A successful interaction will not return a response. Instead, the connection will be
+upgraded to a websocket connection. The client can then receive messages when content is
+written to the node's console.
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|Cray-Tenant-Name|header|[TenantName](#schematenantname)|false|Tenant name.|
+|Cray-Console-Lines|header|int|false|Number of previous lines to display|
+|Cray-Console-Follow|header|string|false|"Upgrade"|
+|Authorization|header|string|false|Bearer token for authentication.|
+|Connection|header|string|false|"Upgrade"|
+|Upgrade|header|string|false|"websocket"|
+
+> Example responses
+> 403 Forbidden Response
+```json
+{
+  "message": "string"
+}
+```
+
+<h3 id="tail_get-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|403|[Forbidden Response](https://tools.ietf.org/html/rfc7231#section-6.5.3)|User does not have permission to access the node.|Inline|
+|404|[Not Found Response](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The node does not exist.|Inline|
+
+<h2 id="schematenantname">TenantName</h2>
+
+```json
+"string"
+
+```
+
+Name of the tenant that owns this resource. Only used in environments
+with multi-tenancy enabled. An empty string or null value means the resource
+is not owned by a tenant. The absence of this field from a resource indicates
+the same.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string¦null|false|read-only|Name of the tenant that owns this resource. Only used in environments<br>with multi-tenancy enabled. An empty string or null value means the resource<br>is not owned by a tenant. The absence of this field from a resource indicates<br>the same.|
+
+## Code Samples
+
+Here is sample python code to create a websocket client for interacting with both console
+endpoints. This code uses the `websockets` library to create a websocket client and
+`aioconsole` to handle user input. The code is designed to be run in an asyncio event loop.
+
+```python
+import asyncio
+import websockets
+import aioconsole
+import json
+
+###########################################################################
+# helper function to run the websocket terminal interaction
+###########################################################################
+async def websocket_terminal_interaction(ctx, endpoint: str, headers: dict[str,str]) -> str:
+    # set up the return value
+    errMsg = ""
+
+    # pull information from context
+    auth = ctx.obj["auth"]
+    tenant = ctx.get('core.tenant', "")
+
+    # add auth header
+    token = ""
+    if auth and auth.session and auth.session.access_token:
+        token = auth.session.access_token
+    if token != "":
+        headers["Authorization"] = f"Bearer {token}"
+
+    # add tenant header
+    if tenant:
+        headers["Cray-Tenant-Name"] = tenant
+
+    # build the uri from the hostname and endpoint - note secure websocket
+    uri = f"wss://api-gw-service-nmn.local/{endpoint}"
+
+    try:
+        # connect to the websocket
+        async with websockets.connect(uri, additional_headers=headers) as websocket:
+            print(f"Connected to {uri}")
+
+            async def send_messages():
+                while True:
+                    try:
+                        message = await aioconsole.ainput("")
+                        await websocket.send(message)
+                    except asyncio.CancelledError:
+                        break
+                    except Exception as e:
+                        print(f"Error sending message: {e}")
+                        break
+
+            async def receive_messages():
+                while True:
+                    try:
+                        message = await websocket.recv()
+                        print(f"{message}", end='', flush=True)
+                    except websockets.ConnectionClosed:
+                        print("Connection closed by the server.")
+                        break
+                    except Exception as e:
+                        print(f"Error receiving message: {e}")
+                        break
+
+            send_task = asyncio.create_task(send_messages())
+            receive_task = asyncio.create_task(receive_messages())
+
+            done, pending = await asyncio.wait(
+                [send_task, receive_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for task in pending:
+                task.cancel()
+    except websockets.InvalidStatus as e:
+        # Expect this to be an unauthorized tenant, try to pull details
+        # from the response body
+        errMsg = "Websocket connection failed"
+        body = e.response.body
+        if body:
+            data = json.loads(body.decode('utf-8'))
+            errMsg = f"{data.get('message', errMsg)}"
+    except websockets.ConnectionClosed as e:
+        # handle the connection getting closed
+        errMsg = f"Connection closed: {e}"
+        body = e.response.body
+        if body:
+            data = json.loads(body.decode('utf-8'))
+            errMsg = f"{data.get('message', errMsg)}"
+    except Exception as e:
+        # gracefully handle any other exceptions
+        errMsg = f"Error: {e}"
+
+    return errMsg
+
+###########################################################################
+# cray console interact
+###########################################################################
+def interact(ctx, xname):
+    """ Interact with the console. """
+    headers = {}
+    endpoint = f"apis/console-operator/console-operator/interact/{xname}"
+    errMsg = asyncio.run(websocket_terminal_interaction(ctx, endpoint, headers))
+
+    # if there was an error, print the help, then the error message
+    if errMsg:
+        print(f"\n\nERROR: {errMsg}")
+
+###########################################################################
+# cray console log
+###########################################################################
+def tail(ctx, xname, lines, follow):
+    """ Tail the console output. """
+
+    # pull out the options and load into the headers
+    headers = {}
+    if lines:
+        headers["Cray-Console-Lines"] = str(lines)
+    if follow:
+        headers["Cray-Console-Follow"] = str(follow)
+
+    # open the websocket
+    endpoint = f"apis/console-operator/console-operator/tail/{xname}"
+    errMsg = asyncio.run(websocket_terminal_interaction(ctx, endpoint, headers))
+
+    # if there was an error, print the help, then the error message
+    if errMsg:
+        print(f"\n\nERROR: {errMsg}")
+```

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -62,33 +62,38 @@ find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
     IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
     echo ""
     echo "Downloading from ${endpoint_url} ..."
-    curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
-    openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
-    if [ -n "${endpoint_title}" ]; then
-      ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
-    fi
-    if [ -n "${endpoint_version}" ]; then
-      ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
-    fi
-    if [[ ${openapi_version} == 3.* ]]; then
-      ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
-      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
-      # Many services have both external (through API Gateway, requires auth) and internal (does not require auth) sample URLs.
-      # Auth requirement can not be scoped to URL, we remove all sample URLs and set one mandatory external URL instead.
-      base_url=$(${yq} e '.servers[] | select(.url == "*/apis/*") | .url | sub(".+/apis/", "/apis/")' "/swagger/${endpoint_name}.yaml" | sort -u | head -1)
-      if [ -z "${base_url}" ]; then
-        base_url="/apis/${endpoint_name}"
-        echo "WARNING: unable to identify sample URL for ${endpoint_name}, guessed as ${base_url}."
+    if [[ ${endpoint_url} == *.md ]]; then
+      echo "Endpoint ${endpoint_url} delivers markdown, does not require conversion."
+      curl -SsL -o "${dest_dir}/${endpoint_name}.md" "${endpoint_url}"
+    else
+      curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+      openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
+      if [ -n "${endpoint_title}" ]; then
+        ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
       fi
-      ${yq} e -i ".servers=[{\"url\": \"https://api-gw-service-nmn.local${base_url}\"}]" "/swagger/${endpoint_name}.yaml"
-    elif [[ ${openapi_version} == 2.* ]]; then
-      ${yq} e -i '.securityDefinitions.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
-      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
-      ${yq} e -i '.host="api-gw-service-nmn.local"' "/swagger/${endpoint_name}.yaml"
-      ${yq} e -i '.schemes=["https"]' "/swagger/${endpoint_name}.yaml"
+      if [ -n "${endpoint_version}" ]; then
+        ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
+      fi
+      if [[ ${openapi_version} == 3.* ]]; then
+        ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+        ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+        # Many services have both external (through API Gateway, requires auth) and internal (does not require auth) sample URLs.
+        # Auth requirement can not be scoped to URL, we remove all sample URLs and set one mandatory external URL instead.
+        base_url=$(${yq} e '.servers[] | select(.url == "*/apis/*") | .url | sub(".+/apis/", "/apis/")' "/swagger/${endpoint_name}.yaml" | sort -u | head -1)
+        if [ -z "${base_url}" ]; then
+          base_url="/apis/${endpoint_name}"
+          echo "WARNING: unable to identify sample URL for ${endpoint_name}, guessed as ${base_url}."
+        fi
+        ${yq} e -i ".servers=[{\"url\": \"https://api-gw-service-nmn.local${base_url}\"}]" "/swagger/${endpoint_name}.yaml"
+      elif [[ ${openapi_version} == 2.* ]]; then
+        ${yq} e -i '.securityDefinitions.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+        ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+        ${yq} e -i '.host="api-gw-service-nmn.local"' "/swagger/${endpoint_name}.yaml"
+        ${yq} e -i '.schemes=["https"]' "/swagger/${endpoint_name}.yaml"
+      fi
+      echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
+      docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
     fi
-    echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
-    docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
   done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
 done
 


### PR DESCRIPTION
# Description

For console service, spec is not generated from swagger file but rather stored directly in `console.md` file (due to usage of websockets not supported by OpenAPI). This change allows specifying `*.md` URLs along with OpenAPI/Swagger `*.yaml`. In this case spec doc is written as is without conversion.

As a test, files `api/console.md` and `api/README.md` (also in this PR) were generated by running changed `gen-api.sh` script against manifest change, proposed in https://github.com/Cray-HPE/csm/pull/4154.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
