### PR TITLE
CASMTRIAGE-8483: reset failed state CFS nodes and set  CFS error count to 0 and disable it in CFS

### DIFF
--- a/workflows/templates/ncn-reboot-common.yaml
+++ b/workflows/templates/ncn-reboot-common.yaml
@@ -93,8 +93,8 @@ spec:
                     if [ -z "$failed_nodes" ]; then
                       echo "INFO All nodes are in configured state in CFS"
                     else
-                      echo "ERROR $failed_nodes is/are in failed state in CFS"
-                      exit 1
+                      echo "Enabling CFS on: ${failed_nodes}"
+                      cray cfs v3 components updatemany --filter-ids "${failed_nodes}" --enabled false --error-count 0
                     fi
 
                     echo "INFO Starting Postgres health check"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

CASMTRIAGE-8483: reset failed state CFS nodes and set  CFS error count to 0 and disable it in CFS
Resolves [CASMTRIAGE-8483](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8483)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
