### PR TITLE
CASMTRIAGE-8452: workflow error check

### DIFF
--- a/scripts/cilium_migration.sh
+++ b/scripts/cilium_migration.sh
@@ -55,6 +55,8 @@ else
   fi
 
   WORKFLOW_NAME=$(grep '^  name:' /usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml | awk '{print $2}')
+  MAX_RETRIES=12
+  ERROR_COUNT=0
 
   echo "INFO Monitoring Cilium workflow status"
   while true; do
@@ -66,6 +68,15 @@ else
     elif [[ $STATUS == "Failed" ]]; then
       echo "ERROR Workflow ${WORKFLOW_NAME} failed"
       exit 1
+    elif [[ $STATUS == "Error" ]]; then
+      ((ERROR_COUNT++))
+      echo "WARNING Workflow ${WORKFLOW_NAME} in Error state (attempt ${ERROR_COUNT}/${MAX_RETRIES})"
+      if [[ $ERROR_COUNT -ge $MAX_RETRIES ]]; then
+        echo "ERROR Workflow ${WORKFLOW_NAME} remained in Error state after ${MAX_RETRIES} retries"
+        exit 1
+      fi
+      sleep 15
+      continue
     elif [[ -z $STATUS ]]; then
       echo "INFO Waiting for workflow ${WORKFLOW_NAME} to be created..."
     else


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

If the workflow created by the cilium_migration.sh script goes in an "Error" state , there might be an intermittent issue or some system-level unexpected issue.
3 retries is being added in case the Error is due to intermittent problem. After the retries if the workflow remains in Error state we exit with error.

Resolves [CASMTRIAGE-8452](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8452)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
