### PR TITLE
CASMPET-7582: Remove PSP

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1171,10 +1171,13 @@ if [[ ${state_recorded} == "0" ]]; then
     tmpdir=$(mktemp -d)
 
     # This is necessary for the initial 1.24.17 to 1.26.15 bump. Otherwise,
-    # kubeadm commands in kubernetes-cloudinit.sh fail.
+    # kubeadm commands in kubernetes-cloudinit.sh fail. We also need to make
+    # sure we don't enable the PodSecurityPolicy plugin by removing it from the
+    # existing configmap.
     echo "Patching kubeadm-config configmap to update kubernetesVersion from 1.24.17 to 1.26.15 ..."
     kubectl -n kube-system get configmap kubeadm-config -o go-template --template '{{ .data.ClusterConfiguration }}' \
       | yq4 e '.kubernetesVersion="v1.26.15"' \
+      | yq4 e '.apiServer.extraArgs.enable-admission-plugins="NodeRestriction"' \
         > "${tmpdir}/kubeadm-config.yaml"
     patch=$(jq -c -n --rawfile text "${tmpdir}/kubeadm-config.yaml" '.data["ClusterConfiguration"]=$text')
     kubectl -n kube-system patch configmap kubeadm-config --type merge --patch "${patch}"
@@ -1187,6 +1190,50 @@ if [[ ${state_recorded} == "0" ]]; then
     kubectl -n kube-system patch configmap kube-proxy --type merge --patch "${patch}"
 
     rm -rf "${tmpdir}"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
+# Remove PodSecurityPolicy from enable-admission-plugins from the kube-apiserver.yaml manifest
+# on each of the master nodes. The change will prompt kubelet to restart the kube-apiserver pod.
+# Removing PodSecurityPolicy causes cascading restarts of many pods.
+state_name="REMOVE_PSP"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    # Get all master nodes
+    apiserver_file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    master_nodes=$(grep -oP "(ncn-m\d+)" /etc/hosts | sort -u)
+    search_string=",PodSecurityPolicy"
+
+    # For each master node, remove PodSecurityPolicy from --enable-admission-plugins.
+    # This will cause kubelet to restart kube-apiserver.
+    for host in $master_nodes; do
+      # yq4 doesn't work in this instance because it doesn't format list items correctly
+      # causing kube-apiserver to CLBO.
+      # Using sed.
+      echo "Modifying ${apiserver_file} on ${host} ..."
+      ssh $host sed -i "s/${search_string}//g" ${apiserver_file}
+      # Need to wait a bit for kube-apiserver to restart before modifying next kube-apiserver.yaml.
+      # If restart the kube-apiserver pods in quick succession, unable to run kubectl commands until
+      # apiserver pods are back up and running.
+      echo "Wait for 2 minutes for kubelet to restart kube-apiserver-${host} ..."
+      sleep 120
+      echo "Wait for pod kube-apiserver-${host} to be Ready ..."
+      kubectl wait pod -n kube-system kube-apiserver-${host} --for=condition=Ready --timeout=5m
+    done
+
+    # undeploy cray-psp
+    echo "Undeploying cray-psp chart ..."
+    undeploy -n services cray-psp
+
+    # Blow away all psp resources since we won't need them in k8s 1.25+
+    echo "Delete all psp resources ..."
+    kubectl delete psp --all=true
+
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
# Description
We need to remove PodSecurityPolicy from the `kube-apiserver` manifests on each of the master nodes while still running K8s v1.24.  Once removed from the `kube-apiserver` manifest, `kubelet` will restart the `kube-apiserver` pod.

After PSP is removed from the `kube-apiserver` manifests, undeploy the `cray-psp` pod.  Then finally, remove all psp resources.

CASMPET-7582: Remove PSP
* remove PodSecurityPolicy from kube-apiserver manifest
* undeploy cray-psp pod
* delete all psp resources
* remove PodSecurityPolicy from enable-admission-plugins in kubeadm-config configmap

