### PR TITLE
CASMTRIAGE-8340: update platform-utils in prerequisites

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1343,7 +1343,7 @@ state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
-	zypper --non-interactive update platform-utils
+    zypper --non-interactive update platform-utils
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1335,6 +1335,21 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Workaround for CASMTRIAGE-8340. A particular etcd test requires an updated
+# version of platform-utils, which is normally not available until we boot into
+# the newer node image, so we upgrade it here.
+state_name="UPDATE_PLATFORM_UTILS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+	zypper --non-interactive update platform-utils
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1337,13 +1337,15 @@ fi
 
 # Workaround for CASMTRIAGE-8340. A particular etcd test requires an updated
 # version of platform-utils, which is normally not available until we boot into
-# the newer node image, so we upgrade it here.
+# the newer node image, so we upgrade it here. We do the update on all masters,
+# to prevent issues if things are run out of order.
 state_name="UPDATE_PLATFORM_UTILS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
-    zypper --non-interactive update platform-utils
+    masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | grep -Ev "^$(hostname -s)$" | tr -t '\n' ',')
+    pdsh -S -b -w ${masters} "zypper --non-interactive update platform-utils"
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
# Description

Update `prerequisites.sh` to update `platform-utils` before running goss tests. A particular etcd test requires an updated version of `platform-utils`, which is normally not available until nodes reboot into new images, but which we now need to have beforehand.

An updated `platform-utils` ought to be available in Nexus by this point, so zypper should fetch the newest version and install it.

[CASMTRIAGE-8340](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8340)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA
