### PR TITLE
CASMPET-7628: Create script to clear iSCSI playbook layer from NCN worker CFS component state

### DIFF
--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -25,7 +25,7 @@
 
 import logging
 import traceback
-from typing import Dict, List, NamedTuple, NoReturn, Union
+from typing import Dict, List, NamedTuple, NoReturn, Optional, Union
 import urllib.parse
 
 from . import api_requests
@@ -73,7 +73,7 @@ class CfsVersion(NamedTuple):
         """
         return f"{self.major}.{self.minor}.{self.patch}"
 
-def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None] = None) -> NoReturn:
+def log_error_raise_exception(msg: str, parent_exception: Optional[Exception] = None) -> NoReturn:
     """
     1) If a parent exception is passed in, make a debug log entry with its stack trace.
     2) Log an error with the specified message.
@@ -92,7 +92,7 @@ def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None]
 
 
 def __list_and_merge(object_field_name: str, url: str,
-                     params: Union[JsonDict, None]=None) -> List[JsonObject]:
+                     params: Optional[JsonDict] = None) -> List[JsonObject]:
     """
     For paginated CFS list endpoints, this repeatedly queries them until all items
     are found, then returns the list.
@@ -112,16 +112,23 @@ def __list_and_merge(object_field_name: str, url: str,
     return obj_list
 
 
-def list_components(id_list: Union[None, List[str], str]=None) -> List[JsonDict]:
+def list_components(id_list: Union[None, List[str], str] = None,
+                    include_state_details: Optional[bool] = None) -> List[JsonDict]:
     """
     Queries CFS to list all components, and returns the list.
     If an id_list is specified, query CFS for just those components.
     Merges paged responses together
+
+    If include_state_details is specified, it will be passed on with the query
     """
-    if id_list is None:
+    if id_list is None and include_state_details is None:
         params = None
     else:
-        params = { "ids": id_list if isinstance(id_list, str) else ",".join(id_list) }
+        params = {}
+        if id_list is not None:
+            params["ids"] = id_list if isinstance(id_list, str) else ",".join(id_list)
+        if include_state_details is not None:
+            params["state_details"] = include_state_details
     return __list_and_merge("components", CFS_V3_COMPS_URL, params=params)
 
 
@@ -161,9 +168,23 @@ def update_components_by_ids(comp_ids: List[str], update_data: JsonObject) -> Js
     return api_requests.patch_retry_validate_return_json(**request_kwargs)
 
 
+def update_components_by_list(patch_data: List[JsonDict]) -> None:
+    """
+    Perform a bulk component update using the specified patch data list.
+    """
+    # Even though it does not follow convention for patch operations,
+    # the status code when successful is 200
+    request_kwargs = {"url": CFS_V3_COMPS_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200},
+                      "json": patch_data}
+    return api_requests.patch_retry_validate_return_json(**request_kwargs)
+
+
 # CFS configuration functions
 
-def create_configuration(config_name: str, layers: List[Dict[str, str]], **config_fields) -> JsonObject:
+def create_configuration(config_name: str, layers: List[Dict[str, str]],
+                         **config_fields) -> JsonObject:
     """
     Creates or updates a CFS configuration with the specified name and layers.
     The layers should be dictionaries with the following fields set:
@@ -288,7 +309,7 @@ def update_options(new_options: CfsOptions) -> CfsOptions:
 
 
 def create_dynamic_session(session_name: str, config_name: str,
-                           xname_limit: Union[List[str], None] = None) -> JsonObject:
+                           xname_limit: Optional[List[str]] = None) -> JsonObject:
     """
     Creates a CFS session of dynamic type with the specified name, running the specified
     CFS configuration. By default this will be run on all applicable nodes, based on
@@ -331,7 +352,7 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> Union[Json
         log_error_raise_exception("Response from CFS has unexpected format", exc)
     return json_object
 
-def list_sessions(params: Union[JsonDict, None]=None) -> List[JsonObject]:
+def list_sessions(params: Optional[JsonDict] = None) -> List[JsonObject]:
     """
     Queries CFS to list all sessions, and returns the list.
     """

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -25,7 +25,8 @@
 
 import logging
 import traceback
-from typing import List, NoReturn
+from typing import List, NoReturn, Optional
+from typing_extensions import Literal
 
 from . import api_requests
 from . import common
@@ -34,8 +35,9 @@ from .types import JSONDecodeError
 SMD_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/smd"
 SMD_HSM_COMPONENTS_URL = f"{SMD_BASE_URL}/hsm/v2/State/Components"
 
+MGMT_NCN_HSM_SUBROLE = Literal['Master', 'Storage', 'Worker']
 
-def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> NoReturn:
+def log_error_raise_exception(msg: str, parent_exception: Optional[Exception] = None) -> NoReturn:
     """
     1) If a parent exception is passed in, make a debug log entry with its stack trace.
     2) Log an error with the specified message.
@@ -50,11 +52,13 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_management_ncn_xnames() -> List[str]:
+def get_management_ncn_xnames(subrole: Optional[MGMT_NCN_HSM_SUBROLE] = None) -> List[str]:
     """
     Return a sorted list of the xnames of the management NCNs
     """
     params = {"type": "Node", "role": "Management"}
+    if subrole is not None:
+        params["subrole"] = subrole
     resp = api_requests.get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
                                            add_api_token=True, params=params)
     try:

--- a/scripts/operations/configuration/refresh_worker_iscsi_config.py
+++ b/scripts/operations/configuration/refresh_worker_iscsi_config.py
@@ -112,23 +112,22 @@ def main() -> None:
 
     if no_iscsi_status:
         print("WARNING: The following workers have no iSCSI layer in their CFS "
-              f"component states; Only their error counts will be reset: {no_iscsi_status}")
+              f"component states; they will not be modified: {no_iscsi_status}")
     print("The following workers will have their CFS states updated and error "
           f"counts reset: {sorted(set(worker_comp_map).difference(no_iscsi_status))}")
 
     comp_patches = []
     for xname, comp in worker_comp_map.items():
-        patch = { "error_count": 0, "id": xname }
-        comp_patches.append(patch)
         if xname in no_iscsi_status:
             continue
-        patch["state"] = []
+        state = []
         for layer in comp["state"]:
             if layer["playbook"] == ISCSI_PLAYBOOK:
                 continue
             # Cannot patch the last_updated field
             del layer["last_updated"]
-            patch["state"].append(layer)
+            state.append(layer)
+        comp_patches.append({ "error_count": 0, "id": xname, "state": state })
 
     print("Updating CFS components...")
     update_components_by_list(comp_patches)

--- a/scripts/operations/configuration/refresh_worker_iscsi_config.py
+++ b/scripts/operations/configuration/refresh_worker_iscsi_config.py
@@ -81,7 +81,7 @@ def main() -> None:
 
     # First check to make sure we got back one component for every worker
     worker_cfs_comp_ids = sorted([ comp["id"] for comp in worker_cfs_comps ])
-    missing_xnames = set(worker_ncn_xnames).difference_update(worker_cfs_comp_ids)
+    missing_xnames = set(worker_ncn_xnames).difference(worker_cfs_comp_ids)
     if missing_xnames:
         raise ScriptException(
             f"No CFS component found for following worker NCNs: {sorted(missing_xnames)}")

--- a/scripts/operations/configuration/refresh_worker_iscsi_config.py
+++ b/scripts/operations/configuration/refresh_worker_iscsi_config.py
@@ -109,17 +109,22 @@ def main() -> None:
           if cfs_comp_has_no_iscsi_status(comp)
         ]
     )
