### PR TITLE
CASMPET-7622: Document iSCSI SBPS configuration in CSM install and Upgrade docs

### DIFF
--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -62,7 +62,7 @@ For more detail about about the CSM upgrade hooks, see the section [description 
    Follow the IUF [Backup](backup.md) instructions.
 
 1. iSCSI SBPS Configuration
-    
+
    In CSM 1.7, selective node personalization of iSCSI SBPS is introduced where it requires to create HSM group named
    `iscsi_worker` and add the xnames of worker nodes which are intended to be configured as iSCSI targets.
    Please refer steps for the same under 'Worker node personalization' section of [iSCSI SBPS Configuration](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)

--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -61,6 +61,12 @@ For more detail about about the CSM upgrade hooks, see the section [description 
 
    Follow the IUF [Backup](backup.md) instructions.
 
+1. iSCSI SBPS Configuration
+    
+   In CSM 1.7, selective node personalization of iSCSI SBPS is introduced where it requires to create HSM group named
+   `iscsi_worker` and add the xnames of worker nodes which are intended to be configured as iSCSI targets.
+   Please refer steps for the same under 'Worker node personalization' section of [iSCSI SBPS Configuration](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
+
 1. Management rollout
 
    > **NOTE** The upgrade of CSM services and validation of CSM health occur automatically in a hook executed before the first management node is rolled out.


### PR DESCRIPTION
# Description

Documentation on selective node personalization of iSCSI SBPS is available in SBPS docs. These documents have to be referenced in CSM install and Upgrade documents. This PR is to update the upgrade document.

Relates to:
CASMPET-7556: 
https://github.com/Cray-HPE/docs-csm/pull/6082
https://github.com/Cray-HPE/docs-csm/pull/6087

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
