### PR TITLE
CASMPET-7603: handle lagged instance reinit correctly

### DIFF
--- a/upgrade/scripts/upgrade/util/postgres-reinit.sh
+++ b/upgrade/scripts/upgrade/util/postgres-reinit.sh
@@ -136,7 +136,7 @@ for pg_line in $(kubectl get sts -A -l application=spilo -o json | jq -r '.items
       reinit_count=1
       reinit_max=3
       while [ "$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica | awk '{print $12}' | sort -u)" != "0" ]; do
-        while read -r line ; do
+        while read -r line; do
           if [ "$(echo $line | awk '{print $12}')" != "0" ]; then
             lagged_instance=$(echo $line | awk '{print $2}')
             echo "Reinit ${lagged_instance} with replication lag: attempt ${reinit_count}/${reinit_max}..."

--- a/upgrade/scripts/upgrade/util/postgres-reinit.sh
+++ b/upgrade/scripts/upgrade/util/postgres-reinit.sh
@@ -136,15 +136,15 @@ for pg_line in $(kubectl get sts -A -l application=spilo -o json | jq -r '.items
       reinit_count=1
       reinit_max=3
       while [ "$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica | awk '{print $12}' | sort -u)" != "0" ]; do
-        for line in $(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica); do
-          if [ "$(echo "$line" | awk '{print $12}')" != "0" ]; then
+        while read -r line ; do
+          if [ "$(echo $line | awk '{print $12}')" != "0" ]; then
             lagged_instance=$(echo $line | awk '{print $2}')
             echo "Reinit ${lagged_instance} with replication lag: attempt ${reinit_count}/${reinit_max}..."
             echo "y" | kubectl exec -i ${leader} -n ${pg_ns} -- patronictl reinit ${pg_cluster} ${lagged_instance} 2> /dev/null || true
             # sleep for some time as reinit takes a while to settle
             sleep ${wait}
           fi
-        done
+        done < <(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep Replica)
         reinit_count=$((reinit_count + 1))
         if [ ${reinit_count} -gt ${reinit_max} ]; then
           echo "Reinit count reached ${reinit_max}. Breaking loop."


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
We previously were hitting lagged instance re-initialization as we did not have lagging in our testing. Gamora testing uncovered the issue while we did not process each instance line correctly. This PR fixes the issue.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
