### PR TITLE
CASMTRIAGE-8424: Check if cray-istio-ingress configuration already exists

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -133,8 +133,10 @@ yq4 -i eval ".spec.proxiedWebAppExternalHostnames.customerManagement |= (. + [\"
 # to reflect this change. We will rename cray-istio to cray-istio-ingress and update the
 # proxiedWebAppExternalHostnames to use cray-istio-ingress instead of cray-istio.
 if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio"' "$c")" != "null" ]; then
-  # Copy the cray-istio configuration to cray-istio-ingress
-  yq4 eval -i '.spec.kubernetes.services."cray-istio-ingress" = .spec.kubernetes.services."cray-istio"' "$c"
+  # If the cray-istio-ingress configuration does not exist, copy the cray-istio configuration to cray-istio-ingress
+  if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c")" == "null" ]; then
+    yq4 eval -i '.spec.kubernetes.services."cray-istio-ingress" = .spec.kubernetes.services."cray-istio"' "$c"
+  fi
   # Delete the old cray-istio key
   yq4 eval -i 'del(.spec.kubernetes.services."cray-istio")' "$c"
 fi


### PR DESCRIPTION
# Description
CASMTRIAGE-8424: Check if cray-istio-ingress configuration already exists before setting it equal to the cray-istio configuration in the customizations.yaml.

When upgrading from 1.7.0-alpha.22 to 1.7.0-beta.2, both the "cray-istio" and "cray-istio-ingress" configurations were present in the `customizations.yaml`.  This appears to be a 1.7.0-alpha.22 issue or specific to `starlord` since `wasp` running 1.7.0-alpha.23 does not have a "cray-istio" configuration so would not hit this problem.

It was assumed that the "cray-istio" configuration would not exist in a CSM 1.7.0 `customizations.yaml`. If a "cray-istio" configuration exists, it must be a CSM 1.6 `customizations.yaml`, so copy the "cray-istio" configuration to the non-existent "cray-istio-ingress" configuration.  The 1.7.0-alpha.22 `customizations.yaml`, however,  had BOTH configurations, so the valid "cray-istio-ingress" configuration was overwritten.

Adding an additional check to check for the existence of the "cray-istio-ingress" configuration before overwriting with the old "cray-istio" configuration.  If the "cray-istio-ingress" configuration exists, leave it alone.

# Testing
On a 1.6.2 customizations.yaml file on `molly`:
```
ncn-m001:~/studenym # echo $c
customizations-1.6.2.yaml
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio"' "$c"
# Override for the ingress-gateway certificate (requested from
# cert-manager). The list of master nodes must be reviewed and
# updated per system until a source exists from which to dynamically
# source them.
certificate:
  dnsNames:
    - ncn-m001.local
    - ncn-m002.local
    - ncn-m003.local
<snip>
  istio-ingressgateway-hmn:
    autoscaleMin: 2
    autoscaleMax: 2
    rollingMaxUnavailable: 50%
    resources:
      requests:
        cpu: 50m
        memory: 256Mi
      limits:
        cpu: '2'
        memory: 4Gi
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c"
null
ncn-m001:~/studenym # if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio"' "$c")" != "null" ]; then
>   # Copy the cray-istio configuration to cray-istio-ingress
>   if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c")" == "null" ]; then
>     echo "cray-istio-ingress is null, so copy cray-istio to cray-istio-ingress"
>     yq4 eval -i '.spec.kubernetes.services."cray-istio-ingress" = .spec.kubernetes.services."cray-istio"' "$c"
>   fi
>   # Delete the old cray-istio key
>   yq4 eval -i 'del(.spec.kubernetes.services."cray-istio")' "$c"
> fi
cray-istio-ingress is null, so copy cray-istio to cray-istio-ingress
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio"' "$c"
null
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c"
# Override for the ingress-gateway certificate (requested from
# cert-manager). The list of master nodes must be reviewed and
# updated per system until a source exists from which to dynamically
# source them.
certificate:
  dnsNames:
    - ncn-m001.local
    - ncn-m002.local
    - ncn-m003.local
<snip>
  istio-ingressgateway-hmn:
    autoscaleMin: 2
    autoscaleMax: 2
    rollingMaxUnavailable: 50%
    resources:
      requests:
        cpu: 50m
        memory: 256Mi
      limits:
        cpu: '2'
        memory: 4Gi
ncn-m001:~/studenym #
```

On a 1.7.0-alpha.22 customizations.yaml on `starlord`:
```
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio"' "$c"
deployments:
  istio-ingressgateway:
    resources:
      requests:
        cpu: "50m"
  istio-ingressgateway-customer-admin:
    resources:
      requests:
        cpu: "50m"
  istio-ingressgateway-customer-user:
    resources:
      requests:
        cpu: "50m"
  istio-ingressgateway-hmn:
    resources:
      requests:
        cpu: "50m"
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c"
# Override for the ingress-gateway certificate (requested from
# cert-manager). The list of master nodes must be reviewed and
# updated per system until a source exists from which to dynamically
# source them.
certificate:
  dnsNames:
    - ncn-m001.local
    - ncn-m002.local
    - ncn-m003.local
<snip>
  istio-ingressgateway-local:
    loadBalancerIP: '{{ network.netstaticips.nmn_api_gw_local }}'
    serviceAnnotations:
      metallb.universe.tf/address-pool: node-management
istio:
  tracing:
    externalAuthority: jaeger-istio.cmn.{{ network.dns.external }}
ncn-m001:~/studenym # if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio"' "$c")" != "null" ]; then
>   # Copy the cray-istio configuration to cray-istio-ingress
>   if [ "$(yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c")" == "null" ]; then
>     yq4 eval -i '.spec.kubernetes.services."cray-istio-ingress" = .spec.kubernetes.services."cray-istio"' "$c"
>   fi
>   # Delete the old cray-istio key
>   yq4 eval -i 'del(.spec.kubernetes.services."cray-istio")' "$c"
> fi
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio"' "$c"
null
ncn-m001:~/studenym # yq4 eval '.spec.kubernetes.services."cray-istio-ingress"' "$c"
# Override for the ingress-gateway certificate (requested from
# cert-manager). The list of master nodes must be reviewed and
# updated per system until a source exists from which to dynamically
# source them.
certificate:
  dnsNames:
    - ncn-m001.local
    - ncn-m002.local
    - ncn-m003.local
<snip>
  istio-ingressgateway-local:
    loadBalancerIP: '{{ network.netstaticips.nmn_api_gw_local }}'
    serviceAnnotations:
      metallb.universe.tf/address-pool: node-management
istio:
  tracing:
    externalAuthority: jaeger-istio.cmn.{{ network.dns.external }}
ncn-m001:~/studenym #
```

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
