### PR TITLE
CASMPET-7609: upgrade_k8s.sh log prefix

### DIFF
--- a/upgrade/scripts/k8s/upgrade_k8s.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s.sh
@@ -102,7 +102,8 @@ pause["1.31"]="3.10"
 pause["1.32"]="3.10"
 
 function prefix() {
-  echo -n "$(date --iso-8601=seconds) $(basename "$0")"
+  # We hardcode a log level of INFO for now to ensure IUF displays our logs.
+  echo -n "INFO $(date --iso-8601=seconds) $(basename "$0")"
 }
 
 function fix_sysconfig() {


### PR DESCRIPTION
# Description

Add an `INFO` prefix to all log lines in upgrade_k8s.sh to ensure that IUF displays log output from this script. We hardcoded this particular log level in the interest of time.

[CASMPET-7609](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7609)

This was tested on `molly` by re-running the `deploy-product` IUF stage, which calls `upgrade_k8s.sh`. The script-specific log output is successfully captured by IUF, as expected.