### PR TITLE
CASMCMS-8131: Document removal of BOS disable_components_on_completion option in CSM 1.7

### DIFF
--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -54,6 +54,8 @@ in chronological order.
 - Top-level Ansible playbooks `ncn-master.yaml`, `ncn-storage.yaml`, and `ncn-worker.yaml` in `csm-config-management` repository in the
   [Version Control Service (VCS)](../../glossary.md#version-control-service-vcs).
   - These have been replaced by the unified `ncn_nodes.yaml` top-level playbook.
+- Experimental `disable_components_on_completion` [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos)
+  [option](../../operations/boot_orchestration/Options.md)
 
 ## Deprecations
 

--- a/operations/boot_orchestration/Options.md
+++ b/operations/boot_orchestration/Options.md
@@ -68,6 +68,7 @@ The following are the BOS global options:
     Determines if a component will be marked as disabled after its desired state matches its current state.
     If false, BOS will continue to maintain the state of the nodes declaratively.
     This is an experimental feature and is not fully supported.
+    This option is [removed in CSM 1.7](../../introduction/deprecated_features/README.md#removals-in-csm-17).
 
 * `discovery_frequency`
 


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/6059