Co-authored-by: David Fluck <david.fluck@hpe.com>

This also resolves CASMTRIAGE-8295 Wasp - Etcd failures due to PSP related issues.

# Testing
Ran this on `molly`. 

```
====> REMOVE_PSP ...
Modifying /etc/kubernetes/manifests/kube-apiserver.yaml on ncn-m001 ...
Modifying /etc/kubernetes/manifests/kube-apiserver.yaml on ncn-m002 ...
Modifying /etc/kubernetes/manifests/kube-apiserver.yaml on ncn-m003 ...
Undeploying cray-psp chart ...
Chart cray-psp exists. Uninstalling it now.
W0613 20:17:27.663194  179317 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
release "cray-psp" uninstalled
Delete all psp resources ...
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
podsecuritypolicy.policy "cray-ceph-csi-cephfs-nodeplugin" deleted
podsecuritypolicy.policy "cray-ceph-csi-cephfs-provisioner" deleted
podsecuritypolicy.policy "cray-ceph-csi-rbd-nodeplugin" deleted
podsecuritypolicy.policy "cray-ceph-csi-rbd-provisioner" deleted
podsecuritypolicy.policy "cray-certmanager-cert-manager" deleted
podsecuritypolicy.policy "cray-certmanager-cert-manager-cainjector" deleted
podsecuritypolicy.policy "cray-certmanager-cert-manager-webhook" deleted
podsecuritypolicy.policy "cray-externaldns-external-dns-services" deleted
podsecuritypolicy.policy "cray-kyverno-admission-controller" deleted
podsecuritypolicy.policy "cray-kyverno-background-controller" deleted
podsecuritypolicy.policy "cray-kyverno-cleanup-admission-reports" deleted
podsecuritypolicy.policy "cray-kyverno-cleanup-cluster-admission-reports" deleted
podsecuritypolicy.policy "cray-kyverno-cleanup-controller" deleted
podsecuritypolicy.policy "cray-kyverno-post-install-job" deleted
podsecuritypolicy.policy "cray-kyverno-psp" deleted
podsecuritypolicy.policy "cray-kyverno-reports-controller" deleted
podsecuritypolicy.policy "cray-spire" deleted
podsecuritypolicy.policy "cray-spire-agent" deleted
podsecuritypolicy.policy "cray-sysmgmt-health-grafana" deleted
podsecuritypolicy.policy "cray-sysmgmt-health-kube-state-metrics" deleted
podsecuritypolicy.policy "cray-sysmgmt-health-prometheus-node-exporter" deleted
podsecuritypolicy.policy "metallb-controller" deleted
podsecuritypolicy.policy "metallb-speaker" deleted
podsecuritypolicy.policy "node-problem-detector" deleted
podsecuritypolicy.policy "privileged" deleted
podsecuritypolicy.policy "restricted" deleted
podsecuritypolicy.policy "restricted-transition" deleted
podsecuritypolicy.policy "sealed-secrets-kube-system" deleted
podsecuritypolicy.policy "spire" deleted
podsecuritypolicy.policy "spire-agent" deleted
====> REMOVE_PSP has been completed
```

`prerequisites.sh` completed successfully.  The "Upgrade CSM Services" stage, which deploys the 1.24 manifests completed successfully.  

The pods are running as expected.
```
ncn-m001:/etc/cray/upgrade/csm/log # kubectl get pods -A | grep -Ev "Running|Complete"
NAMESPACE        NAME                                                              READY   STATUS      RESTARTS        AGE
services         cray-dhcp-kea-helper-29168307-cws2w                               1/2     NotReady    0               32s
services         hms-discovery-29168307-s9j4l                                      1/2     NotReady    0               32s
ncn-m001:/etc/cray/upgrade/csm/log # kubectl get pods -A | grep -Ev "Running|Complete"
NAMESPACE        NAME                                                              READY   STATUS      RESTARTS        AGE
ncn-m001:/etc/cray/upgrade/csm/log #
```

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
