### PR TITLE
CASMCMS-9443: Document new csm.ssh_config Ansible role

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,10 @@
 
 ### Customer-requested enhancements
 
+* CSM now provides the `csm.ssh_config` Ansible role to automatically restore the root user's SSH configuration file during
+  [Management Node Personalization](operations/configuration_management/Management_Node_Personalization.md).
+  For more details, see [SSH configuration files](operations/CSM_product_management/Set_Up_Passwordless_SSH.md#ssh-configuration-files).
+
 ### Documentation enhancements
 
 ## Noteworthy changes

--- a/operations/CSM_product_management/Configure_the_root_Password_and_SSH_Keys_in_Vault.md
+++ b/operations/CSM_product_management/Configure_the_root_Password_and_SSH_Keys_in_Vault.md
@@ -4,6 +4,9 @@ This procedure sets the `root` user password and SSH keys on management nodes. T
 and SSH keys are set and managed in Vault, and they are applied on management nodes by the
 `csm.password` and `csm.ssh_keys` Ansible roles provided by the CSM product.
 
+Additionally, if the `root` user SSH configuration is set in Vault, then it will be applied on
+management nodes by the `csm.ssh_config` Ansible role provided by the CSM product.
+
 This procedure should be run during CSM installation and any later time when the `root` password or
 SSH keys need to be changed per site requirements.
 
@@ -29,7 +32,9 @@ Specifically, the `write_root_secrets_to_vault.py` script reads the following fr
 - The private SSH key from `/root/.ssh/id_rsa`.
 - The public SSH key from `/root/.ssh/id_rsa.pub`.
 
+If the `--config-file` argument is used, the script will also read in the `root` user's SSH configuration file.
 For more information on this script, see [Update Root Secrets In Vault](../security_and_authentication/Update_Root_Secrets_In_Vault.md).
+For more information on creating an SSH configuration file, see [SSH configuration files](Set_Up_Passwordless_SSH.md#ssh-configuration-files).
 
 This script can be run on any Kubernetes management NCN (master or worker). It only needs to be run once for
 the cluster, because the same Vault credentials are used for all management NCNs.

--- a/operations/CSM_product_management/Set_Up_Passwordless_SSH.md
+++ b/operations/CSM_product_management/Set_Up_Passwordless_SSH.md
@@ -235,12 +235,16 @@ Host x*c?s*b?n?
   StrictHostKeyChecking no
 ```
 
-This file must be manually created by administrators. Note that this file does not persist across node rebuilds.
+This file must be manually created by administrators. Note that after a node rebuild, if this file is not
+saved to Vault, then it must be manually restored.
+
 CSM provides some tools to help backup and restore the contents of this file.
 
 - [Back up the SSH configuration to Vault](#back-up-the-ssh-configuration-to-vault)
 - [Delete the SSH configuration from Vault](#delete-the-ssh-configuration-from-vault)
 - [Restore the SSH configuration from Vault](#restore-the-ssh-configuration-from-vault)
+    - [Automatic restore](#automatic-restore)
+    - [Manual restore](#manual-restore)
 
 ### Back up the SSH configuration to Vault
 
@@ -273,7 +277,15 @@ each will overwrite the data from the previous. The expectation is that all NCNs
 
 ### Restore the SSH configuration from Vault
 
-(`ncn#`) The contents of the root SSH configuration file can be restored from Vault using the following script:
+#### Automatic restore
+
+If the SSH configuration has been saved in Vault, then it is restored on management nodes when
+[Management Node Personalization](../configuration_management/Management_Node_Personalization.md) occurs,
+by the CSM-provided `csm.ssh_config` Ansible role.
+
+#### Manual restore
+
+(`ncn#`) The contents of the root SSH configuration file can be manually restored from Vault using the following script:
 
 > The `docs-csm` RPM must be installed in order to use this script. See
 > [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -135,7 +135,7 @@ Follow each step below:
 ## Restore manual configuration
 
 Restore any configurations for the node that are not automatically performed by [CFS](../../../glossary.md#configuration-framework-service-cfs)
-live node personalization. For example, [SSH configuration files](../../CSM_product_management/Set_Up_Passwordless_SSH.md#ssh-configuration-files).
+live node personalization.
 
 ## Validation
 

--- a/operations/security_and_authentication/Update_Root_Secrets_In_Vault.md
+++ b/operations/security_and_authentication/Update_Root_Secrets_In_Vault.md
@@ -2,7 +2,14 @@
 
 * [Overview](#overview)
 * [Automated tools](#automated-tools)
+    * [`write_root_secrets_to_vault.py`](#write_root_secrets_to_vaultpy)
+    * [`write_ssh_config_to_vault.py`](#write_ssh_config_to_vaultpy)
+    * [`restore_ssh_config_from_vault.py`](#restore_ssh_config_from_vaultpy)
+    * [Related tools](#related-tools)
 * [Manual procedures](#manual-procedures)
+    * [Password hash](#password-hash)
+    * [SSH keys](#ssh-keys)
+    * [SSH configuration](#ssh-configuration)
 
 ## Overview
 
@@ -20,6 +27,10 @@ The path to the secret and the SSH key fields are configurable locations in the 
 Ansible role located in the CSM configuration management Git repository that is in use.
 See `roles/csm.ssh_keys/README.md` in the repository for more information.
 
+The path to the secret and the configuration field are configurable locations in the CSM `csm.ssh_config`
+Ansible role located in the CSM configuration management Git repository that is in use.
+See `roles/csm.ssh_config/README.md` in the repository for more information.
+
 The path to the secret and the password field are configurable locations in
 the CSM `csm.password` Ansible role located in the CSM configuration
 management Git repository that is in use. See `roles/csm.password/README.md` in the
@@ -35,6 +46,11 @@ to safely update the data in Vault.
 
 > The `docs-csm` RPM must be installed in order to use these tools. See
 > [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation)
+
+* [`write_root_secrets_to_vault.py`](#write_root_secrets_to_vaultpy)
+* [`write_ssh_config_to_vault.py`](#write_ssh_config_to_vaultpy)
+* [`restore_ssh_config_from_vault.py`](#restore_ssh_config_from_vaultpy)
+* [Related tools](#related-tools)
 
 ### `write_root_secrets_to_vault.py`
 
@@ -59,6 +75,10 @@ see its usage.
 See [Adding switch admin password to Vault](../network/management_network/README.md#adding-switch-admin-password-to-Vault).
 
 ## Manual procedures
+
+* [Password hash](#password-hash)
+* [SSH keys](#ssh-keys)
+* [SSH configuration](#ssh-configuration)
 
 ### Password hash
 
@@ -86,7 +106,7 @@ the values in the Ansible role. See `roles/csm.password/README.md` in the reposi
    > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
    > `password` field in the `secret/csm/users/root` secret is being updated,
    > then any other desired fields are also included in the `write` command. For example the user's
-   > [SSH keys](#ssh-keys).
+   > [SSH keys](#ssh-keys) and/or [SSH configuration](#ssh-configuration).
    > **Any fields omitted from the `write` command will be cleared from Vault.**
 
     * The `vault login` command will request the token value from the output of the previous step.
@@ -127,7 +147,7 @@ the values in the Ansible role. See `roles/csm.ssh_keys/README.md` in the reposi
    > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
    > `ssh_private_key` and `ssh_public_key` fields in the `secret/csm/users/root` secret are being updated,
    > then any other desired fields are also included in the `write` command. For example the user's
-   > [password hash](#password-hash).
+   > [password hash](#password-hash) and/or [SSH configuration](#ssh-configuration).
    > **Any fields omitted from the `write` command will be cleared from Vault.**
 
     * The `vault login` command will request the token value from the output of the previous step.
@@ -140,6 +160,48 @@ the values in the Ansible role. See `roles/csm.ssh_keys/README.md` in the reposi
     export VAULT_ADDR=http://cray-vault:8200
     vault login
     vault write secret/csm/users/root ssh_private_key='...' ssh_public_key='...' [... other fields (see warning above) ...]
+    vault read secret/csm/users/root
+    exit
+    ```
+
+### SSH configuration
+
+The path to the secret and the SSH configuration field are configurable locations in
+the CSM `csm.ssh_config` Ansible role located in the CSM configuration
+management Git repository that is in use.
+
+If not using the defaults as shown in the command examples, ensure that the paths are consistent between Vault and
+the values in the Ansible role. See `roles/csm.ssh_config/README.md` in the repository for more information.
+
+1. (`ncn-mw#`) Get the Vault root token.
+
+    ```bash
+    kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
+    ```
+
+1. (`ncn-mw#`) Open an interactive shell in the Vault Kubernetes pod.
+
+    ```bash
+    kubectl exec -itn vault cray-vault-0 -c vault -- sh
+    ```
+
+1. (`cray-vault#`) Write the SSH configuration to Vault.
+
+   > ***WARNING***: The CSM instance of Vault does not support the `patch` operation. Ensure that if the
+   > `ssh_config` field in the `secret/csm/users/root` secret is being updated,
+   > then any other desired fields are also included in the `write` command. For example the user's
+   > [password hash](#password-hash) and/or [SSH keys](#ssh-keys).
+   > **Any fields omitted from the `write` command will be cleared from Vault.**
+
+    * The `vault login` command will request the token value from the output of the previous step.
+    * The `ssh_config` field should contain the exact content from the SSH configuration file.
+    * **`NOTE`**: It is important to enclose the key content in single quotes to preserve any special characters.
+    * The `vault read` command allows the administrator to verify that the contents of the secret were stored correctly.
+
+    ```bash
+    export VAULT_ADDR=http://cray-vault:8200
+    vault login
+    vault write secret/csm/users/root ssh_config='...' [... other fields (see warning above) ...]
     vault read secret/csm/users/root
     exit
     ```


### PR DESCRIPTION
This documents the new `csm.ssh_config` Ansible role in the release notes, and a few other relevant places.

I also made some slight tweaks and linting in this PR (shockingly), and those will be backported.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/6017
1.5: https://github.com/Cray-HPE/docs-csm/pull/6018
1.4: https://github.com/Cray-HPE/docs-csm/pull/6019