### PR TITLE
CASMTRIAGE-8286

### DIFF
--- a/operations/network/customer_accessible_networks/can_to_chn/scripts/util/update-customizations-network.sh
+++ b/operations/network/customer_accessible_networks/can_to_chn/scripts/util/update-customizations-network.sh
@@ -24,42 +24,40 @@
 #
 
 usage() {
-    echo >&2 "usage: ${0##*/} [-i] [CUSTOMIZATIONS-YAML]"
-    exit 1
+  echo >&2 "usage: ${0##*/} [-i] [CUSTOMIZATIONS-YAML]"
+  exit 1
 }
 
 args=()
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-        -h)
-            usage
-            ;;
-        -i)
-            inplace="yes"
-            ;;
-        *)
-            args+=("$1")
-            ;;
-    esac
-    shift
+  case "$1" in
+    -h)
+      usage
+      ;;
+    -i)
+      inplace="yes"
+      ;;
+    *)
+      args+=("$1")
+      ;;
+  esac
+  shift
 done
 
 set -- "${args[@]}"
 
 [[ $# -eq 1 ]] || usage
 
-
 customizations="$1"
 
-if [[ ! -f "$customizations" ]]; then
-    echo >&2 "error: no such file: $customizations"
-    usage
+if [[ ! -f $customizations ]]; then
+  echo >&2 "error: no such file: $customizations"
+  usage
 fi
 
-if ! command -v yq &> /dev/null
-then
-    echo >&2 "error: yq could not be found"
-    exit 1
+if ! command -v yq &> /dev/null; then
+  echo >&2 "error: yq could not be found"
+  exit 1
 fi
 
 c="$(mktemp)"
@@ -69,12 +67,12 @@ cp "$customizations" "$c"
 
 # Get token to access SLS data
 # shellcheck disable=SC2046,SC2155
-export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
 
 # shellcheck disable=SC2166
 if [ -z "${TOKEN}" -o "${TOKEN}" == "" -o "${TOKEN}" == "null" ]; then
-    echo >&2 "error: failed to obtain token from keycloak"
-    exit 1
+  echo >&2 "error: failed to obtain token from keycloak"
+  exit 1
 fi
 
 # Get Networks from SLS
@@ -82,8 +80,8 @@ NETWORKSJSON=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-ser
 
 # shellcheck disable=SC2166
 if [ -z "${NETWORKSJSON}" -o "${NETWORKSJSON}" == "" -o "${NETWORKSJSON}" == "null" ]; then
-    echo >&2 "error: failed to get Networks from SLS"
-    exit 1
+  echo >&2 "error: failed to get Networks from SLS"
+  exit 1
 fi
 
 errors=0
@@ -91,141 +89,141 @@ peerindex=0
 
 # Gather the metallb peer information and add it to customizations
 for n in "NMN" "CMN" "CHN"; do
-numpeers=0
+  numpeers=0
 
-    netName=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .Name')
+  netName=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .Name')
 
-    if [ -z "${netName}" ]; then
-        if [ "$n" == "CHN" ]; then
-            echo >&2 "info:  No CHN defined in SLS"
-        else
-            echo >&2 "error:  No ${n} defined in SLS"
-            errors=$((errors+1))
+  if [ -z "${netName}" ]; then
+    if [ "$n" == "CHN" ]; then
+      echo >&2 "info:  No CHN defined in SLS"
+    else
+      echo >&2 "error:  No ${n} defined in SLS"
+      errors=$((errors + 1))
+    fi
+    continue
+  fi
+
+  peerASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.PeerASN')
+  myASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.MyASN')
+
+  # shellcheck disable=SC2166
+  if [ -z "${peerASN}" -o "${peerASN}" == "null" -o "${peerASN}" == "" ]; then
+    echo >&2 "error:  PeerASN missing in SLS for network ${n}"
+    errors=$((errors + 1))
+  fi
+
+  # shellcheck disable=SC2166
+  if [ -z "${myASN}" -o "${myASN}" == "null" -o "${myASN}" == "" ]; then
+    echo >&2 "error:  MyASN missing in SLS for network ${n}"
+    errors=$((errors + 1))
+  fi
+
+  subnets=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[].Name')
+  for i in ${subnets}; do
+    if [[ ${n} == "CHN" && ${i} == "bootstrap_dhcp" ]]; then
+      reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
+      for j in ${reservations}; do
+        if [[ ${j} =~ "chn-switch".* ]]; then
+          numpeers=$((numpeers + 1))
+          peerIP=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" --arg j "$j" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[] | select(.Name == $j) | .IPAddress')
+
+          # shellcheck disable=SC2166
+          if [ -z "${peerIP}" -o "${peerIP}" == "null" -o "${peerIP}" == "" ]; then
+            echo >&2 "error:  IPAddress missing in SLS for ${j} in network ${n}"
+            errors=$((errors + 1))
+          fi
+
+          if [ $errors -eq 0 ]; then
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-address' "${peerIP}"
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-asn' "${peerASN}"
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].my-asn' "${myASN}"
+            peerindex=$((peerindex + 1))
+          fi
         fi
-        continue
-    fi
+      done
 
-    peerASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.PeerASN')
-    myASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.MyASN')
+    elif [[ (${n} == "NMN" || ${n} == "CMN") && ${i} == "network_hardware" ]]; then
+      reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
+      for j in ${reservations}; do
+        if [[ ${j} =~ .*"spine".* ]]; then
+          numpeers=$((numpeers + 1))
+          peerIP=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" --arg j "$j" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[] | select(.Name == $j) | .IPAddress')
 
-    # shellcheck disable=SC2166
-    if [ -z "${peerASN}" -o "${peerASN}" == "null" -o "${peerASN}" == "" ]; then
-        echo >&2 "error:  PeerASN missing in SLS for network ${n}"
-        errors=$((errors+1))
-    fi
+          # shellcheck disable=SC2166
+          if [ -z "${peerIP}" -o "${peerIP}" == "null" -o "${peerIP}" == "" ]; then
+            echo >&2 "error:  IPAddress missing in SLS for ${j} in network ${n}"
+            errors=$((errors + 1))
+          fi
 
-    # shellcheck disable=SC2166
-    if [ -z "${myASN}" -o "${myASN}" == "null" -o "${myASN}" == "" ]; then
-        echo >&2 "error:  MyASN missing in SLS for network ${n}"
-        errors=$((errors+1))
-    fi
-
-    subnets=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[].Name')
-    for i in ${subnets}; do
-        if [[ "${n}" == "CHN" && "${i}" == "bootstrap_dhcp" ]]; then
-            reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
-            for j in ${reservations}; do
-                if [[ "${j}" =~ "chn-switch".* ]]; then
-                    numpeers=$((numpeers+1))
-                    peerIP=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" --arg j "$j" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[] | select(.Name == $j) | .IPAddress')
-
-                    # shellcheck disable=SC2166
-                    if [ -z "${peerIP}" -o "${peerIP}" == "null" -o "${peerIP}" == "" ]; then
-                        echo >&2 "error:  IPAddress missing in SLS for ${j} in network ${n}"
-                        errors=$((errors+1))
-                    fi
-
-                    if [ $errors -eq 0 ]; then
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-address' "${peerIP}"
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-asn' "${peerASN}"
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].my-asn' "${myASN}"
-                        peerindex=$((peerindex+1))
-                    fi
-                fi
-            done
-
-        elif [[ ("${n}" == "NMN" || "${n}" == "CMN")  && "${i}" == "network_hardware" ]]; then
-            reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
-            for j in ${reservations}; do
-                if [[ "${j}" =~ .*"spine".* ]]; then
-                    numpeers=$((numpeers+1))
-                    peerIP=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" --arg j "$j" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[] | select(.Name == $j) | .IPAddress')
-
-                    # shellcheck disable=SC2166
-                    if [ -z "${peerIP}" -o "${peerIP}" == "null" -o "${peerIP}" == "" ]; then
-                        echo >&2 "error:  IPAddress missing in SLS for ${j} in network ${n}"
-                        errors=$((errors+1))
-                    fi
-
-                    if [ $errors -eq 0 ]; then
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-address' "${peerIP}"
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-asn' "${peerASN}"
-                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].my-asn' "${myASN}"
-                        peerindex=$((peerindex+1))
-                    fi
-                fi
-            done
+          if [ $errors -eq 0 ]; then
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-address' "${peerIP}"
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-asn' "${peerASN}"
+            yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].my-asn' "${myASN}"
+            peerindex=$((peerindex + 1))
+          fi
         fi
