### PR TITLE
CASM-4572 Add argo workflows for the Rolling Reboot of worker nodes,storage nodes

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-reboot.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-reboot.yaml
@@ -24,7 +24,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name:  management-storage-nodes-reboot
+  name: management-storage-nodes-reboot
 spec:
   tolerations:
     - key: "node-role.kubernetes.io/master"
@@ -76,7 +76,7 @@ spec:
                 - name: dryRun
                   value: "{{$.DryRun}}"
                 - name: mediaHost
-                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
                     echo "NOTICE This workflow will reboot storage nodes according to --limit-management-rollout parameter."
@@ -101,7 +101,7 @@ spec:
                 - name: dryRun
                   value: "{{$.DryRun}}"
                 - name: mediaHost
-                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
                     echo '{{inputs.parameters.global_params}}' > global.params.data
@@ -179,13 +179,13 @@ spec:
               - name: dryRun
                 value: "{{$.DryRun}}"
               - name: mediaHost
-                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
               - name: scriptContent
                 value: |
                   sets="{{inputs.parameters.sets}}"
                   current_count="{{inputs.parameters.counter}}"
                   # Storage Nodes reboot sequentially. Add single node to set
-                  IFS=' ' read -ra set_array  <<< "$sets"
+                  IFS=' ' read -ra set_array <<< "$sets"
                   reboot_set=${set_array[$current_count]}
                   if [[ -z $reboot_set ]]; then
                     echo "NOTICE This step received no nodes to reboot. Exiting without rebooting any storage nodes"
@@ -268,7 +268,7 @@ spec:
                 - name: dryRun
                   value: 'false'
           - name: wait-for-cfs
-            dependencies: 
+            dependencies:
               - wait-for-cloud-init
             templateRef:
               name: ncn-reboot-common
@@ -280,7 +280,7 @@ spec:
                 - name: targetNcn
                   value: "{{inputs.parameters.targetNcn}}"
           - name: platform-health-checks
-            dependencies: 
+            dependencies:
               - wait-for-cfs
               - wait-for-node-health
             templateRef:

