### PR TITLE
CASMTRIAGE-8426: fix PREPARE_KUBEADM in prerequisites.sh

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -36,6 +36,7 @@ trap 'err_report' ERR INT TERM HUP EXIT
 declare -a UNMOUNTS=()
 
 PRIMARY_NODE="ncn-m001"
+KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/version)
 
 while [[ $# -gt 0 ]]; do
   key=$1
@@ -1256,9 +1257,12 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Only run PREPARE_KUBEADM if we're on Kubernetes 1.24, otherwise the step will
+# fail. This can occur when upgrading internally between CSM 1.7 versions,
+# because Kubernetes will remain at 1.32.
 state_name="PREPARE_KUBEADM"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" ]]; then
+if [[ ${state_recorded} == "0" && ${KUBERNETES_MINOR_VERSION} -eq 24 ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     tmpdir=$(mktemp -d)

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1298,7 +1298,7 @@ fi
 # Removing PodSecurityPolicy causes cascading restarts of many pods.
 state_name="REMOVE_PSP"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" ]]; then
+if [[ ${state_recorded} == "0" && ${KUBERNETES_MINOR_VERSION} -eq 24 ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     # Get all master nodes


### PR DESCRIPTION
# Description
Update prerequisites.sh to only run `PREPARE_KUBEADM` if we're on Kubernetes 1.24 (and if the step hasn't been run before), which implies an upgrade from 1.6 to 1.7. Otherwise, the step will fail when upgrading between patch versions on 1.7, because of kubeadm config file structure changes across Kubernetes versions.

`KUBERNETES_MINOR_VERSION` is read from the existing `version` file, which ought to be consistent across versions as well, because prerequisites are run before node rollout.