### PR TITLE
CASMTRIAGE-8239: argo fails to exit with code 1

### DIFF
--- a/workflows/templates/base/ssh.template.argo.yaml
+++ b/workflows/templates/base/ssh.template.argo.yaml
@@ -64,7 +64,7 @@ spec:
             cat ${ts}.sh
           else
             scp -i /myssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${ts}.sh root@$HOST:/tmp/${ts}.sh
-            ssh -i /myssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$HOST "/tmp/${ts}.sh; rm /tmp/${ts}.sh"
+            ssh -i /myssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$HOST "echo 'Running /tmp/${ts}.sh'; /tmp/${ts}.sh; exit_code=\$?; rm /tmp/${ts}.sh; exit \$exit_code"
           fi
         volumeMounts:
           - name: ssh


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Even when the script running in ssh-template had errors and gave exit code 1, the "rm /tmp/${ts}.sh" overrode the exit code and hence argo would continue without any errors.
Adding a condition so that the exit code is same as the exit code of the script being executed.

Relates to:
-  [CASMTRIAGE-8239](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8239)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
