### PR TITLE
CASMTRIAGE-8466: Update Complete path for ncn-m001-bootparameters-update.done

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -175,7 +175,7 @@ spec:
                     else
                       echo "WARNING "
                       echo "WARNING Note: master node ncn-m001 has not been successfully upgraded during previous run." 
-                      echo "WARNING To Re-run ncn-m001 upgrade, run the command: 'rm -f ncn-m001-bootparameters-update.done' "
+                      echo "WARNING To Re-run ncn-m001 upgrade, run the command: 'rm -f /etc/cray/upgrade/csm/iuf/ncn-m001-bootparameters-update.done' "
                       echo "WARNING This should be done only if the conditions causing upgrade failure during previous run has been fixed."
                       echo "WARNING "
                       exit 1


### PR DESCRIPTION
# Description

CASMTRIAGE-8466: Update Complete path for ncn-m001-bootparameters-update.done
* Resolves [CASMTRIAGE-8434](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8466)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.


[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams