### PR TITLE
CASMNET-2344 - Cilium migration cannot be rerun in the event of a failure.

### DIFF
--- a/workflows/templates/cilium.migrate.yaml
+++ b/workflows/templates/cilium.migrate.yaml
@@ -82,7 +82,7 @@ spec:
               - name: scriptContent
                 value: |
                   TARGET_NCN="{{inputs.parameters.targetNcn}}"
-                  ssh "${TARGET_NCN}" mv /etc/cni/net.d/10-weave.conflist /etc/cni/net.d/10-weave.conflist.cilium_bak
+                  ssh "${TARGET_NCN}" "if [[ -f /etc/cni/net.d/10-weave.conflist ]]; then mv /etc/cni/net.d/10-weave.conflist /etc/cni/net.d/10-weave.conflist.cilium_bak;fi"
         - name: migrate-multus-config
           dependencies:
             - drain

--- a/workflows/templates/cilium.post-migrate.yaml
+++ b/workflows/templates/cilium.post-migrate.yaml
@@ -133,7 +133,7 @@ spec:
                   export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
                   export WEAVE_MTU=$(craysys metadata get kubernetes-weave-mtu)
                   envsubst < /srv/cray/resources/common/weave.yaml > /tmp/weave.yaml 
-                  kubectl delete -f /tmp/weave.yaml
+                  kubectl delete -f /tmp/weave.yaml --ignore-not-found=true
                   sleep 30
         - name: update-bss-primary-cni
           dependencies:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

There are two scenarios that prevent the Cilium migration workflow from being rerun.

The first occurs if the node has already been migrated and the `10-weave.conflist` file has already been moved out of the way.
```
cilium-live-migration-8438d-shell-script-1860055568: TARGET_NCN="ncn-m001"
cilium-live-migration-8438d-shell-script-1860055568: ++ TARGET_NCN=ncn-m001
cilium-live-migration-8438d-shell-script-1860055568: ssh "${TARGET_NCN}" mv /etc/cni/net.d/10-weave.conflist /etc/cni/net.d/10-weave.conflist.cilium_bak
cilium-live-migration-8438d-shell-script-1860055568: ++ ssh ncn-m001 mv /etc/cni/net.d/10-weave.conflist /etc/cni/net.d/10-weave.conflist.cilium_bak
cilium-live-migration-8438d-shell-script-1860055568: mv: cannot stat '/etc/cni/net.d/10-weave.conflist': No such file or directory
cilium-live-migration-8438d-shell-script-1860055568: Error: exit status 1
```
The second occurs at the end of the workflow if the Weave resources have already been deleted from the system.
```
cilium-live-migration-4c9b5-shell-script-324046327: kubectl delete -f /tmp/weave.yaml
cilium-live-migration-4c9b5-shell-script-324046327: ++ kubectl delete -f /tmp/weave.yaml
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": serviceaccounts "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": clusterroles.rbac.authorization.k8s.io "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": clusterrolebindings.rbac.authorization.k8s.io "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": roles.rbac.authorization.k8s.io "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": rolebindings.rbac.authorization.k8s.io "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error from server (NotFound): error when deleting "/tmp/weave.yaml": daemonsets.apps "weave-net" not found
cilium-live-migration-4c9b5-shell-script-324046327: Error: exit status 1
```

This PR handles both these cases so that the entire workflow can be rerun if necessary.

These changes have been tested on the vshasta system `molly`.

Relates to:
- [CASMNET-2344](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2344)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
