### PR TITLE
CASMTRIAGE-8339: Configure istio hpa to system size

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -9,6 +9,7 @@ directory which contains important customizations for various products.
     1. [Setup LDAP configuration](#setup-ldap-configuration)
     1. [Customize DNS Configuration](#customize-dns-configuration)
     1. [Configure Prometheus SNMP Exporter](#configure-prometheus-snmp-exporter)
+    1. [Configure Max Istio Gateway Pods](#configure-max-istio-gateway-pods)
 1. [Encrypt secrets](#4-encrypt-secrets)
 1. [Customer-Specific Customizations](#5-customer-specific-customizations)
 
@@ -416,6 +417,60 @@ the [Prometheus SNMP Exporter](../operations/network/management_network/snmp_exp
 information and review the
 [Adding SNMP Credentials to the System](../operations/network/management_network/snmp_exporter_configs.md#adding-snmp-credentials-to-the-system)
 section for links to the relevant procedures.
+
+### Configure Max Istio Gateway Pods
+
+The Istio Gatways have a Horizontal Pod Autoscaler configured to allow Kubernetes to grow and shrink the
+deployment as needed due to increased load. This by default is configured to a max of 6 and a minumum of 3
+pods. On some smaller systems this leads to Kubernetes attempting to start up more pods than avaliable
+worker nodes. This leads to test failures and a pod stuck in the pending state. The minumum and maximum
+should be configured to fit the system.
+
+This step can be skipped if the default of a maximum of 6 pods and a minimum of 3 pods is approprate for
+the system size.
+
+1. (`pit#`) Set the minimum and maximum replicas wanted
+
+> ***NOTE*** the maximum should not be higher than the total number of worker nodes on a system, and
+the minimum has to be less than or equal to the maximum. This can have both be the same value but
+that will mean the pods will never automatically create or remove pods as load changes.
+
+```bash
+max_amount=4
+min_amount=3
+```
+
+1. (`pit#`) Update the customizations file.
+
+```bash
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway.autoscaleMax' \
+  "$max_amount"
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway.autoscaleMin' \
+  "$min_amount"
+
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-admin.autoscaleMax' \
+  "$max_amount"
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-admin.autoscaleMin' \
+  "$min_amount"
+
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-user.autoscaleMax' \
+  "$max_amount"
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-user.autoscaleMin' \
+  "$min_amount"
+
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-hmn.autoscaleMax' \
+  "$max_amount"
+yq write -i ${SITE_INIT}/customizations.yaml \
+  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-hmn.autoscaleMin' \
+  "$min_amount"
+```
 
 ## 4. Encrypt secrets
 

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -443,33 +443,14 @@ min_amount=3
 1. (`pit#`) Update the customizations file.
 
 ```bash
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway.autoscaleMax' \
-  "$max_amount"
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway.autoscaleMin' \
-  "$min_amount"
-
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-admin.autoscaleMax' \
-  "$max_amount"
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-admin.autoscaleMin' \
-  "$min_amount"
-
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-user.autoscaleMax' \
-  "$max_amount"
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-customer-user.autoscaleMin' \
-  "$min_amount"
-
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-hmn.autoscaleMax' \
-  "$max_amount"
-yq write -i ${SITE_INIT}/customizations.yaml \
-  'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway-hmn.autoscaleMin' \
-  "$min_amount"
+for gw in "" -customer-admin -customer-user -hmn; do
+  yq write -i ${SITE_INIT}/customizations.yaml \
+    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax' \
+    "$max_amount"
+  yq write -i ${SITE_INIT}/customizations.yaml \
+    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin' \
+    "$min_amount"
+done
 ```
 
 ## 4. Encrypt secrets

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -420,13 +420,13 @@ section for links to the relevant procedures.
 
 ### Configure Max Istio Gateway Pods
 
-The Istio Gatways have a Horizontal Pod Autoscaler configured to allow Kubernetes to grow and shrink the
-deployment as needed due to increased load. This by default is configured to a max of 6 and a minumum of 3
-pods. On some smaller systems this leads to Kubernetes attempting to start up more pods than avaliable
-worker nodes. This leads to test failures and a pod stuck in the pending state. The minumum and maximum
+The Istio Gateways have a `Horizontal Pod Autoscaler` configured to allow Kubernetes to grow and shrink the
+deployment as needed due to increased load. This by default is configured to a max of 6 and a minimum of 3
+pods. On some smaller systems this leads to Kubernetes attempting to start up more pods than available
+worker nodes. This leads to test failures and a pod stuck in the pending state. The minimum and maximum
 should be configured to fit the system.
 
-This step can be skipped if the default of a maximum of 6 pods and a minimum of 3 pods is approprate for
+This step can be skipped if the default of a maximum of 6 pods and a minimum of 3 pods is appropriate for
 the system size.
 
 1. (`pit#`) Set the minimum and maximum replicas wanted

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -429,29 +429,29 @@ should be configured to fit the system.
 This step can be skipped if the default of a maximum of 6 pods and a minimum of 3 pods is appropriate for
 the system size.
 
-1. (`pit#`) Set the minimum and maximum replicas wanted
+1. (`pit#`) Set the minimum and maximum replicas wanted.
 
-> ***NOTE*** the maximum should not be higher than the total number of worker nodes on a system, and
-the minimum has to be less than or equal to the maximum. This can have both be the same value but
-that will mean the pods will never automatically create or remove pods as load changes.
+    > ***NOTE:*** The maximum should not be higher than the total number of worker nodes on a system, and
+    the minimum has to be less than or equal to the maximum. This can have both be the same value but
+    that will mean the pods will never automatically create or remove pods as load changes.
 
-```bash
-max_amount=4
-min_amount=3
-```
+    ```bash
+    max_amount=4
+    min_amount=3
+    ```
 
 1. (`pit#`) Update the customizations file.
 
-```bash
-for gw in "" -customer-admin -customer-user -hmn; do
-  yq write -i ${SITE_INIT}/customizations.yaml \
-    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax' \
-    "$max_amount"
-  yq write -i ${SITE_INIT}/customizations.yaml \
-    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin' \
-    "$min_amount"
-done
-```
+    ```bash
+    for gw in "" -customer-admin -customer-user -hmn; do
+      yq write -i ${SITE_INIT}/customizations.yaml \
+        'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax' \
+        "$max_amount"
+      yq write -i ${SITE_INIT}/customizations.yaml \
+        'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin' \
+        "$min_amount"
+    done
+    ```
 
 ## 4. Encrypt secrets
 

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -148,15 +148,13 @@ worker_count=$(cray hsm state components list --role Management --subrole Worker
 istio_ingress_path=".spec.kubernetes.services.cray-istio-ingress.deployments"
 
 if [ $worker_count -lt 6 ]; then
-  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway.autoscaleMax = $worker_count)) += 0" "$c"
-  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMax = $worker_count)) += 0" "$c"
-  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMax = $worker_count)) += 0" "$c"
-  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMax = $worker_count)) += 0" "$c"
+  for gw in "" -customer-admin -customer-user -hmn; do
+    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway${gw}.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway${gw}.autoscaleMax = $worker_count)) += 0" "$c"
+  done
   if [ $worker_count -lt 3 ]; then
