### PR TITLE
CASMCMS-8843: Document how BOS sessions interact with HSM locks

### DIFF
--- a/operations/boot_orchestration/BOS_Services.md
+++ b/operations/boot_orchestration/BOS_Services.md
@@ -80,6 +80,8 @@ This operator marks sessions as complete and saves a final status for the sessio
 
 This operator monitors for pending sessions, and translates the session template into a list of components and the boot artifacts and configuration to be set as the desired state for those components.
 
+Related: [BOS sessions and HSM locks](Sessions.md#bos-sessions-and-hsm-locks).
+
 ### `status`
 
 This operator monitors all components that are enabled in BOS and sets their `phase` based on the components desired and current state in BOS, the components power state as reported by HSM, and the component's configuration status as reported by CFS.

--- a/operations/boot_orchestration/Sessions.md
+++ b/operations/boot_orchestration/Sessions.md
@@ -1,6 +1,6 @@
 # BOS Sessions
 
-The Boot Orchestration Service (BOS) creates a session when it is asked to perform an operation on a session template.
+The Boot Orchestration Service (BOS) creates a session when it is asked to perform an operation on a [session template](Session_Templates.md).
 Sessions provide a way to track the status of many nodes at once as they perform the same operation with the same session template information.
 When creating a session, both the operation and session template are required parameters.
 
@@ -21,3 +21,20 @@ Session in BOS v2 are constructs intended to help users track an operation acros
 A session will continue to track a component until the component reaches its desired state and is disabled or until another sessions takes over managing that component.
 Additional status information is also available for sessions to track information such as how many components are at each step in the process.
 See [View the Status of a BOS Session](View_the_Status_of_a_BOS_Session.md) for more information.
+
+## BOS sessions and HSM locks
+
+As part of a `pending` BOS session being started, the BOS [`session-setup` operator](BOS_Services.md#session-setup)
+determines which nodes are targeted for the session. For example, it removes nodes whose architectures are not compatible with
+the boot sets in the session template, and this is also when it applies the
+[session limit](Limit_the_Scope_of_a_BOS_Session.md) (if one was specified).
+Prior to CSM 1.7, this process does NOT include removing nodes that are locked in the
+[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
+(For more information on these locks, see [Manage HMS Locks](../hardware_state_manager/Manage_HMS_Locks.md).)
+
+If a node is locked in HSM, then BOS will not be directly aware of that. Instead, any calls it makes to the
+[Power Control Service (PCS)](../../glossary.md#power-control-service-pcs) for that node will fail.
+The associated error message in BOS for that component is generally not specific about the true cause of the problem.
+
+In CSM 1.7, this behavior is improved by having locked nodes removed by the `session-setup` operator as part of its
+initial filtering.


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/6044, documenting how BOS behaved in CSM 1.6