### PR TITLE
CASMHMS-6549: Document prerequisites for upgrading from CSM 1.5.x to CSM 1.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Cray System Management Documentation
 
+* [Prerequisites](#prerequisites)
 * [Scope and audience](#scope-and-audience)
 * [Table of contents](#table-of-contents)
 * [Copyright and license](#copyright-and-license)
+
+## Prerequisites
+
+Before upgrading from CSM 1.5.x to any CSM 1.6.x release, CSM 1.5.3 is
+required at a bare minimum. If attempting to upgrade from CSM 1.5.2 or
+earlier, major problems may be experienced during the upgrade.
 
 ## Scope and audience
 

--- a/RELEASE_NOTES_1.6.2.md
+++ b/RELEASE_NOTES_1.6.2.md
@@ -10,6 +10,12 @@ see [CSM 1.6 release notes](RELEASE_NOTES.md).
 * [Bug fixes](#bug-fixes)
 * [Known issues](#known-issues)
 
+## Prerequisites
+
+Before upgrading from CSM 1.5.x to any CSM 1.6.x release, CSM 1.5.3 is
+required at a bare minimum. If attempting to upgrade from CSM 1.5.2 or
+earlier, major problems may be experienced during the upgrade.
+
 ## Additions and improvements
 
 ### General

--- a/RELEASE_NOTES_1.6.2.md
+++ b/RELEASE_NOTES_1.6.2.md
@@ -10,12 +10,6 @@ see [CSM 1.6 release notes](RELEASE_NOTES.md).
 * [Bug fixes](#bug-fixes)
 * [Known issues](#known-issues)
 
-## Prerequisites
-
-Before upgrading from CSM 1.5.x to any CSM 1.6.x release, CSM 1.5.3 is
-required at a bare minimum. If attempting to upgrade from CSM 1.5.2 or
-earlier, major problems may be experienced during the upgrade.
-
 ## Additions and improvements
 
 ### General


### PR DESCRIPTION
# Description

Document prerequisetes for upgrading from CSM 1.5.x to CSM 1.6.x

- [CASMHMS-6549](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6549)

## Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.