### PR TITLE
CASMTRIAGE-8448: Update platform-utils to highest available version

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1397,9 +1397,13 @@ if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
-    # We install platform-utils 1.7.1 specifically as it contains a backported
-    # bugfix necessary for the etcd test to run.
-    pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils=1.7.1"
+    # We install platform-utils 1.7.1 specifically when at K8s 1.24 as it contains
+    # a backported bugfix necessary for the etcd test to run.
+    if [ ${KUBERNETES_MINOR_VERSION} -eq 24 ]; then
+      pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils=1.7.1"
+    else
+      pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils"
+    fi
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
# Description
CASMTRIAGE-8448: If at K8s 1.24, upgrade platform-utils to 1.7.1, otherwise upgrade platform-utils to highest available version.

When upgrading from CSM 1.7.0-alpha.22 to CSM 1.7.0-beta.2, `platform-utils` did not get updated in `prerequisites.sh` to pick up the etcd test fix in `platform-utils-1.8.3-1`.  

In CSM 1.7.0-alpha.22, `platform-utils` is at 1.8.2-1.  CSM 1.7.0-beta.1 is the first tarball to contain the `platform-utils-1.8.3-1` rpm.  This issue can still be encountered if upgrading from pre-CSM 1.7.0-beta.1 to pre-CSM 1.7.0-beta.1.  In that case, the workaround would be to pull down and manually install `platform-utils-1.8.3-1`.

# Testing
Tested out on `beau` which is running `csm-1.7.0-beta.1`. I downgraded `platform-utils` on `ncn-m001` to 1.8.2-1 expecting `platform-utils` to be upgraded on `ncn-m001` and left alone on the nodes already at `platform-utils-1.8.3-1`.

