### PR TITLE
CASMTRIAGE-8456 - vShasta: cilium migration fails, Argo pod kills itself

### DIFF
--- a/workflows/cilium/cilium-live-migration.j2
+++ b/workflows/cilium/cilium-live-migration.j2
@@ -12,6 +12,7 @@ metadata:
     target-ncns:  {{ target_ncns|join('.') }}
   name: cilium-live-migration-{{ uid }}
 spec:
+  activeDeadlineSeconds: 86400
   podMetadata:
     annotations:
       sidecar.istio.io/inject: "false"    
@@ -69,6 +70,17 @@ spec:
                 value: {{ ncn }} 
               - name: dryRun
                 value: "false"
+            podSpecPatch: |
+              affinity:
+                podAntiAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    - labelSelector:
+                        matchExpressions:
+                          - key: kubernetes.io/hostname
+                            operator: In
+                            values:
+                              - {{ ncn }}
+                      topologyKey: kubernetes.io/hostname
             {% set ns.prev_ncn = ncn %}
           {% endfor %}
           - name: post-migrate-cilium


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

It's possible for the Cilium migration to kill the pod that's running it when draining nodes.

This PR adds antiAffinity to the workflow so pods related to a node migration can never be scheduled on the node being migrated.

This PR also explicitly sets activeDeadlineSeconds to avoid another issue where restarting the Argo workflow server causes spawned jobs to have ARGO_DEADLINE set to 60 seconds and kill the pod.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
