### PR TITLE
CASMPET-7621: DOCS: Update CSM upgrade docs with iSCSI worker step

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -21,6 +21,18 @@ Once this step has completed:
 
 - Host firmware has been updated on management nodes
 
+Note: In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective worker
+node personalization is supported where if user/admin wants to limit some worker nodes to be configured as iSCSI targets, 
+then it requires to create an HSM group by name `iscsi_worker` and add the worker node xnames to this group which are required to be configured as iSCSI targets. For the steps/procedure for the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
+
+This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes will
+be configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at: 
+
+TBD
+
+For more information on iSCSI SBPS, see [iSCSI SBPS](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
+
+
 ## 2. Execute the IUF `management-nodes-rollout` stage
 
 This section describes how to update software on management nodes. It describes how to test a new image and CFS configuration on a single node first to ensure they work as expected before rolling the changes out to the other management

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -22,11 +22,11 @@ Once this step has completed:
 - Host firmware has been updated on management nodes
 
 Note: In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective worker
-node personalization is supported where if user/admin wants to limit some worker nodes to be configured as iSCSI targets, 
+node personalization is supported where if user/admin wants to limit some worker nodes to be configured as iSCSI targets,
 then it requires to create an HSM group by name `iscsi_worker` and add the worker node xnames to this group which are required to be configured as iSCSI targets. For the steps/procedure for the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
 
-This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes will
-be configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this selective node personalization. Procedure/steps for the same are at: 
+This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes willbe configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this
+selective node personalization. Procedure/steps for the same are at:
 
 TBD
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -25,7 +25,7 @@ Note: In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets b
 node personalization is supported where if user/admin wants to limit some worker nodes to be configured as iSCSI targets,
 then it requires to create an HSM group by name `iscsi_worker` and add the worker node xnames to this group which are required to be configured as iSCSI targets. For the steps/procedure for the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
 
-This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes willbe configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this
+This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes will be configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this
 selective node personalization. Procedure/steps for the same are at:
 
 TBD

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -32,7 +32,6 @@ TBD
 
 For more information on iSCSI SBPS, see [iSCSI SBPS](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
 
-
 ## 2. Execute the IUF `management-nodes-rollout` stage
 
 This section describes how to update software on management nodes. It describes how to test a new image and CFS configuration on a single node first to ensure they work as expected before rolling the changes out to the other management

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -21,16 +21,10 @@ Once this step has completed:
 
 - Host firmware has been updated on management nodes
 
-Note: In CSM 1.6.0, all the worker nodes were configured as iSCSI SBPS targets by default. In CSM 1.7.0, selective worker
-node personalization is supported where if user/admin wants to limit some worker nodes to be configured as iSCSI targets,
-then it requires to create an HSM group by name `iscsi_worker` and add the worker node xnames to this group which are required to be configured as iSCSI targets. For the steps/procedure for the same, see [HSM groups iSCSI](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/HSM_groups_iscsi.md)
-
-This has to be done before "management-nodes-rollout" stage during upgrade. If this is not done, all the worker nodes will be configured as iSCSI targets. But this HSM group can be created post upgrade and re-run iSCSI CFS layer to avail this
-selective node personalization. Procedure/steps for the same are at:
-
-TBD
-
-For more information on iSCSI SBPS, see [iSCSI SBPS](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/iscsi_sbps/iscsi_sbps.md)
+Note: In CSM 1.6, all the worker nodes are configured as iSCSI SBPS targets. In CSM 1.7.0, selective worker node
+personalization is introduced where if user/admin wants to limit some worker nodes to be configured as iSCSI targets,
+then it requires to create an HSM group by name `iscsi_worker` and add the worker node xnames to this group which are
+intended to be configured as iSCSI targets. For details, see [Management Node Personalization](../configuration_management/Management_Node_Personalization.md) and [worker node personalization](../iscsi_sbps/iscsi_sbps.md#1-worker-node-personalization)
 
 ## 2. Execute the IUF `management-nodes-rollout` stage
 


### PR DESCRIPTION
# Description
This is to update CSM upgrade doc with the iSCSI worker selective node personalization as per https://jira-pro.it.hpe.com:8443/browse/CASMPET-7619. Referencing this doc in CSM 1.7.0 upgrade doc.

Relates to:
CASMPET-7619
https://github.com/Cray-HPE/docs-csm/pull/6132

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.