```
ncn-m001:~/studenym # rpm -qa platform-utils
platform-utils-1.8.2-1.noarch
ncn-m001:~/studenym # zypper search -s platform-utils
Loading repository data...
Reading installed packages...

S  | Name           | Type    | Version | Arch   | Repository
---+----------------+---------+---------+--------+------------------
i+ | platform-utils | package | 1.8.2-1 | noarch | (System Packages)
v  | platform-utils | package | 1.8.3-1 | noarch | csm-noos
v  | platform-utils | package | 1.7.1-1 | noarch | csm-noos

    Note: For an extended search including not yet activated remote resources please use 'zypper
    search-packages'.
ncn-m001:~/studenym # ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',')
ncn-m001:~/studenym # echo $ncns
ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003,
ncn-m001:~/studenym # KUBERNETES_MINOR_VERSION=$(cut -d'.' -f2 /etc/cray/kubernetes/version)
ncn-m001:~/studenym # echo $KUBERNETES_MINOR_VERSION
32
ncn-m001:~/studenym #     if [ ${KUBERNETES_MINOR_VERSION} -eq 24 ]; then
>       pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils=1.7.1"
>     else
>       pdsh -S -b -w ${ncns} "zypper --non-interactive update platform-utils"
>     fi
ncn-w002: Warning: Permanently added 'ncn-w002' (ED25519) to the list of known hosts.
ncn-s001: Warning: Permanently added 'ncn-s001' (ED25519) to the list of known hosts.
ncn-w003: Warning: Permanently added 'ncn-w003' (ED25519) to the list of known hosts.
ncn-w001: Warning: Permanently added 'ncn-w001' (ED25519) to the list of known hosts.
ncn-s003: Warning: Permanently added 'ncn-s003' (ED25519) to the list of known hosts.
ncn-s002: Warning: Permanently added 'ncn-s002' (ED25519) to the list of known hosts.
ncn-m001: Loading repository data...
ncn-m001: Reading installed packages...
ncn-m001: Resolving package dependencies...
ncn-m001:
ncn-m001: The following item is locked and will not be changed by any action:
ncn-m001:  Installed:
ncn-m001:   kernel-default
ncn-m001:
ncn-m001: The following package is going to be upgraded:
ncn-m001:   platform-utils
ncn-m001:
ncn-m001: The following package has no support information from its vendor:
ncn-m001:   platform-utils
ncn-m001:
ncn-m001: 1 package to upgrade.
ncn-m001:
ncn-m001: Package download size:    25.3 KiB
ncn-m001:
ncn-m001: Package install size change:
ncn-m001:             |      69.9 KiB  required by packages that will be installed
ncn-m001:        0 B  |  -   69.9 KiB  released by packages that will be removed
ncn-m001:
ncn-m001: Backend:  classic_rpmtrans
ncn-m001: Continue? [y/n/v/...? shows all options] (y): y
ncn-m001: Retrieving: platform-utils-1.8.3-1.noarch (csm-noos) (1/1),  25.3 KiB
ncn-m001: Retrieving: platform-utils-1.8.3-1.noarch.rpm [.done]
ncn-m001:
ncn-m001: Checking for file conflicts: [..done]
ncn-m001: (1/1) Installing: platform-utils-1.8.3-1.noarch [..done]
ncn-m001: There are running programs which still use files and libraries deleted or updated by recent upgrades. They should be restarted to benefit from the latest updates. Run 'zypper ps -s' to list these programs.
ncn-m001:
ncn-m002: Retrieving repository 'csm-noos' metadata [...done]
ncn-m002: Building repository 'csm-noos' cache [....done]
ncn-m003: Retrieving repository 'csm-noos' metadata [...done]
ncn-m003: Building repository 'csm-noos' cache [....done]
ncn-m002: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-m002: Building repository 'csm-sle-15sp6' cache [....done]
ncn-m002: Loading repository data...
ncn-m002: Reading installed packages...
ncn-m003: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-m003: Building repository 'csm-sle-15sp6' cache [....done]
ncn-m003: Loading repository data...
ncn-m003: Reading installed packages...
ncn-m002: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-m002: Resolving package dependencies...
ncn-m003: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-m003: Resolving package dependencies...
ncn-w002: Retrieving repository 'csm-noos' metadata [...done]
ncn-w002: Building repository 'csm-noos' cache [....done]
ncn-w001: Retrieving repository 'csm-noos' metadata [...done]
ncn-w001: Building repository 'csm-noos' cache [....done]
ncn-w002: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-w001: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-w002: Building repository 'csm-sle-15sp6' cache [....done]
ncn-w002: Loading repository data...
ncn-m002:
ncn-m002: The following item is locked and will not be changed by any action:
ncn-m002:  Installed:
ncn-m002:   kernel-default
ncn-m002: Nothing to do.
ncn-w002: Reading installed packages...
ncn-w001: Building repository 'csm-sle-15sp6' cache [....done]
ncn-w001: Loading repository data...
ncn-w001: Reading installed packages...
ncn-w002: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-w002: Resolving package dependencies...
ncn-w001: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-w001: Resolving package dependencies...
ncn-m003:
ncn-m003: The following item is locked and will not be changed by any action:
ncn-m003:  Installed:
ncn-m003:   kernel-default
ncn-m003: Nothing to do.
ncn-w003: Retrieving repository 'csm-noos' metadata [...done]
ncn-w003: Building repository 'csm-noos' cache [....done]
ncn-w003: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-w003: Building repository 'csm-sle-15sp6' cache [....done]
ncn-w003: Loading repository data...
ncn-w003: Reading installed packages...
ncn-w001:
ncn-w001: The following item is locked and will not be changed by any action:
ncn-w001:  Installed:
ncn-w001:   kernel-default
ncn-w001: Nothing to do.
ncn-w003: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-w003: Resolving package dependencies...
ncn-w002:
ncn-w002: The following item is locked and will not be changed by any action:
ncn-w002:  Installed:
ncn-w002:   kernel-default
ncn-w002: Nothing to do.
ncn-w003:
ncn-w003: The following item is locked and will not be changed by any action:
ncn-w003:  Installed:
ncn-w003:   kernel-default
ncn-w003: Nothing to do.
ncn-s002: Retrieving repository 'csm-noos' metadata [...done]
ncn-s002: Building repository 'csm-noos' cache [....done]
ncn-s001: Retrieving repository 'csm-noos' metadata [...done]
ncn-s001: Building repository 'csm-noos' cache [....done]
ncn-s003: Retrieving repository 'csm-noos' metadata [...done]
ncn-s002: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-s002: Building repository 'csm-sle-15sp6' cache [....done]
ncn-s002: Loading repository data...
ncn-s002: Reading installed packages...
ncn-s003: Building repository 'csm-noos' cache [....done]
ncn-s002: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-s002: Resolving package dependencies...
ncn-s001: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-s001: Building repository 'csm-sle-15sp6' cache [....done]
ncn-s001: Loading repository data...
ncn-s001: Reading installed packages...
ncn-s001: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-s001: Resolving package dependencies...
ncn-s003: Retrieving repository 'csm-sle-15sp6' metadata [...done]
ncn-s003: Building repository 'csm-sle-15sp6' cache [....done]
ncn-s003: Loading repository data...
ncn-s003: Reading installed packages...
ncn-s003: No update candidate for 'platform-utils-1.8.3-1.noarch'. The highest available version is already installed.
ncn-s003: Resolving package dependencies...
ncn-s001:
ncn-s001: The following item is locked and will not be changed by any action:
ncn-s001:  Installed:
ncn-s001:   kernel-default
ncn-s001: Nothing to do.
ncn-s002:
ncn-s002: The following item is locked and will not be changed by any action:
ncn-s002:  Installed:
ncn-s002:   kernel-default
ncn-s002: Nothing to do.
ncn-s003:
ncn-s003: The following item is locked and will not be changed by any action:
ncn-s003:  Installed:
ncn-s003:   kernel-default
ncn-s003: Nothing to do.
ncn-m001:~/studenym # $?
-bash: 0: command not found
ncn-m001:~/studenym # rpm -qa platform-utils
platform-utils-1.8.3-1.noarch
ncn-m001:~/studenym #
```
# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