+    have_iscsi_status = sorted(set(worker_comp_map).difference(no_iscsi_status))
+
+    if not have_iscsi_status:
+        print("WARNING: No workers have iSCSI layers in their CFS component states; nothing to do")
+        return
 
     if no_iscsi_status:
         print("WARNING: The following workers have no iSCSI layer in their CFS "
               f"component states; they will not be modified: {no_iscsi_status}")
+
     print("The following workers will have their CFS states updated and error "
-          f"counts reset: {sorted(set(worker_comp_map).difference(no_iscsi_status))}")
+          f"counts reset: {have_iscsi_status}")
 
     comp_patches = []
-    for xname, comp in worker_comp_map.items():
-        if xname in no_iscsi_status:
-            continue
+    for xname in have_iscsi_status:
+        comp = worker_comp_map[xname]
         state = []
         for layer in comp["state"]:
             if layer["playbook"] == ISCSI_PLAYBOOK:

--- a/scripts/operations/configuration/refresh_worker_iscsi_config.py
+++ b/scripts/operations/configuration/refresh_worker_iscsi_config.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Usage: refresh_worker_iscsi_config.py
+
+This script modifies the CFS component status of worker NCNs to clear out
+the iSCSI playbook entry. It also sets the error count for the component to 0.
+
+This will cause CFS batcher to schedule new CFS sessions to run that playbook
+on the workers. This is needed because changes to the iSCSI HSM group do not
+take effect until the playbook is re-run.
+
+The script will abort without doing any of the above if any of the CFS components
+for the NCN workers has a configuration status of pending. This indicates that
+a CFS session is currently underway for that component, or may be starting
+imminently.
+"""
+
+import argparse
+from functools import partial
+import sys
+
+from python_lib.cfs import list_components, update_components_by_list
+from python_lib.common import ScriptException, print_err
+from python_lib.hsm import get_management_ncn_xnames
+from python_lib.types import JsonDict
+
+
+ISCSI_PLAYBOOK = "config_sbps_iscsi_targets.yml"
+
+get_worker_ncn_xnames = partial(get_management_ncn_xnames, subrole="Worker")
+
+def cfs_comp_has_no_iscsi_status(comp: JsonDict) -> bool:
+    """
+    Returns False if the iscsi playbook is listed in any of the state layers
+    Returns True otherwise
+    """
+    return all(layer["playbook"] != ISCSI_PLAYBOOK for layer in comp.get("state", []))
+
+
+def main() -> None:
+    """
+    Parses the command line arguments, does the stuff.
+    But since there are no arguments, it just makes sure of that.
+
+    Raises ScriptException if there is an error
+    """
+    parser = argparse.ArgumentParser(
+        description="Clears iSCSI layer from CFS component status of NCN worker nodes")
+    parser.parse_args()
+
+    worker_ncn_xnames = get_worker_ncn_xnames()
+    if not worker_ncn_xnames:
+        raise ScriptException("No worker NCNs found in HSM")
+
+    worker_cfs_comps = list_components(id_list=worker_ncn_xnames,
+                                       include_state_details=True)
+
+    # First check to make sure we got back one component for every worker
+    worker_cfs_comp_ids = sorted([ comp["id"] for comp in worker_cfs_comps ])
+    missing_xnames = set(worker_ncn_xnames).difference_update(worker_cfs_comp_ids)
+    if missing_xnames:
+        raise ScriptException(
+            f"No CFS component found for following worker NCNs: {sorted(missing_xnames)}")
+
+    # Make sure we did not get back more than one component for any worker
+    if len(worker_cfs_comp_ids) != len(set(worker_cfs_comp_ids)):
+        raise ScriptException("CFS returned multiple worker NCN components with the same id")
+
+    # Map worker xnames to their CFS components
+    worker_comp_map = { comp['id']: comp
+                       for comp in worker_cfs_comps
+                       if comp['id'] in worker_ncn_xnames }
+
+    # Make sure no worker components have pending status
+    pending_workers = sorted([ xname for xname, comp in worker_comp_map.items()
+                               if comp.get("configuration_status") == "pending" ])
+
+    if pending_workers:
+        raise ScriptException(
+            f"One or more workers have CFS components with 'pending' status: {pending_workers}")
+
+    # Warn if any workers have no iSCSI layer in their status
+    no_iscsi_status = sorted(
+        [ xname for xname, comp in worker_comp_map.items()
+          if cfs_comp_has_no_iscsi_status(comp)
+        ]
+    )
+
+    if no_iscsi_status:
+        print("WARNING: The following workers have no iSCSI layer in their CFS "
+              f"component states; Only their error counts will be reset: {no_iscsi_status}")
+    print("The following workers will have their CFS states updated and error "
+          f"counts reset: {sorted(set(worker_comp_map).difference(no_iscsi_status))}")
+
+    comp_patches = []
+    for xname, comp in worker_comp_map.items():
+        patch = { "error_count": 0, "id": xname }
+        comp_patches.append(patch)
+        if xname in no_iscsi_status:
+            continue
+        patch["state"] = []
+        for layer in comp["state"]:
+            if layer["playbook"] == ISCSI_PLAYBOOK:
+                continue
+            # Cannot patch the last_updated field
+            del layer["last_updated"]
+            patch["state"].append(layer)
+
+    print("Updating CFS components...")
+    update_components_by_list(comp_patches)
+    print("Update successful. CFS batcher should soon start sessions to "
+          "configure the nodes whose states were updated")
+
+
+if __name__ == '__main__':
+    try:
+        main()
+        print("SUCCESS")
+    except ScriptException as exc:
+        print_err(str(exc))
+        sys.exit(1)


### PR DESCRIPTION
CASMPET-7616 allows administrators to limit which worker NCNs are enabled for iSCSI. This is done using an HSM group. If the group is changed, then in order for the changes to take effect, the iSCSI CFS playbook needs to run on the workers. This will not happen automatically, because CFS will not realize that the HSM group has changed.

CASMPET-7619 is going to document the procedures to alter which worker NCNs are enabled for iSCSI. This means it will need to tell admins to re-run the iSCSI CFS layer on the worker nodes, after they've made their changes. However, there are some subtleties to consider.

The default way that we force CFS to re-run on a node is to clear its state entirely. This causes CFS to run through all of the layers in its desired configuration. This can take a long time, even if most of them have already run previously.

Another alternative is to update the states of the worker NCN components in CFS, and instead of clearing the states, just remove the iSCSI layer. This will cause CFS to create a session to only run that specific layer, which is what we want. The issue here is that this is pretty tedious, especially if done from the command line.

This PR addresses this concern by writing a script to do this for them. It leverages a lot of existing Python modules we've written for other purposes, so the API side of interacting with CFS (and HSM) didn't require many code changes. It mostly had to add in some logic to glue them together (as well as some minor linting and additions).

This script takes no arguments and does the following:
1. Gets a list of worker NCNs from HSM
2. Queries CFS to get the corresponding components and their current states
3. Does some sanity checking to make sure that what we got back from CFS looks right in general (no missing components, no duplicate components, etc).
4. Checks to make sure no components have pending status. If any do, exit the script. This indicates that CFS is in the process of configuring them, or will be soon. In this case, the user should wait until that is done before running the script.
5. Checks to see if any of the components are missing iSCSI layers in their state. If any are, a warning will be printed. This would only be the case if the node has never had CFS run before, or if the node has a desired configuration which does not include the iSCSI layer. These nodes will not be updated in CFS.
6. Updates all of the worker NCN components in CFS. All of them have their error counts set to 0, and have the iSCSI layers in their states removed (but the rest of the layers are not modified).

I have tested this on fanta and drax and verified that it works as expected (both for nodes that have the iSCSI layer and nodes that do not). I also verified that it correctly detected pending components and aborted.

There will be partial backports of this to earlier releases, but only for applicable linting or CFS/HSM module improvements. The main script will not be backported.