### PR TITLE
CASMPET-7494: Kubernetes upgrade to 1.32

### DIFF
--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,10 +34,11 @@ RUNDIR="${TMPDIR:-/tmp}/encryption-tmp-$$"
 KUBETIMEOUT="${KUBETIMEOUT:-300s}"
 
 if [ -f /etc/cray/kubernetes/upgrade ]; then
-  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/upgrade_version)
+  KUBERNETES_MINOR_VERSION="$(cut -d'.' -f2 /etc/cray/kubernetes/upgrade_version)"
 else
-  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/version)
+  KUBERNETES_MINOR_VERSION="$(cut -d'.' -f2 /etc/cray/kubernetes/version)"
 fi
+export KUBERNETES_MINOR_VERSION
 
 cleanup() {
   rm -fr "${RUNDIR}"
@@ -231,11 +232,11 @@ writeconfig() {
     src="${PREFIX?}/${shasum?}.yaml"
   fi
 
-  if [[ "${KUBERNETES_MINOR_VERSION}" -lt 25 ]]; then
+  if [ ${KUBERNETES_MINOR_VERSION} -lt 25 ]; then
     kubeadmcfg="/srv/cray/resources/common/1.24/kubeadm.cfg"
-  elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 27 ]]; then
+  elif [ ${KUBERNETES_MINOR_VERSION} -lt 27 ]; then
     kubeadmcfg="/srv/cray/resources/common/1.25/kubeadm.cfg"
-  elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 31 ]]; then
+  elif [ ${KUBERNETES_MINOR_VERSION} -lt 31 ]; then
     kubeadmcfg="/srv/cray/resources/common/1.27/kubeadm.cfg"
   else
     kubeadmcfg="/srv/cray/resources/common/1.31/kubeadm.cfg"

--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -33,6 +33,12 @@ RUNDIR="${TMPDIR:-/tmp}/encryption-tmp-$$"
 # Let us control how long we wait for deletes or other kubectl ... --timeout actions
 KUBETIMEOUT="${KUBETIMEOUT:-300s}"
 
+if [ -f /etc/cray/kubernetes/upgrade ]; then
+  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/upgrade_version)
+else
+  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/version)
+fi
+
 cleanup() {
   rm -fr "${RUNDIR}"
 }
@@ -225,7 +231,17 @@ writeconfig() {
     src="${PREFIX?}/${shasum?}.yaml"
   fi
 
-  if ! updatek8sconfig "${src}" /etc/kubernetes/manifests/kube-apiserver.yaml /srv/cray/resources/common/kubeadm.cfg /etc/cray/kubernetes/kubeadm.yaml; then
+  if [[ "${KUBERNETES_MINOR_VERSION}" -lt 25 ]]; then
+    kubeadmcfg="/srv/cray/resources/common/1.24/kubeadm.cfg"
+  elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 27 ]]; then
+    kubeadmcfg="/srv/cray/resources/common/1.25/kubeadm.cfg"
+  elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 31 ]]; then
+    kubeadmcfg="/srv/cray/resources/common/1.27/kubeadm.cfg"
+  else
+    kubeadmcfg="/srv/cray/resources/common/1.31/kubeadm.cfg"
+  fi
+
+  if ! updatek8sconfig "${src}" /etc/kubernetes/manifests/kube-apiserver.yaml "${kubeadmcfg}" /etc/cray/kubernetes/kubeadm.yaml; then
     printf "fatal: Update of k8s config to use %s failed\n" "${src}" >&2
     return 1
   fi

--- a/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
+++ b/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
@@ -34,7 +34,6 @@ if [[ -z ${CSM_ARTI_DIR} ]]; then
 fi
 
 k8s_version=$(kubeadm version -o json | jq -r '.clientVersion.gitVersion' | grep -o "v1.[^.]*")
-k8s_minor_version=$(echo ${k8s_version} | cut -d "." -f2)
 
 # Change working directory to CSM_ARTI_DIR
 pushd ${CSM_ARTI_DIR}
@@ -55,4 +54,3 @@ done
 
 # Return to previous working directory
 popd
-

--- a/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
+++ b/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+# Do we have additional charts to deploy after the K8s upgrade?
+# Source /etc/cray/upgrade/csm/myenv to get CSM_ARTI_DIR
+source /etc/cray/upgrade/csm/myenv
+
+if [[ -z ${CSM_ARTI_DIR} ]]; then
+  echo "ERROR The CSM_ARTI_DIR environment variable is not set and must be present in /etc/cray/upgrade/csm/myenv."
+  exit 1
+fi
+
+k8s_version=$(kubeadm version -o json | jq -r '.clientVersion.gitVersion' | grep -o "v1.[^.]*")
+k8s_minor_version=$(echo ${k8s_version} | cut -d "." -f2)
+
+# Change working directory to CSM_ARTI_DIR
+pushd ${CSM_ARTI_DIR}
+
+# Deploy charts in given manifest
+function deploy() {
+  # Loftsman may not be able to connect to $NEXUS_URL due to certificate
+  # trust issues, so use --charts-path instead of --charts-repo.
+  loftsman ship --charts-path "${CSM_ARTI_DIR}/helm" --manifest-path "$1"
+}
+
+# If there are post-upgrade-*-<k8s_version>.yaml files, deploy charts in those files.
+manifests_dir="${CSM_ARTI_DIR}/build/manifests"
+find "${manifests_dir}/" -name "post-upgrade-*-${k8s_version}.yaml" | sort | while read -r manifest; do
+  echo "INFO Deploying ${manifest} ..."
+  deploy "${manifest}"
+done
+
+# Return to previous working directory
+popd
+

