### PR TITLE
CASMTRIAGE-8297: Fix promote-initial-master.sh

### DIFF
--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -56,6 +56,13 @@ export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
 # version. Otherwise, use kubeadm.k8s.io/v1beta4.
 if [[ ${KUBERNETES_MINOR_VERSION} -lt 25 ]]; then
   k8scfg="/srv/cray/resources/common/1.24/kubeadm.cfg"
+
+  # Special case for K8s 1.24 -> 1.26 upgrade. Use existing kubeadm.cfg that is
+  # present on the previous node image.
+  if [ ! -f "${k8scfg}" ]; then
+    export KUBERNETES_VERSION="v${KUBERNETES_VERSION}"
+    k8scfg="/srv/cray/resources/common/kubeadm.cfg"
+  fi
 elif [[ ${KUBERNETES_MINOR_VERSION} -lt 27 ]]; then
   k8scfg="/srv/cray/resources/common/1.25/kubeadm.cfg"
 elif [[ ${KUBERNETES_MINOR_VERSION} -lt 31 ]]; then


### PR DESCRIPTION
# Description

Add a special case for populating kubeadm.cfg when upgrading from K8s 1.24 on metal instances. We believe this fixes a bug that prevents Kubernetes from starting up properly after IUF runs promote-initial-master.sh, which worked on vShasta upgrades, but did not work on metal upgrades. Our best guess is that a metal-specific upgrade codepath ran that broke an assumption that promote-initial-master.sh held, namely.that promote-initial-master.sh always runs on the new, upgrade node image. If that is not the case, then this fix accounts for that condition.

[CASMTRIAGE-8297](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8297)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.