### PR TITLE
CASMPET-7620: DOCS: Update CSM install docs with iSCSI worker step

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -19,7 +19,8 @@ and BMC/controller passwords.
 1. [Set up passwordless SSH](#5-set-up-passwordless-ssh)
 1. [Configure the root password and SSH keys in Vault](#6-configure-the-root-password-and-ssh-keys-in-vault)
 1. [Add switch admin password to Vault](#7-add-switch-admin-password-to-vault)
-1. [Configure management nodes with CFS](#8-configure-management-nodes-with-cfs)
+1. [iSCSI SBPS configuration](#8-iscsi-sbps-configuration)
+1. [Configure management nodes with CFS](#9-configure-management-nodes-with-cfs)
 1. [Proceed to next topic](#9-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
@@ -124,7 +125,7 @@ to managed nodes.
 
 This procedure sets up resources in Kubernetes (a Kubernetes Secret and ConfigMap) which are later
 applied to the management nodes using CFS node personalization in section
-[7. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
+[7. Configure management nodes with CFS](#9-configure-management-nodes-with-cfs) below.
 
 ## 6. Configure the root password and SSH keys in Vault
 
@@ -133,7 +134,7 @@ for the procedure to configure the `root` password and SSH keys in Vault.
 
 This procedure writes the `root` password hash and SSH keys to Vault which are later
 applied to the management nodes using CFS node personalization in section
-[7. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
+[7. Configure management nodes with CFS](#9-configure-management-nodes-with-cfs) below.
 
 ## 7. Add switch admin password to Vault
 
@@ -159,7 +160,21 @@ Password read from Vault matches what was written
 SUCCESS
 ```
 
-## 8. Configure management nodes with CFS
+## 8. iSCSI SBPS configuration
+
+In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective 
+node personalization is supported where if user/admin wants to limit some worker nodes to be configured as 
+iSCSI targets, then it requires to create an HSM group name `iscsi_worker` and add the worker node xnames
+of the nodes which are required to be configured as iSCSI targets to this group. For the steps/procedue for 
+the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md) 
+
+This has to be done before "Configure management nodes with CFS" during CSM installation. If this is not done,
+all the worker nodes will be configured as iSCSI targets. But this `iscsi_worker` HSM group can be created post
+install and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at: 
+
+TBD
+
+## 9. Configure management nodes with CFS
 
 Management nodes need to be configured after booting for administrative access, security, and other
 purposes. The [Configuration Framework Service (CFS)](../operations/configuration_management/Configuration_Management.md)
@@ -198,7 +213,7 @@ then applies that configuration to the management nodes.
 
     The number reported should match the number of management nodes in the system. If there are failures, see [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md).
 
-## 9. Proceed to next topic
+## 10. Proceed to next topic
 
 After completing the operational procedures above which configure administrative access, the next
 step is to validate the health of management nodes and CSM services.

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -165,7 +165,7 @@ SUCCESS
 In CSM 1.6, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
 node personalization is introduced where if user/admin wants to limit some worker nodes to be configured as
 iSCSI targets, then it requires to create an HSM group named `iscsi_worker` and add the worker node xnames
-which are intended to be configured as iSCSI targets to this group. For details, see [Management Node Personalization](../configuration_management/Management_Node_Personalization.md) 
+which are intended to be configured as iSCSI targets to this group. For details, see [Managing selective node personalization](../iscsi_sbps/Managing_selective_node_personalization.md)
 
 ## 9. Configure management nodes with CFS
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -174,6 +174,8 @@ install and re-run iSCSI CFS layer to avail this selective node personalization.
 
 TBD
 
+For more information on iSCSI SBPS, see [iSCSI SBPS](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
+
 ## 9. Configure management nodes with CFS
 
 Management nodes need to be configured after booting for administrative access, security, and other

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -162,13 +162,10 @@ SUCCESS
 
 ## 8. iSCSI SBPS configuration
 
-In CSM 1.6.0, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
+In CSM 1.6, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
 node personalization is introduced where if user/admin wants to limit some worker nodes to be configured as
 iSCSI targets, then it requires to create an HSM group named `iscsi_worker` and add the worker node xnames
-which are intended to be configured as iSCSI targets to this group. For details, see [worker node personalization](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization) 
-
-The `iscsi_worker` HSM group has to be created before "Configure management nodes with CFS" during CSM installation.
-If this is not done, all the worker nodes will be configured as iSCSI targets like in CSM 1.6.0.
+which are intended to be configured as iSCSI targets to this group. For details, see [Management Node Personalization](../configuration_management/Management_Node_Personalization.md) 
 
 ## 9. Configure management nodes with CFS
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -21,7 +21,7 @@ and BMC/controller passwords.
 1. [Add switch admin password to Vault](#7-add-switch-admin-password-to-vault)
 1. [iSCSI SBPS configuration](#8-iscsi-sbps-configuration)
 1. [Configure management nodes with CFS](#9-configure-management-nodes-with-cfs)
-1. [Proceed to next topic](#9-proceed-to-next-topic)
+1. [Proceed to next topic](#10101010101010101010-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.
@@ -162,15 +162,15 @@ SUCCESS
 
 ## 8. iSCSI SBPS configuration
 
-In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective 
-node personalization is supported where if user/admin wants to limit some worker nodes to be configured as 
+In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective
+node personalization is supported where if user/admin wants to limit some worker nodes to be configured as
 iSCSI targets, then it requires to create an HSM group name `iscsi_worker` and add the worker node xnames
-of the nodes which are required to be configured as iSCSI targets to this group. For the steps/procedue for 
-the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md) 
+of the nodes which are required to be configured as iSCSI targets to this group. For the steps/procedure for
+the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
 
 This has to be done before "Configure management nodes with CFS" during CSM installation. If this is not done,
 all the worker nodes will be configured as iSCSI targets. But this `iscsi_worker` HSM group can be created post
-install and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at: 
+install and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at:
 
 TBD
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -21,7 +21,7 @@ and BMC/controller passwords.
 1. [Add switch admin password to Vault](#7-add-switch-admin-password-to-vault)
 1. [iSCSI SBPS configuration](#8-iscsi-sbps-configuration)
 1. [Configure management nodes with CFS](#9-configure-management-nodes-with-cfs)
-1. [Proceed to next topic](#10101010101010101010-proceed-to-next-topic)
+1. [Proceed to next topic](#10-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -165,7 +165,7 @@ SUCCESS
 In CSM 1.6, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
 node personalization is introduced where if user/admin wants to limit some worker nodes to be configured as
 iSCSI targets, then it requires to create an HSM group named `iscsi_worker` and add the worker node xnames
-which are intended to be configured as iSCSI targets to this group. For details, see [Managing selective node personalization](../iscsi_sbps/Managing_selective_node_personalization.md)
+which are intended to be configured as iSCSI targets to this group. For details, see [Managing selective node personalization](../iscsi_sbps/Managing_selective_node_personalization.md) and [worker node personalization](../iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization)
 
 ## 9. Configure management nodes with CFS
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -162,19 +162,13 @@ SUCCESS
 
 ## 8. iSCSI SBPS configuration
 
-In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective
-node personalization is supported where if user/admin wants to limit some worker nodes to be configured as
-iSCSI targets, then it requires to create an HSM group name `iscsi_worker` and add the worker node xnames
-of the nodes which are required to be configured as iSCSI targets to this group. For the steps/procedure for
-the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+In CSM 1.6.0, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
+node personalization is introduced where if user/admin wants to limit some worker nodes to be configured as
+iSCSI targets, then it requires to create an HSM group named `iscsi_worker` and add the worker node xnames
+which are intended to be configured as iSCSI targets to this group. For details, see [worker node personalization](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization) 
 
-This has to be done before "Configure management nodes with CFS" during CSM installation. If this is not done,
-all the worker nodes will be configured as iSCSI targets. But this `iscsi_worker` HSM group can be created post
-install and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at:
-
-TBD
-
-For more information on iSCSI SBPS, see [iSCSI SBPS](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
+The `iscsi_worker` HSM group has to be created before "Configure management nodes with CFS" during CSM installation.
+If this is not done, all the worker nodes will be configured as iSCSI targets like in CSM 1.6.0.
 
 ## 9. Configure management nodes with CFS
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -165,7 +165,7 @@ SUCCESS
 In CSM 1.6, all the worker nodes were configured and enabled as iSCSI SBPS targets. In CSM 1.7.0, selective
 node personalization is introduced where if user/admin wants to limit some worker nodes to be configured as
 iSCSI targets, then it requires to create an HSM group named `iscsi_worker` and add the worker node xnames
-which are intended to be configured as iSCSI targets to this group. For details, see [Managing selective node personalization](../iscsi_sbps/Managing_selective_node_personalization.md) and [worker node personalization](../iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization)
+which are intended to be configured as iSCSI targets to this group. For details, see [Managing selective node personalization](../operations/iscsi_sbps/Managing_selective_node_personalization.md) and [worker node personalization](../operations/iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization)
 
 ## 9. Configure management nodes with CFS
 


### PR DESCRIPTION
# Description
This is to update CSM install docs with the iSCSI worker selective node personalization as per https://jira-pro.it.hpe.com:8443/browse/CASMPET-7619. Referencing this doc in CSM 1.7.0 installation doc. 

Relates to:
CASMPET-7619
https://github.com/Cray-HPE/docs-csm/pull/6132

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
