### PR TITLE
CASMCMS-9458 - update kernel params for IMS remote build node boot.

### DIFF
--- a/operations/image_management/Configure_a_Remote_Build_Node.md
+++ b/operations/image_management/Configure_a_Remote_Build_Node.md
@@ -345,7 +345,7 @@ image that is installed with CSM. This image may be used to boot multiple remote
         {
             "boot_sets": {
                 "compute": {
-                    "kernel_parameters": "ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=live:s3://boot-images/<REMOTE_IMS_NODE_IMAGE_ID>/rootfs nmd_data=url=s3://boot-images/<REMOTE_IMS_NODE_IMAGE_ID>/rootfs,etag=<REMOTE_IMS_NODE_IMAGE_ETAG>",
+                    "kernel_parameters": "console=ttyS0,115200 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=live:s3://boot-images/<REMOTE_IMS_NODE_IMAGE_ID>/rootfs nmd_data=url=s3://boot-images/<REMOTE_IMS_NODE_IMAGE_ID>/rootfs,etag=<REMOTE_IMS_NODE_IMAGE_ETAG>",
                     "node_roles_groups": [ "Compute"],
                     "etag": "<REMOTE_IMS_NODE_IMAGE_ETAG>",
                     "arch": "<REMOTE_NODE_ARCH>",


### PR DESCRIPTION
# Description

Add console specification to the kernel params for the directions on booting a remote build node. This will set up console logging which will assist in determining anything going wrong with the boot.

I tested this on Mug.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
