### PR TITLE
CASMHMS-6549: Document prerequisites for upgrading from CSM 1.5.x to CSM 1.6.x

### DIFF
--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -3,6 +3,12 @@
 
 Before beginning an upgrade from CSM 1.5 to CSM 1.6, there are a few things to do on the system first.
 
+## Beginning upgrade version
+
+Before beginning a CSM 1.6 upgrade, the system being upgraded should be
+running CSM 1.5.3 or later. If attempting to upgrade from CSM 1.5.2 or
+earlier, major problems may be experienced during the upgrade.
+
 ## Reduced resiliency during upgrade
 
 **Warning:** Management service resiliency is reduced during the upgrade.


### PR DESCRIPTION
# Description

Update CSM 1.5 docs to indicate CSM 1.5.3 or later is required before upgrading to CSM 1.6.

- [CASMHMS-6549](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6549)

## Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.