### PR TITLE
CASMCMS-9427: Document fixed regression bug in CSM 1.7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,8 @@
   fixing a bug that caused BOS [sessions](operations/boot_orchestration/Sessions.md) to be stuck in `pending` state.
 * BOS logging is significantly more memory efficient, fixing a problem where logging on large scale systems
   could cause [BOS operator](operations/boot_orchestration/BOS_Services.md#bos-operators) Kubernetes pods to be `OOMKilled`.
+* When using the API or CLI to [Modify a BOS session template](operations/boot_orchestration/Manage_a_Session_Template.md#modify-a-session-template),
+  it is no longer required to specify `boot_sets` in the update data (this fixes a regression bug present in CSM 1.6).
 
 ## Deprecations
 

--- a/operations/boot_orchestration/Manage_a_Session_Template.md
+++ b/operations/boot_orchestration/Manage_a_Session_Template.md
@@ -141,4 +141,5 @@ cray bos v2 sessiontemplates delete <SESSION_TEMPLATE_NAME>
 cray bos v2 sessiontemplates update --file <INPUT_FILE> <TEMPLATE_NAME>
 ```
 
-The format of this input file is the same as the one used to [Create a session template](#create-a-session-template).
+The format of this input file is the same as the one used to [Create a session template](#create-a-session-template), except that
+the `boot_sets` field is NOT required (unlike when creating a session template).


### PR DESCRIPTION
This updates the CSM documentation to reflect a fixed regression bug from CSM 1.6, related to modifying BOS session templates.

CSM 1.6 PR:
https://github.com/Cray-HPE/docs-csm/pull/6013