### PR TITLE
CASMINST-7373: adding job yaml and script for k8s upgrade

### DIFF
--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -35,12 +35,12 @@ Once this step has completed:
 >
 > The output from the `deploy-product` stage will look like:
 >
-> ```bash
+> ```text
 > INFO Job upgrade-k8s-job-zm55x has been created in the argo namespace. This is performing k8s upgrade from 1.26 to 1.32
 > INFO Monitor the job and ensure it is successful before proceeding to next stage.
 > ```  
 >
-> To monitor the job, run:
+> (`ncn-mw#`) To monitor the job, run:
 >
 > ```bash
 > kubectl wait job -n argo upgrade-k8s-job-zm55x --for=condition=complete --timeout=120m

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -26,6 +26,26 @@ Refer to that table and any corresponding product documents before continuing to
 
 Once this step has completed:
 
+> **NOTE**  
+> In CSM 1.7, as part of the `deploy-product` stage during CSM upgrade:  
+>
+> - Kubernetes will be upgraded from version 1.26 to 1.32.5.  
+> - The `deploy-product-onexit` hook will launch a Kubernetes upgrade job that runs outside of IUF, in the `argo` namespace.  
+> - This job must be monitored manually and must complete successfully before proceeding to the next stage.  
+>
+> The output from the `deploy-product` stage will look like:
+>
+> ```bash
+> INFO Job upgrade-k8s-job-zm55x has been created in the argo namespace. This is performing k8s upgrade from 1.26 to 1.32
+> INFO Monitor the job and ensure it is successful before proceeding to next stage.
+> ```  
+>
+> To monitor the job, run:
+>
+> ```bash
+> kubectl wait job -n argo upgrade-k8s-job-zm55x --for=condition=complete --timeout=120m
+> ```
+
 - New versions of product microservices have been deployed
 - Per-stage product hooks have executed for the `deploy-product` stage
 

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -27,7 +27,7 @@ Refer to that table and any corresponding product documents before continuing to
 Once this step has completed:
 
 > **NOTE**  
-> In CSM 1.7, as part of the `deploy-product` stage during CSM upgrade:  
+> As part of the `deploy-product` stage during upgrades from CSM 1.6 to CSM 1.7:  
 >
 > - Kubernetes will be upgraded from version 1.26 to 1.32.5.  
 > - The `deploy-product-onexit` hook will launch a Kubernetes upgrade job that runs outside of IUF, in the `argo` namespace.  

--- a/upgrade/scripts/k8s/upgrade_k8s_job.yaml
+++ b/upgrade/scripts/k8s/upgrade_k8s_job.yaml
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: upgrade-k8s-job-
+  namespace: argo
+spec:
+  completions: 1
+  backoffLimit: 25
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"  # Disable sidecar injection for this Job's pod
+    spec:
+      containers:
+      - name: upgrade-k8s-job
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: ["sh", "-c"]
+        args:
+        - |
+          ssh -i /myssh/id_rsa -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null root@ncn-m001 "/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_steps.sh"
+        volumeMounts:
+        - mountPath: /myssh
+          name: ssh
+      restartPolicy: OnFailure
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      volumes:
+      - name: ssh
+        hostPath:
+          path: /root/.ssh
+

--- a/upgrade/scripts/k8s/upgrade_k8s_steps.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s_steps.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+echo "INFO Running k8s upgrade script"
+. /etc/cray/upgrade/csm/myenv
+
+DONE_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}"
+
+if [[ -f "$DONE_DIR/upgrade_k8s_1_29.done" ]]; then
+  echo "INFO kubernetes upgrade to v1.29 already completed, skipping."
+else
+  echo "INFO Starting the kubernetes upgrade to v1.29"
+  /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.27.16 1.28.15 1.29.15"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to upgrade kubernetes to v1.29"
+    exit 1
+  else
+    touch "$DONE_DIR/upgrade_k8s_1_29.done"
+    echo "INFO Successfully upgraded kubernetes to v1.29"
+  fi
+fi
+
+if [[ -f "$DONE_DIR/deploy_charts_post_k8s_upgrade.done" ]]; then
+  echo "INFO deploy manifests for v1.29 already completed, skipping."
+else
+  echo "INFO Deploying manifests for v1.29"
+  /usr/share/doc/csm/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to deploy manifests for v1.29"
+    exit 1
+  else
+    touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
+    echo "INFO Successfully deployed manifests for v1.29"
+  fi
+fi
+
+if [[ -f "$DONE_DIR/upgrade_k8s_1_32.done" ]]; then
+  echo "INFO kubernetes upgrade to v1.32 already completed, skipping."
+else
+  echo "INFO Starting the kubernetes upgrade to v1.32"
+  /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.30.12 1.31.8 1.32.5"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to upgrade kubernetes to v1.32"
+    exit 1
+  else
+    touch "$DONE_DIR/upgrade_k8s_1_32.done"
+    echo "INFO Successfully upgraded kubernetes to v1.32"
+  fi
+fi
+
+if [[ -f "$DONE_DIR/cleanup_bss.done" ]]; then
+  echo "INFO BSS cleanup already completed, skipping."
+else
+  echo "INFO Remove upgrade and upgrade_version file creation from BSS for masters and workers."
+  /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.sh
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to update BSS to remove upgrade and upgrade_version."
+    exit 1
+  else
+    touch "$DONE_DIR/cleanup_bss.done"
+    echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
+  fi
+fi
+
+echo "INFO Deploying manifests for v1.32"
+pushd ${CSM_ARTI_DIR}
+if [[ -f "$DONE_DIR/deploy_manifests.done" ]]; then
+  echo "INFO Manifests deployment already completed, skipping."
+else
+  ./upgrade.sh
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to deploy manifests for v1.32"
+    exit 1
+  else
+    popd +0
+    echo "INFO Successfully deployed manifests for v1.32"
+    touch "$DONE_DIR/deploy_manifests.done"
+  fi
+fi
+
+# If all steps succeeded, remove all .done files
+rm -f "$DONE_DIR"/*.done

--- a/upgrade/scripts/k8s/upgrade_k8s_steps.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s_steps.sh
@@ -38,14 +38,13 @@ else
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to upgrade kubernetes to v1.29"
     exit 1
-  else
-    touch "$DONE_DIR/upgrade_k8s_1_29.done"
-    if [[ $? -ne 0 ]]; then
-      echo "ERROR Failed to create done file for v1.29 upgrade"
-      exit 1
-    fi
-    echo "INFO Successfully upgraded kubernetes to v1.29"
   fi
+  touch "$DONE_DIR/upgrade_k8s_1_29.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for v1.29 upgrade"
+    exit 1
+  fi
+  echo "INFO Successfully upgraded kubernetes to v1.29"
 fi
 
 if [[ -f "$DONE_DIR/deploy_charts_post_k8s_upgrade.done" ]]; then
@@ -56,14 +55,13 @@ else
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to deploy manifests for v1.29"
     exit 1
-  else
-    touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
-    if [[ $? -ne 0 ]]; then
-      echo "ERROR Failed to create done file for v1.29 charts deployment"
-      exit 1
-    fi
-    echo "INFO Successfully deployed manifests for v1.29"
   fi
+  touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for v1.29 charts deployment"
+    exit 1
+  fi
+  echo "INFO Successfully deployed manifests for v1.29"
 fi
 
 if [[ -f "$DONE_DIR/upgrade_k8s_1_32.done" ]]; then
@@ -74,13 +72,12 @@ else
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to upgrade kubernetes to v1.32"
     exit 1
-  else
-    touch "$DONE_DIR/upgrade_k8s_1_32.done"
-    if [[ $? -ne 0 ]]; then
-      echo "ERROR Failed to create done file for v1.32 upgrade"
-    fi
-    echo "INFO Successfully upgraded kubernetes to v1.32"
   fi
+  touch "$DONE_DIR/upgrade_k8s_1_32.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for v1.32 upgrade"
+  fi
+  echo "INFO Successfully upgraded kubernetes to v1.32"
 fi
 
 if [[ -f "$DONE_DIR/cleanup_bss.done" ]]; then
@@ -91,14 +88,13 @@ else
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to update BSS to remove upgrade and upgrade_version."
     exit 1
-  else
-    touch "$DONE_DIR/cleanup_bss.done"
-    if [[ $? -ne 0 ]]; then
-      echo "ERROR Failed to create done file for BSS cleanup"
-      exit 1
-    fi
-    echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
   fi
+  touch "$DONE_DIR/cleanup_bss.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for BSS cleanup"
+    exit 1
+  fi
+  echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
 fi
 
 echo "INFO Deploying manifests for v1.32"
@@ -114,14 +110,12 @@ else
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to deploy manifests for v1.32"
     exit 1
-  else
-    echo "INFO Successfully deployed manifests for v1.32"
-    touch "$DONE_DIR/deploy_manifests.done"
-    if [[ $? -ne 0 ]]; then
-      echo "ERROR Failed to create done file for v1.32 manifests deployment"
-      exit 1
-    fi
-
+  fi
+  echo "INFO Successfully deployed manifests for v1.32"
+  touch "$DONE_DIR/deploy_manifests.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for v1.32 manifests deployment"
+    exit 1
   fi
 fi
 

--- a/upgrade/scripts/k8s/upgrade_k8s_steps.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s_steps.sh
@@ -26,6 +26,8 @@
 echo "INFO Running k8s upgrade script"
 . /etc/cray/upgrade/csm/myenv
 
+set -u
+
 DONE_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}"
 
 if [[ -f "$DONE_DIR/upgrade_k8s_1_29.done" ]]; then
@@ -38,6 +40,10 @@ else
     exit 1
   else
     touch "$DONE_DIR/upgrade_k8s_1_29.done"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR Failed to create done file for v1.29 upgrade"
+      exit 1
+    fi
     echo "INFO Successfully upgraded kubernetes to v1.29"
   fi
 fi
@@ -52,6 +58,10 @@ else
     exit 1
   else
     touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR Failed to create done file for v1.29 charts deployment"
+      exit 1
+    fi
     echo "INFO Successfully deployed manifests for v1.29"
   fi
 fi
@@ -66,6 +76,9 @@ else
     exit 1
   else
     touch "$DONE_DIR/upgrade_k8s_1_32.done"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR Failed to create done file for v1.32 upgrade"
+    fi
     echo "INFO Successfully upgraded kubernetes to v1.32"
   fi
 fi
@@ -80,23 +93,35 @@ else
     exit 1
   else
     touch "$DONE_DIR/cleanup_bss.done"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR Failed to create done file for BSS cleanup"
+      exit 1
+    fi
     echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
   fi
 fi
 
 echo "INFO Deploying manifests for v1.32"
-pushd ${CSM_ARTI_DIR}
+
 if [[ -f "$DONE_DIR/deploy_manifests.done" ]]; then
   echo "INFO Manifests deployment already completed, skipping."
 else
+  pushd "${CSM_ARTI_DIR}" || {
+    echo "ERROR Failed to change directory to ${CSM_ARTI_DIR}"
+    exit 1
+  }
   ./upgrade.sh
   if [[ $? -ne 0 ]]; then
     echo "ERROR Failed to deploy manifests for v1.32"
     exit 1
   else
-    popd +0
     echo "INFO Successfully deployed manifests for v1.32"
     touch "$DONE_DIR/deploy_manifests.done"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR Failed to create done file for v1.32 manifests deployment"
+      exit 1
+    fi
+
   fi
 fi
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

The Kubernetes upgrade, previously part of the deploy-product-onexit hook, was causing issues due to a kubelet restart during execution.
This PR moves the upgrade logic to a dedicated script: upgrade_k8s_steps.sh.
The script will be executed by a Kubernetes Job defined in upgrade_k8s_job.yaml.
The Job itself will be created as part of the deploy-product-onexit hook, ensuring the upgrade runs in a controlled and isolated environment.

Resolves [CASMINST-7373](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7373)
CSM PR- https://github.com/Cray-HPE/csm/pull/4263 

Testing steps:

- The fix was tested on #molly by executing the deploy-product stage.
- During the upgrade, the kubelet restarted, which caused the pod executing the Job to be terminated.
- Due to the Job's restart policy, it automatically restarted and successfully completed the upgrade.
- This confirms that the Job is resilient to kubelet restarts and performs the upgrade reliably.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
