### PR TITLE
CASMCMS-9457: Improve CFS source docs

### DIFF
--- a/operations/configuration_management/Adding_Additional_Inventory.md
+++ b/operations/configuration_management/Adding_Additional_Inventory.md
@@ -70,3 +70,33 @@ Example configuration:
   }
 }
 ```
+
+## Using sources in additional inventory
+
+When adding additional inventory to a configuration, either the `clone_url` or `source` values can be used to reference a Git repo.
+`clone_url` can be used for repos where CFS can use the default username, password and CA certificate, such as internal repos.
+`source` allows the layer to reference a CFS source which can include information beyond a single `clone_url`. See [CFS Sources](CFS_Sources.md) for more information.
+
+In the following example, a `source` is specified for the additional inventory rather than a
+`clone_url`. The `layers` still use `clone_url` in this example. A source named "inventory" must
+exist in CFS in order for this example to work. See [Create a CFS Source](CFS_Sources.md#create-a-cfs-source)
+for instructions on creating a CFS source.
+
+Example configuration:
+
+```json
+{
+  "layers": [
+    {
+      "name": "configurations-layer-example-1",
+      "clone_url": "https://api-gw-service-nmn.local/vcs/cray/example-repo.git",
+      "playbook": "site.yml",
+      "commit": "<git commit id>"
+    }
+  ],
+  "additional_inventory": {
+    "source": "inventory",
+    "commit": "a7d08b6e1be590ac01711e39c684b6893c1da0a9"
+  }
+}
+```

--- a/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
+++ b/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
@@ -12,6 +12,9 @@ For convenience all changes are listed here.
   (E.g. `{"components":[]}` for the components endpoint).
   Responses will also include a `next` section that is used for paging through records.
   See [Paging CFS Records](Paging_CFS_Records.md) for more information.
+* The v3 API supports the creation of [CFS Sources](CFS_Sources.md) which allows CFS to use
+  configuration and inventory content from external repositories. See [Using sources in a configuration layer](CFS_Configurations.md#using-sources-in-a-configuration-layer)
+  and [Using sources in additional inventory](Adding_Additional_Inventory.md#using-sources-in-additional-inventory).
 * Component records no longer include the `state` list of applied playbooks by default.
   The `state` can requested with the `state_details` parameter.
 * Some fields now have maximum sizes:

--- a/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
+++ b/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
@@ -18,9 +18,9 @@ For convenience all changes are listed here.
 * Component records no longer include the `state` list of applied playbooks by default.
   The `state` can requested with the `state_details` parameter.
 * Some fields now have maximum sizes:
-  * Configuration names are now limited to 60 characters
-  * Additional inventory URLs are limited to 240 characters
-  * Configuration layer names are limited to 45 characters
+    * Configuration names are now limited to 60 characters
+    * Additional inventory URLs are limited to 240 characters
+    * Configuration layer names are limited to 45 characters
 * The v3 API has three new global options: `default_page_size`, `debug_wait_time` and `include_ara_links`.
   See [CFS Global Options](CFS_Global_Options.md) for more information.
 * Session and component records now include a `logs` field with a link to the ARA UI with the appropriate filter for that session or component.


### PR DESCRIPTION
# Description
Improve documentation of CFS `source`, including the following:

- Include mention of CFS sources in the differences between CFS v2 and v3 since they were added in v3. Added this early in the list of differences right after paging, property name changes, and response format changes because it's a pretty big addition.
- Add a brief example showing use of `source` in `additional_inventory` property of a CFS configuration, using the similar example of using `source` in a configuration layer as a starting point.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
