### PR TITLE
CASMTRIAGE-8425 - prerequisites.sh error at DELETE_CRAY_ISTIO_HELM_SECRETS

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -693,7 +693,7 @@ function delete_helm_secrets() {
   chart_name="$1"
 
   # Find all secrets matching the Helm release pattern for the given chart across all namespaces
-  secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$")
+  secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$" || [[ "$?" == "1" ]])
 
   if [[ -z $secrets ]]; then
     echo "No Helm secrets found for chart '$chart_name' in any namespace"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -693,7 +693,7 @@ function delete_helm_secrets() {
   chart_name="$1"
 
   # Find all secrets matching the Helm release pattern for the given chart across all namespaces
-  secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$" || [[ "$?" == "1" ]])
+  secrets=$(kubectl get secrets --all-namespaces --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" | grep "sh\.helm\.release\.v1\.$chart_name\.v[0-9]\+$" || [[ $? == 1 ]])
 
   if [[ -z $secrets ]]; then
     echo "No Helm secrets found for chart '$chart_name' in any namespace"


### PR DESCRIPTION
# Description

The `DELETE_CRAY_ISTIO_HELM_SECRETS` step of `prerequisites.sh` can fail if the system does not have the `cray-istio` Helm chart installed because `prerequisites.sh` is run with the bash `set -e` option and the return code from a failed grep isn't caught.

This PR catches the return code from grep so the existing error handling in `delete_helm_secrets()` works rather than the script aborting due to `set -e`.

This change has been tested on starlord during a CSM 1.7.0-alpha.22 to 1.7.0-beta.2 upgrade.

Relates to:
- [CASMTRIAGE-8425](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8425)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