-    done
-
-    if [ $numpeers -eq 0 ]; then
-        echo >&2 "error: No peers found for network ${n}"
-        errors=$((errors+1))
+      done
     fi
+  done
+
+  if [ $numpeers -eq 0 ]; then
+    echo >&2 "error: No peers found for network ${n}"
+    errors=$((errors + 1))
+  fi
 
 done
 
 # Stop here if we had any problems getting the peer information
 if [ $errors -gt 0 ]; then
-    exit 1
+  exit 1
 fi
 
 # Gather the metallb pool information and add it to customizations
 poolindex=0
 
-# delete all address pools before re-creating them, this is needed for CAN > CHN cleanup 
+# delete all address pools before re-creating them, this is needed for CAN > CHN cleanup
 yq d -i "$c" 'spec.network.metallb.address-pools'
 
 networks=$(echo "${NETWORKSJSON}" | jq -r '.[].Name')
 for n in ${networks}; do
-    subnets=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[].Name')
-    for i in ${subnets}; do
-        if [[ "${i}" =~ .*"_metallb_".* ]]; then
-            poolName=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .MetalLBPoolName')
-            poolCIDR=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .CIDR')
+  subnets=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[].Name')
+  for i in ${subnets}; do
+    if [[ ${i} =~ .*"_metallb_".* ]]; then
+      poolName=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .MetalLBPoolName')
+      poolCIDR=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .CIDR')
 
