### PR TITLE
CASMPET-7556: Document on how to create HSM groups before bootprep time

### DIFF
--- a/operations/iscsi_sbps/HSM_groups_iscsi.md
+++ b/operations/iscsi_sbps/HSM_groups_iscsi.md
@@ -15,7 +15,7 @@ ncn-m001:~ # cray hsm groups create --label iscsi_worker --description "iscsi no
 URI = "/hsm/v2/groups/iscsi_worker"
 ```
 
-HSM group `iscsi_worker` created with xname x3000c0s5b0n0 added. Adding one more xname of worker node is as below:
+HSM group `iscsi_worker` created with xname `x3000c0s5b0n0` added. Adding one more xname of worker node is as below:
 
 ```text
 ncn-m001:~ # cray hsm groups members create --id x3000c0s18b0n0 iscsi_worker
@@ -34,6 +34,7 @@ ids = [ "x3000c0s5b0n0", "x3000c0s18b0n0",]
 
 Example:
 
+```text
 ncn-m001:~ # XNAME=$( ssh ncn-m001 cat /etc/cray/xname )
 ncn-m001:~ # echo $XNAME
 x3000c0s1b0n0
@@ -151,6 +152,6 @@ x3000c0s18b0n0             : ok=10   changed=7    unreachable=0    failed=0    s
 x3000c0s5b0n0              : ok=7    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 All playbooks completed successfully
-
+```
 Note:- This indicates that iSCSI SBPS node personalisation playbooks have been applied on 
 selected nodes and iSCSI SBPS enabled.

--- a/operations/iscsi_sbps/HSM_groups_iscsi.md
+++ b/operations/iscsi_sbps/HSM_groups_iscsi.md
@@ -1,11 +1,11 @@
-# Selective Node Personalisation 
+# Selective Node Personalization
 
