### PR TITLE
CASMPET-7623 Remove obsolete CRDs

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -810,6 +810,24 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+state_name="REMOVE_OBSOLETE_CRDS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    # These CRDs are from CSM 1.3 and were part of cray-opa-gatekeeper which
+    # was removed in CSM 1.4, but the CRDs were never cleaned up during any of
+    # the previous upgrades
+    old_psp_crds=$(kubectl get crd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -e '^configs.*gatekeeper.sh' -e '^constraint.*gatekeeper.sh' -e '^k8spsp.*gatekeeper.sh' || true)
+    if [ -n "${old_psp_crds}" ]; then
+      kubectl delete crd ${old_psp_crds} || true
+    fi
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then


### PR DESCRIPTION
# Description
CSM 1.3 had k8spsp* CRDs that were part of
cray-opa-keycloak which was removed in 1.4. The
CRDs should have been removed during upgrades but
never were, so they continued to persist.

Issue: https://jira-pro.it.hpe.com:8443/browse/CASMPET-7623

# Testing
This new chunk of code was pulled out and ran on `drax` with the `--dry-run=server` option to `kubectl delete crd ...` so that it didn't make any actual changes.  The `grep` argument was changed to `k8spspX` to verify what happens when there are no matches (which resulted in adding `|| true` after the `grep`)

From the test log:
```
====> REMOVE_OBSOLETE_CRDS ...
customresourcedefinition.apiextensions.k8s.io "k8spspallowedusers.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspallowprivilegeescalationcontainer.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspapparmor.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspcapabilities.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspflexvolumes.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspforbiddensysctls.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspfsgroup.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spsphostfilesystem.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spsphostnamespace.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spsphostnetworkingports.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspprivilegedcontainer.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspprocmount.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspreadonlyrootfilesystem.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspseccomp.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspselinuxv2.constraints.gatekeeper.sh" deleted (server dry run)
customresourcedefinition.apiextensions.k8s.io "k8spspvolumetypes.constraints.gatekeeper.sh" deleted (server dry run)
```
# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
