### PR TITLE
CASMCMS-8843: Document change to how BOS handles nodes locked in HSM

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,9 @@
 * CSM now provides the `csm.ssh_config` Ansible role to automatically restore the root user's SSH configuration file during
   [Management Node Personalization](operations/configuration_management/Management_Node_Personalization.md).
   For more details, see [SSH configuration files](operations/CSM_product_management/Set_Up_Passwordless_SSH.md#ssh-configuration-files).
+* When a [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos) session starts,
+  any nodes that are locked in the [Hardware State Manager (HSM)](glossary.md#hardware-state-manager-hsm) are removed from the session.
+  For more information, see [BOS sessions and HSM locks](operations/boot_orchestration/Sessions.md#bos-sessions-and-hsm-locks).
 
 ### Documentation enhancements
 

--- a/operations/boot_orchestration/BOS_Services.md
+++ b/operations/boot_orchestration/BOS_Services.md
@@ -80,6 +80,8 @@ This operator marks sessions as complete and saves a final status for the sessio
 
 This operator monitors for pending sessions, and translates the session template into a list of components and the boot artifacts and configuration to be set as the desired state for those components.
 
+Related: [BOS sessions and HSM locks](Sessions.md#bos-sessions-and-hsm-locks).
+
 ### `status`
 
 This operator monitors all components that are enabled in BOS and sets their `phase` based on the components desired and current state in BOS, the components power state as reported by HSM, and the component's configuration status as reported by CFS.

--- a/operations/boot_orchestration/Sessions.md
+++ b/operations/boot_orchestration/Sessions.md
@@ -1,6 +1,6 @@
 # BOS Sessions
 
-The Boot Orchestration Service (BOS) creates a session when it is asked to perform an operation on a session template.
+The Boot Orchestration Service (BOS) creates a session when it is asked to perform an operation on a [session template](Session_Templates.md).
 Sessions provide a way to track the status of many nodes at once as they perform the same operation with the same session template information.
 When creating a session, both the operation and session template are required parameters.
 
@@ -21,3 +21,26 @@ Session in BOS v2 are constructs intended to help users track an operation acros
 A session will continue to track a component until the component reaches its desired state and is disabled or until another sessions takes over managing that component.
 Additional status information is also available for sessions to track information such as how many components are at each step in the process.
 See [View the Status of a BOS Session](View_the_Status_of_a_BOS_Session.md) for more information.
+
+## BOS sessions and HSM locks
+
+As part of a `pending` BOS session being started, the BOS [`session-setup` operator](BOS_Services.md#session-setup)
+determines which nodes are targeted for the session. For example, it removes nodes whose architectures are not compatible with
+the boot sets in the session template, and this is also when it applies the
+[session limit](Limit_the_Scope_of_a_BOS_Session.md) (if one was specified).
+Included in this process is a query to the [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm)
+for a list of all locked nodes. (For more information on these locks, see
+[Manage HMS Locks](../hardware_state_manager/Manage_HMS_Locks.md).)
+
+Any nodes which are locked in HSM are removed from the BOS session at this time (because any
+[Power Control Service (PCS)](../../glossary.md#power-control-service-pcs) operations on locked nodes are guaranteed to fail).
+The status for the resulting BOS session will only show the nodes which were not removed during this process. However,
+the `session-setup` operator Kubernetes pod log will contain information on which nodes were removed and for what reason.
+
+This check only happens when the session first starts. If a node is locked in HSM while the session is already running, then BOS
+will not be directly aware of that. Instead, any calls it makes to PCS for that node will fail.
+Depending on how far along that node is in the BOS session, this may or may not result in that node failing to boot.
+
+Prior to CSM 1.7, BOS never checked for HSM locks. Instead, locked nodes would be included in the session,
+and the PCS failures described above would result in their boots failing. The associated error message
+in BOS for that component was generally not helpful in determining the true cause of the problem.


### PR DESCRIPTION
CASMCMS-8843 modified how BOS sessions handle nodes that are locked in HSM.
This updates the release notes and BOS documentation accordingly.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/6045
1.5: https://github.com/Cray-HPE/docs-csm/pull/6046
1.4: https://github.com/Cray-HPE/docs-csm/pull/6047
1.3: https://github.com/Cray-HPE/docs-csm/pull/6048