### PR TITLE
CASMNET-2360 - Exclude SMA kafka network policies from Cilium migration

### DIFF
--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -135,8 +135,8 @@ spec:
                   rm -f /tmp/netpol.yaml
                   for i in $(kubectl get netpol -A --no-headers | awk '{print $1}' | sort -u );do
                     echo "--- namespace ${i} ---"
-                    # Not stashing network policies for cray-shared-kafka because they get recreated by the operator
-                    for j in $(kubectl -n ${i} get netpol --no-headers | grep -v cray-shared-kafka | awk '{print $1}');do
+                    # Not stashing network policies for cray-shared-kafka or SMA kafka because they get recreated by the operator
+                    for j in $(kubectl -n ${i} get netpol --no-headers | egrep -v "cray-shared-kafka|cluster" | awk '{print $1}');do
                       echo "Saving off network policy ${j}"
                       echo "---" >> /tmp/netpol.yaml
                       kubectl -n ${i} get netpol ${j} -o yaml >> /tmp/netpol.yaml


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The Cilium migration workflow already excludes the `cray-shared-kafka` NetworkPolicy resources from the backup taken during the `stash-netpol` step as they are managed by the operator and are recreated as soon as they are deleted.

The SMA Kafka cluster policies require the same treatment.
```
ncn-m001:~ # kubectl -n sma get netpol
NAME                               POD-SELECTOR                                                                               AGE
cluster-entity-operator            strimzi.io/cluster=cluster,strimzi.io/kind=Kafka,strimzi.io/name=cluster-entity-operator   16h
cluster-kafka-exporter             strimzi.io/cluster=cluster,strimzi.io/kind=Kafka,strimzi.io/name=cluster-kafka-exporter    16h
cluster-network-policy-kafka       strimzi.io/cluster=cluster,strimzi.io/kind=Kafka,strimzi.io/name=cluster-kafka             16h
cluster-network-policy-zookeeper   strimzi.io/cluster=cluster,strimzi.io/kind=Kafka,strimzi.io/name=cluster-zookeeper         17h
```
This change has been tested on wasp.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