-            # shellcheck disable=SC2166
-            if [ -z "${poolName}" -o "${poolName}" == "null" -o "${poolName}" == "" ]; then
-                echo >&2 "error:  MetalLBPoolName missing in SLS for subnet ${i} in network ${n}"
-                errors=$((errors+1))
-            fi
+      # shellcheck disable=SC2166
+      if [ -z "${poolName}" -o "${poolName}" == "null" -o "${poolName}" == "" ]; then
+        echo >&2 "error:  MetalLBPoolName missing in SLS for subnet ${i} in network ${n}"
+        errors=$((errors + 1))
+      fi
 
-            # shellcheck disable=SC2166
-            if [ -z "${poolCIDR}" -o "${poolCIDR}" == "null " -o "${poolCIDR}" == "" ]; then
-                echo >&2 "error:  CIDR missing in SLS for subnet ${i} in network ${n}"
-                errors=$((errors+1))
-            fi
+      # shellcheck disable=SC2166
+      if [ -z "${poolCIDR}" -o "${poolCIDR}" == "null " -o "${poolCIDR}" == "" ]; then
+        echo >&2 "error:  CIDR missing in SLS for subnet ${i} in network ${n}"
+        errors=$((errors + 1))
+      fi
 
-            if [ $errors -eq 0 ]; then
-                yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].name' ${poolName}
-                yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].protocol' 'bgp'
-                yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].addresses[0]' ${poolCIDR}
-                poolindex=$((poolindex+1))
-            fi
-        fi
-    done
+      if [ $errors -eq 0 ]; then
+        yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].name' ${poolName}
+        yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].protocol' 'bgp'
+        yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].addresses[0]' ${poolCIDR}
+        poolindex=$((poolindex + 1))
+      fi
+    fi
+  done
 done
 
 # Stop here if we had any problems getting the pool information
 if [ $errors -gt 0 ]; then
-    exit 1
+  exit 1
 fi
 
 # argo/cray-nls
 yq w -i --style=single "$c" spec.kubernetes.services.cray-nls.externalHostname 'cmn.{{ network.dns.external }}'
 
-if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement(.==argo.cmn.{{ network.dns.external }})')" ]];then
-   yq w -i --style=single "$c" spec.proxiedWebAppExternalHostnames.customerManagement[+] 'argo.cmn.{{ network.dns.external }}'
+if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement(.==argo.cmn.{{ network.dns.external }})')" ]]; then
+  yq w -i --style=single "$c" spec.proxiedWebAppExternalHostnames.customerManagement[+] 'argo.cmn.{{ network.dns.external }}'
 fi
 
 # cray-opa
@@ -251,13 +249,13 @@ if [[ -z "$(yq r "$c" "spec.network.netstaticips.nmn_ncn_storage_mons")" ]]; the
   loop_idx=0
   for node in ${mon_nodes}; do
     yq w -i $c "spec.network.netstaticips.nmn_ncn_storage_mons[${loop_idx}]" "${node}"
