### PR TITLE
CASMTRIAGE-8434: Make argo workflow fail if internal scripts returns non-zero exit code

### DIFF
--- a/workflows/templates/base/iufBase.template.argo.yaml
+++ b/workflows/templates/base/iufBase.template.argo.yaml
@@ -135,8 +135,8 @@ spec:
             echo "====================="
             cat /tmp/${ts}.sh
             touch {{inputs.parameters.script_output_file}}
-          else
-            bash -e /tmp/${ts}.sh
+          elif ! bash -e /tmp/${ts}.sh; then
+            exit 1
           fi
 
           # make sure the output file is not empty otherwise Argo barfs

--- a/workflows/templates/base/kubectlAndCurl.template.argo.yaml
+++ b/workflows/templates/base/kubectlAndCurl.template.argo.yaml
@@ -101,6 +101,6 @@ spec:
             echo "=======DRY RUN======="
             echo "====================="
             cat ${ts}.sh
-          else
-            bash -e ${ts}.sh
+          elif ! bash -e ${ts}.sh; then
+            exit 1
           fi


### PR DESCRIPTION

# Description

CASMTRIAGE-8434 Make argo workflow fail if internal scripts returns non-zero exit code
* Resolves [CASMTRIAGE-8434](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8434)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.


[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams