### PR TITLE
CASMPET-7596 (CAST-38296): Add procedure to increase nexus pvc size

### DIFF
--- a/operations/package_repository_management/Nexus_Space_Cleanup.md
+++ b/operations/package_repository_management/Nexus_Space_Cleanup.md
@@ -110,3 +110,45 @@ If no other methods of cleaning work, then submit a help request to expand the `
 to proceed. Expanding the PVC will also require future work to allow for further upgrades.
 
 **CAUTION:** This is an irreversible step and is not recommended.
+
+1. Scale Nexus to 0
+
+    ```bash
+    kubectl scale deployment nexus -n nexus --replicas=0
+    ```
+
+1. Increase nexus-data `pvc` storage size
+
+    ```bash
+    kubectl edit pvc nexus-data -n nexus
+    ```
+
+    ```yaml
+    spec:
+      resources:
+        requests:
+          storage: 1500Gi  (was 1000Gi)
+    ```
+
+1. Scale nexus back to 1
+
+    ```bash
+    kubectl scale deployment nexus -n nexus --replicas=1
+    ```
+
+1. Update the customizations.yaml to persist the `pvc` size change.
+
+    ```bash
+    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+    ```
+
+    Edit customizations.yaml to add cray-nexus sonatype-nexus.persistence.storageSize
+          cray-nexus:
+            sonatype-nexus:
+              persistence:
+                storageSize: 1500Gi
+
+    ```bash
+    kubectl delete secret -n loftsman site-init
+    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+    ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Adds in procedure to increase nexus pvc size.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
