### PR TITLE
CASMPET-7608: Add 5 minute wait for nexus pod to be Ready after worker drain

### DIFF
--- a/upgrade/scripts/k8s/upgrade_k8s.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s.sh
@@ -256,6 +256,9 @@ for host in ${workers}; do
     ssh "${host}" zypper --non-interactive install "kubernetes-cni-${k8s_cni[${minor_target_version}]}"
     ssh "${host}" kubeadm upgrade node
     kubectl drain --ignore-daemonsets --delete-emptydir-data "${host}"
+    # Wait for nexus pod to be Ready
+    echo "$(prefix) Wait for nexus to be Ready ..."
+    kubectl wait pod -n nexus -l app=nexus --for=condition=Ready --timeout=5m
 
     # Fix /etc/sysconfig/kubelet
     fix_sysconfig "${host}"


### PR DESCRIPTION

# Description
When the worker node that the nexus pod is running on is drained, it sometimes takes a bit for the nexus service to become available after it is evicted.  The `upgrade_k8s.sh` script needs to wait for nexus to be `Ready` before attempting to do a `zypper install`.

# Testing
Did a quick test on `molly` by draining the worker node that nexus was running on, running `kubectl wait`, and then doing a `zypper search` to make sure the `kubectl` packages were available.

```
ncn-m001:~ # kubectl get pod -n nexus -o wide
NAME                         READY   STATUS    RESTARTS   AGE    IP            NODE       NOMINATED NODE   READINESS GATES
cray-precache-images-4ddxs   1/1     Running   0          70m    10.48.5.67    ncn-w002   <none>           <none>
cray-precache-images-f98qq   1/1     Running   0          70m    10.48.2.217   ncn-w001   <none>           <none>
cray-precache-images-n5vst   1/1     Running   0          70m    10.48.0.227   ncn-w003   <none>           <none>
nexus-69945b67dc-w72gj       2/2     Running   0          179m   10.48.2.85    ncn-w001   <none>           <none>
ncn-m001:~ # kubectl drain --ignore-daemonsets --delete-emptydir-data ncn-w001
node/ncn-w001 cordoned

<snip>

evicting pod services/cray-shared-kafka-zookeeper-1
pod/cray-shared-kafka-zookeeper-1 evicted
evicting pod services/cray-shared-kafka-kafka-0
pod/cray-shared-kafka-kafka-0 evicted
node/ncn-w001 drained
ncn-m001:~ # kubectl wait pod -n nexus -l app=nexus --for=condition=Ready --timeout=5m
pod/nexus-69945b67dc-fbm9v condition met
ncn-m001:~ # ssh ncn-w001 zypper search -s kubectl
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ED25519 key sent by the remote host is
SHA256:9dDoDzbet0y2HBEoRU2oqs02SuVumMybhe1OkgXEreE.
Please contact your system administrator.
Add correct host key in /root/.ssh/known_hosts to get rid of this message.
Offending ECDSA key in /root/.ssh/known_hosts:18
You can use following command to remove the offending key:
ssh-keygen -R ncn-w001 -f /root/.ssh/known_hosts
Password authentication is disabled to avoid man-in-the-middle attacks.
Keyboard-interactive authentication is disabled to avoid man-in-the-middle attacks.
UpdateHostkeys is disabled because the host key is not trusted.
Loading repository data...
Reading installed packages...

S  | Name                          | Type    | Version            | Arch   | Repository
---+-------------------------------+---------+--------------------+--------+---------------------------------------------
i+ | cray-kubectl-hns-plugin       | package | 1.0.2-1            | x86_64 | CSM Embedded NCN Packages (added by Ansible)
i+ | cray-kubectl-kubelogin-plugin | package | 1.25.3-1           | x86_64 | CSM Embedded NCN Packages (added by Ansible)
i+ | kubectl                       | package | 1.32.5-150500.1.1  | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.31.8-150500.1.1  | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.30.12-150500.1.1 | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.29.15-150500.1.1 | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.28.15-150500.1.1 | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.27.16-150500.1.1 | x86_64 | CSM No-OS Packages (added by Ansible)
v  | kubectl                       | package | 1.26.15-150500.1.1 | x86_64 | CSM No-OS Packages (added by Ansible)
ncn-m001:~ # kubectl uncordon ncn-w001
node/ncn-w001 uncordoned
ncn-m001:~ #
```

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
