### PR TITLE
CASMTRIAGE-8340: update platform utils to 1.7.1 in prerequisites

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1361,8 +1361,8 @@ if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | grep -Ev "^$(hostname -s)$" | tr -t '\n' ',')
-	# We install platform-utils 1.7.1 specifically as it contains a backported
-	# bugfix necessary for the etcd test to run.
+    # We install platform-utils 1.7.1 specifically as it contains a backported
+    # bugfix necessary for the etcd test to run.
     pdsh -S -b -w ${masters} "zypper --non-interactive update platform-utils=1.7.1"
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1351,6 +1351,25 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Workaround for CASMTRIAGE-8340. A particular etcd test requires an updated
+# version of platform-utils, which is normally not available until we boot into
+# the newer node image, so we upgrade it here. We do the update on all masters,
+# to prevent issues if things are run out of order.
+state_name="UPDATE_PLATFORM_UTILS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | grep -Ev "^$(hostname -s)$" | tr -t '\n' ',')
+	# We install platform-utils 1.7.1 specifically as it contains a backported
+	# bugfix necessary for the etcd test to run.
+    pdsh -S -b -w ${masters} "zypper --non-interactive update platform-utils=1.7.1"
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then


### PR DESCRIPTION
# Description

Update prerequisites.sh to install platform-utils 1.7.1 before running goss tests. A particular etcd test requires an updated version of platform-utils, which is normally not available until nodes reboot into new images, but which we now need to have beforehand. Additionally, we need to use 1.7.1 instead of the latest version, because 1.8.0 and higher require python11-boto3, which is unavailable in CSM 1.6, so we use a version with the bugfix backported.