-    loop_idx=$(( loop_idx+1 ))
+    loop_idx=$((loop_idx + 1))
   done
   yq w -i --style=single "$c" spec.kubernetes.services.cray-sysmgmt-health.cephExporter.endpoints '{{ network.netstaticips.nmn_ncn_storage_mons }}'
 fi
 
-if [[ "$inplace" == "yes" ]]; then
-    cp "$c" "$customizations"
+if [[ $inplace == "yes" ]]; then
+  cp "$c" "$customizations"
 else
-    cat "$c"
+  cat "$c"
 fi

--- a/operations/network/customer_accessible_networks/can_to_chn/scripts/util/update-customizations-network.sh
+++ b/operations/network/customer_accessible_networks/can_to_chn/scripts/util/update-customizations-network.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -232,8 +232,8 @@ fi
 yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway-hmn.issuers.shasta-hmn' 'https://api.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta'
 yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway-hmn.issuers.keycloak-hmn' 'https://auth.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta'
 
-# cray-istio
-yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-hmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
+# cray-istio-ingress
+yq w -i "$c" 'spec.kubernetes.services.cray-istio-ingress.services.istio-ingressgateway-hmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
 
 # cray-ims
 # Note to future developers: This is needed to address CASMTRIAGE-4098. It is only needed on upgrades to csm-1.2 and csm-1.3.

--- a/operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md
+++ b/operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md
@@ -55,26 +55,40 @@ This procedure requires administrative privileges.
     ```text
     Name:                     istio-ingressgateway-cmn
     Namespace:                istio-system
-    Labels:                   app=istio-ingressgateway
-                              chart=cray-istio
-                              heritage=Tiller
-                              istio=ingressgateway
-                              release=cray-istio
+    Labels:                   app=istio-ingressgateway-customer-admin
+                              app.kubernetes.io/instance=cray-istio-ingress
+                              app.kubernetes.io/managed-by=Helm
+                              app.kubernetes.io/name=istio-ingressgateway
+                              app.kubernetes.io/part-of=istio
+                              app.kubernetes.io/version=1.26.0
+                              helm.sh/chart=cray-istio-ingress-4.0.0
+                              install.operator.istio.io/owning-resource=unknown
+                              istio=ingressgateway-customer-admin
+                              istio.io/rev=default
+                              operator.istio.io/component=IngressGateways
+                              peerauthentication=ingressgateway
+                              release=cray-istio-ingress
     Annotations:              external-dns.alpha.kubernetes.io/hostname: api.cmn.SYSTEM_DOMAIN_NAME,auth.cmn.SYSTEM_DOMAIN_NAME,nexus.cmn.SYSTEM_DOMAIN_NAME
+                              meta.helm.sh/release-name: cray-istio-ingress
+                              meta.helm.sh/release-namespace: istio-system
                              ** metallb.universe.tf/address-pool: customer-management**
-    Selector:                 app=istio-ingressgateway,istio=ingressgateway,release=cray-istio
+    Selector:                 app=istio-ingressgateway-customer-admin,istio=ingressgateway-customer-admin
     Type:                     LoadBalancer
-    IP:                       10.28.192.172
-    Port:                     http2 80/TCP
-    TargetPort:               80/TCP
-    NodePort:                 http2 30708/TCP
-    Endpoints:                10.39.0.5:80
-    Port:                     https 443/TCP
-    TargetPort:               443/TCP
-    NodePort:                 https 31430/TCP
-    Endpoints:                10.39.0.5:443
+    IP Family Policy:         SingleStack
+    IP Families:              IPv4
+    IP:                       10.16.148.118
+    IPs:                      10.16.148.118
+    Port:                     http2  80/TCP
+    TargetPort:               8080/TCP
+    NodePort:                 http2  32458/TCP
+    Endpoints:                10.32.3.74:8080,10.32.1.197:8080,10.32.5.106:8080
+    Port:                     https  443/TCP
+    TargetPort:               8443/TCP
+    NodePort:                 https  32076/TCP
+    Endpoints:                10.32.3.74:8443,10.32.1.197:8443,10.32.5.106:8443
     Session Affinity:         None
     External Traffic Policy:  Cluster
+    Internal Traffic Policy:  Cluster
     Events:                   <none>
     ```
 

