### PR TITLE
CASMTRIAGE-8373 drax: prerequisites.sh, UPDATE_CRAY_POSTGRES_OPERATOR_CRDS failing.

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -755,8 +755,19 @@ update_cray_postgres_operator_crds() {
       postgres_crd_file=postgres-operator-crds-1.10.1.yaml
       postgres_crd_path=$(tar -tf "${postgres_chart_path}" --no-anchored "${postgres_crd_file}" 2> /dev/null)
       if [ -n "${postgres_crd_path}" ]; then
+        # Remove the "last-applied-configuration" and "preserveUnknownFields" fields
+        postgres_crds=$(kubectl get crd -l app.kubernetes.io/name=postgres-operator -o jsonpath='{.items[*].metadata.name}')
+        for crd in ${postgres_crds}; do
+          kubectl patch --type merge crd ${crd} -p '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration": null}},"spec":{"preserveUnknownFields": null}}'
+        done
         # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
         tar --extract --file="${postgres_chart_path}" --to-stdout ${postgres_crd_path} | kubectl apply -f -
+        # Remove the last-applied-configuration that "kubectl apply" added
+        # Just in case, fetch the list of crds again
+        postgres_crds=$(kubectl get crd -l app.kubernetes.io/name=postgres-operator -o jsonpath='{.items[*].metadata.name}')
+        for crd in ${postgres_crds}; do
+          kubectl patch --type merge crd ${crd} -p '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration": null}}}'
+        done
       else
         echo "File '${postgres_crd_file}' does not exist in ${postgres_chart_path}"
       fi


### PR DESCRIPTION
# Description
When upgrading drax to 1.7 via:

     1.3.5 -> 1.4.4 -> 1.5.4 -> 1.6.2-rc.1 -> 1.7.0-beta.1

the postgres CRD update in CSM 1.7 failed with

    The CustomResourceDefinition "operatorconfigurations.acid.zalan.do"
    is invalid: spec.preserveUnknownFields: Invalid value: true: must
    be false in order to use defaults in the schema

This does not happen on an upgrade from a fresh 1.6 install, so this is carry-over from an earlier install or upgrade.

This is fixed by patching the current CRDs to remove the spec.preserveUnknownFields field, prior to updating the CRDs.

And since we're patching the CRDs anyway, also remove the "last-applied-configuration" annotation that kubectl added.

Relates to:
 * [CASMTRIAGE-8373 ](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8373)

Testing:
Tested in isolation on `sigma7-1`, a CSM 1.7 Mercury deployment.  It was also tested in isolation on `drax` using the `--dry-run=server` option of `kubectl`.  It has now been patched on `drax`, and the upgrade is being resumed.
# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