--- a/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-reboot.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-storage-nodes-reboot.yaml
@@ -1,0 +1,361 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name:  management-storage-nodes-reboot
+spec:
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+  entrypoint: main
+  templates:
+    - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "management-storage-nodes-reboot"
+            - key: stage
+              value: "management-nodes-rollout"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      dag:
+        tasks:
+          - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+          - name: INFO-to-read
+            dependencies:
+              - start-operation
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                - name: scriptContent
+                  value: |
+                    echo "NOTICE This workflow will reboot storage nodes according to --limit-management-rollout parameter."
+          - name: verify-pre-reboot-checks
+            dependencies:
+              - INFO-to-read
+            templateRef:
+              name: ncn-reboot-common
+              template: verify-pre-reboot-checks
+            arguments:
+              parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+          - name: get-storage-reboot-sets
+            dependencies:
+              - verify-pre-reboot-checks
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                - name: scriptContent
+                  value: |
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
+                    reboot_set=""
+                    if [[ -n $(echo $limit_management_nodes | grep 'Management_Storage') ]]; then
+                      for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+                        reboot_set="${reboot_set},${storage_node}"
+                      done
+                    else
+                      #reboot storage nodes specified by hostnames
+                      storage_nodes_to_reboot="${limit_management_nodes}"
+                      for storage_node in $storage_nodes_to_reboot; do
+                        reboot_set="${reboot_set},${storage_node}"
+                      done
+                    fi
+                    #remove comma from reboot set make every node a set to reboot sequentially
+                    reboot_set=$(echo "$reboot_set"|tr ',' ' ')
+                    echo $reboot_set
+          - name: process-storage-reboot-sets
+            dependencies:
+              - get-storage-reboot-sets
+            template: process-sets
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{tasks.get-storage-reboot-sets.outputs.result}}"
+          - name: reboot-storage-sets
+            dependencies:
+              - process-storage-reboot-sets
+            template: reboot-set-of-storage-nodes
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{tasks.process-storage-reboot-sets.outputs.parameters.sets}}"
+                - name: counter
+                  value: "0"
+                - name: limit
+                  value: "{{tasks.process-storage-reboot-sets.outputs.parameters.num_sets}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+          - name: end-operation
+            dependencies:
+              - reboot-storage-sets
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+          - name: prom-metrics
+            dependencies:
+              - start-operation
+              - end-operation
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{tasks.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{tasks.end-operation.outputs.result}}"
+    - name: reboot-set-of-storage-nodes
+      inputs:
+        parameters:
+          - name: sets
+          - name: counter
+          - name: limit
+          - name: global_params
+      dag:
+        tasks:
+          - name: get-reboot-set
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                
+              - name: scriptContent
+                value: |
+                  sets="{{inputs.parameters.sets}}"
+                  current_count="{{inputs.parameters.counter}}"
+                  # Storage Nodes reboot sequentially. Add single node to set
+                  IFS=' ' read -ra set_array  <<< "$sets"
+                  reboot_set=${set_array[$current_count]}
+                  if [[ -z $reboot_set ]]; then
+                    echo "NOTICE This step received no nodes to reboot. Exiting without rebooting any storage nodes"
+                    exit 0
+                  fi
+                  echo $reboot_set
+          - name: reboot-storage-node
+            dependencies:
+              - get-reboot-set
+            template: reboot-storage-node
+            arguments:
+              parameters:
+                - name: targetNcn
+                  value: "{{tasks.get-reboot-set.outputs.result}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+          - name: move-to-next-set
+            template: move-to-next-set
+            dependencies:
+              - reboot-storage-node
+            arguments:
+              parameters:
+                - name: count
+                  value: "{{inputs.parameters.counter}}"
+          - name: continue
+            dependencies:
+              - move-to-next-set
+            template: reboot-set-of-storage-nodes
+            when: "{{tasks.move-to-next-set.outputs.result}} < {{inputs.parameters.limit}}"
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{inputs.parameters.sets}}"
+                - name: counter
+                  value: "{{tasks.move-to-next-set.outputs.result}}"
+                - name: limit
+                  value: "{{inputs.parameters.limit}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+    - name: reboot-storage-node
+      inputs:
+        parameters:
+          - name: global_params
+          - name: targetNcn
+      dag:
+        tasks:
+          - name: reboot-node
+            templateRef:
+              name: ncn-reboot-common
+              template: reboot-ncn
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+                - name: targetNcn
+                  value: "{{inputs.parameters.targetNcn}}"
+          - name: wait-for-cloud-init
+            dependencies:
+              - reboot-node
+            templateRef:
+              name: ncn-reboot-common
+              template: wait-for-cloud-init
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: targetNcn
+                  value: "{{inputs.parameters.targetNcn}}"
+          - name: wait-for-node-health
+            templateRef:
+              name: check-ceph-health
+              template: main
+            dependencies:
+              # check health once node reboot is complete
+              - wait-for-cloud-init
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: 'false'
+          - name: wait-for-cfs
+            dependencies: 
+              - wait-for-cloud-init
+            templateRef:
+              name: ncn-reboot-common
+              template: wait-for-cfs
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: targetNcn
+                  value: "{{inputs.parameters.targetNcn}}"
+          - name: platform-health-checks
+            dependencies: 
+              - wait-for-cfs
+              - wait-for-node-health
+            templateRef:
+              name: ncn-reboot-common
+              template: platform-health-checks
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+    - name: process-sets
+      inputs:
+        parameters:
+          - name: sets
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          sets="{{inputs.parameters.sets}}"
+          echo $sets > /tmp/sets
+          num_sets=$(echo $sets | wc -w)
+          echo $num_sets > /tmp/num_sets
+      outputs:
+        parameters:
+          - name: sets
+            valueFrom:
+              path: "/tmp/sets"
+          - name: num_sets
+            valueFrom:
+              path: "/tmp/num_sets"
+    - name: move-to-next-set
+      inputs:
+        parameters:
+          - name: count
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          current_count="{{inputs.parameters.count}}"
+          counter=$((current_count + 1 ))
+          echo $counter
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: "opname"
+                value: "management-storage-nodes-reboot"
+              - key: stage
+                value: "management-nodes-rollout"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: "opstart"
+                value: "{{inputs.parameters.opstart}}"
+              - key: "opend"
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-reboot.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-reboot.yaml
@@ -1,0 +1,546 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: management-worker-nodes-reboot
+spec:
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+  entrypoint: main
+  templates:
+    - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "management-worker-nodes-reboot"
+            - key: stage
+              value: "management-nodes-rollout"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      dag:
+        tasks:
+          - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+          - name: INFO-to-read
+            dependencies:
+              - start-operation
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                - name: scriptContent
+                  value: |
+                    echo "NOTICE This workflow will reboot worker nodes according to --limit-management-rollout parameter."
+          - name: verify-pre-reboot-checks
+            dependencies:
+              - INFO-to-read
+            templateRef:
+              name: ncn-reboot-common
+              template: verify-pre-reboot-checks
+            arguments:
+              parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+          - name: get-worker-reboot-sets
+            dependencies:
+              - verify-pre-reboot-checks
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: mediaHost
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                - name: scriptContent
+                  value: |
+                    echo '{{inputs.parameters.global_params}}' > global.params.data
+                    limit_management_nodes=$(cat global.params.data | jq -r '.input_params.limit_management_nodes[]')
+                    percent_rollout=$(cat global.params.data | jq -r '.input_params.concurrent_management_rollout_percentage')
+                    total_worker_nodes=$(kubectl get node --selector='!node-role.kubernetes.io/control-plane' --no-headers=true | awk '{print $1}' | tr "\n", " ")
+                    array_total_worker_nodes=($total_worker_nodes)
+                    num_total_worker_nodes=${#array_total_worker_nodes[@]}
+
+                    # set the number of worker nodes that should be reboot concurrently
+                    workers_per_set=$(( $(( percent_rollout * num_total_worker_nodes )) / 100 ))
+                    if [[ $workers_per_set -eq 0 ]]; then
+                      workers_per_set=1
+                    elif [ $workers_per_set -eq $num_total_worker_nodes ] && [ $workers_per_set -gt 1 ]; then
+                      workers_per_set=$((workers_per_set-1))
+                    fi
+
+                    # get workers to reboot
+                    if [[ -n $(echo $limit_management_nodes | grep 'Management_Worker') ]]; then
+                      worker_nodes_to_reboot=$(kubectl get node --selector='!node-role.kubernetes.io/control-plane' --no-headers=true | awk '{print $1}' | tr "\n", " ")
+                      labeled_workers=$(kubectl get nodes --selector='iuf-prevent-reboot=true' -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
+                      for labeled_worker in $labeled_workers; do
+                        worker_nodes_to_reboot=$(echo $worker_nodes_to_reboot | sed s/"$labeled_worker"//)
+                      done
+                    else
+                      # reboot worker nodes specified by hostnames
+                      worker_nodes_to_reboot="${limit_management_nodes}"
+                      labeled_workers=$(kubectl get nodes --selector='iuf-prevent-reboot=true' -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
+                      for labeled_worker in $labeled_workers; do
+                        worker_nodes_to_reboot=$(echo $worker_nodes_to_reboot | sed s/"$labeled_worker"//)
+                      done
+                    fi
+
+                    index=0
+                    set=""
+                    output=""
+                    for node in $worker_nodes_to_reboot; do
+                      index=$(( index + 1 ))
+                      set="${set},${node}"
+                      if [[ $index -eq $workers_per_set ]]; then
+                        output="${output} ${set#?}"
+                        index=0
+                        set=""
+                      fi
+                    done
+                    if [[ -n ${set} ]]; then
+                      output="${output} ${set#?}"
+                    fi
+                    echo "${output#?}"
+          - name: process-worker-reboot-sets
+            dependencies:
+              - get-worker-reboot-sets
+            template: process-sets
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{tasks.get-worker-reboot-sets.outputs.result}}"
+          - name: reboot-worker-sets
+            dependencies:
+              - process-worker-reboot-sets
+            template: reboot-set-of-workers
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{tasks.process-worker-reboot-sets.outputs.parameters.sets}}"
+                - name: counter
+                  value: "0"
+                - name: limit
+                  value: "{{tasks.process-worker-reboot-sets.outputs.parameters.num_sets}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+          - name: end-operation
+            dependencies:
+              - reboot-worker-sets
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+          - name: prom-metrics
+            dependencies:
+              - start-operation
+              - end-operation
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{tasks.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{tasks.end-operation.outputs.result}}"
+    - name: process-sets
+      inputs:
+        parameters:
+          - name: sets
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          sets="{{inputs.parameters.sets}}"
+          echo $sets > /tmp/sets
+          num_sets=$(echo $sets | wc -w)
+          echo $num_sets > /tmp/num_sets
+      outputs:
+        parameters:
+          - name: sets
+            valueFrom:
+              path: "/tmp/sets"
+          - name: num_sets
+            valueFrom:
+              path: "/tmp/num_sets"
+    - name: reboot-set-of-workers
+      inputs:
+        parameters:
+          - name: sets
+          - name: counter
+          - name: limit
+          - name: global_params
+      dag:
+        tasks:
+          - name: get-reboot-set
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                
+              - name: scriptContent
+                value: |
+                  sets="{{inputs.parameters.sets}}"
+                  current_count="{{inputs.parameters.counter}}"
+                  IFS=' ' read -ra set_array  <<< "$sets"
+                  reboot_set=${set_array[$current_count]}
+                  if [[ -z $reboot_set ]]; then
+                    echo "NOTICE This step received no nodes to reboot. Continuing without rebooting any worker nodes"
+                    exit 0
+                  fi
+                  echo $reboot_set | jq -R 'split(",")'
+          - name: drain-reboot-set
+            dependencies:
+              - get-reboot-set
+            template: drain-set
+            arguments:
+              parameters:
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+                - name: targetNcns
+                  value: "{{tasks.get-reboot-set.outputs.result}}"
+          - name: reboot-and-post-check
+            dependencies:
+              - drain-reboot-set
+            template: reboot-worker
+            arguments:
+              parameters:
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+                - name: targetNcn
+                  value: "{{item}}"
+            withParam: "{{tasks.get-reboot-set.outputs.result}}"
+          - name: platform-health-checks
+            dependencies: 
+              - reboot-and-post-check
+            templateRef:
+              name: ncn-reboot-common
+              template: platform-health-checks
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+          - name: check-bgp-session
+            dependencies: 
+              - reboot-and-post-check
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    echo "INFO Validating BGP peering sessions"
+                    if ! GOSS_BASE=/opt/cray/tests/install/ncn goss \
+                      -g /opt/cray/tests/install/ncn/tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml \
+                      --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate >/dev/null 2>&1; then
+                      echo "ERROR Validation connection to the BGP neighbors of a switch. run 'canu validate network bgp --verbose' to see the status of all BGP neighbors"
+                      exit 1
+                    else
+                      echo "INFO Successfully Validated connection to the BGP neighbors of a switch"
+                    fi
+          - name: move-to-next-set
+            template: move-to-next-set
+            dependencies:
+              -  platform-health-checks
+              - check-bgp-session
+            arguments:
+              parameters:
+                - name: count
+                  value: "{{inputs.parameters.counter}}"
+          - name: continue
+            dependencies:
+              - move-to-next-set
+            template: reboot-set-of-workers
+            when: "{{tasks.move-to-next-set.outputs.result}} < {{inputs.parameters.limit}}"
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{inputs.parameters.sets}}"
+                - name: counter
+                  value: "{{tasks.move-to-next-set.outputs.result}}"
+                - name: limit
+                  value: "{{inputs.parameters.limit}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+    - name: drain-set
+      inputs:
+        parameters:
+          - name: global_params
+          - name: targetNcns
+      parallelism: 1
+      dag:
+        tasks:
+          - name: drain
+            template: drain-reboot-set
+            arguments:
+              parameters:
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
+                - name: targetNcn
+                  value: '{{item}}'
+            withParam: '{{inputs.parameters.targetNcns}}'
+    - name: drain-reboot-set
+      inputs:
+        parameters:
+          - name: global_params
+          - name: targetNcn
+      dag:
+        tasks:    
+          - name: failover-leader
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: '{{$.DryRun}}'
+                - name: mediaHost
+                  value: ncn-m001
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                    echo "INFO Fail Over pods on node '${TARGET_NCN}'"
+                    /usr/share/doc/csm/upgrade/scripts/k8s/failover-leader.sh $TARGET_NCN
+          - name: drain-worker
+            templateRef:
+              name: kubectl-and-curl-template
+              template: shell-script
+            dependencies:
+              - failover-leader
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: '{{$.DryRun}}'
+                - name: mediaHost
+                  value: ncn-m001
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                    echo "INFO Draining node '${TARGET_NCN}'"
+                    result=$(csi automate ncn kubernetes --action drain-ncn --ncn "$TARGET_NCN" --kubeconfig mykubeconfig/admin.conf 2>&1)
+                    if [[ $? -eq 0 ]] || [[ "$result" == *"Pod disruption budgets satisfied"* ]]; then
+                      echo "INFO: Node $TARGET_NCN drained successfully"
+                    else
+                      echo "WARNING: Initial drain did not succeed due to Pod disruption budgets. Retrying after deleting pods."
+                      PODS_TO_DELETE=$(echo "$result" | grep -oP 'Cannot evict pod \K[^:]*')
+
+                      # Delete each offending pod
+                      for pod in $PODS_TO_DELETE; do
+                        # Attempt to find the namespace of the pod
+                        NS=$(kubectl get pod --all-namespaces --field-selector spec.nodeName=$TARGET_NCN -o json | \
+                              jq -r ".items[] | select(.metadata.name==\"$pod\") | .metadata.namespace")
+
+                        if [[ -n "$NS" ]]; then
+                          echo "Force deleting pod $pod in namespace $NS..."
+                          kubectl delete pod "$pod" -n "$NS" --grace-period=0 --force
+                        else
+                          echo "WARNING: Could not find namespace for pod $pod; skipping"
+                        fi
+                      done
+
+                      result=$(csi automate ncn kubernetes --action drain-ncn --ncn "$TARGET_NCN" --kubeconfig mykubeconfig/admin.conf 2>&1)
+
+                      if [[ "$result" == *"Pod disruption budgets satisfied"* ]]; then
+                        echo "INFO: Node $TARGET_NCN drained successfully on retry"
+                        echo $result
+                      else
+                        echo "ERROR: Failed to drain node $TARGET_NCN after retry"
+                        echo "INFO: Uncordoning node $TARGET_NCN to restore scheduling"
+                        kubectl uncordon "$TARGET_NCN"
+                        exit 1
+                      fi
+                    fi
+    - name: reboot-worker
+      inputs:
+        parameters:
+          - name: global_params
+          - name: targetNcn
+      dag:
+        tasks:
+        - name: reboot-node
+          templateRef:
+            name: ncn-reboot-common
+            template: reboot-ncn
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: global_params
+                value: "{{inputs.parameters.global_params}}"
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
+        - name: wait-for-cloud-init
+          dependencies: 
+            - reboot-node
+          templateRef:
+            name: ncn-reboot-common
+            template: wait-for-cloud-init
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
+              - name: mediaHost
+                value: 'ncn-m001'
+        - name: wait-for-k8s
+          dependencies: 
+            - wait-for-cloud-init
+          templateRef:
+            name: kubectl-and-curl-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: 'ncn-m001'
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  # Wait for Kubernetes membership
+                  echo "INFO Waiting for node to rejoin Kubernetes: ${TARGET_NCN}"
+                  MAX_RETRY=45
+                  n=0
+                  until csi automate ncn kubernetes --action is-member --ncn "$TARGET_NCN" --kubeconfig mykubeconfig/admin.conf; do
+                    n=$((n+1))
+                    if [[ $n -ge $MAX_RETRY ]]; then
+                      echo "ERROR: Node did not rejoin Kubernetes in time."
+                      exit 1
+                    fi
+                    echo "DEBUG Waiting for node to rejoin Kubernetes: ${TARGET_NCN}"
+                    sleep 15
+                  done
+        - name: wait-for-cfs
+          dependencies: 
+            - wait-for-cloud-init
+          templateRef:
+            name: ncn-reboot-common
+            template: wait-for-cfs
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
+        - name: uncordon-node
+          dependencies: 
+            - wait-for-k8s
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: 'ncn-m001'
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  # Uncordon the node
+                  kubectl uncordon "$TARGET_NCN"
+                  echo "INFO Successfully Uncordon: ${TARGET_NCN}"
+    - name: move-to-next-set
+      inputs:
+        parameters:
+          - name: count
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          current_count="{{inputs.parameters.count}}"
+          counter=$((current_count + 1 ))
+          echo $counter
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: "opname"
+                value: "management-worker-nodes-rollout"
+              - key: stage
+                value: "management-nodes-rollout"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: "opstart"
+                value: "{{inputs.parameters.opstart}}"
+              - key: "opend"
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-reboot.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-reboot.yaml
@@ -76,7 +76,7 @@ spec:
                 - name: dryRun
                   value: "{{$.DryRun}}"
                 - name: mediaHost
-                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
                     echo "NOTICE This workflow will reboot worker nodes according to --limit-management-rollout parameter."
@@ -101,7 +101,7 @@ spec:
                 - name: dryRun
                   value: "{{$.DryRun}}"
                 - name: mediaHost
-                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                  
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
                 - name: scriptContent
                   value: |
                     echo '{{inputs.parameters.global_params}}' > global.params.data
@@ -229,12 +229,12 @@ spec:
               - name: dryRun
                 value: "{{$.DryRun}}"
               - name: mediaHost
-                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"                
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_host')}}"
               - name: scriptContent
                 value: |
                   sets="{{inputs.parameters.sets}}"
                   current_count="{{inputs.parameters.counter}}"
-                  IFS=' ' read -ra set_array  <<< "$sets"
+                  IFS=' ' read -ra set_array <<< "$sets"
                   reboot_set=${set_array[$current_count]}
                   if [[ -z $reboot_set ]]; then
                     echo "NOTICE This step received no nodes to reboot. Continuing without rebooting any worker nodes"
@@ -263,7 +263,7 @@ spec:
                   value: "{{item}}"
             withParam: "{{tasks.get-reboot-set.outputs.result}}"
           - name: platform-health-checks
-            dependencies: 
+            dependencies:
               - reboot-and-post-check
             templateRef:
               name: ncn-reboot-common
@@ -273,7 +273,7 @@ spec:
                 - name: dryRun
                   value: "{{$.DryRun}}"
           - name: check-bgp-session
-            dependencies: 
+            dependencies:
               - reboot-and-post-check
             templateRef:
               name: ssh-template
@@ -296,7 +296,7 @@ spec:
           - name: move-to-next-set
             template: move-to-next-set
             dependencies:
-              -  platform-health-checks
+              - platform-health-checks
               - check-bgp-session
             arguments:
               parameters:
@@ -340,7 +340,7 @@ spec:
           - name: global_params
           - name: targetNcn
       dag:
-        tasks:    
+        tasks:
           - name: failover-leader
             templateRef:
               name: ssh-template
@@ -425,7 +425,7 @@ spec:
               - name: targetNcn
                 value: "{{inputs.parameters.targetNcn}}"
         - name: wait-for-cloud-init
-          dependencies: 
+          dependencies:
             - reboot-node
           templateRef:
             name: ncn-reboot-common
@@ -439,7 +439,7 @@ spec:
               - name: mediaHost
                 value: 'ncn-m001'
         - name: wait-for-k8s
-          dependencies: 
+          dependencies:
             - wait-for-cloud-init
           templateRef:
             name: kubectl-and-curl-template
@@ -467,7 +467,7 @@ spec:
                     sleep 15
                   done
         - name: wait-for-cfs
-          dependencies: 
+          dependencies:
             - wait-for-cloud-init
           templateRef:
             name: ncn-reboot-common
@@ -479,7 +479,7 @@ spec:
               - name: targetNcn
                 value: "{{inputs.parameters.targetNcn}}"
         - name: uncordon-node
-          dependencies: 
+          dependencies:
             - wait-for-k8s
           templateRef:
             name: ssh-template

--- a/workflows/templates/ncn-reboot-common.yaml
+++ b/workflows/templates/ncn-reboot-common.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: dryRun
                   value: "{{inputs.parameters.dryRun}}"
                 - name: mediaHost
-                  value: "{{inputs.parameters.media_host}}"                         
+                  value: "{{inputs.parameters.media_host}}"
                 - name: scriptContent
                   value: |
                     echo "INFO NCN pre-reboot checks"
@@ -58,7 +58,7 @@ spec:
                     else
                       echo "INFO Successfully completed platform health check"
                     fi
-                    
+
                     echo "INFO Checking the status of the slurmctld pod"
                     result=$(kubectl get pod -n user -lapp=slurmctld -o jsonpath="{.items[*].status.phase}" 2>&1)
                     if [[ "$result" != "Running" ]]; then
@@ -67,7 +67,7 @@ spec:
                     else
                       echo "INFO $(kubectl get pod -n user -lapp=slurmctld -o jsonpath="{.items[*].metadata.name}") is running"
                     fi
-                    
+
                     echo "INFO Checking the status of the slurmdbd pod"
                     result=$(kubectl get pod -n user -lapp=slurmdbd -o jsonpath="{.items[*].status.phase}" 2>&1)
                     if [[ "$result" != "Running" ]]; then
@@ -87,7 +87,7 @@ spec:
                     else
                       echo "INFO Successfully Validated connection to the BGP neighbors of a switch"
                     fi
-                    
+
                     echo "INFO Checking if any nodes are in a failed state in CFS"
                     failed_nodes=$(cray cfs v3 components list --status failed --format json | jq -r '[.components[].id]|join(",")' 2>&1)
                     if [ -z "$failed_nodes" ]; then
@@ -125,7 +125,7 @@ spec:
                 - name: dryRun
                   value: "{{inputs.parameters.dryRun}}"
                 - name: mediaHost
-                  value: "{{inputs.parameters.media_host}}"                         
+                  value: "{{inputs.parameters.media_host}}"
                 - name: scriptContent
                   value: |
                     TARGET_NCN="{{inputs.parameters.targetNcn}}"
@@ -259,7 +259,7 @@ spec:
                     while ! ssh "${TARGET_NCN}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'ls /var/log/cloud-init-output.log'
                     do
                       echo "DEBUG wait for ssh: $TARGET_NCN"
-                      sleep $(( ( RANDOM % 10 )  + 1 ))
+                      sleep $(( ( RANDOM % 10 ) + 1 ))
                     done
 
                     # wait for cloud-init

--- a/workflows/templates/ncn-reboot-common.yaml
+++ b/workflows/templates/ncn-reboot-common.yaml
@@ -1,0 +1,303 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: ncn-reboot-common
+  namespace: argo
+spec:
+  templates:
+    - name: verify-pre-reboot-checks
+      inputs:
+        parameters:
+          - name: dryRun
+          - name: media_host
+            value: 'ncn-m001'
+      dag:
+        tasks:
+          - name: verify-pre-reboot-checks
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: mediaHost
+                  value: "{{inputs.parameters.media_host}}"                         
+                - name: scriptContent
+                  value: |
+                    echo "INFO NCN pre-reboot checks"
+
+                    echo "INFO Starting platform health check"
+                    result=$(/opt/cray/platform-utils/ncnHealthChecks.sh 2>&1)
+                    if [[ "$result" == *"FAILED"* ]]; then
+                      echo "ERROR platform health check has failed"
+                      exit 1
+                    else
+                      echo "INFO Successfully completed platform health check"
+                    fi
+                    
+                    echo "INFO Checking the status of the slurmctld pod"
+                    result=$(kubectl get pod -n user -lapp=slurmctld -o jsonpath="{.items[*].status.phase}" 2>&1)
+                    if [[ "$result" != "Running" ]]; then
+                      echo "ERROR slurmctld Pod is not running"
+                      exit 1
+                    else
+                      echo "INFO $(kubectl get pod -n user -lapp=slurmctld -o jsonpath="{.items[*].metadata.name}") is running"
+                    fi
+                    
+                    echo "INFO Checking the status of the slurmdbd pod"
+                    result=$(kubectl get pod -n user -lapp=slurmdbd -o jsonpath="{.items[*].status.phase}" 2>&1)
+                    if [[ "$result" != "Running" ]]; then
+                      echo "ERROR slurmdbd pod is not running"
+                      exit 1
+                    else
+                      echo "INFO $(kubectl get pod -n user -lapp=slurmdbd -o jsonpath="{.items[*].metadata.name}") is running"
+                    fi
+
+                    echo "INFO Validating BGP peering sessions"
+                    if ! GOSS_BASE=/opt/cray/tests/install/ncn goss \
+                      -g /opt/cray/tests/install/ncn/tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml \
+                      --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate >/dev/null 2>&1
+                    then
+                      echo "ERROR Validation connection to the BGP neighbors of a switch. run 'canu validate network bgp --verbose' to see the status of all BGP neighbors"
+                      exit 1
+                    else
+                      echo "INFO Successfully Validated connection to the BGP neighbors of a switch"
+                    fi
+                    
+                    echo "INFO Checking if any nodes are in a failed state in CFS"
+                    failed_nodes=$(cray cfs v3 components list --status failed --format json | jq -r '[.components[].id]|join(",")' 2>&1)
+                    if [ -z "$failed_nodes" ]; then
+                      echo "INFO All nodes are in configured state in CFS"
+                    else
+                      echo "ERROR $failed_nodes is/are in failed state in CFS"
+                      exit 1
+                    fi
+
+                    echo "INFO Starting Postgres health check"
+                    if ! /opt/cray/tests/install/ncn/automated/ncn-postgres-tests >/dev/null 2>&1
+                    then
+                      echo "ERROR NCN Postgres health check has failed"
+                      echo "ERROR run the script "/opt/cray/tests/install/ncn/scripts/postgresql_backups_check.sh -p" to see a printed description of the errors"
+                      exit 1
+                    else
+                      echo "INFO Successfully completed NCN Postgres health check"
+                    fi
+    - name: reboot-ncn
+      inputs:
+        parameters:
+          - name: dryRun
+          - name: global_params
+          - name: targetNcn
+          - name: media_host
+            value: 'ncn-m001'
+      dag:
+        tasks:
+          - name: reboot-node
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: mediaHost
+                  value: "{{inputs.parameters.media_host}}"                         
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                    TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
+                    # Get Keycloak token
+                    CLIENT_SECRET=$(kubectl get secret admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)
+                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                      -d client_id=admin-client \
+                      -d client_secret="$CLIENT_SECRET" \
+                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
+                    # Get xnames
+                    TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+                      "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" |
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"${TARGET_NCN}\")) | .Xname")
+
+                    TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+                      "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" |
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"${TARGET_NCN}\")) | .Parent")
+
+                    # Get IPMI credentials
+                    IPMI_USERNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+                      "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds" |
+                      jq -r ".Targets[] | select(.Xname == \"$TARGET_MGMT_XNAME\") | .Username")
+
+                    IPMI_PASSWORD=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+                      "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds" |
+                      jq -r ".Targets[] | select(.Xname == \"$TARGET_MGMT_XNAME\") | .Password")
+
+                    # Power functions
+                    check_power_status() {
+                      output=$(ipmitool -I lanplus -U "${IPMI_USERNAME}" -P "${IPMI_PASSWORD}" -H "${TARGET_NCN_mgmt_host}" power status 2>&1)
+                      if [[ $? -ne 0 ]]; then
+                        echo "ERROR Failed getting power status $TARGET_NCN"
+                        exit 1
+                      else
+                        echo "$output" | awk '{print $4}'
+                      fi
+                    }
+
+                    echo "Powering off ${TARGET_NCN_mgmt_host}"
+                    if ! ipmitool -I lanplus -U "${IPMI_USERNAME}" -P "${IPMI_PASSWORD}" -H "${TARGET_NCN_mgmt_host}" power off; then
+                      echo "ERROR Failed powering off $TARGET_NCN"
+                      exit 1
+                    else
+                      echo "INFO powering off $TARGET_NCN"
+                    fi
+                    while [[ "$(check_power_status)" != "off" ]]; do
+                      echo "INFO: Waiting for node power off"
+                      sleep 5
+                    done
+                    echo "INFO Successfully power off $TARGET_NCN"
+                    if ! ipmitool -I lanplus -U "${IPMI_USERNAME}" -P "${IPMI_PASSWORD}" -H "${TARGET_NCN_mgmt_host}" power on; then
+                      echo "ERROR Failed powering on $TARGET_NCN"
+                      exit 1
+                    else
+                      echo "INFO powering on $TARGET_NCN"
+                    fi
+                    while [[ "$(check_power_status)" != "on" ]]; do
+                      echo "INFO: Waiting for node power on"
+                      sleep 5
+                    done
+                    echo "INFO Successfully rebooted $TARGET_NCN"
+    - name: wait-for-cfs
+      inputs:
+        parameters:
+          - name: targetNcn
+          - name: dryRun
+      dag:
+        tasks:
+        - name: wait-for-cfs
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: 'ncn-m001'
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  # Get Keycloak token
+                  CLIENT_SECRET=$(kubectl get secret admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)
+                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                    -d client_id=admin-client \
+                    -d client_secret="$CLIENT_SECRET" \
+                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                  TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+                    "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" |
+                    jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"${TARGET_NCN}\")) | .Xname")
+                  # Wait for CFS configuration
+                  echo "INFO: Waiting for CFS configuration for $TARGET_XNAME..."
+                  while true; do
+                    CONFIG_STATUS=$(cray cfs v3 components describe "$TARGET_XNAME" --format json | jq -r .configuration_status)
+                    if [[ "$CONFIG_STATUS" == "failed" ]]; then
+                      echo "ERROR: Node configuration failed"
+                      exit 1
+                    elif [[ "$CONFIG_STATUS" == "configured" ]]; then
+                      echo "INFO: Node successfully configured"
+                      break
+                    else
+                      echo "DEBUG: Waiting for node configuration to complete..."
+                      sleep 10
+                    fi
+                  done
+    - name: wait-for-cloud-init
+      inputs:
+        parameters:
+          - name: dryRun
+          - name: targetNcn
+          - name: media_host
+            value: 'ncn-m001'
+      dag:
+        tasks:
+          - name: wait-for-cloud-init
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{inputs.parameters.targetNcn}}
+
+                    # wait random seconds (1-10s) until ssh is working
+                    echo "INFO wait for ssh: $TARGET_NCN"
+                    while ! ssh "${TARGET_NCN}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'ls /var/log/cloud-init-output.log'
+                    do
+                      echo "DEBUG wait for ssh: $TARGET_NCN"
+                      sleep $(( ( RANDOM % 10 )  + 1 ))
+                    done
+
+                    # wait for cloud-init
+                    # ssh commands are expected to fail for a while, so we temporarily disable set -e
+                    set +e
+                    echo "INFO waiting for cloud-init: $TARGET_NCN "
+                    while true ; do
+                        ssh "${TARGET_NCN}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'cat /var/log/cloud-init-output.log | grep "The system is finally up"' &> /dev/null && break
+                        echo "DEBUG waiting for cloud-init: $TARGET_NCN"
+                        sleep 20
+                    done
+                    # Restore set -e
+                    set -e
+    - name: platform-health-checks
+      inputs:
+        parameters:
+          - name: dryRun
+          - name: media_host
+            value: 'ncn-m001'
+      dag:
+        tasks:
+        - name: platform-health-checks
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: mediaHost
+                value: "{{inputs.parameters.media_host}}"
+              - name: scriptContent
+                value: |
+                    echo "INFO Starting platform health check"
+                    result=$(/opt/cray/platform-utils/ncnHealthChecks.sh 2>&1)
+                    if [[ "$result" == *"FAILED"* ]]; then
+                      echo "ERROR platform health check has failed"
+                      exit 1
+                    else
+                      echo "INFO Successfully completed platform health check"
+                    fi


### PR DESCRIPTION
# Description

CASM-4572 Add argo workflows for the Rolling Reboot of worker nodes,storage nodes

* Related PR 
cray-nls PR: https://github.com/Cray-HPE/cray-nls/pull/229
iuf-cli PR: https://github.com/Cray-HPE/iuf-cli/pull/194

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