--- a/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
@@ -131,19 +131,19 @@ yaml_path="$base.cray-metallb.metallb.controller.resources.requests.cpu"
 cray_metallb_controller_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_metallb_controller_new_cpu_request
 
-yaml_path="$base.cray-istio.deployments.istio-ingressgateway.resources.requests.cpu"
+yaml_path="$base.cray-istio-ingress.deployments.istio-ingressgateway.resources.requests.cpu"
 cray_istio_ingressgateway_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_istio_ingressgateway_new_cpu_request
 
-yaml_path="$base.cray-istio.deployments.istio-ingressgateway-customer-admin.resources.requests.cpu"
+yaml_path="$base.cray-istio-ingress.deployments.istio-ingressgateway-customer-admin.resources.requests.cpu"
 cray_istio_admin_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_istio_admin_new_cpu_request
 
-yaml_path="$base.cray-istio.deployments.istio-ingressgateway-customer-user.resources.requests.cpu"
+yaml_path="$base.cray-istio-ingress.deployments.istio-ingressgateway-customer-user.resources.requests.cpu"
 cray_istio_user_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_istio_user_new_cpu_request
 
-yaml_path="$base.cray-istio.deployments.istio-ingressgateway-hmn.resources.requests.cpu"
+yaml_path="$base.cray-istio-ingress.deployments.istio-ingressgateway-hmn.resources.requests.cpu"
 cray_istio_hmn_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_istio_hmn_new_cpu_request
 

--- a/upgrade/scripts/upgrade/tds_cpu_requests.yaml
+++ b/upgrade/scripts/upgrade/tds_cpu_requests.yaml
@@ -77,7 +77,7 @@ spec:
               resources:
                 requests:
                   cpu: "500m"
-      cray-istio:
+      cray-istio-ingress:
         deployments:
           istio-ingressgateway:
             resources:

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -120,6 +120,20 @@ yq4 -i eval ".spec.kubernetes.services[\"kyverno-policy\"].checkImagePolicy += (
 yq4 -i eval '.spec.kubernetes.services.["cray-hubble"].externalHostname = "hubble.cmn.{{ network.dns.external }}"' "$c"
 yq4 -i eval ".spec.proxiedWebAppExternalHostnames.customerManagement |= (. + [\"{{ kubernetes.services['cray-hubble'].externalHostname }}\"] | unique)" "$c"
 
+# From CSM 1.7, cray-istio is no longer used for ingress, so we need to update the customizations.yaml
+# to reflect this change. We will rename cray-istio to cray-istio-ingress and update the
+# proxiedWebAppExternalHostnames to use cray-istio-ingress instead of cray-istio.
+if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio"' "$c")" != "null" ]; then
+  # Copy the cray-istio configuration to cray-istio-ingress
+  yq4 eval -i '.spec.kubernetes.services."cray-istio-ingress" = .spec.kubernetes.services."cray-istio"' "$c"
+  # Delete the old cray-istio key
+  yq4 eval -i 'del(.spec.kubernetes.services."cray-istio")' "$c"
+fi
+
+# Update proxiedWebAppExternalHostnames references from cray-istio to cray-istio-ingress
+yq4 eval -i 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*cray-istio*"))' "$c"
+yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-istio-ingress'].istio.tracing.externalAuthority }}\"" -i "$c"
+
 metallb_path='.spec.kubernetes.services."cray-metallb".metallb'
 config_inline_key='configInline'
 config_inline_new_key='configInlineHistorical'


### PR DESCRIPTION
# Description
Upgrading `istio` involves some changes in upgrade workflow.  Since istio 1.26.0 version deprecates the istio-operator so we need to undeploy the charts `cray-istio-deploy` and `cray-istio-operator` before installing the new istio version, also we need to make sure that the pods have the updated version of sidecars.The new istio version has some change in the chart names.
OLD CHART STRUCTURE:
```
cray-istio
cray-istio-deploy
cray-istio-operator
```
NEW CHART STRUCTURE:
```
cray-istio-ingress
cray-istio-base
cray-istio-pilot
```
So the customizations and other files need to be updated with the new names. This change handles that.

Resolves [CASMTRIAGE-8286](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8286)

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
