### PR TITLE
CASMCMS-9427: Document session template update regression bug in CSM 1.6

### DIFF
--- a/operations/boot_orchestration/Manage_a_Session_Template.md
+++ b/operations/boot_orchestration/Manage_a_Session_Template.md
@@ -142,3 +142,5 @@ cray bos v2 sessiontemplates update --file <INPUT_FILE> <TEMPLATE_NAME>
 ```
 
 The format of this input file is the same as the one used to [Create a session template](#create-a-session-template).
+Note that due to a regression in CSM 1.6, this includes a requirement that the `boot_sets` field be specified (even if no changes are being made to its contents).
+This regression bug is corrected in CSM 1.7. In CSM 1.6, the workaround is to specify the current `boot_set` contents in the input file.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -83,11 +83,13 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Console SSH Key Permissions](known_issues/console_ssh_key_permissions.md)
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
+* `boot_sets` field always required when [Modifying a BOS session template](../operations/boot_orchestration/Manage_a_Session_Template.md#modify-a-session-template)
 
 ## Booting
 
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
+* `boot_sets` field always required when [Modifying a session template](../operations/boot_orchestration/Manage_a_Session_Template.md#modify-a-session-template)
 
 ### UAN boot issues
 


### PR DESCRIPTION
CSM 1.,6 version of https://github.com/Cray-HPE/docs-csm/pull/6012

Instead of announcing the change, this makes clear the limitation that exists in CSM 1.6, and explains that it is improved in CSM 1.7.