### PR TITLE
CASMPET-7607: Undeploy old spire chart in prerequisites

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -253,6 +253,22 @@ function do_upgrade_csm_chart {
   fi
 }
 
+# Undeploy the chart if it exists on the system.
+# Use this if a chart has been removed from a manifest and needs
+# to be removed from the system as part of an upgrade.
+function undeploy() {
+  # Check if the chart exists by running helm status
+  if [[ $(helm status -o json "$@" 2> /dev/null | jq -r .info.status) == "deployed" ]]; then
+    echo "Chart ${*: -1} exists. Uninstalling it now."
+    # Remove the chart completely without keeping history.
+    helm uninstall "$@"
+    return $?
+  else
+    echo "Chart ${*: -1} doesn't exist"
+    return 0
+  fi
+}
+
 function is_vshasta_node {
   # This is the best check for an image specifically booted to vshasta
   [[ -f /etc/google_system ]] && return 0
@@ -558,6 +574,25 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Undeploy old spire chart if it exists
+# In 1.7 the old spire server is removed.
+# The new cray-spire server should be around from 1.5 on.
+state_name="UNDEPLOY_SPIRE_CHART"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    # We first need to change the serviceAccountName in cray-spire daemonset request-ncn-join-token in
+    # case it is using the cray-spire-request-ncn-join-token service account which will be deleted with the
+    # undeploy of spire.
+    kubectl patch daemonsets.apps -n spire request-ncn-join-token --type='json' -p='[{"op": "replace", "path": '/spec/template/spec/serviceAccountName', "value":"default"}]'
+    undeploy -n spire spire
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 # Pre-cache images needed for istio upgrade. As soon as cray-istio-pilot is upgraded, network
 # connection to nexus will be broken, due to istio proxy and istiod versions mismatch. Upgrade of
 # cray-istio will fix that, but images must be pre-cached for it to succeed.
@@ -587,22 +622,6 @@ kubectl annotate backupstoragelocations default -n velero \
   meta.helm.sh/release-namespace=velero --overwrite \
   && echo "Successfully annotated Velero Backup Storage Locations" \
   || echo "Failed to annotate Velero Backup Storage Locations"
-
-# Undeploy the chart if it exists on the system.
-# Use this if a chart has been removed from a manifest and needs
-# to be removed from the system as part of an upgrade.
-function undeploy() {
-  # Check if the chart exists by running helm status
-  if [[ $(helm status -o json "$@" 2> /dev/null | jq -r .info.status) == "deployed" ]]; then
-    echo "Chart ${*: -1} exists. Uninstalling it now."
-    # Remove the chart completely without keeping history.
-    helm uninstall "$@"
-    return $?
-  else
-    echo "Chart ${*: -1} doesn't exist"
-    return 0
-  fi
-}
 
 # Undeploy Istio charts if they exist
 # cray-istio-operator and cray-istio-deploy are removed with upgrade to Istio 1.26.0


### PR DESCRIPTION
# Description
Undeploy the old spire chart in `prerequisites.sh` so that we don't have to spend time fixing/reinitializing the `spire-postgres` cluster only to remove it when csm's `upgrade.sh` is executed.

# Testing
Upgrade on `molly` with `prerequisites.sh` change succeeded ...
```
ncn-m001:~ # cat /etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001/state
[2025-06-27 17:31:14] BACKUP_SNAPSHOT
[2025-06-27 17:31:15] CHECK_WEAVE
[2025-06-27 17:32:12] UPDATE_SSH_KEYS
[2025-06-27 17:33:20] REPAIR_AND_VERIFY_CHRONY_CONFIG
[2025-06-27 17:33:53] CHECK_CLOUD_INIT_PREREQ
[2025-06-27 17:33:54] UPDATE_DOC_RPM
[2025-06-27 17:33:57] UPDATE_CUSTOMIZATIONS
[2025-06-27 17:57:06] SETUP_NEXUS
[2025-06-27 17:57:11] UPGRADE_SYSMGMT_CHART_CSM_CONFIG
[2025-06-27 17:58:12] WAIT_FOR_CSM_CONFIG_IMPORT
[2025-06-27 17:58:13] UNDEPLOY_SPIRE_CHART
[2025-06-27 17:58:37] PRECACHE_ISTIO_IMAGES
[2025-06-27 17:58:38] UNDEPLOY_ISTIO_CHARTS
[2025-06-27 17:58:50] LABEL_ISTIO_BASE_RESOURCES
[2025-06-27 17:58:55] UPGRADE_PLATFORM_CHART_CRAY_ISTIO_BASE
[2025-06-27 17:59:04] LABEL_ISTIO_PILOT_RESOURCES
[2025-06-27 17:59:08] UPGRADE_PLATFORM_CHART_CRAY_ISTIO_PILOT
[2025-06-27 17:59:28] LABEL_ISTIO_INGRESS_RESOURCES
[2025-06-27 18:00:22] UPGRADE_PLATFORM_CHART_CRAY_ISTIO_INGRESS
[2025-06-27 18:00:25] UPGRADE_PLATFORM_CHART_CRAY_KIALI
[2025-06-27 18:00:26] DELETE_CRAY_ISTIO_HELM_SECRETS
[2025-06-27 18:53:19] RESTART_SERVICES_REFRESH_ISTIO
[2025-06-27 18:53:20] UPDATE_CRAY_POSTGRES_OPERATOR_CRDS
[2025-06-27 18:53:47] UPGRADE_PLATFORM_CHART_CRAY_POSTGRES_OPERATOR
[2025-06-27 18:53:50] RE_UPDATE_CRAY_POSTGRES_OPERATOR_CRDS
[2025-06-27 18:59:53] FIX_POSTGRES
[2025-06-27 19:12:49] UPLOAD_NEW_NCN_IMAGE
[2025-06-27 19:12:52] UPDATE_CLOUD_INIT_RECORDS
[2025-06-27 19:13:23] UPDATE_NCN_CLOUD_INIT_PACKAGE_LISTS_AND_REPO_DEFINITIONS
[2025-06-27 19:13:39] UPDATE_NCN_KERNEL_PARAMETERS
[2025-06-27 19:13:49] UPGRADE_PRECACHE_CHART
[2025-06-27 19:13:52] UPGRADE_PLATFORM_CHART_TRUSTEDCERTS_OPERATOR
[2025-06-27 19:13:55] BACKUP_BSS_DATA
[2025-06-27 19:14:08] UPDATE_BSS_DATA_NCNS
[2025-06-27 19:14:08] PREPARE_KUBEADM
[2025-06-27 19:20:15] REMOVE_PSP
[2025-06-27 19:36:06] POSTGRES_REINIT
[2025-06-27 19:36:09] UPDATE_PLATFORM_UTILS
[2025-06-27 19:39:46] PREFLIGHT_CHECK
ncn-m001:~ #


Total Duration: 180.001s
Count: 19, Failed: 0, Skipped: 5
====> PREFLIGHT_CHECK has been completed
tail: output.log: file truncated

^C
ncn-m001:~ # kubectl get pods -n spire
NAME                                          READY   STATUS      RESTARTS   AGE
cray-spire-agent-cq7sv                        1/1     Running     0          3h49m
cray-spire-agent-p2mv6                        1/1     Running     0          3h49m
cray-spire-agent-xmx9q                        1/1     Running     0          3h49m
cray-spire-create-pooler-schema-1-l7r42       0/3     Completed   0          3h49m
cray-spire-jwks-7896948f4b-49w4r              3/3     Running     0          66m
cray-spire-jwks-7896948f4b-d84xl              3/3     Running     0          66m
cray-spire-jwks-7896948f4b-ghhmz              3/3     Running     0          65m
cray-spire-postgres-0                         3/3     Running     0          26m
cray-spire-postgres-1                         3/3     Running     0          37m
cray-spire-postgres-2                         3/3     Running     0          26m
cray-spire-postgres-pooler-5997f6f6f5-5mr2w   2/2     Running     0          3h46m
cray-spire-postgres-pooler-5997f6f6f5-rhpmg   2/2     Running     0          3h46m
cray-spire-postgres-pooler-5997f6f6f5-xvrcw   2/2     Running     0          3h46m
cray-spire-postgres-pooler-85bf68f64b-d6z5s   0/2     Pending     0          66m
cray-spire-server-0                           2/2     Running     0          3h49m
cray-spire-server-1                           2/2     Running     0          3h46m
cray-spire-server-2                           2/2     Running     0          3h45m
cray-spire-update-bss-1-v6nmn                 0/2     Completed   0          3h15m
request-ncn-join-token-2xbrh                  2/2     Running     0          65m
request-ncn-join-token-6kn9t                  2/2     Running     0          65m
request-ncn-join-token-6lls9                  2/2     Running     0          65m
request-ncn-join-token-9wtq5                  2/2     Running     0          66m
request-ncn-join-token-g4q2x                  2/2     Running     0          64m
request-ncn-join-token-gjmkl                  2/2     Running     0          65m
tpm-provisioner-0                             2/2     Running     0          66m
ncn-m001:~ # helm list -n spire
NAME           	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                	APP VERSION
cray-spire     	spire    	1       	2025-06-27 15:53:13.019529551 +0000 UTC	deployed	cray-spire-1.6.8     	1.5.5
tpm-provisioner	spire    	1       	2025-06-27 15:34:10.508192194 +0000 UTC	deployed	tpm-provisioner-1.0.0	1.0.1
ncn-m001:~ # helm history -n spire spire
Error: release: not found
ncn-m001:~ #
```

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