--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -54,11 +54,11 @@ export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
 
 # For K8s 1.24 through 1.30, use the kubeadm.k8s.io/v1beta3 API
 # version. Otherwise, use kubeadm.k8s.io/v1beta4.
-if [[ "${KUBERNETES_MINOR_VERSION}" -lt 25 ]]; then
+if [[ ${KUBERNETES_MINOR_VERSION} -lt 25 ]]; then
   k8scfg="/srv/cray/resources/common/1.24/kubeadm.cfg"
-elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 27 ]]; then
+elif [[ ${KUBERNETES_MINOR_VERSION} -lt 27 ]]; then
   k8scfg="/srv/cray/resources/common/1.25/kubeadm.cfg"
-elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 31 ]]; then
+elif [[ ${KUBERNETES_MINOR_VERSION} -lt 31 ]]; then
   k8scfg="/srv/cray/resources/common/1.27/kubeadm.cfg"
 else
   k8scfg="/srv/cray/resources/common/1.31/kubeadm.cfg"

--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -34,7 +34,13 @@ fi
 source /srv/cray/resources/common/vars.sh
 source /srv/cray/scripts/metal/lib.sh
 #shellcheck disable=SC2155
-export KUBERNETES_VERSION="v$(cat /etc/cray/kubernetes/version)"
+if [ -f /etc/cray/kubernetes/upgrade ]; then
+  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/upgrade_version)
+  export KUBERNETES_VERSION="$(cat /etc/cray/kubernetes/upgrade_version)"
+else
+  export KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/version)
+  export KUBERNETES_VERSION="$(cat /etc/cray/kubernetes/version)"
+fi
 #shellcheck disable=SC2046
 echo $(kubeadm init phase upload-certs --upload-certs 2>&1 | tail -1) > /etc/cray/kubernetes/certificate-key
 #shellcheck disable=SC2155
@@ -46,9 +52,20 @@ export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
 #shellcheck disable=SC2155
 export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
 
+# For K8s 1.24 through 1.30, use the kubeadm.k8s.io/v1beta3 API
+# version. Otherwise, use kubeadm.k8s.io/v1beta4.
+if [[ "${KUBERNETES_MINOR_VERSION}" -lt 25 ]]; then
+  k8scfg="/srv/cray/resources/common/1.24/kubeadm.cfg"
+elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 27 ]]; then
+  k8scfg="/srv/cray/resources/common/1.25/kubeadm.cfg"
+elif [[ "${KUBERNETES_MINOR_VERSION}" -lt 31 ]]; then
+  k8scfg="/srv/cray/resources/common/1.27/kubeadm.cfg"
+else
+  k8scfg="/srv/cray/resources/common/1.31/kubeadm.cfg"
+fi
+
 # Note: for pre 1.3 the kubeadm source file had a .yaml suffix for 1.3+ it is
 # .cfg if we have the .yaml file symlink .cfg to that for 1.2 upgrades.
-k8scfg="/srv/cray/resources/common/kubeadm.cfg"
 k8syaml="/srv/cray/resources/common/kubeadm.yaml"
 if [ -f "${k8syaml}" ]; then
   ln -sf "${k8syaml}" "${k8scfg}"

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -161,27 +161,6 @@ function deploy() {
   loftsman ship --charts-path "${CSM_ARTI_DIR}/helm" --manifest-path "$1"
 }
 
-# Undeploy the chart if it exists on the system.
-# Use this if a chart has been removed from a manifest and needs
-# to be removed from the system as part of an upgrade.
-function undeploy() {
-  # Now that we're using --keep-history, helm status will return with a STATUS
-  # of "uninstalled" if the chart has already been uninstalled.
-  # If the chart is missing (rc==1) or if uninstalled, return success.
-  helm status "$@" || return 0
-  if [ "$(helm status "$@" | grep STATUS | awk '{print $2}')" = "uninstalled" ]; then
-    return 0
-  fi
-  # Remove the chart.
-  helm uninstall "$@" --keep-history
-}
-
-# Undeploy services if they exist
-if [ ${k8s_minor_version} -gt 24 ]; then
-  # cray-psp is removed in CSM 1.7 with upgrade to K8s >= 1.25, if it exists
-  undeploy -n services cray-psp
-fi
-
 # If there are post-upgrade-*-<k8s_version>.yaml files, deploy charts in those files.
 manifests_dir="${CSM_ARTI_DIR}/build/manifests"
 find "${manifests_dir}/" -name "post-upgrade-*-${k8s_version}.yaml" | sort | while read -r manifest; do

--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -149,7 +149,6 @@ done
 # Source /etc/cray/upgrade/csm/myenv to get CSM_ARTI_DIR
 source /etc/cray/upgrade/csm/myenv
 k8s_version=$(kubeadm version -o json | jq -r '.clientVersion.gitVersion' | grep -o "v1.[^.]*")
-k8s_minor_version=$(echo ${k8s_version} | cut -d "." -f2)
 
 # Change working directory to CSM_ARTI_DIR
 pushd ${CSM_ARTI_DIR}

