### PR TITLE
CASMINST-7370: make API generator fail on inaccessible swagger URL

### DIFF
--- a/gen-api.sh
+++ b/gen-api.sh
@@ -64,9 +64,9 @@ find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
     echo "Downloading from ${endpoint_url} ..."
     if [[ ${endpoint_url} == *.md ]]; then
       echo "Endpoint ${endpoint_url} delivers markdown, does not require conversion."
-      curl -SsL -o "${dest_dir}/${endpoint_name}.md" "${endpoint_url}"
+      curl -SsLf -o "${dest_dir}/${endpoint_name}.md" "${endpoint_url}"
     else
-      curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+      curl -SsLf -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
       openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
       if [ -n "${endpoint_title}" ]; then
         ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"


### PR DESCRIPTION
# Description
When swagger URL is not accessible, [API docs generator](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/gen-api.sh) should fail to provide valid verification of URLs. It currently doesn't.

Tested locally using invalid URL provided by https://github.com/Cray-HPE/csm/pull/4223 (cray-rrs repo is currently private, so swagger URL is not accessible).

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