-* [Steps to create HSM group](#steps-to-create-HSM-group)
-* [CFS configuration /component update](#cfs-configuration-/component-update)
+`iscsi_worker` is the HSM group name needs to be created for iSCSI SBPS selective node personalization.
+
+* [Steps to create HSM group](#steps-to-create-hsm-group)
+* [CFS configuration and component update](#cfs-configuration-and-component-update)
 
 ## Steps to create HSM group
-
-`iscsi_worker` is the HSM group name needs to be created for iSCSI SBPS.
 
 Example:
 
@@ -26,11 +26,13 @@ URI = "/hsm/v2/groups/iscsi_worker/members/x3000c0s18b0n0"
 The group members of `iscsi_worker` can be listed as below:
 
 ```text
-ncn-m001:~ # cray hsm groups members list iscsi_worker	
+ncn-m001:~ # cray hsm groups members list iscsi_worker
 ids = [ "x3000c0s5b0n0", "x3000c0s18b0n0",]
 ```
 
-## CFS configuration /component update
+## CFS configuration and component update
+
+In scenario's like an upgraded system where HSM groups are not created, then below steps can be followed for selective node personalization post HSM groups creation.
 
 Example:
 
@@ -153,5 +155,6 @@ x3000c0s5b0n0              : ok=7    changed=3    unreachable=0    failed=0    s
 
 All playbooks completed successfully
 ```
-Note:- This indicates that iSCSI SBPS node personalisation playbooks have been applied on 
-selected nodes and iSCSI SBPS enabled.
+
+Note:- This indicates that iSCSI SBPS node personalisation playbooks have been applied on
+selected nodes and iSCSI SBPS is enabled.

--- a/operations/iscsi_sbps/HSM_groups_iscsi.md
+++ b/operations/iscsi_sbps/HSM_groups_iscsi.md
@@ -1,0 +1,156 @@
+# Selective Node Personalisation 
+
+* [Steps to create HSM group](#steps-to-create-HSM-group)
+* [CFS configuration /component update](#cfs-configuration-/component-update)
+
+## Steps to create HSM group
+
+`iscsi_worker` is the HSM group name needs to be created for iSCSI SBPS.
+
+Example:
+
+```text
+ncn-m001:~ # cray hsm groups create --label iscsi_worker --description "iscsi node personalization" --members-ids x3000c0s5b0n0
+[[results]]
+URI = "/hsm/v2/groups/iscsi_worker"
+```
+
+HSM group `iscsi_worker` created with xname x3000c0s5b0n0 added. Adding one more xname of worker node is as below:
+
+```text
+ncn-m001:~ # cray hsm groups members create --id x3000c0s18b0n0 iscsi_worker
+[[results]]
+URI = "/hsm/v2/groups/iscsi_worker/members/x3000c0s18b0n0"
+```
+
+The group members of `iscsi_worker` can be listed as below:
+
+```text
+ncn-m001:~ # cray hsm groups members list iscsi_worker	
+ids = [ "x3000c0s5b0n0", "x3000c0s18b0n0",]
+```
+
+## CFS configuration /component update
+
+Example:
+
+ncn-m001:~ # XNAME=$( ssh ncn-m001 cat /etc/cray/xname )
+ncn-m001:~ # echo $XNAME
+x3000c0s1b0n0
+ncn-m001:~ # CONFIG=$( cray cfs components describe $XNAME --format json | jq -r '.desiredConfig' )
+ncn-m001:~ # echo $CONFIG
+management-main-1874509.1
+ncn-m001:~ # craycfs configurations describe $CONFIG --format json | jq -r '. | del(.name) | del(.lastUpdated)' > ${CONFIG}.json
+ncn-m001:~ # cat management-main-1874509.1.json
+{
+  "layers": [
+    {
+      "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+      "commit": "67098595b52d0739382611ef6fe15a918978910d",
+      "name": "csm-sbps_iscsi_targets-1.6.1-rc.7",
+      "playbook": "config_sbps_iscsi_targets.yml"
+    }
+  ]
+}
+
+ncn-m001:~ # cray cfs configurations update --file ${CONFIG}.json ${CONFIG}
+lastUpdated = "2025-05-27T11:17:51Z"
+name = "management-main-1874509.1"
+[[layers]]
+cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+commit = "67098595b52d0739382611ef6fe15a918978910d"
+name = "csm-sbps_iscsi_targets-1.6.1-rc.7"
+playbook = "config_sbps_iscsi_targets.yml"
+
+
+ncn-m001:~ # cray cfs components update $XNAME --state []
+desiredConfig = "management-main-1874509.1"
+enabled = true
+errorCount = 0
+id = "x3000c0s1b0n0"
+state = []
+
+[tags]
+
+ncn-m001:~ # cray cfs components describe $XNAME
+configurationStatus = "pending"
+desiredConfig = "management-main-1874509.1"
+enabled = true
+errorCount = 0
+id = "x3000c0s1b0n0"
+state = []
+
+[tags]
+
+......
+
+ncn-m001:~ # cray cfs components describe $XNAME
+configurationStatus = "configured"
+desiredConfig = "management-main-1874509.1"
+enabled = true
+errorCount = 0
+id = "x3000c0s1b0n0"
+[[state]]
+cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+commit = "67098595b52d0739382611ef6fe15a918978910d_skipped"
+lastUpdated = "2025-05-27T11:20:52Z"
+playbook = "config_sbps_iscsi_targets.yml"
+sessionName = "batcher-66eee897-aa2a-4d92-9a2c-565e9bde3665"
+
+[tags]
+
+ncn-m001:~ # kubectl get pods --no-headers -o custom-columns=":metadata.name" -n services -l cfsession=batcher-66eee897-aa2a-4d92-9a2c-565e9bde3665
+cfs-19e2e4f7-aae8-4847-b4b3-288888b24769-dx75v
+ncn-m001:~ # CFS_POD_NAME=cfs-19e2e4f7-aae8-4847-b4b3-288888b24769-dx75v
+ncn-m001:~ # kubectl logs -n services "${CFS_POD_NAME}" ansible
+Waiting for Inventory
+Inventory generation completed
+SSH keys migrated to /root/.ssh
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+HTTP/1.1 200 OK
+content-type: text/html; charset=UTF-8
+cache-control: no-cache, max-age=0
+x-content-type-options: nosniff
+date: Tue, 27 May 2025 11:19:11 GMT
+server: envoy
+transfer-encoding: chunked
+
+Sidecar available
+Running config_sbps_iscsi_targets.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
+
+PLAY [iscsi_worker] ************************************************************
+
+TASK [csm.sbps.apply_label : Apply k8s label on worker nodes] ******************
+changed: [x3000c0s18b0n0]
+changed: [x3000c0s5b0n0]
+
+TASK [csm.sbps.enable_spire : restart_spire_agent] *****************************
+changed: [x3000c0s18b0n0]
+changed: [x3000c0s5b0n0]
+
+TASK [csm.sbps.lio_config : provision_iscsi_server] ****************************
+changed: [x3000c0s18b0n0]
+changed: [x3000c0s5b0n0]
+
+TASK [csm.sbps.dns_srv_records : Remove previous /tmp/hsn_nmn_info.txt] ********
+changed: [x3000c0s18b0n0]
+
+TASK [csm.sbps.dns_srv_records : Get Host Name, HSN and NMN details of each worker node] ***
+changed: [x3000c0s18b0n0 -> x3000c0s18b0n0]
+
+TASK [csm.sbps.dns_srv_records : Update Host Name, HSN and NMN details for each worker node] ***
+changed: [x3000c0s18b0n0 -> x3000c0s18b0n0]
+
+TASK [csm.sbps.dns_srv_records : Create DNS "SRV" and "A" records of HSN and NMN for each worker node] ***
+changed: [x3000c0s18b0n0 -> x3000c0s18b0n0]
+
+PLAY RECAP *********************************************************************
+x3000c0s18b0n0             : ok=10   changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+x3000c0s5b0n0              : ok=7    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+
+All playbooks completed successfully
+
+Note:- This indicates that iSCSI SBPS node personalisation playbooks have been applied on 
+selected nodes and iSCSI SBPS enabled.

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -265,7 +265,30 @@ Node personalization is the prerequisite step of SBPS solution where we need to 
 with necessary provisioning, configuration and enable required components. The required RPMs for `targetcli` command / LIO are part of NCN node image in CSM 1.6.
 The SBPS Marshal Agent gets installed during node personalization using CFS.
 
-This can be done in two ways:
+In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personlization is introduced. Steps to personalize worker nodes for fresh install /upgradescenarios is as below:
+
+1)	Fresh Install:
+
+Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md 
+before the step #8 in the document: [configure_administrative_access](../1.7/install/configure_administrative_access.md)
+
+2)	Upgrade scenario:
+
+Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
+[HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+
+before management node rollout mentioned in: 
+[upgrade_csm_and_additional_products_with_iuf](../1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+
+3)	For already upgraded system:
+
+Please follow the steps mentioned in the document:
+[HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+
+This involves creating the HSM group followed by cfs configuration/ component update for enabling iSCSI SBPS on the selected worker nodes.
+
+Post HSM groups creation, node personalisation can be done in two ways (except for aleady upgraded system):
 
 #### Automatic setup with bootprep
 

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -288,9 +288,7 @@ In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, se
    3.1 Create HSM group
    3.2 Enable/ Configure iSCSI SBPS
 
-   As mentioned in 1.1 create HSM group followed by `CFS` configuration/component update mentioned for enabling iSCSI SBPS on the selected worker nodes.
-
-Post HSM groups creation, node personalisation can be done in two ways (except for already upgraded system):
+   As mentioned in 1.1 create HSM group followed by `CFS` configuration/component update mentioned in [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md). An alternative to `CFS` configuration/component update is using [Manual setup with CFS session](#manual-setup-with-cfs-session)
 
 #### Automatic setup with bootprep
 

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -265,26 +265,25 @@ Node personalization is the prerequisite step of SBPS solution where we need to 
 with necessary provisioning, configuration and enable required components. The required RPMs for `targetcli` command / LIO are part of NCN node image in CSM 1.6.
 The SBPS Marshal Agent gets installed during node personalization using CFS.
 
-In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personlization is introduced. Steps to personalize worker nodes for fresh install /upgradescenarios is as below:
+In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personalization is introduced. Steps to personalize worker nodes for fresh install /upgrade scenarios is as below:
 
 1)	Fresh Install:
 
-Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
-https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md 
-before the step #8 in the document: [configure_administrative_access](../1.7/install/configure_administrative_access.md)
+Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
+before the step #8 in the document: [configure_administrative_access](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
 
 2)	Upgrade scenario:
 
 Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
-[HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+[HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
 
 before management node rollout mentioned in: 
-[upgrade_csm_and_additional_products_with_iuf](../1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+[upgrade_csm_and_additional_products_with_iuf](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
 
 3)	For already upgraded system:
 
 Please follow the steps mentioned in the document:
-[HSM_groups_iscsi](../1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+[HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
 
 This involves creating the HSM group followed by cfs configuration/ component update for enabling iSCSI SBPS on the selected worker nodes.
 

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -265,29 +265,31 @@ Node personalization is the prerequisite step of SBPS solution where we need to 
 with necessary provisioning, configuration and enable required components. The required RPMs for `targetcli` command / LIO are part of NCN node image in CSM 1.6.
 The SBPS Marshal Agent gets installed during node personalization using CFS.
 
-In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personalization is introduced. Steps to personalize worker nodes for fresh install /upgrade scenarios is as below:
+In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personalization is introduced and steps for the same for different scenarios is as below:
 
 1)	Fresh Install:
 
-Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
-before the step #8 in the document: [configure_administrative_access](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
+Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+before the step #8 in the document: [configure administrative access](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
 
-2)	Upgrade scenario:
+iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
+
+2)	Upgrade:
 
 Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
-[HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
-
+[HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
 before management node rollout mentioned in: 
-[upgrade_csm_and_additional_products_with_iuf](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+[upgrade csm and_additional products with iuf](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
 
-3)	For already upgraded system:
+iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
 
-Please follow the steps mentioned in the document:
-[HSM_groups_iscsi](https://github.com/Cray-HPE/docs-csm/pull/6079/files#diff-775d94ec3760c7d8f5dfec207a07578957f166aafb548b7abe71084856c01aee)
+3)	Post upgrade:
 
-This involves creating the HSM group followed by cfs configuration/ component update for enabling iSCSI SBPS on the selected worker nodes.
+Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
+[HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+followed by `CFS` configuration/ component update for enabling iSCSI SBPS on the selected worker nodes.
 
-Post HSM groups creation, node personalisation can be done in two ways (except for aleady upgraded system):
+Post HSM groups creation, node personalisation can be done in two ways (except for already upgraded system):
 
 #### Automatic setup with bootprep
 

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -267,27 +267,27 @@ The SBPS Marshal Agent gets installed during node personalization using CFS.
 
 In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, selective worker node personalization is introduced and steps for the same for different scenarios is as below:
 
-1)	Fresh Install:
+1) Fresh Install:
+   1.1 Create HSM group:
+   1.2 Enable/ Configure iSCSI SBPS:
 
-Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
-before the step #8 in the document: [configure administrative access](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
-
-iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
-
-2)	Upgrade:
-
-Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
-[HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
-before management node rollout mentioned in: 
-[upgrade csm and_additional products with iuf](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+For creating HSM group, we need to create HSM group as mentioned in section `Steps to create HSM group` of [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md) before the step #8 in the document [configure administrative access] (https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
 
 iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
 
-3)	Post upgrade:
+2) Upgrade:
+   2.1 Create HSM group
+   2.2 Enable/ Configure iSCSI SBPS
 
-Create HSM group `iscsi_worker` as mentioned in section `Steps to create HSM group` of 
-[HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
-followed by `CFS` configuration/ component update for enabling iSCSI SBPS on the selected worker nodes.
+As mentioned in 1.1 create HSM group before management node rollout mentioned in [upgrade CSM and additional products with IUF](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+
+iSCSI SBPS will be enabled /configured during bootprep stage mentioned in [Automatic setup with bootprep](#automatic-setup-with-bootprep)
+
+3) Post Upgrade:
+   3.1 Create HSM group
+   3.2 Enable/ Configure iSCSI SBPS
+
+As mentioned in 1.1 create HSM group followed by `CFS` configuration/component update mentioned for enabling iSCSI SBPS on the selected worker nodes.
 
 Post HSM groups creation, node personalisation can be done in two ways (except for already upgraded system):
 

--- a/operations/iscsi_sbps/iscsi_sbps.md
+++ b/operations/iscsi_sbps/iscsi_sbps.md
@@ -271,23 +271,24 @@ In CSM 1.6.0, all worker nodes are configured as iSCSI targets. In CSM 1.7.0, se
    1.1 Create HSM group:
    1.2 Enable/ Configure iSCSI SBPS:
 
-For creating HSM group, we need to create HSM group as mentioned in section `Steps to create HSM group` of [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md) before the step #8 in the document [configure administrative access] (https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
+   For creating HSM group, we need to create HSM group as mentioned in section `Steps to create HSM group` of
+   [HSM groups iscsi](https://github.com/Cray-HPE/docs-csm/tree/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md). And this has to be done before the step #8 in the document [configure administrative access] (https://github.com/Cray-HPE/docs-csm/blob/release/1.7/install/configure_administrative_access.md)
 
-iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
+   iSCSI SBPS will be enabled /configured during bootprep stage mentioned at [Automatic setup with bootprep](#automatic-setup-with-bootprep)
 
 2) Upgrade:
    2.1 Create HSM group
    2.2 Enable/ Configure iSCSI SBPS
 
-As mentioned in 1.1 create HSM group before management node rollout mentioned in [upgrade CSM and additional products with IUF](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
+   As mentioned in 1.1 create HSM group before management node rollout mentioned in [upgrade CSM and additional products with IUF](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md)
 
-iSCSI SBPS will be enabled /configured during bootprep stage mentioned in [Automatic setup with bootprep](#automatic-setup-with-bootprep)
+   iSCSI SBPS will be enabled /configured during bootprep stage mentioned in [Automatic setup with bootprep](#automatic-setup-with-bootprep)
 
 3) Post Upgrade:
    3.1 Create HSM group
    3.2 Enable/ Configure iSCSI SBPS
 
-As mentioned in 1.1 create HSM group followed by `CFS` configuration/component update mentioned for enabling iSCSI SBPS on the selected worker nodes.
+   As mentioned in 1.1 create HSM group followed by `CFS` configuration/component update mentioned for enabling iSCSI SBPS on the selected worker nodes.
 
 Post HSM groups creation, node personalisation can be done in two ways (except for already upgraded system):
 


### PR DESCRIPTION
# Description

Selective worker node personalisation for iSCSI SBPS is introduced in CSM 1.7.0. This change is for documentation for the same.  

Relates to:
CASMPET-7260: 
https://github.com/Cray-HPE/csm-config/pull/357

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [NA] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information
