### PR TITLE
CASMPET-7585: Exit if set-bss-images-cfs-config.yaml can't get image from IMS

### DIFF
--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -65,14 +65,8 @@ spec:
                     # BELOW IS TEMPORARY UNTIL LIBCSM IS UPDATED
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
                     if [[ -z $image_manifest_str ]]; then
-                      echo "WARN IMS is not reachable or image: $IMAGE_ID does not exist. Will retry."
-                      count=0
-                      while [[ -z $image_manifest_str && $count -lt 30 ]]; do
-                        sleep 10
-                        image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
-                        ((count++))
-                      done
-                      echo "INFO Tried ${count} times before reaching IMS."
+                      echo "ERROR IMS is not reachable or image: $IMAGE_ID does not exist. Exiting and will retry."
+                      exit 1
                     fi
                     echo "INFO Moving on with image '$image_manifest_str'"
                     image_manifest_str=${image_manifest_str#*s3://}


### PR DESCRIPTION
# Description
During a worker node rebuild on vShasta, it is common for IMS to not be available when the `set-bss-images-cfs-config.yaml` script runs.  When that is the case, exit the script and let IUF retry.

CASMPET-7585: Exit if set-bss-images-cfs-config.yaml can't get image from IMS

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
