### PR TITLE
CASMPET-7580: Create states and shows logs for undeploying charts and deleting secrets

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -586,16 +586,29 @@ fi
 # to be removed from the system as part of an upgrade.
 function undeploy() {
   # Check if the chart exists by running helm status
-  # If the chart is missing (rc==1), return success.
-  helm status "$@" || return 0
-  # Remove the chart completely without keeping history.
-  helm uninstall "$@"
+  if helm status "$@"; then
+    # Remove the chart completely without keeping history.
+    helm uninstall "$@"
+    return $?
+  else
+    return 0
+  fi
 }
 
 # Undeploy Istio charts if they exist
 # cray-istio-operator and cray-istio-deploy are removed with upgrade to Istio 1.26.0
-undeploy -n istio-system cray-istio-operator
-undeploy -n istio-system cray-istio-deploy
+state_name="UNDEPLOY_ISTIO_CHARTS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    undeploy -n istio-system cray-istio-operator
+    undeploy -n istio-system cray-istio-deploy
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
 
 # Apply labels to Istio Base Resources
 # Running the label-istio-resources script to apply necessary labels to cray-istio-base chart resources.
@@ -666,7 +679,19 @@ function delete_helm_secrets() {
   done <<< "$secrets"
 }
 
-delete_helm_secrets cray-istio
+# State for deleting Helm secrets
+state_name="DELETE_CRAY_ISTIO_HELM_SECRETS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    # Delete all Helm secrets for a given chart across all namespaces and versions
+    delete_helm_secrets cray-istio
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
 
 # Restart vault pods because pods were having the older proxyv2 image version.
 # Running the rollout restart script to restart the required resources in istio-injection=enabled namespaces.

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -586,11 +586,13 @@ fi
 # to be removed from the system as part of an upgrade.
 function undeploy() {
   # Check if the chart exists by running helm status
-  if helm status "$@"; then
+  if [[ $(helm status -o json "$@" 2> /dev/null | jq -r .info.status) == "deployed" ]]; then
+    echo "Chart ${*: -1} exists. Uninstalling it now."
     # Remove the chart completely without keeping history.
     helm uninstall "$@"
     return $?
   else
+    echo "Chart ${*: -1} doesn't exist"
     return 0
   fi
 }


### PR DESCRIPTION
# Description
Upgrading `istio` involves some changes in upgrade workflow.  Since istio 1.26.0 version deprecates the istio-operator so we need to undeploy the charts `cray-istio-deploy` and `cray-istio-operator` before installing the new istio version, also we need to label the istio resources and at the end delete the helm secrets of old istio ingress chart. We need to populate these steps in the logs. This change handles that.

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
