### PR TITLE
CASMTRIAGE-8378: delete upgrade file in post-upgrade cleanup

### DIFF
--- a/upgrade/scripts/upgrade/cleanup.sh
+++ b/upgrade/scripts/upgrade/cleanup.sh
@@ -31,3 +31,4 @@ TOKEN=$(curl -s -S -d grant_type=client_credentials \
 export TOKEN
 
 python3 /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.py
+rm -f /etc/cray/kubernetes/upgrade

--- a/upgrade/scripts/upgrade/cleanup.sh
+++ b/upgrade/scripts/upgrade/cleanup.sh
@@ -31,4 +31,7 @@ TOKEN=$(curl -s -S -d grant_type=client_credentials \
 export TOKEN
 
 python3 /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.py
-rm -f /etc/cray/kubernetes/upgrade
+
+# Remove the upgrade file from all NCN hosts.
+ncns=$(grep -oP 'ncn-\aw\d+' /etc/hosts | sort -u | tr -t '\n' ',')
+pdsh -S -b -w ${ncns} "rm -f /etc/cray/kubernetes/upgrade"

--- a/upgrade/scripts/upgrade/cleanup.sh
+++ b/upgrade/scripts/upgrade/cleanup.sh
@@ -33,5 +33,5 @@ export TOKEN
 python3 /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.py
 
 # Remove the upgrade file from all NCN hosts.
-ncns=$(grep -oP 'ncn-\aw\d+' /etc/hosts | sort -u | tr -t '\n' ',')
+ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
 pdsh -S -b -w ${ncns} "rm -f /etc/cray/kubernetes/upgrade"


### PR DESCRIPTION
# Description

Delete /etc/cray/kubernetes/upgrade file at the end of the post-upgrade cleanup process. BSS will ensure that this file doesn't get recreated on boot, but the file will continue to exist until a reboot, unless we delete it. This ensures that the file doesn't exist longer than it has to.