### PR TITLE
CASMPET-7583: Update Statefulsets' Istio sidecars by Deleting them

### DIFF
--- a/upgrade/scripts/upgrade/rollout-restart.sh
+++ b/upgrade/scripts/upgrade/rollout-restart.sh
@@ -36,6 +36,7 @@ ISTIO_PILOT_IMAGE="istio/pilot:${ISTIO_VERSION}"
 # Define wait times in seconds
 VAULT_PODS_WAIT_TIME=120
 RESOURCE_RESTART_WAIT_TIME=180
+STATEFULSET_POD_WAIT_TIME=180
 
 # This part of script is to delete the pods on vault namespace which do not have the correct proxyv2 version
 # This is done because the vault is not updated in CSM1.6, this restart of vault may not be needed in future
@@ -151,6 +152,55 @@ check_pod_uses_istio_proxy() {
   fi
 }
 
+# Function to check if a StatefulSet has OnDelete update strategy
+check_statefulset_update_strategy() {
+  local namespace=$1
+  local statefulset_name=$2
+  local update_strategy
+  update_strategy=$(kubectl get statefulset "$statefulset_name" -n "$namespace" -o jsonpath="{.spec.updateStrategy.type}" 2> /dev/null)
+
+  if [[ $update_strategy == "OnDelete" ]]; then
+    return 0 # StatefulSet has OnDelete strategy
+  else
+    return 1 # StatefulSet has RollingUpdate or other strategy
+  fi
+}
+
+# Function to delete StatefulSet pods and wait for them to be recreated
+delete_statefulset_pods() {
+  local namespace=$1
+  shift
+  local pods_to_delete=("$@")
+
+  echo "Deleting StatefulSet pods in namespace: $namespace"
+  for pod in "${pods_to_delete[@]}"; do
+    echo "Deleting pod: $pod in namespace: $namespace"
+    kubectl delete pod "$pod" -n "$namespace" --grace-period=30
+  done
+
+  echo "Waiting for $((STATEFULSET_POD_WAIT_TIME / 60)) minutes for StatefulSet pods to be recreated..."
+  sleep $STATEFULSET_POD_WAIT_TIME
+
+  # Verify that all deleted pods have been recreated and are running
+  echo "Verifying recreated StatefulSet pods..."
+  for pod in "${pods_to_delete[@]}"; do
+    echo "Checking status of recreated pod: $pod"
+    pod_status=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.status.phase}' 2> /dev/null || echo "NotFound")
+    if [[ $pod_status == "Running" ]]; then
+      echo "Pod $pod is running successfully"
+      # Check if it has the correct Istio version
+      images=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.spec.containers[*].image}")
+      if echo "$images" | grep -q -e "${ISTIO_PILOT_IMAGE}" -e "${ISTIO_PROXYV2_IMAGE}"; then
+        echo "Pod $pod now has the correct Istio version"
+      else
+        echo "WARNING: Pod $pod still does not have the correct Istio version"
+      fi
+    else
+      echo "WARNING: Pod $pod status is: $pod_status"
+    fi
+  done
+}
+
 # Function to perform rollout restart and check status for a given resource
 restart_and_check_status() {
   local namespace=$1
@@ -207,8 +257,9 @@ restart_and_check_status() {
 # Get all namespaces
 namespaces=$(kubectl get namespaces -l istio-injection=enabled -o jsonpath="{.items[*].metadata.name}")
 
-# Initialize an associative array to keep track of resources to restart
+# Initialize associative arrays to keep track of resources to restart and StatefulSet pods to delete
 declare -A resources_to_restart
+declare -A statefulset_pods_to_delete
 
 # Loop through each namespace
 for ns in $namespaces; do
@@ -227,8 +278,24 @@ for ns in $namespaces; do
 
         # Check if the resource uses Istio proxy
         if check_pod_uses_istio_proxy "$ns" "$pod"; then
-          resource_key="$ns/$resource_type/$resource_name"
-          resources_to_restart["$resource_key"]=$resource_type
+          if [[ $resource_type == "StatefulSet" ]]; then
+            # Check if StatefulSet has OnDelete update strategy
+            if check_statefulset_update_strategy "$ns" "$resource_name"; then
+              # For StatefulSets with OnDelete strategy, collect pods to delete
+              statefulset_pods_to_delete["$ns"]+="$pod "
+              echo "Added StatefulSet pod $pod to deletion list for namespace $ns (OnDelete strategy)"
+            else
+              # For StatefulSets with RollingUpdate strategy, add to restart list
+              resource_key="$ns/$resource_type/$resource_name"
+              resources_to_restart["$resource_key"]=$resource_type
+              echo "Added $resource_type/$resource_name to restart list for namespace $ns (RollingUpdate strategy)"
+            fi
+          else
+            # For other resources, add to restart list
+            resource_key="$ns/$resource_type/$resource_name"
+            resources_to_restart["$resource_key"]=$resource_type
+            echo "Added $resource_type/$resource_name to restart list for namespace $ns"
+          fi
         else
           echo "Pod $pod does not use Istio proxy. Skipping restart for its controlling resource."
         fi
@@ -247,7 +314,19 @@ for resource_key in "${!resources_to_restart[@]}"; do
   echo "$resource_key"
 done
 
-# Restart resources at the end
+# Print the list of StatefulSet pods to delete
+echo "StatefulSet pods to delete:"
+for namespace in "${!statefulset_pods_to_delete[@]}"; do
+  echo "Namespace: $namespace - Pods: ${statefulset_pods_to_delete[$namespace]}"
+done
+
+# Delete StatefulSet pods first
+for namespace in "${!statefulset_pods_to_delete[@]}"; do
+  IFS=' ' read -r -a pods <<< "${statefulset_pods_to_delete[$namespace]}"
+  delete_statefulset_pods "$namespace" "${pods[@]}"
+done
+
+# Restart other resources
 declare -A namespace_resources
 
 for resource_key in "${!resources_to_restart[@]}"; do

--- a/upgrade/scripts/upgrade/rollout-restart.sh
+++ b/upgrade/scripts/upgrade/rollout-restart.sh
@@ -278,18 +278,11 @@ for ns in $namespaces; do
 
         # Check if the resource uses Istio proxy
         if check_pod_uses_istio_proxy "$ns" "$pod"; then
-          if [[ $resource_type == "StatefulSet" ]]; then
-            # Check if StatefulSet has OnDelete update strategy
-            if check_statefulset_update_strategy "$ns" "$resource_name"; then
-              # For StatefulSets with OnDelete strategy, collect pods to delete
-              statefulset_pods_to_delete["$ns"]+="$pod "
-              echo "Added StatefulSet pod $pod to deletion list for namespace $ns (OnDelete strategy)"
-            else
-              # For StatefulSets with RollingUpdate strategy, add to restart list
-              resource_key="$ns/$resource_type/$resource_name"
-              resources_to_restart["$resource_key"]=$resource_type
-              echo "Added $resource_type/$resource_name to restart list for namespace $ns (RollingUpdate strategy)"
-            fi
+          # Check if StatefulSet has OnDelete update strategy
+          if [[ $resource_type == "StatefulSet" ]] && check_statefulset_update_strategy "$ns" "$resource_name"; then
+            # For StatefulSets with OnDelete strategy, collect pods to delete
+            statefulset_pods_to_delete["$ns"]+="$pod "
+            echo "Added StatefulSet pod $pod to deletion list for namespace $ns (OnDelete strategy)"
           else
             # For other resources, add to restart list
             resource_key="$ns/$resource_type/$resource_name"


### PR DESCRIPTION
# Description
Upgrading `istio` involves some changes in upgrade workflow.  Since istio 1.26.0 version deprecates the istio-operator so we need to undeploy the charts `cray-istio-deploy` and `cray-istio-operator` before installing the new istio version, also we need to make sure that the pods have the updated version of sidecars.The Statefulsets have an update strategy of `OnDelete` so we need to delete them to update the sidecars. This change handles that.

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
