### PR TITLE
CASMTRIAGE-8379: Upgrade platform-utils to 1.7.1 on all ncns

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1374,17 +1374,17 @@ fi
 
 # Workaround for CASMTRIAGE-8340. A particular etcd test requires an updated
 # version of platform-utils, which is normally not available until we boot into
-# the newer node image, so we upgrade it here. We do the update on all masters,
-# to prevent issues if things are run out of order.
+# the newer node image, so we upgrade it here. We do the update on all ncns,
+# for consistency.
 state_name="UPDATE_PLATFORM_UTILS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
-    masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | grep -Ev "^$(hostname -s)$" | tr -t '\n' ',')
+    ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
     # We install platform-utils 1.7.1 specifically as it contains a backported
     # bugfix necessary for the etcd test to run.
-    pdsh -S -b -w ${masters} "zypper --non-interactive update platform-utils=1.7.1"
+    pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils=1.7.1"
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
# Description
Upgrade `platform-utils` to 1.7.1 on all ncns before PREFLIGHT_CHECK in `prerequisites.sh` to pick up an etcd test fix.

# Testing
Tested on `vinland`
```
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # echo $ncns
ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003,ncn-w004,ncn-w005,
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 #
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils=1.7.1"
ncn-s001: Loading repository data...
ncn-m001: Loading repository data...
ncn-s002: Loading repository data...
ncn-s003: Loading repository data...
ncn-s001: Reading installed packages...
ncn-m001: Reading installed packages...
ncn-s002: Reading installed packages...
ncn-s003: Reading installed packages...
ncn-m002: Loading repository data...
ncn-m002: Reading installed packages...
ncn-m003: Loading repository data...
ncn-m003: Reading installed packages...

<snip>

ncn-w002: Loading repository data...
ncn-w001: Loading repository data...
ncn-w002: Reading installed packages...
ncn-w001: Reading installed packages...
ncn-w004: Loading repository data...
ncn-m002: There is an update candidate 'platform-utils-1.8.3-1.noarch' for 'platform-utils-1.7.1-1.noarch', but it does not match the specified version, architecture, or repository.
ncn-m002: Resolving package dependencies...
ncn-w004: Reading installed packages...

<snip>

ncn-w003: Reading installed packages...
ncn-w005: Loading repository data...
ncn-w001: There is an update candidate 'platform-utils-1.8.3-1.noarch' for 'platform-utils-1.7.0-1.noarch', but it does not match the specified version, architecture, or repository.
ncn-w001: Resolving package dependencies...
ncn-w002: There is an update candidate 'platform-utils-1.8.3-1.noarch' for 'platform-utils-1.7.0-1.noarch', but it does not match the specified version, architecture, or repository.
ncn-w002: Resolving package dependencies...

<snip>

ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # ssh ncn-s001 rpm -qa platform-utils
platform-utils-1.7.1-1.noarch
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # ssh ncn-s003 rpm -qa platform-utils
platform-utils-1.7.1-1.noarch
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # ssh ncn-w003 rpm -qa platform-utils
platform-utils-1.7.1-1.noarch
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # ssh ncn-w005 rpm -qa platform-utils
platform-utils-1.7.1-1.noarch
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 # rpm -qa platform-utils
platform-utils-1.7.1-1.noarch
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-beta.1/ncn-m001 #
```

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
