### PR TITLE
CASMTRIAGE-8097 - cray-uas-mgr still installed in CSM 1.6.1

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -263,6 +263,22 @@ function is_vshasta_node {
   return $?
 }
 
+# Undeploy the chart if it exists on the system.
+# Use this if a chart has been removed from a manifest and needs
+# to be removed from the system as part of an upgrade.
+function undeploy() {
+  # Check if the chart exists by running helm status
+  if [[ $(helm status -o json "$@" 2> /dev/null | jq -r .info.status) == "deployed" ]]; then
+    echo "Chart ${*: -1} exists. Uninstalling it now."
+    # Remove the chart completely without keeping history.
+    helm uninstall "$@"
+    return $?
+  else
+    echo "Chart ${*: -1} doesn't exist"
+    return 0
+  fi
+}
+
 function set_backupBucket_var {
   backupBucket="config-data"
   cray artifacts list "${backupBucket}" || backupBucket="vbis"
@@ -615,6 +631,21 @@ fi
 do_upgrade_csm_chart cray-kyverno platform.yaml
 do_upgrade_csm_chart kyverno-policy platform.yaml
 do_upgrade_csm_chart cray-kyverno-policies-upstream platform.yaml
+
+# Undeploy old cray-uas-mgr chart if it exists
+# UAI was deprecated in CSM 1.5 and has been removed in CSM 1.6
+state_name="UNDEPLOY_UAS_CHART"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    undeploy -n services cray-uas-mgr
+    undeploy -n services update-uas
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
 
 # Pre-cache images needed for istio upgrade. As soon as cray-istio-deploy is upgraded, network
 # connection to nexus will be broken, due to istio proxy and istiod versions mismatch. Upgrade of


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

cray-uas-mgr was deprecated in CSM 1.5 and removed from the product manifests in CSM 1.6.

It also needs to be removed during a CSM 1.5 to 1.6 upgrade.

Relates to:

[CASMTRIAGE-8097](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8097)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
