### PR TITLE
CASM-5648: Updated cray-product-catalog-update image version to 1.9.1 for release/1.5

### DIFF
--- a/workflows/templates/base/update-product-catalog.template.argo.yaml
+++ b/workflows/templates/base/update-product-catalog.template.argo.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,7 @@ spec:
     inputs:
       parameters:
         - name: cray-product-catalog-update-image
-          value: "artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:1.8.8"
+          value: "artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:1.9.1"
         - name: product-catalog-configmap-name
           value: "cray-product-catalog"
         - name: product-catalog-configmap-namespace


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

The cray-product-catalog-update image version 1.8.8 was not included in the CSM 1.5.x tarball. During recent live debugging, as noted by @haroldlongley in the related ticket, the image was updated to version 1.9.1 as a workaround. This PR reflects that change by updating the image version to 1.9.1 in the release/1.5 branch.

Resolves [CASM-5648](https://jira-pro.it.hpe.com:8443/browse/CASM-5648) raised for [CAST-38344](https://jira-pro.it.hpe.com:8443/browse/CAST-38344)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
