### PR TITLE
CASMCMS-9024 - include DST signing keys for ims kiwi-ng recipe builds.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ### Miscellaneous functionality
 
 * Console logs and interaction is now available and tenant aware through the `cray` CLI, see [console](operations/conman/ConMan.md#console) for more information.
+* Recipe builds using kiwi-ng now include the signing keys contained in the `hpe-signing-key` secret, which allows for the verification of the recipe build artifacts.
 
 ### New hardware support
 


### PR DESCRIPTION
# Description

Add to the release notes that IMS recipe builds now include the DST signing keys stored in the k8s secret.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