--- a/upgrade/scripts/k8s/upgrade_k8s.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+PROG=$(basename "$0")
+usage()
+{
+  echo "Usage: ${PROG} [-h] -v <kubernetes_versions_array>"
+  echo "    -h                Print this help message"
+  echo "    -v                Array containing all kubernetes intermediate versions along with from and to versions needed"
+  echo "                      to perform the upgrade in increasing order. List cannot contain more than 3 versions."
+  echo "                      Example: '1.27.16 1.28.15 1.29.15'"
+  echo "    -d                When running outside of IUF, drain and uncordon master nodes when upgrading kubelet."
+}
+
+while getopts "v:dh" opt; do
+  case "${opt}" in
+    v)
+      # shellcheck disable=SC2206
+      KUBERNETES_VERSIONS=(${OPTARG})
+      # Length of list cannot be more than 3
+      if [ ${#KUBERNETES_VERSIONS[@]} -gt 3 ]; then
+        echo "Too many versions! Cannot have more than 3."
+        usage >&2
+        exit 1
+      fi
+      ;;
+    d)
+      echo "Drain master nodes when upgrading kubelet."
+      DRAIN="true"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+[ $# -gt 0 ] && { echo "${PROG}: Too many arguments" >&2; usage >&2; exit 1; }
+
+if [[ ! -v KUBERNETES_VERSIONS ]]; then
+  echo "Missing option '-v' which is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -v DRAIN ]]; then
+  # Not draining master nodes before kubelet upgrade because could terminate argo pod
+  # running this script. If running script outside of IUF, use '-d' option.
+  echo "DO NOT drain master nodes when upgrading kubelet."
+  DRAIN="false"
+fi
+
+# Hashmaps for rpms we need to install per k8s version beyond k8s v1.26
+# Assumption is that we're already at k8s v1.26
+#
+# Note: there is no hash map for cri-tools because it is upgraded automatically
+# by kubeadm.
+declare -A k8s_cni
+k8s_cni["1.27"]="1.2.0"
+k8s_cni["1.28"]="1.2.0"
+k8s_cni["1.29"]="1.3.0"
+k8s_cni["1.30"]="1.4.0"
+k8s_cni["1.31"]="1.5.1"
+k8s_cni["1.32"]="1.6.0"
+
+declare -A pause
+pause["1.27"]="3.9"
+pause["1.28"]="3.9"
+pause["1.29"]="3.9"
+pause["1.30"]="3.9"
+pause["1.31"]="3.10"
+pause["1.32"]="3.10"
+
+function prefix() {
+  echo -n "$(date --iso-8601=seconds) $(basename "$0")"
+}
+
+function fix_sysconfig() {
+  # fix_sysconfig $host
+  # Where 'host' is a master or worker host. For example, ncn-m001
+  NODE_IP=$(ssh $1 "dig +short \$(hostname).nmn | grep -v -E '^;;'")
+
+  ssh "$1" "cat > /etc/sysconfig/kubelet <<EOF
+KUBELET_EXTRA_ARGS=\"--node-ip ${NODE_IP}\"
+EOF"
+}
+
+function update_kubelet_config_cm() {
+  # First, update kubelet-config configmap to add containerRuntimeEndpoint. This
+  # is necessary because --container-runtime-endpoint was deprecated as a kubelet
+  # command line argument in K8s 1.27.
+  workdir="$(mktemp -d)"
+  kubectl get configmap kubelet-config -n kube-system -o yaml > "${workdir}/kubelet-config.yaml"
+  yq4 eval -P '.data.kubelet' "${workdir}/kubelet-config.yaml" > "${workdir}/kubelet-config-kubelet.yaml"
+  yq4 eval -i -P '.containerRuntimeEndpoint = "unix:///run/containerd/containerd.sock"' "${workdir}/kubelet-config-kubelet.yaml"
+
+  # Merge our kubelet config back into the kubelet-config manifest.
+  if IFS= read -rd '' -a kubelet_config; then
+    :
+  fi <<< "$(cat "${workdir}/kubelet-config-kubelet.yaml")"
+  kubelet_config=$kubelet_config yq4 eval -i '.data.kubelet = strenv(kubelet_config)' "${workdir}/kubelet-config.yaml"
+
+  # Update the kubelet-config configmap.
+  kubectl -n kube-system apply -f "${workdir}/kubelet-config.yaml"
+}
+
+function migrate_kubeadmcfg_yaml() {
+  # migrate_kubeadmcfg_yaml ncn-m001
+  # Given master host, run kubeadm config migrate on /etc/kubernetes/kubeadmcfg.yaml
+  host=$1
+  yaml_file="/etc/kubernetes/kubeadmcfg.yaml"
+  workdir="$(mktemp -d)"
+  echo "$(prefix) INFO Working directory for $host is $workdir"
+  old_yaml_file="${workdir}/v1beta3-kubeadmcfg.yaml"
+  new_yaml_file="${workdir}/v1beta4-kubeadmcfg.yaml"
+  # Make a copy of yaml file
+  ssh "$host" "mkdir -p $workdir; cp ${yaml_file} ${old_yaml_file}"
+  # Migrate v1beta3 config to v1beta4 config
+  ssh $host kubeadm config migrate --old-config ${old_yaml_file} | yq4 '. | select(.kind == "ClusterConfiguration") | pick(["apiVersion", "kind", "kubernetesVersion", "caCertificateValidityPeriod", "certificateValidityPeriod", "etcd"])' > ${new_yaml_file}
+  # The new_yaml_file is located on the calling host
+  # Update cert validity period to 3 years
+  yq4 eval -i -P '.certificateValidityPeriod = "26280h0m0s"' ${new_yaml_file}
+  # Copy new_yaml_file to $host:$yaml_file
+  scp $new_yaml_file $host:${yaml_file}
+}
+
+masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u)
+workers=$(grep -oP 'ncn-w\d+' /etc/hosts | sort -u)
+
+# We'll only upgrade the kubelet on the masters and the workers to the target version
+# which is the last version in the KUBERNETES_VERSIONS list
+target_version="${KUBERNETES_VERSIONS[-1]}"
+v_target_version="v${target_version}"
+minor_target_version=$(echo "$target_version" | cut -d'.' -f1-2)
+
+echo "$(prefix) Beginning Kubernetes upgrade to ${target_version}."
+
+for version in "${KUBERNETES_VERSIONS[@]}"; do
+  minor_version=$(echo "$version" | cut -d'.' -f1-2)
+
+  if [[ $(bc -l <<< "${minor_version} < 1.27") -eq 1 ]]; then
+    echo "$(prefix) ERROR Upgrade version cannot be less than v1.27. Exiting ..." >&2
+    usage >&2
+    exit 1
+  fi
+
+  # If there is one time config map work to do for a k8s version, put it here
+  if [ "$minor_version" = "1.27" ]; then
+    # Edit kubelet-config cm
+    update_kubelet_config_cm
+  fi
+
+  for host in ${masters}; do
+    # Check that current k8s version is less than or equal to the minor_version.
+    # We don't want to downgrade, so if minor_version is less than current version, do nothing.
+    current_version=$(ssh $host kubeadm version -o json | jq -r '.clientVersion.gitVersion' | cut -c 2-5)
+    if [[ $(bc -l <<< "${minor_version} > ${current_version}") -eq 1 ]]; then
+      echo "$(prefix) Installing [kubeadm-${version}] on [${host}]."
+      ssh "${host}" zypper --non-interactive install "kubeadm-${version}"
+      ssh "${host}" zypper --non-interactive install "kubernetes-cni-${k8s_cni[${minor_version}]}"
+
+      echo "$(prefix) Running kubeadm upgrade apply v${version} on [${host}]."
+      if [[ $(bc -l <<< "${minor_version} < 1.30") -eq 1 ]]; then
+        ssh "${host}" kubeadm upgrade apply -y "v${version}" --force
+      else
+        ssh "${host}" kubeadm upgrade apply -y "v${version}"
+      fi
+    else
+      echo "$(prefix) INFO Version ${minor_version} is less than ${current_version}. Don't need to upgrade kubeadm for '$host'."
+    fi
+  done
+done
+
+# Upgrade kubelet on master nodes for target_version.
+echo "$(prefix) Upgrading kubelet on master nodes to ${target_version}."
+
+for host in ${masters}; do
+  # Check current kubelet version. If less than 
+  current_version=$(ssh $host kubelet --version | awk '{ print $2 }' | cut -c 2-5)
+  if [[ $(bc -l <<< "${minor_target_version} > ${current_version}") -eq 1 ]]; then
+    if [ "$DRAIN" = "true" ]; then
+      # Drain the node, ignoring daemonsets and deleting emptydir data.
+      echo "$(prefix) Draining node: [${host}]."
+      kubectl drain "${host}" --ignore-daemonsets --delete-emptydir-data
+    fi
+
+    # Fix /etc/sysconfig/kubelet
+    fix_sysconfig "${host}"
+
+    # Update pause version in containerd
+    pause_version="pause:${pause[${minor_target_version}]}"
+    ssh "${host}" sed -i -e "s/pause:3.9/$pause_version/g" /etc/containerd/config.toml
+    # Restart containerd.
+    ssh "${host}" systemctl restart containerd
+
+    # Update kubelet and kubectl. We don't need to update these one at a
+    # time; we can skip up to three versions at a time.
+    echo "$(prefix) Installing [kubelet-${target_version}] and [kubectl-${target_version}] on [${host}]."
+    ssh "${host}" zypper --non-interactive install "kubelet-${target_version}" "kubectl-${target_version}"
+
+    # Reload daemons and restart kubelet.
+    ssh "${host}" systemctl daemon-reload
+    ssh "${host}" systemctl restart kubelet
+
+    # Update K8s version in /etc/cray/kubernetes/kubeadmcfg.yaml, only on masters
+    ssh "${host}" "V_TARGET_VERSION=$v_target_version yq4 eval -i -P '.kubernetesVersion = strenv(V_TARGET_VERSION)' '/etc/kubernetes/kubeadmcfg.yaml'"
+
+    if [ "$DRAIN" = "true" ]; then
+      # Mark the node ready for scheduling.
+      echo "$(prefix) Uncordoning node: [${host}]."
+      kubectl uncordon "${host}"
+    fi
+  else
+    echo "$(prefix) INFO Version ${minor_target_version} is less than ${current_version}. Don't need to upgrade kubelet for '$host'."
+  fi
+done
+
+echo "$(prefix) Upgrading kubelet on worker nodes to ${target_version}."
+
+for host in ${workers}; do
+  # Check current kubelet version. If less than 
+  current_version=$(ssh $host kubelet --version | awk '{ print $2 }' | cut -c 2-5)
+  if [[ $(bc -l <<< "${minor_target_version} > ${current_version}") -eq 1 ]]; then
+    echo "$(prefix) Installing [kubeadm-${target_version}] on [${host}]."
+    ssh "${host}" zypper --non-interactive install "kubeadm-${target_version}"
+    ssh "${host}" zypper --non-interactive install "kubernetes-cni-${k8s_cni[${minor_target_version}]}"
+    ssh "${host}" kubeadm upgrade node
+    kubectl drain --ignore-daemonsets --delete-emptydir-data "${host}"
+
+    # Fix /etc/sysconfig/kubelet
+    fix_sysconfig "${host}"
+    # Remove --container-runtime=remote argument from KUBELET_KUBEADM_ARGS.
+    kube_kubeadm_args='KUBELET_KUBEADM_ARGS="--container-runtime-endpoint=/run/containerd/containerd.sock --pod-infra-container-image=artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:'${pause[${minor_target_version}]}'"'
+    echo "$kube_kubeadm_args" > /var/lib/kubelet/kubeadm-flags.env
+
+    # Update pause version in containerd
+    pause_version="pause:${pause[${minor_target_version}]}"
+    ssh "${host}" sed -i -e "s/pause:3.9/$pause_version/g" /etc/containerd/config.toml
+    # Restart containerd.
+    ssh "${host}" systemctl restart containerd
+
+    # Update kubelet and kubectl. We don't need to update these one at a
+    # time; we can skip up to three versions at a time.
+    echo "$(prefix) Installing [kubelet-${target_version}] and [kubectl-${target_version}] on [${host}]."
+    ssh "${host}" zypper --non-interactive install "kubelet-${target_version}" "kubectl-${target_version}"
+
+    # Reload daemons and restart kubelet.
+    ssh "${host}" systemctl daemon-reload
+    ssh "${host}" systemctl restart kubelet
+
+    kubectl uncordon "${host}"
+
+    # Need to wait 2 minutes for pods to settle before doing another drain.
+    echo "$(prefix) Waiting 2 minutes for pods to settle ..."
+    sleep 120
+  else
+    echo "$(prefix) INFO Version ${minor_target_version} is less than ${current_version}. Don't need to upgrade kubelet for '$host'."
+  fi
+done
+
+echo "$(prefix) Upgrade to ${target_version} complete."
+
+echo "$(prefix) Verifying that all ncn nodes at expected K8s ${v_target_version}"
+all_ncns="${masters} ${workers}"
+BAD_NODES=0
+for host in ${all_ncns}; do
+  # Check kubeadm version on all nodes and make sure it matches v_target_version
+  current_version=$(ssh $host kubeadm version -o json | jq -r '.clientVersion.gitVersion')
+  current_minor_version=$(echo "$current_version" | cut -c 2-5)
+  if [ "${current_minor_version}" = "1.32" ]; then
+    echo "$(prefix) ${host} version is already at ${current_version}"
+  elif [ "${current_version}" != "${v_target_version}" ]; then
+    echo "$(prefix) ERROR K8s version on $host is ${current_version} expected ${v_target_version}." >&2
+    ((BAD_NODES++))
+  else
+    echo "$(prefix) ${host} version is ${current_version} expect ${v_target_version}"
+  fi
+done
+
+# If we have any bad nodes ... exit
+if [ $BAD_NODES -gt 0 ]; then
+  echo "$(prefix) ERROR ${BAD_NODES} nodes not at expected K8s ${v_target_version} version. Exiting ..." >&2
+  exit 1
+fi
+
+# If minor_target_version is 1.32, on all master nodes
+# migrate kubeadmcfg.yaml and kubeadm.cfg to v1beta4 and renew all certificates
+if [ "${minor_target_version}" = "1.32" ]; then
+  for host in ${masters}; do
+    echo "$(prefix) Migrating /etc/kubernetes/kubeadmcfg.yaml to v1beta4 on each of the master nodes."
+    migrate_kubeadmcfg_yaml $host
+    # Generate certs with new kubeadmcfg.yaml on each master node
+    ssh $host kubeadm certs renew all --config /etc/kubernetes/kubeadmcfg.yaml
+    ssh $host kubeadm certs check-expiration
+    # Running kubeadm upgrade apply will restart all kube-system pods and services
+    current_version=$(ssh $host kubeadm version -o json | jq -r '.clientVersion.gitVersion')
+    ssh $host kubeadm upgrade apply -y "${current_version}"
+  done
+  echo "$(prefix) Migration to kubeadm v1beta4 complete."
+  echo "$(prefix) All certificates have been renewed."
+fi

--- a/upgrade/scripts/k8s/upgrade_k8s.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s.sh
@@ -161,12 +161,12 @@ workers=$(grep -oP 'ncn-w\d+' /etc/hosts | sort -u)
 # which is the last version in the KUBERNETES_VERSIONS list
 target_version="${KUBERNETES_VERSIONS[-1]}"
 v_target_version="v${target_version}"
-minor_target_version=$(echo "$target_version" | cut -d'.' -f1-2)
+minor_target_version=${target_version%.*}
 
 echo "$(prefix) Beginning Kubernetes upgrade to ${target_version}."
 
 for version in "${KUBERNETES_VERSIONS[@]}"; do
-  minor_version=$(echo "$version" | cut -d'.' -f1-2)
+  minor_version=${version%.*}
 
   if [[ $(bc -l <<< "${minor_version} < 1.27") -eq 1 ]]; then
     echo "$(prefix) ERROR Upgrade version cannot be less than v1.27. Exiting ..." >&2
@@ -219,7 +219,7 @@ for host in ${masters}; do
 
     # Update pause version in containerd
     pause_version="pause:${pause[${minor_target_version}]}"
-    ssh "${host}" sed -i -e "s/pause:3.9/$pause_version/g" /etc/containerd/config.toml
+    ssh "${host}" sed -i -e "s/pause:[0-9]*.[0-9]*/$pause_version/g" /etc/containerd/config.toml
     # Restart containerd.
     ssh "${host}" systemctl restart containerd
 
@@ -265,7 +265,7 @@ for host in ${workers}; do
 
     # Update pause version in containerd
     pause_version="pause:${pause[${minor_target_version}]}"
-    ssh "${host}" sed -i -e "s/pause:3.9/$pause_version/g" /etc/containerd/config.toml
+    ssh "${host}" sed -i -e "s/pause:[0-9]*.[0-9]*/$pause_version/g" /etc/containerd/config.toml
     # Restart containerd.
     ssh "${host}" systemctl restart containerd
 
@@ -296,7 +296,8 @@ BAD_NODES=0
 for host in ${all_ncns}; do
   # Check kubeadm version on all nodes and make sure it matches v_target_version
   current_version=$(ssh $host kubeadm version -o json | jq -r '.clientVersion.gitVersion')
-  current_minor_version=$(echo "$current_version" | cut -c 2-5)
+  current_minor_version=${current_version%.*}
+  current_minor_version=${current_minor_version#v}
   if [ "${current_minor_version}" = "1.32" ]; then
     echo "$(prefix) ${host} version is already at ${current_version}"
   elif [ "${current_version}" != "${v_target_version}" ]; then

--- a/upgrade/scripts/k8s/upgrade_k8s.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s.sh
@@ -25,8 +25,7 @@
 set -euo pipefail
 
 PROG=$(basename "$0")
-usage()
-{
+usage() {
   echo "Usage: ${PROG} [-h] -v <kubernetes_versions_array>"
   echo "    -h                Print this help message"
   echo "    -v                Array containing all kubernetes intermediate versions along with from and to versions needed"
@@ -61,8 +60,12 @@ while getopts "v:dh" opt; do
       ;;
   esac
 done
-shift $((OPTIND-1))
-[ $# -gt 0 ] && { echo "${PROG}: Too many arguments" >&2; usage >&2; exit 1; }
+shift $((OPTIND - 1))
+[ $# -gt 0 ] && {
+  echo "${PROG}: Too many arguments" >&2
+  usage >&2
+  exit 1
+}
 
 if [[ ! -v KUBERNETES_VERSIONS ]]; then
   echo "Missing option '-v' which is required" >&2
@@ -202,7 +205,7 @@ done
 echo "$(prefix) Upgrading kubelet on master nodes to ${target_version}."
 
 for host in ${masters}; do
-  # Check current kubelet version. If less than 
+  # Check current kubelet version.
   current_version=$(ssh $host kubelet --version | awk '{ print $2 }' | cut -c 2-5)
   if [[ $(bc -l <<< "${minor_target_version} > ${current_version}") -eq 1 ]]; then
     if [ "$DRAIN" = "true" ]; then
@@ -245,7 +248,7 @@ done
 echo "$(prefix) Upgrading kubelet on worker nodes to ${target_version}."
 
 for host in ${workers}; do
-  # Check current kubelet version. If less than 
+  # Check current kubelet version.
   current_version=$(ssh $host kubelet --version | awk '{ print $2 }' | cut -c 2-5)
   if [[ $(bc -l <<< "${minor_target_version} > ${current_version}") -eq 1 ]]; then
     echo "$(prefix) Installing [kubeadm-${target_version}] on [${host}]."

--- a/upgrade/scripts/upgrade/cleanup.py
+++ b/upgrade/scripts/upgrade/cleanup.py
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 import json
 import os
 import sys

--- a/upgrade/scripts/upgrade/cleanup.py
+++ b/upgrade/scripts/upgrade/cleanup.py
@@ -1,0 +1,52 @@
+import json
+import os
+import sys
+
+import requests
+
+# This script is idempotent; it can be run multiple times without consequence.
+def main():
+    token = os.getenv("TOKEN")
+    if not token:
+        print("ERROR Missing keycloak token. Is TOKEN environment variable set?", file=sys.stderr)
+        sys.exit(1)
+
+    headers = { "Authorization": f"Bearer {token}" }
+    bss_url = "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters"
+    response = requests.get(bss_url, headers=headers)
+
+    response = response.json()
+
+    nodes = []
+    for node in response:
+        metadata = node.get("cloud-init", {}).get("meta-data", {})
+        # Some meta-data fields are null.
+        if metadata is not None:
+            hostname = metadata.get("local-hostname")
+            # Some local-hostname fields are null.
+            if hostname is not None:
+                # We only care about master and worker nodes.
+                if hostname.startswith("ncn-m") or hostname.startswith("ncn-w"):
+                    nodes.append(node)
+
+    for node in nodes:
+        runcmd = node.get("cloud-init", {}).get("user-data", {}).get("runcmd")
+        hostname = node.get("cloud-init").get("meta-data").get("local-hostname")
+
+        if runcmd is not None:
+            print(f"Patching BSS runcmd for node: {hostname}.")
+
+            # Delete the lines we added in upgrade.sh.
+            runcmd = [x for x in runcmd if x != "touch /etc/cray/kubernetes/upgrade" and x != "mkdir -p /etc/cray/kubernetes"]
+            node["cloud-init"]["user-data"]["runcmd"] = runcmd
+
+            response = requests.put(bss_url, headers=headers, json=node)
+            if response.status_code != 200:
+                print(f"ERROR Unable to patch BSS runcmd for node: {hostname}.", file=sys.stderr)
+                print(response.text)
+
+                sys.exit(1)
+
+
+if __name__=='__main__':
+    main()

--- a/upgrade/scripts/upgrade/cleanup.py
+++ b/upgrade/scripts/upgrade/cleanup.py
@@ -28,7 +28,28 @@ import sys
 
 import requests
 
+# This script removes the following runcmd lines from BSS for all master and
+# worker nodes:
+#
+#    mkdir -p /etc/cray/kubernetes
+#    touch /etc/cray/kubernetes/upgrade
+#
+# These are added at the beginning of the upgrade process, in CSM upgrade.sh, to
+# signal to later stages that an upgrade is occurring, mostly for
+# Kubernetes-specific behavior. There is an additional file,
+# /etc/cray/kubernetes/upgrade_version, which is added via the node image, and
+# which specifies the initial Kubernetes upgrade target, 1.26.15. We don't need
+# to do anything for this file.
+#
+# If /etc/cray/kubernetes/upgrade is not removed, subsequent node reboots will
+# cause kubernetes-cloudinit.sh (and potentially other scripts) to assume an
+# upgrade to Kubernetes 1.26.15 is occurring, which will do things like
+# downgrade Kubernetes RPMs. Removing these two lines from runcmd ensures that
+# that does not happen.
+#
 # This script is idempotent; it can be run multiple times without consequence.
+# If the runcmd blocks have already been modified for a given node, the script
+# will PUT the original config back to the BSS API.
 def main():
     token = os.getenv("TOKEN")
     if not token:

--- a/upgrade/scripts/upgrade/cleanup.sh
+++ b/upgrade/scripts/upgrade/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Export a keycloak token so we can access BSS.
+TOKEN=$(curl -s -S -d grant_type=client_credentials \
+  -d client_id=admin-client \
+  -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
+  https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+export TOKEN
+
+python3 ./cleanup.py

--- a/upgrade/scripts/upgrade/cleanup.sh
+++ b/upgrade/scripts/upgrade/cleanup.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # Export a keycloak token so we can access BSS.
 TOKEN=$(curl -s -S -d grant_type=client_credentials \

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1168,6 +1168,36 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+state_name="PREPARE_KUBEADM"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    tmpdir=$(mktemp -d)
+
+    # This is necessary for the initial 1.24.17 to 1.26.15 bump. Otherwise,
+    # kubeadm commands in kubernetes-cloudinit.sh fail.
+    echo "Patching kubeadm-config configmap to update kubernetesVersion from 1.24.17 to 1.26.15 ..."
+    kubectl -n kube-system get configmap kubeadm-config -o go-template --template '{{ .data.ClusterConfiguration }}' \
+      | yq4 e '.kubernetesVersion="v1.26.15"' \
+        > "${tmpdir}/kubeadm-config.yaml"
+    patch=$(jq -c -n --rawfile text "${tmpdir}/kubeadm-config.yaml" '.data["ClusterConfiguration"]=$text')
+    kubectl -n kube-system patch configmap kubeadm-config --type merge --patch "${patch}"
+
+    echo "Patching kube-proxy configmap to remove udpIdleTimeout ..."
+    kubectl -n kube-system get configmap kube-proxy -o go-template --template '{{ index .data "config.conf" }}' \
+      | yq4 e 'del(.udpIdleTimeout)' \
+        > "${tmpdir}/kube-proxy.yaml"
+    patch=$(jq -c -n --rawfile text "${tmpdir}/kube-proxy.yaml" '.data["config.conf"]=$text')
+    kubectl -n kube-system patch configmap kube-proxy --type merge --patch "${patch}"
+
+    rm -rf "${tmpdir}"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 # Disable CFS on the NCNs, to prevent new sessions from being launched during the upgrade.
 # Note that it is possible CFS sessions are currently underway on the NCNs. Disabling them
 # will not prevent currently scheduled CFS sessions from executing -- it will just prevent

--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -92,10 +92,6 @@ kubectl get sts -A -l application=spilo -o json \
     kubectl rollout restart -n "${namespace}" statefulset "${sts}"
   done
 # restart cray-spire-postgres, kubectl rollout restart does not work for this cluster
-echo "Waiting for 300 seconds for cray-spire-postgres to be ready"
-sleep 300
-echo "Restarting all cray-spire-postgres members"
-kubectl exec -n spire cray-spire-postgres-0 -c postgres -- patronictl restart cray-spire-postgres --force
 echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
 sleep 300
 wait_for postgres_pods_running "all postgres pods running"

--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -91,6 +91,11 @@ kubectl get sts -A -l application=spilo -o json \
     echo "Rolling restart ${sts} in namespace ${namespace} ..."
     kubectl rollout restart -n "${namespace}" statefulset "${sts}"
   done
+# restart cray-spire-postgres, kubectl rollout restart does not work for this cluster
+echo "Waiting for 300 seconds for cray-spire-postgres to be ready"
+sleep 300
+echo "Restarting all cray-spire-postgres members"
+kubectl exec -n spire cray-spire-postgres-0 -c postgres -- patronictl restart cray-spire-postgres --force
 echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
 sleep 300
 wait_for postgres_pods_running "all postgres pods running"

--- a/upgrade/scripts/upgrade/util/fix-postgres.sh
+++ b/upgrade/scripts/upgrade/util/fix-postgres.sh
@@ -91,7 +91,6 @@ kubectl get sts -A -l application=spilo -o json \
     echo "Rolling restart ${sts} in namespace ${namespace} ..."
     kubectl rollout restart -n "${namespace}" statefulset "${sts}"
   done
-# restart cray-spire-postgres, kubectl rollout restart does not work for this cluster
 echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
 sleep 300
 wait_for postgres_pods_running "all postgres pods running"

--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -62,7 +62,6 @@ spec:
                   if [[ -n $IMAGE_ID ]]; then
                     # USE BELOW COMMAND ONCE LIBCSM IS UPDATED IN CSM
                     # bss-set-image --xnames $TARGET_XNAME --image_id $IMAGE_ID
-                    
                     # BELOW IS TEMPORARY UNTIL LIBCSM IS UPDATED
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
                     if [[ -z $image_manifest_str ]]; then

--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -66,9 +66,16 @@ spec:
                     # BELOW IS TEMPORARY UNTIL LIBCSM IS UPDATED
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
                     if [[ -z $image_manifest_str ]]; then
-                      echo "ERROR IMS is not reachable or image: $IMAGE_ID does not exist. Exiting and will retry."
-                      exit 1
+                      echo "WARN IMS is not reachable or image: $IMAGE_ID does not exist. Will retry."
+                      count=0
+                      while [[ -z $image_manifest_str && $count -lt 30 ]]; do
+                        sleep 10
+                        image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
+                        ((count++))
+                      done
+                      echo "INFO Tried ${count} times before reaching IMS."
                     fi
+                    echo "INFO Moving on with image '$image_manifest_str'"
                     image_manifest_str=${image_manifest_str#*s3://}
                     bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
                     bucket_rm="${bucket}/"

--- a/workflows/templates/storage.create-rgw-buckets.yaml
+++ b/workflows/templates/storage.create-rgw-buckets.yaml
@@ -35,7 +35,7 @@ spec:
           - name: targetNcn
       dag:
         tasks:
-          - name: create-rgw-buckets-task 
+          - name: create-rgw-buckets-task
             templateRef:
               name: ssh-template
               template: shell-script


### PR DESCRIPTION
# Description

This changeset introduces functionality to upgrade from Kubernetes 1.24 to 1.32 for CSM 1.7.

Relates to: cray-hpe/csm#4164

# Changes

CASMPET-7527: create K8s 1.26 upgrade/1.32 fresh install node image

Our new node image must now support an upgrade target (K8s 1.26) that is
different from the fresh install target (K8s 1.32). This necessitates
certain changes in docs-csm:

* Update encryption.sh and promote-initial-master.sh to be aware of the
  two separate versions of kubeadm.cfg now that we ship both in the same
  node image. Add logic to select the appropriate kubeadm.cfg file based
  on the Kubernetes version.

* Update scripts that modify kubeadm.cfg to be aware of version-specific
  kubeadm.cfg

* Update encryption.sh to be aware of the new node-images upgrade
  file. Additionally, add logic to template version-specific kubeadm.cfg
  files.

* Update promote-initial-master.sh to be aware of upgrade-specific
  Kubernetes versions.

* Update upgrade_control_plane.sh to remove udpIdleTimeout from the
  kube-proxy configmap, which is necessary to upgrade to K8s 1.26.

* Bump kubernetesVersion in kubeadm-config configmap as part of
  prerequisites, otherwise subsequent invocations of kubeadm fail due to
  strict version drift checking.

* Delete the udpIdleTimeout key from the kube-proxy configmap as part of
  prerequisites, which is necessary for K8s 1.26.

* Make upgrade-specific scripts aware of /etc/cray/kubernetes/upgrade
  and /etc/cray/kubernetes/upgrade_version files, to decide what to do
  based on whether or not we're upgrading.

CASMINST-7341: fix IMS retry loop

* Add retry loop to get image from IMS in set-bss-images-cfs-config.yaml

CASMPET-7523: k8s_upgrade.sh script to upgrade k8s from 1.26 to 1.32

* Add post-upgrade script, upgrade_k8s.sh, which handles the remaining
  Kubernetes upgrades from 1.26 to 1.32 after the existing upgrade
  process goes from 1.24 to 1.26. This script allows you to specify up
  to three Kubernetes versions to move at a time, and handles any
  version-specific behavior as part of the upgrade process, such as
  migrating Kubernetes configuration files.

* Add '-d' option to upgrade_k8s.sh to drain and uncordon master nodes
  when upgrading kubelet.

CASMPET-7524: Add K8s upgrade blocks to deploy-product-onexit.sh

* Add deploy_charts_post_k8s_upgrade.sh script.

CASMPET-7574: Remove undeploy function and undeploy cray-psp since it
fails with k8s 1.26

CASMPET-7562: add upgrade cleanup script

* Add cleanup.py and cleanup.sh driver script. upgrade.sh fetches a
  keycloak token, then invokes cleanup.py, which removes the runcmd
  lines that create the /etc/cray/kubernetes directory, and the
  /etc/cray/kubernetes/upgrade file for all worker and master
  nodes. This is necessary to avoid re-creating the upgrade file when a
  node reboots, which would cause it to attempt to "upgrade" to
  Kubernetes 1.26 (in kubernetes-cloudinit.sh, primarily). This would
  break various Kubernetes-related functionality.

  The script itself is straightforward: it fetches existing BSS runcmd
  blocks for all hosts, filters out all hosts that are neither masters
  nor workers, removes the relevant runcmd lines, then PUTs the modified
  individual node BSS configurations back to the BSS API. Because of the
  way the BSS API works, this script can be run multiple times without
  consequence. If the runcmd lines have already been removed on a
  previous run, we'll still PUT to the BSS API, but it will be the
  existing node configuration, and will thus be a no-op.

Other changes:

* patronictl seems to break when it attempts to restart
  cray-spire-postgres pods that don't have hosts assigned yet. This
  might be a rare and unfortunate race condition, but attempt to wait
  300 seconds to see if that fixes things for now.

* Add '-d' option to upgrade_k8s.sh to drain and uncordon master nodes
  when upgrading kubelet.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
