### PR TITLE
CASMTRIAGE-8451/CASMNET-2357/CASMTRIAGE-8473 - Cilium migration fixes

### DIFF
--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -91,9 +91,23 @@ spec:
               - name: scriptContent
                 value: |
                   kubectl apply --server-side -f /srv/cray/resources/common/cilium-node-config.yaml
+        - name: "apply-cilium-net-attach-definition"
+          dependencies:
+            - install-cilium-migration-chart
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  kubectl apply --server-side -f /srv/cray/resources/common/cilium-net-attach-def.yml
         - name: "wait-for-cilium-status"
           dependencies:
             - install-cilium-migration-chart 
+            - apply-cilium-net-attach-definition
           templateRef:
             name: ssh-template
             template: shell-script
@@ -134,3 +148,17 @@ spec:
                     kubectl -n argo create configmap stash-netpol --from-file=/tmp/netpol.yaml
                   fi
                   kubectl get netpol -A
+        - name: "set-check-image-to-audit"
+          dependencies:
+            - wait-for-cilium-status
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  echo "Setting Kyverno check-image policy to Audit mode"
+                  kubectl -n kyverno patch cpol check-image --type=json -p '[{"op": "replace", "path": "/spec/validationFailureAction", "value": "Audit"}]'

--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -1,7 +1,7 @@
-
+#
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/templates/cilium.post-migrate.yaml
+++ b/workflows/templates/cilium.post-migrate.yaml
@@ -116,7 +116,7 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  kubectl delete -n kube-system ciliumnodeconfig cilium-default 
+                  kubectl delete -n kube-system ciliumnodeconfig cilium-default --ignore-not-found=true
         - name: remove-weave 
           dependencies:
             - delete-cilium-node-config 

--- a/workflows/templates/cilium.post-migrate.yaml
+++ b/workflows/templates/cilium.post-migrate.yaml
@@ -162,3 +162,17 @@ spec:
 
                   rm $ORIG_PARAMS
                   rm $NEW_PARAMS
+        - name: set-check-image-to-enforce
+          dependencies:
+            - remove-weave
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  echo "Setting Kyverno check-image policy to Enforce mode"
+                  kubectl -n kyverno patch cpol check-image --type=json -p '[{"op": "replace", "path": "/spec/validationFailureAction", "value": "Enforce"}]'


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Durinv testing on vShasta is was observed that Kyverno could cause the workflow to stall because it blocked the startup of workflow pods while Nexus was down.

```
admission webhook "mutate.kyverno.svc-ignore" denied the request: 

resource Pod/argo/cilium-live-migration-f0dd6-shell-script-2358462432 was blocked due to the following policies 

check-image:
  check-image: 'failed to verify image registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0:
    .attestors[0].entries[0].keys: GET https://registry.local/v2/: unexpected status
    code 503 Service Unavailable; GET https://registry.local/v2/: unexpected status
    code 503 Service Unavailable; .attestors[0].entries[1].keys: GET https://registry.local/v2/:
    unexpected status code 503 Service Unavailable; GET https://registry.local/v2/:
    unexpected status code 503 Service Unavailable; .attestors[0].entries[2].keys:
    GET https://registry.local/v2/: unexpected status code 503 Service Unavailable;
    GET https://registry.local/v2/: unexpected status code 503 Service Unavailable;
    .attestors[0].entries[3].keys: GET https://registry.local/v2/: unexpected status
    code 503 Service Unavailable; GET https://registry.local/v2/: unexpected status
    code 503 Service Unavailable; .attestors[0].entries[4].keys: GET https://registry.local/v2/:
    unexpected status code 503 Service Unavailable; GET https://registry.local/v2/:
    unexpected status code 503 Service Unavailable'
```

This PR places the Kyverno `check-image` policy into Audit mode for the duration of the Cilium migration.

This PR also applies a missing network-attachment-definition that is applying during a fresh install but missing from the live migration case.

Relates to:
- [CASMTRIAGE-8451](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8451)
- [CASMNET-2357](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2357)
- [CASMTRIAGE-8473](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8473)

These modifications were tested by running the migration workflow on surtur.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
