### PR TITLE
CASMINST-7404: Linting; remove workaround for fixed problem

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -78,7 +78,7 @@ to configure `sat` and authenticate to the API Gateway.
 The [Baseboard Management Controllers (BMCs)](../glossary.md#baseboard-management-controller-bmc) that control management nodes
 will not have been marked with the `Management` role in the [Hardware State Manager (HSM)](../glossary.md#hardware-state-manager-hsm).
 It is important to mark them with the `Management` role so that they can be easily included in the locking/unlocking operations required
-as protections actions by the [Firmware Action Service (FAS)](../glossary.md#firmware-action-service-fas) and the
+for protection from actions by the [Firmware Action Service (FAS)](../glossary.md#firmware-action-service-fas) and the
 [Power Control Service (PCS)](../glossary.md#power-control-service-pcs).
 
 **Set BMC `Management` roles now!**

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -11,8 +11,10 @@ and BMC/controller passwords.
 ## Topics
 
 1. [Configure the Cray and SAT command line interfaces](#1-configure-the-cray-and-sat-command-line-interfaces)
-    - [Automatic configuration using temporary Keycloak account](#automatic-configuration-using-temporary-keycloak-account)
-    - [Manual configuration](#manual-configuration)
+    - [Cray CLI configuration](#cray-cli-configuration)
+        - [Automatic configuration using temporary Keycloak account](#automatic-configuration-using-temporary-keycloak-account)
+        - [Manual configuration](#manual-configuration)
+    - [SAT CLI configuration](#sat-cli-configuration)
 1. [Set `Management` role on the BMCs of management nodes](#2-set-management-role-on-the-bmcs-of-management-nodes)
 1. [Lock management nodes](#3-lock-management-nodes)
 1. [Configure BMC and controller parameters with SCSD](#4-configure-bmc-and-controller-parameters-with-scsd)
@@ -28,15 +30,15 @@ and BMC/controller passwords.
 ## 1. Configure the Cray and SAT command line interfaces
 
 The `cray` command line interface (CLI) is a framework created to integrate all of the system
-management REST APIs into easily usable commands. The System Admin Toolkit (SAT) CLI, `sat`, is an
-additional CLI that automates common administrative workflows.
+management REST APIs into easily usable commands. The [System Admin Toolkit (SAT)](../glossary.md#system-admin-toolkit-sat)
+CLI (`sat`) is an additional CLI that automates common administrative workflows.
 
 Later procedures in the installation workflow use the `cray` and `sat` commands to interact with
 multiple services. The `cray` and `sat` CLI configurations need to be initialized for the Linux
 account. The Keycloak user who initializes these CLI configurations needs to be authorized for
 administrative actions.
 
-### Cray CLI Configuration
+### Cray CLI configuration
 
 There are two options to proceed with `cray` CLI authentication:
 
@@ -66,16 +68,18 @@ Manually configure the `cray` CLI with a valid Keycloak account using the follow
 
     See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak).
 
-### SAT CLI Configuration
+### SAT CLI configuration
 
 Follow the procedures in [SAT Configuration](../operations/system_admin_toolkit/configuration/README.md)
 to configure `sat` and authenticate to the API Gateway.
 
 ## 2. Set `Management` role on the BMCs of management nodes
 
-The BMCs that control management nodes will not have been marked with the `Management` role in HSM. It is important
-to mark them with the `Management` role so that they can be easily included in the locking/unlocking operations required
-as protections for FAS and PCS actions.
+The [Baseboard Management Controllers (BMCs)](../glossary.md#baseboard-management-controller-bmc) that control management nodes
+will not have been marked with the `Management` role in the [Hardware State Manager (HSM)](../glossary.md#hardware-state-manager-hsm).
+It is important to mark them with the `Management` role so that they can be easily included in the locking/unlocking operations required
+as protections actions by the [Firmware Action Service (FAS)](../glossary.md#firmware-action-service-fas) and the
+[Power Control Service (PCS)](../glossary.md#power-control-service-pcs).
 
 **Set BMC `Management` roles now!**
 
@@ -108,11 +112,11 @@ For more information about locking and unlocking nodes, see [Lock and Unlock Nod
 
 > **`NOTE`** If there are no liquid-cooled cabinets present in the HPE Cray EX system, then this step can be skipped.
 
-The System Configuration Service (SCSD) allows administrators to set various BMC and controller parameters for
-components in liquid-cooled cabinets. At this point in the install, SCSD should be used to set the
-SSH key in the node controllers (BMCs) to enable troubleshooting. If any of the nodes fail to power
-down or power up as part of the compute node booting process, it may be necessary to look at the logs
-on the BMC for node power down or node power up.
+The [System Configuration Service (SCSD)](../glossary.md#system-configuration-service-scsd) allows administrators to set
+various BMC and controller parameters for components in liquid-cooled cabinets. At this point in the install, SCSD should
+be used to set the SSH key in the node controllers (BMCs) to enable troubleshooting. If any of the nodes fail to power
+down or power up as part of the compute node booting process, it may be necessary to look at the logs on the BMC for node
+power down or node power up.
 
 See [Configure BMC and Controller Parameters with SCSD](../operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md).
 
@@ -123,8 +127,8 @@ for the procedure to configure passwordless SSH between management nodes and fro
 to managed nodes.
 
 This procedure sets up resources in Kubernetes (a Kubernetes Secret and ConfigMap) which are later
-applied to the management nodes using CFS node personalization in section
-[7. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
+applied to the management nodes by the [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs)
+during node personalization in section [8. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
 
 ## 6. Configure the root password and SSH keys in Vault
 
@@ -132,12 +136,12 @@ See [Configure the `root` password and SSH keys in Vault](../operations/CSM_prod
 for the procedure to configure the `root` password and SSH keys in Vault.
 
 This procedure writes the `root` password hash and SSH keys to Vault which are later
-applied to the management nodes using CFS node personalization in section
-[7. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
+applied to the management nodes by CFS during node personalization in section
+[8. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
 
 ## 7. Add switch admin password to Vault
 
-If CSM has been installed and Vault is running, add the switch credentials into Vault. Certain
+If CSM has been installed and Vault is running, then add the switch credentials into Vault. Certain
 tests, including `goss-switch-bgp-neighbor-aruba-or-mellanox` use these credentials to test the
 state of the switch. This step is not required to configure the management network. If Vault is
 unavailable, this step can be temporarily skipped. Any automated tests that depend on the switch
@@ -150,8 +154,7 @@ to verify that it was written correctly.
 /usr/share/doc/csm/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
 ```
 
-On success, the script will exit with return code 0 and have the following final lines
-of output:
+On success, the script will exit with return code 0 and its final lines of output will look similar to the following:
 
 ```text
 Writing switch admin password to Vault
@@ -162,15 +165,17 @@ SUCCESS
 ## 8. Configure management nodes with CFS
 
 Management nodes need to be configured after booting for administrative access, security, and other
-purposes. The [Configuration Framework Service (CFS)](../operations/configuration_management/Configuration_Management.md)
+purposes. The [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs)
 is used to apply post-boot configuration in a decoupled, layered manner. Individual software products
-provide one or more layers included in a CFS configuration. The CFS configuration is applied to components,
-including management nodes, during post-boot node personalization.
+provide one or more layers included in a CFS configuration. The CFS configuration is applied to node
+images (during image customization) and to booted nodes (during node personalization). This includes
+both management nodes and managed nodes.
 
-The procedure here creates a CFS configuration that contains only the layer provided by the CSM product and
-then applies that configuration to the management nodes.
+The procedure in this step creates a CFS configuration that contains only the base layers provided by the CSM product, and then applies
+that configuration to the booted management nodes. Later, [SAT Bootprep](../operations/system_admin_toolkit/usage/SAT_Bootprep.md)
+will generate the full CFS configuration including additional CSM layers and all product layers.
 
-1. (`ncn-m001#`) Set the variable `CSM_RELEASE` to the CSM release version.
+1. (`ncn-mw#`) Set the variable `CSM_RELEASE` to the CSM release version.
 
     For example:
 
@@ -178,7 +183,7 @@ then applies that configuration to the management nodes.
     CSM_RELEASE="1.6.0"
     ```
 
-1. (`ncn-m001#`) Run the `apply_csm_configuration.sh` script.
+1. (`ncn-mw#`) Run the `apply_csm_configuration.sh` script.
 
     This script creates a new CFS configuration named `management-csm-${CSM_RELEASE}`
     and applies it to the management node components in CFS, enables them,
@@ -196,7 +201,8 @@ then applies that configuration to the management nodes.
     Configuration complete. 9 component(s) completed successfully.  0 component(s) failed.
     ```
 
-    The number reported should match the number of management nodes in the system. If there are failures, see [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md).
+    The number reported should match the number of management nodes in the system.
+    If there are failures, see [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md).
 
 ## 9. Proceed to next topic
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -7,9 +7,8 @@ This section updates the software running on management NCNs.
     - [2.1 `management-nodes-rollout` with CSM upgrade](#21-management-nodes-rollout-with-csm-upgrade)
     - [2.2 `management-nodes-rollout` without CSM upgrade](#22-management-nodes-rollout-without-csm-upgrade)
     - [2.3 NCN worker nodes](#23-ncn-worker-nodes)
-- [3. Restart `goss-servers` on all NCNs](#3-restart-goss-servers-on-all-ncns)
-- [4. Update management host Slingshot NIC firmware](#4-update-management-host-slingshot-nic-firmware)
-- [5. Next steps](#5-next-steps)
+- [3. Update management host Slingshot NIC firmware](#3-update-management-host-slingshot-nic-firmware)
+- [4. Next steps](#4-next-steps)
 
 ## 1. Update management host firmware (FAS)
 
@@ -277,7 +276,7 @@ Refer to that table and any corresponding product documents before continuing to
      - All management NCNs have been upgraded to the image and CFS configuration created in the previous steps of this workflow
      - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
-Continue to the next section [3. Restart `goss-servers` on all NCNs](#3-restart-goss-servers-on-all-ncns).
+Continue to the next section [3. Update management host Slingshot NIC firmware](#3-update-management-host-slingshot-nic-firmware).
 
 ### 2.2 `management-nodes-rollout` without CSM upgrade
 
@@ -416,7 +415,7 @@ Once this step has completed:
 - Management NCN storage and NCN master nodes have be updated with the CFS configuration created in the previous steps of this workflow.
 - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
-Continue to the next section [3. Restart `goss-servers` on all NCNs](#3-restart-goss-servers-on-all-ncns).
+Continue to the next section [3. Update management host Slingshot NIC firmware](#3-update-management-host-slingshot-nic-firmware).
 
 ### 2.3 NCN worker nodes
 
@@ -510,22 +509,7 @@ Return to the procedure that was being followed for `management-nodes-rollout` t
 either [Management-nodes-rollout with CSM upgrade](#21-management-nodes-rollout-with-csm-upgrade) or
 [Management-nodes-rollout without CSM upgrade](#22-management-nodes-rollout-without-csm-upgrade).
 
-## 3. Restart `goss-servers` on all NCNs
-
-**`NOTE`** Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
-
-If the CSM version is 1.6.0 or lower, then the `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN.
-This is necessary due to a timing issue that is fixed in CSM 1.6.1.
-
-(`ncn-m001#`) Restart `goss-servers`.
-
-```bash
-ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-ncn_nodes=${ncn_nodes%,}
-pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-```
-
-## 4. Update management host Slingshot NIC firmware
+## 3. Update management host Slingshot NIC firmware
 
 **`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
@@ -545,7 +529,7 @@ Once this step has completed:
 - Service checks have been run to verify product microservices are executing as expected
 - Per-stage product hooks have executed for the `deploy-product` and `post-install-service-check` stages
 
-## 5. Next steps
+## 4. Next steps
 
 - If performing an initial install or an upgrade of non-CSM products only, then return to the
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -57,7 +57,7 @@ procedures based on whether or not CSM is being upgraded:
 
 Starting with CSM `V1.7.0`, administrators can use an IMS image and configuration from CFS built outside of IUF to perform the `management-nodes-rollout` stage. The image and configuration can be explicitly passed in the IUF CLI command.
 
-For example, to upgrade a storage node using an image and CFS configuration created outside of the `prepare-images` stage, the command could look like this:
+(`ncn-m001#`) For example, to upgrade a storage node using an image and CFS configuration created outside of the `prepare-images` stage, the command could look like this:
 
 ```bash
 iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run \
@@ -66,10 +66,21 @@ iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run \
     -r management-nodes-rollout --limit-management-rollout ${STORAGE_CANARY}
 ```
 
-The CFS configuration and IMS image being used can be described like shown below:
+(`ncn-m001#`) The CFS configuration can be described using the following command:
 
 ```bash
-ncn-m001:~ # cray cfs configurations describe management-main-1.7-1715924
+cray cfs configurations describe <cfs_configuration_name>
+```
+
+For example:
+
+```bash
+cray cfs configurations describe management-main-1.7-1715924
+```
+
+Example output:
+
+```toml
 lastUpdated = "2025-04-14T19:22:00Z"
 name = "management-main-1.7-1715924"
 [[layers]]
@@ -85,8 +96,21 @@ name = "shs-mellanox_install-integration-12.0.0"
 playbook = "shs_mellanox_install.yml"
 ```
 
+(`ncn-m001#`) The IMS image can be described using the following command:
+
 ```bash
-ncn-m001:~ # cray ims images describe f9fb3b2b-5527-47cb-a2de-8fa9dec7cec6
+cray ims images describe <ims_image_ID>
+```
+
+For example:
+
+```bash
+cray ims images describe f9fb3b2b-5527-47cb-a2de-8fa9dec7cec6
+```
+
+Example output:
+
+```toml
 arch = "x86_64"
 created = "2025-04-14T19:44:21.862319"
 id = "f9fb3b2b-5527-47cb-a2de-8fa9dec7cec6"
@@ -100,7 +124,8 @@ type = "s3"
 [metadata]
 ```
 
-> **Important:** There is no built-in mechanism to validate the image and configuration being passed belong to the same role and subrole. Administrators must ensure that the correct image and configuration are used for the corresponding node and subrole.
+> **Important:** There is no built-in mechanism to validate the image and configuration being passed belong to the same role and subrole.
+Administrators must ensure that the correct image and configuration are used for the corresponding node and subrole.
 
 For the new parameters added, please refer to the command information in the [IUF run command details](../IUF.md#run) documentation.
 
@@ -291,12 +316,12 @@ Refer to that table and any corresponding product documents before continuing to
 
         ```bash
         /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-        --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $MASTER_XNAMES --clear-state
+            --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $MASTER_XNAMES --clear-state
         ```
 
         Sample output for configuring multiple management nodes is:
 
-          ```bash
+          ```text
           Taking snapshot of existing management-23.11.0 configuration to /root/apply_csm_configuration.20240305_173700.vKxhqC backup-management-23.11.0.json
           Setting desired configuration, clearing state, clearing error count, enabling components in CFS
           desiredConfig = "management-23.11.0"
@@ -349,7 +374,7 @@ Refer to that table and any corresponding product documents before continuing to
 
         ```bash
         /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-        --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $STORAGE_XNAMES --clear-state
+            --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames $STORAGE_XNAMES --clear-state
         ```
 
         Sample output for configuring multiple management nodes is:
@@ -414,13 +439,10 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     ```bash
     WORKER_CANARY=ncn-w001
-    ```
-
-    ```bash
     iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout ${WORKER_CANARY}
     ```
 
-1. Verify the canary node booted successfully with the desired image and CFS configuration.
+1. (`ncn-m001#`) Verify that the canary node booted successfully with the desired image and CFS configuration.
 
     ```bash
     XNAME=$(ssh $WORKER_CANARY 'cat /etc/cray/xname')
@@ -434,7 +456,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     kubectl label nodes "${WORKER_CANARY}" --overwrite iuf-prevent-rollout=true
     ```
 
-1. (`ncn-m001#`) Verify the IUF node labels are present on the desired node.
+1. (`ncn-m001#`) Verify that the IUF node labels are present on the desired node.
 
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
@@ -448,20 +470,18 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
-    1. (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
+    - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 
         ```bash
         iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout Management_Worker
         ```
 
-    1. (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes. The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
+    - (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes.
+      The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
 
         ```bash
         WORKER_NODES=$(kubectl get node | grep -P 'ncn-w\d+' | grep -v $WORKER_CANARY |  awk '{print $1}' | xargs)
         echo $WORKER_NODES
-        ```
-
-        ```bash
         iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout $WORKER_NODES
         ```
 
@@ -475,8 +495,10 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     ```bash
     for ncn in $(cray hsm state components list --subrole Worker --type Node \
-      --format json | jq -r .Components[].ID | grep b0n | sort); do cray cfs components describe \
-      $ncn --format json | jq -r ' .id+" "+.desiredConfig+" status="+.configurationStatus'; done
+        --format json | jq -r .Components[].ID | grep b0n | sort)
+    do
+        cray cfs components describe $ncn --format json | jq -r ' .id+" "+.desiredConfig+" status="+.configurationStatus'
+    done
     ```
 
 Once this step has completed:
@@ -484,14 +506,16 @@ Once this step has completed:
 - Management NCN worker nodes have been rebuilt with the image and CFS configuration created in previous steps of this workflow
 - Per-stage product hooks have executed for the `management-nodes-rollout` stage
 
-Return to the procedure that was being followed for `management-nodes-rollout` to complete the next step, either [Management-nodes-rollout with CSM upgrade](#21-management-nodes-rollout-with-csm-upgrade) or
+Return to the procedure that was being followed for `management-nodes-rollout` to complete the next step:
+either [Management-nodes-rollout with CSM upgrade](#21-management-nodes-rollout-with-csm-upgrade) or
 [Management-nodes-rollout without CSM upgrade](#22-management-nodes-rollout-without-csm-upgrade).
 
 ## 3. Restart `goss-servers` on all NCNs
 
 **`NOTE`** Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
 
-If the CSM version is 1.6.0 or lower, then the `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
+If the CSM version is 1.6.0 or lower, then the `goss-servers` service needs to be restarted on all NCNs. This ensures the correct tests are run on each NCN.
+This is necessary due to a timing issue that is fixed in CSM 1.6.1.
 
 (`ncn-m001#`) Restart `goss-servers`.
 
@@ -505,13 +529,15 @@ pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
 
 **`NOTE`** This subsection is optional and can be skipped if upgrading only CSM through IUF.
 
-If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of the _HPE Slingshot Installation Guide for CSM_ for details on how to update NIC firmware on management nodes.
+If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of the _HPE Slingshot Installation Guide for CSM_
+for details on how to update NIC firmware on management nodes.
 
 After updating management host Slingshot NIC firmware, all nodes where the firmware was updated must be power cycled.  
 
 Choose one of the below options to reboot worker nodes:
-To manually reboot the nodes follow the [Reboot NCNs manually](../../node_management/Reboot_NCNs_manual.md#ncn-worker-nodes) for all nodes where the firmware was updated.  
-To use IUF to reboot the nodes, follow the [Reboot NCNs with IUF](../../node_management/Reboot_NCNs_iuf.md#ncn-worker-nodes) for all nodes where the firmware was updated.
+
+- To manually reboot the nodes follow the [Reboot NCNs manually](../../node_management/Reboot_NCNs_manual.md#ncn-worker-nodes) for all nodes where the firmware was updated.  
+- To use IUF to reboot the nodes, follow the [Reboot NCNs with IUF](../../node_management/Reboot_NCNs_iuf.md#ncn-worker-nodes) for all nodes where the firmware was updated.
 
 Once this step has completed:
 
@@ -521,14 +547,14 @@ Once this step has completed:
 
 ## 5. Next steps
 
-- If performing an initial install or an upgrade of non-CSM products only, return to the
+- If performing an initial install or an upgrade of non-CSM products only, then return to the
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+- If performing an upgrade that includes upgrading CSM and additional products with IUF, then
   return to the [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
   workflow to continue the upgrade.
 
-- If performing an upgrade that includes upgrading only CSM, return to the
+- If performing an upgrade that includes upgrading only CSM, then return to the
   [Upgrade only CSM through IUF](../../../upgrade/Upgrade_Only_CSM_with_iuf.md)
   workflow to continue the upgrade.

--- a/operations/node_management/Reboot_NCNs_manual.md
+++ b/operations/node_management/Reboot_NCNs_manual.md
@@ -26,16 +26,6 @@ This page provides instructions for doing a manual reboot of NCN nodes. There is
 
     Refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md) for an overview of the health checks.
 
-    1. (`ncn-mw#`) If the CSM version is 1.6.0 or lower, then restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary due to a timing issue that is fixed in CSM 1.6.1.
-
-        > Skip this step if the CSM version is 1.6.1 or above. This step will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
-
-        ```bash
-        ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-        ncn_nodes=${ncn_nodes%,}
-        pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-        ```
-
     1. (`ncn-mw#`) Run the platform health script.
 
         Run this on any master or worker node. The output of the following script will need to be referenced in some of the remaining sub-steps.

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -27,14 +27,6 @@ echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
-> **`NOTE:`** (`ncn#`) If the CSM version is 1.6.0 or lower, then restart the `goss-servers` service on the rebuilt node after it has been rebuilt.
-> This is necessary because of a timing issue that is fixed in CSM 1.6.1.
-> The service restart will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
->
-> ```bash
-> ssh "${NODE}" 'systemctl restart goss-servers'
-> ```
-
 - [Worker node](#worker-node)
 - [Master node](#master-node)
 - [Storage node](#storage-node)

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -55,30 +55,6 @@ If running these checks after the initial CSM install, then to find details on c
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a `PASS` or `FAIL`.
 
-If the CSM version is 1.6.0 or lower, then before running health checks, restart the `goss-servers` service on all NCNs to ensure the correct tests are run on each node. This is necessary because of a timing issue that is fixed in CSM 1.6.1.
-
-> Skip the `goss-servers` service restart if the CSM version is 1.6.1 or above.
-> The restart will cause no harm if done on CSM 1.6.1 or higher, but it is unnecessary.
-
-Run one of the two commands below depending on if it is being executed from `ncn-m001` or from the PIT node.
-
-- (`ncn-m001#`) Run the following from `ncn-m001` to restart `goss-servers`.
-
-    ```bash
-    ncn_nodes=$(grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | tr -t '\n' ',')
-    ncn_nodes=${ncn_nodes%,}
-    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-    ```
-
-- (`pit#`) Run the following from the PIT node to restart `goss-servers`.
-
-    ```bash
-    mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt'
-    ncn_nodes=$(grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | sed -e "s/-mgmt//" | tr -t '\n' ',')
-    ncn_nodes=${ncn_nodes%,}
-    pdsh -S -b -w $ncn_nodes 'systemctl restart goss-servers'
-    ```
-
 Available platform health checks:
 
 1. [NCN health checks](#11-ncn-health-checks)


### PR DESCRIPTION
This PR mostly is generic linting with no content changes, fixing things I noticed while helping the iSCSI and rack resiliency teams with their documentation PRs.

The exception is that it also removes the workaround steps added by CASMPET-7265. The problem that it added workarounds for was fixed in CSM 1.6.1 and never existed in CSM 1.7. I am sure that this was added before the `release/1.7` branch had been split off, which is why it got copied over when that branch was created. I am surprised that no ticket was open when the change was made, though, as a reminder to remove this from the CSM 1.7 docs once it was possible. I just happened to notice that this was in there by chance.

I will be backporting some of the linting changes, but not the workaround removal, since that change is only needed for CSM 1.7.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/6151
1.5: https://github.com/Cray-HPE/docs-csm/pull/6152
1.4: https://github.com/Cray-HPE/docs-csm/pull/6153
1.3: https://github.com/Cray-HPE/docs-csm/pull/6154
1.2: https://github.com/Cray-HPE/docs-csm/pull/6155
1.0: https://github.com/Cray-HPE/docs-csm/pull/6156