### PR TITLE
CASMTRIAGE-8248 hotfix for CSM 1.6 CSM 1.5 CASMTRIAGE-8205 Enable sig…

### DIFF
--- a/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,7 +77,7 @@ spec:
         arguments:
           parameters:
           - name: nexus_setup_image
-            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.10.1
+            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
           - name: nexus_admin_credential_secret_name
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
           - name: content

--- a/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,7 +77,7 @@ spec:
         arguments:
           parameters:
           - name: nexus_setup_image
-            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.10.1
+            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
           - name: nexus_admin_credential_secret_name
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
           - name: content

--- a/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,7 +77,7 @@ spec:
         arguments:
           parameters:
           - name: nexus_setup_image
-            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.10.1
+            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
           - name: nexus_admin_credential_secret_name
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
           - name: content

--- a/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,7 +77,7 @@ spec:
         arguments:
           parameters:
           - name: nexus_setup_image
-            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.10.1
+            value: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
           - name: nexus_admin_credential_secret_name
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.secret_name}}"
           - name: content


### PR DESCRIPTION
## Summary and Scope

IUF uses skopeo to upload docker images to nexus repository CSM add on products when installed with iuf , report errors in deliver-product stage when signed images are uploaded. This PR addresses issue of uploading signed images with skopeo.

Add nexus-setup image and update iuf workflowtemplates with new image 0.12.1.
Enable signatures along with docker image in skopeo sync.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8248](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8248)
* Merge after `https://github.com/Cray-HPE/csm-hotfixes/pull/73`

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