-    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway.autoscaleMin = $worker_count)) += 0" "$c"
-    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMin = $worker_count)) += 0" "$c"
-    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMin = $worker_count)) += 0" "$c"
-    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMin = $worker_count)) += 0" "$c"
+    for gw in "" -customer-admin -customer-user -hmn; do
+      yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway${gw}.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway${gw}.autoscaleMin = $worker_count)) += 0" "$c"
+    done
   fi
 fi
 

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -143,6 +143,23 @@ fi
 yq4 eval -i 'del(.spec.proxiedWebAppExternalHostnames.customerManagement.[] | select(. == "*cray-istio*"))' "$c"
 yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement += \"{{ kubernetes.services['cray-istio-ingress'].istio.tracing.externalAuthority }}\"" -i "$c"
 
+# Update cray-istio-ingress HPA to limit to amount of workers avaliable
+worker_count=$(cray hsm state components list --role Management --subrole Worker --type Node --format json | jq -r '.Components | map(.ID) | join("\n")' | wc -l)
+istio_ingress_path=".spec.kubernetes.services.cray-istio-ingress.deployments"
+
+if [ $worker_count -lt 6 ]; then
+  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway.autoscaleMax = $worker_count)) += 0" "$c"
+  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMax = $worker_count)) += 0" "$c"
+  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMax = $worker_count)) += 0" "$c"
+  yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMax // (${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMax = $worker_count)) += 0" "$c"
+  if [ $worker_count -lt 3 ]; then
+    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway.autoscaleMin = $worker_count)) += 0" "$c"
+    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-customer-admin.autoscaleMin = $worker_count)) += 0" "$c"
+    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-customer-user.autoscaleMin = $worker_count)) += 0" "$c"
+    yq4 eval -i "(${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMin // (${istio_ingress_path}.istio-ingressgateway-hmn.autoscaleMin = $worker_count)) += 0" "$c"
+  fi
+fi
+
 metallb_path='.spec.kubernetes.services."cray-metallb".metallb'
 config_inline_key='configInline'
 config_inline_new_key='configInlineHistorical'


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This adds a section to configure the istio hpa so it matches a system size. This will automatically setup on upgrade for smaller systems, and adds a note in the install for fresh installs.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
