### PR TITLE
CASMPET-7599: postgres reinit script workaround

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -249,6 +249,20 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+# Workaround for CASMPET-7599
+state_name="POSTGRES_FIXUP"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    "${basedir}/util/postgres-reinit.sh"
+  } >> "${LOG_FILE}" 2>&1
+  #shellcheck disable=SC2046
+  record_state "${state_name}" "$(hostname)"
+else
+  echo "====> ${state_name} has been completed"
+fi
+
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."
 GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-post-csm-service-upgrade-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1316,6 +1316,19 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Workaround for CASMPET-7599
+state_name="POSTGRES_REINIT"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    "${locOfScript}/util/postgres-reinit.sh"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then

--- a/upgrade/scripts/upgrade/util/postgres-reinit.sh
+++ b/upgrade/scripts/upgrade/util/postgres-reinit.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -eo pipefail
+
+# After postgresql-operator upgrade, some postgres replicas may failed to start or have lagging issues:
+# - operator will perform rolling restart of all postgresql clusters to add new mount to each pod, but restart sequence
+#   may get stuck on pod trying to update its own label during CSM 1.6 upgrade (CASMINST-6728). Is this still the case?
+# - Use "patronictl reinit" command seem to be able to work around the issue
+#
+
+function postgres_operator_running() {
+  if [ "$(kubectl -n services get pod -l app.kubernetes.io/name=postgres-operator --no-headers | awk '{ print $2 ":" $3 }')" == "2/2:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_pods_running() {
+  if [ "$(kubectl get pod -l application=spilo -A --no-headers | awk '{ print $3 ":" $4 }' | sort -u)" == "3/3:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_clusters_running() {
+  if [ "$(kubectl get postgresql -A -o json | jq -r '.items[].status.PostgresClusterStatus' | sort -u)" == "Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function wait_for() {
+  local command="${1}"
+  local message="${2}"
+  local count=0
+  local total=120
+  local sleep=5
+  while true; do
+    if ${command}; then
+      echo "${message}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}'
+      break
+    else
+      if [ "${count}" -ge "${total}" ]; then
+        echo "ERROR: giving up for ${message} after ${total} attempts"
+        exit 1
+      fi
+      count=$((count + 1))
+      echo "Waiting for ${message}, sleeping for ${sleep} seconds and retry, attempt ${count}/${total} ..."
+      sleep ${sleep}
+    fi
+  done
+}
+
+wait_for postgres_operator_running "postgres-operator pod running"
+# Only recover postgres clusters in argo, services, spire namespaces - but wait for all clusters (such as sma) to be healthy, as
+# preflight checks at the end of prerequisites script will need all clusters anyway.
+for pg_line in $(kubectl get sts -A -l application=spilo -o json | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services" or .metadata.namespace == "spire") | (.metadata.namespace + ":" + .metadata.name)'); do
+  pg_cluster=${pg_line#*:}
+  pg_ns=${pg_line%:*}
+  echo "Working on ${pg_cluster} in namespace ${pg_ns} ..."
+  count=1
+  total=3
+  wait=60
+  pg_pod=""
+  leader=""
+  while [ ${count} -le ${total} ]; do
+    # find one pod from the cluster to run patroni command
+    if kubectl get pods -n ${pg_ns} -l application=spilo --no-headers | grep ${pg_cluster} | grep "3/3" | grep -m 1 Running; then
+      pg_pod=$(kubectl get pods -n ${pg_ns} -l application=spilo --no-headers | grep ${pg_cluster} | grep "3/3" | grep -m 1 Running | awk '{print $1}')
+      echo "INFO: found a running pod ${pg_pod}"
+      break
+    else
+      echo "WARNING: No fully running pod is found for ${pg_cluster} in ${pg_ns}. Rollout restart it and sleep for ${wait} seconds, attempt ${count}/${total})..."
+      kubectl rollout restart sts ${pg_cluster} -n ${pg_ns}
+      sleep ${wait}
+      count=$((count + 1))
+      continue
+    fi
+  done
+
+  if [ -z "${pg_pod}" ]; then
+    echo "ERROR: Unable to recover ${pg_cluster} in ${pg_ns} automatically. You may have to re-install the chart."
+    exit 1
+  fi
+
+  count=1
+  while [ ${count} -le ${total} ]; do
+    # Make sure leader exists for the recovery
+    if kubectl exec -i ${pg_pod} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep Leader | grep running; then
+      leader=$(kubectl exec -i ${pg_pod} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep Leader | awk '{print $2}')
+      echo "INFO: found the leader pod ${leader}"
+      # reinit instances not in "running" state
+      reinit_count=1
+      reinit_max=5
+      while kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -v -m 1 "running"; do
+        # get the first instance not in running state
+        failed_instance=$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -v -m 1 "running" | awk '{print $2}')
+        echo "Reinit ${failed_instance} not in running state: attempt ${reinit_count}/${reinit_max}..."
+        echo "y" | kubectl exec -i ${leader} -n ${pg_ns} -- patronictl reinit ${pg_cluster} ${failed_instance} 2> /dev/null || true
+        # sleep for some time as reinit takes a while to settle
+        sleep ${wait}
+        reinit_count=$((reinit_count + 1))
+        if [ ${reinit_count} -gt ${reinit_max} ]; then
+          echo "Reinit count reached ${reinit_max}. Breaking loop."
+          break
+        fi
+      done
+
+      # Reinit instances with replication lag
+      reinit_count=1
+      reinit_max=3
+      while [ "$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica | awk '{print $12}' | sort -u)" != "0" ]; do
+        for line in $(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica); do
+          if [ "$(echo "$line" | awk '{print $12}')" != "0" ]; then
+            lagged_instance=$(echo $line | awk '{print $2}')
+            echo "Reinit ${lagged_instance} with replication lag: attempt ${reinit_count}/${reinit_max}..."
+            echo "y" | kubectl exec -i ${leader} -n ${pg_ns} -- patronictl reinit ${pg_cluster} ${lagged_instance} 2> /dev/null || true
+            # sleep for some time as reinit takes a while to settle
+            sleep ${wait}
+          fi
+        done
+        reinit_count=$((reinit_count + 1))
+        if [ ${reinit_count} -gt ${reinit_max} ]; then
+          echo "Reinit count reached ${reinit_max}. Breaking loop."
+          break
+        fi
+      done
+    else
+      echo "WARNING: No running leader is found for ${pg_cluster} in ${pg_ns}. Rollout restart it and sleep for ${wait} seconds, attempt ${count}/${total})..."
+      kubectl rollout restart sts ${pg_cluster} -n ${pg_ns}
+      sleep ${wait}
+      count=$((count + 1))
+      continue
+    fi
+    break
+  done
+  if [ -z "${leader}" ]; then
+    echo "ERROR: Unable to recover ${pg_cluster} in ${pg_ns} automatically. You may have to re-install the chart."
+    exit 1
+  fi
+
+done < <(kubectl get sts -A -l application=spilo -o json | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services" or .metadata.namespace == "spire") | (.metadata.namespace + ":" + .metadata.name)')
+
+wait_for postgres_pods_running "all postgres pods running"
+wait_for postgres_clusters_running "all postgres clusters in state Running"
+echo "State of postgres clusters after the fixup:"
+kubectl get postgresql -A


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
During the upgrade, postgres clusters may end up with SyncFailed state with some replicas not in running state or with lags. This PR attempts to reinit replicas not in running state prior to CSM health check.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
