### PR TITLE
CASMPET-7604 postgres CRD install/upgrade fix

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -716,38 +716,54 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
-state_name="UPDATE_CRAY_POSTGRES_OPERATOR_CRDS"
-state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
-  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
-  {
-    postgres_chart_path=$(find "${CSM_ARTI_DIR}/helm" -name "cray-postgres-operator*.tgz")
-    if [[ -z $postgres_chart_path ]]; then
-      echo "Error: failed to find cray-postgres-operator chart in ${CSM_ARTI_DIR}/helm."
-      exit 1
-    fi
-    # check if file exists before applying crds, needed for backwards compatibility
-    if tar -tf "$postgres_chart_path" cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml > /dev/null 2>&1; then
-      # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
-      tar --extract --file="$postgres_chart_path" --to-stdout cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml | kubectl apply -f -
-      # 5 second sleep is necessary for cray-postgres-operator chart deploy. Chart fails with CRD error if no sleep
-      sleep 5
-    else
-      echo "File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in $postgres_chart_path"
-    fi
-  } >> "${LOG_FILE}" 2>&1
-  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
-else
-  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
-fi
+# We have a strange situation where upgrading the CRDs gets
+# reverted when the postgres operator is updated.  It doesn't
+# happen all the time, but a brute-force fix is to upgrade the
+# CRDs both before and after upgrading the postgres operator.
+
+update_cray_postgres_operator_crds() {
+  state_name=$1
+  state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+  if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+    echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+    {
+      postgres_chart_path=$(find "${CSM_ARTI_DIR}/helm" -name "cray-postgres-operator*.tgz")
+      if [[ -z $postgres_chart_path ]]; then
+        echo "Error: failed to find cray-postgres-operator chart in ${CSM_ARTI_DIR}/helm."
+        exit 1
+      fi
+      # check if file exists before applying crds, needed for backwards compatibility
+      postgres_crd_file=postgres-operator-crds-1.10.1.yaml
+      postgres_crd_path=$(tar -tf "${postgres_chart_path}" --no-anchored "${postgres_crd_file}" 2> /dev/null)
+      if [ -n "${postgres_crd_path}" ]; then
+        # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
+        tar --extract --file="${postgres_chart_path}" --to-stdout ${postgres_crd_path} | kubectl apply -f -
+      else
+        echo "File '${postgres_crd_file}' does not exist in ${postgres_chart_path}"
+      fi
+    } >> "${LOG_FILE}" 2>&1
+    record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+  else
+    echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+  fi
+}
+
+update_cray_postgres_operator_crds UPDATE_CRAY_POSTGRES_OPERATOR_CRDS
+# A 10 second sleep is necessary before cray-postgres-operator chart deploy. Chart fails with CRD error if no sleep
+sleep 10
 
 # Workaround for CASMTRIAGE-8332 before upgrading postgres-operator for CSM 1.7.x
-kubectl label --overwrite rolebinding --namespace default postgres-pod app.kubernetes.io/managed-by=Helm
-kubectl annotate --overwrite rolebinding --namespace default postgres-pod meta.helm.sh/release-name=cray-postgres-operator
-kubectl annotate --overwrite rolebinding --namespace default postgres-pod meta.helm.sh/release-namespace=services
+{
+  kubectl label --overwrite rolebinding --namespace default postgres-pod app.kubernetes.io/managed-by=Helm || true
+  kubectl annotate --overwrite rolebinding --namespace default postgres-pod meta.helm.sh/release-name=cray-postgres-operator || true
+  kubectl annotate --overwrite rolebinding --namespace default postgres-pod meta.helm.sh/release-namespace=services || true
+} >> "${LOG_FILE}" 2>&1
 
 # Upgrade postgres-operator
 do_upgrade_csm_chart cray-postgres-operator platform.yaml
+
+# Upgrade the postgres CRDs again
+update_cray_postgres_operator_crds RE_UPDATE_CRAY_POSTGRES_OPERATOR_CRDS
 
 state_name="FIX_POSTGRES"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")


### PR DESCRIPTION
# Description

Helm only installs CRDs during an initial install, and it does not install CRDs that already exist.
During an upgrade helm does not update CRDs, they
need to be upgraded manually, which is handled in
the prerequesits.sh script.

Issue:
  The prerequisites.sh script manually updates the
  postgres CRDs prior to upgrading cray-postgres-operator,
  but it has been observed that during that upgrade some
  of the CRDs get reverted for some unknown reason.
Fix:
  The CRDs are now updated both before and after
  the cray-postgres-operator upgrade.

Issue:
  The location of the CRD file in the helm chart has
  moved from the /files directory to the /crds directory
Fix:
  Use the --no-anchored option of tar and just the name
  of the CRD file to find the pathname in the chart to
  the CRD file.  This will work no matter which directory
  in which it is located in the chart

Issue:
  A 5 second sleep after updating the CRDs, prior to upgrading
  the cray-postgres-operator chart, occasionally was not enough
  time and the helm upgrade would fail with a CRD issue
Fix:
  Make it a 10 second sleep

Issue:
  It was discovered that a previous fix to add labels/annotations
  to the postgres-pod rolebinding would abort the script if they
  didn't exist, and that the messages for this were not going into
  the log file.
Fix:
  The commands are now redirected into the log file, and a
  "|| true" is added to each command so that if they fail the
  script will continue.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
# Testing

The section of code was extracted and put into a standalone script `pre.sh`, that had stubs and definitions to allow the code to be run.  Here are the results:
```
sigma7-1:~/cray-postgres-operator # ./pre.sh
====> UPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
====> RE_UPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
sigma7-1:~/cray-postgres-operator # cat LOG
====> UPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
Warning: resource customresourcedefinitions/operatorconfigurations.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do configured
Warning: resource customresourcedefinitions/postgresqls.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
Warning: resource customresourcedefinitions/postgresteams.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do configured
Error from server (NotFound): rolebindings.rbac.authorization.k8s.io "postgres-pod" not found
Error from server (NotFound): rolebindings.rbac.authorization.k8s.io "postgres-pod" not found
Error from server (NotFound): rolebindings.rbac.authorization.k8s.io "postgres-pod" not found
Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Wed Jun 25 18:44:37 2025
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
====> RE_UPDATE_CRAY_POSTGRES_OPERATOR_CRDS ...
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do unchanged
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do unchanged
sigma7-1:~/cray-postgres-operator # !vi
vi pre.sh
sigma7-1:~/cray-postgres-operator # helm history cray-postgres-operator -n services
REVISION	UPDATED                 	STATUS    	CHART                        	APP VERSION	DESCRIPTION     
1       	Wed Jun 25 18:44:00 2025	superseded	cray-postgres-operator-1.8.5 	1.8.2      	Install complete
2       	Wed Jun 25 18:44:37 2025	deployed  	cray-postgres-operator-1.10.2	1.10.1     	Upgrade complete
sigma7-1:~/cray-postgres-operator # kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
NAME                                     READY   STATUS    RESTARTS   AGE
cray-postgres-operator-c5895766d-46mb6   2/2     Running   0          80s
sigma7-1:~/cray-postgres-operator # 
```
Note the line towards the end:
```
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
```
that `configured` indicates that the CRD had gotten reverted, and now the new one was put back in place.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
