### PR TITLE
CASMPET-7640: DOCS: Create/restore iSCSI verification procedures

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -528,6 +528,7 @@ dropdown
 dryrun
 eBGP
 eC
+enablement
 etcd
 ex2500
 exascale
@@ -1023,6 +1024,13 @@ etag
 etag
 etags
 
+- operations/iscsi_sbps/iSCSI_SBPS_Metrics.md
+IOPs
+LUNs
+
+- operations/iscsi_sbps/iSCSI_SBPS_Verification.md
+LUNs
+
 - operations/iuf/IUF.md
 cray-product-catalog
 sessionid
@@ -1137,13 +1145,6 @@ Expat-15
 - troubleshooting/known_issues/antero_node_NID_allocation.md
 # To allow Site Init
 Init
-
-
-- operations/configuration_management/iSCSI_SBPS_Node_Personalization.md
-enablement
-LUNs
-fileio
-iscsi-sbps-targets-config
 
 - troubleshooting/debugging_with_hms_pprof_images.md
 mutexes

--- a/operations/README.md
+++ b/operations/README.md
@@ -865,3 +865,5 @@ Below are the documents related to iSCSI-based boot content projection.
 
 - [iSCSI SBPS](iscsi_sbps/README.md)
 - [Managing Selective Node Personalization](iscsi_sbps/Managing_Selective_Node_Personalization.md)
+- [iSCSI SBPS Verification](iscsi_sbps/iSCSI_SBPS_Verification.md)
+- [iSCSI SBPS Metrics](iscsi_sbps/iSCSI_SBPS_Metrics.md)

--- a/operations/iscsi_sbps/Managing_Selective_Node_Personalization.md
+++ b/operations/iscsi_sbps/Managing_Selective_Node_Personalization.md
@@ -20,15 +20,19 @@
 
 ## Overview
 
-The selective iSCSI worker node personalization feature allows administrators to specify which worker NCNs are enabled as
+All worker NCNs are *configured* to be potential iSCSI targets.
+The selective iSCSI worker node personalization feature allows administrators to specify which worker NCNs are *enabled* as
 iSCSI targets. The mechanism by which an administrator specifies this is the `iscsi_worker`
 [component group](../hardware_state_manager/Component_Groups_and_Partitions.md#groups) in the
 [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
 The existence of this group on the system means that selective iSCSI worker node personalization is enabled.
 If the group does not exist, then the feature is disabled, and all worker nodes will be enabled as iSCSI targets.
-While it is technically possible to create this group and leave it empty, this will mean that no worker nodes will be
-enabled as iSCSI targets, which in turn will mean that no managed nodes will be able to boot. Therefore CSM generally
-treats it as an error if the HSM group exists but it contains no worker nodes.
+
+While it is technically possible to create this group and leave it empty, this would mean that no worker nodes would be
+enabled as iSCSI targets, which in turn would mean that no managed nodes would be able to boot. Therefore CSM
+treats it as an error if the HSM group exists but contains no worker nodes.
+
+Any members of the group that are not worker nodes are ignored and have no effect on iSCSI enablement.
 
 The [Group commands](#group-commands) section goes over the commands used to create, remove, or modify the group.
 The [Procedures](#procedures) section discusses the different contexts in which this may be done, and any additional
@@ -51,6 +55,8 @@ For more in-depth information on managing HSM groups in general, see
 
 (`ncn-mw#`) Create the `iscsi_worker` group.
 
+> The `description` field is not required to be specified; it has no operational effect.
+
 ```bash
 cray hsm groups create --label iscsi_worker --description "iscsi node personalization" --members-ids x3000c0s5b0n0,x3001c0s35b0n0
 ```
@@ -67,7 +73,7 @@ created with the correct members, see [Listing group members](#listing-group-mem
 
 ### Adding a worker to the group
 
-(`ncn-mw#`) Add one more worker node to the `iscsi_worker` group.
+(`ncn-mw#`) Add an additional worker node to the `iscsi_worker` group.
 
 > Note: Each command may only add a single worker.
 
@@ -131,8 +137,8 @@ message = "deleted 1 entry"
 ## Procedures
 
 The procedures vary for enabling or disabling this feature, or modifying the set of worker nodes that are enabled as iSCSI
-targets. It depends on whether this is being done during a fresh install of CSM, an upgrade from CSM 1.6 to CSM 1.7,
-as part of adding or removing a worker NCN, or on an operational CSM 1.7+ system.
+targets. It depends on whether this is being done during a fresh install of CSM, during an upgrade from CSM 1.6 to CSM 1.7,
+as part of adding or removing a worker NCN, or as a procedure on an operational CSM 1.7+ system.
 
 * [CSM install](#csm-install)
 * [CSM upgrade from 1.6 to 1.7](#csm-upgrade-from-16-to-17)
@@ -146,8 +152,9 @@ as part of adding or removing a worker NCN, or on an operational CSM 1.7+ system
 ### CSM install
 
 During a CSM install, if the administrator wants to enable this feature, they should
-[create the `iscsi_worker` HSM group](#creating-the-group) as part of
-[Configure Administrative Access](../../install/configure_administrative_access.md)
+[create the `iscsi_worker` HSM group](#creating-the-group) as part of the
+[iSCSI SBPS configuration](../../install/configure_administrative_access.md#8-iscsi-sbps-configuration)
+step in the [Configure Administrative Access](../../install/configure_administrative_access.md) procedure.
 
 The feature will take effect when
 [Management Node Personalization](../configuration_management/Management_Node_Personalization.md)
@@ -189,7 +196,7 @@ read the section that applies to the current operation and whether or not the `i
 >     * If it succeeds, then the group exists (and its member list will be shown).
 >     * If the group does not exist, then the command will fail with an error that it cannot find the group.
 > * Both before and after the overall add or remove procedure, administrators may wish to validate the iSCSI configuration.
->   by running [GOSS tests for SBPS](https://github.com/Cray-HPE/sbps-marshal/blob/main/GOSS_tests_for_sbps.md).
+>   See [iSCSI SBPS Verification](iSCSI_SBPS_Verification.md).
 
 * [Adding worker NCN when `iscsi_sbps` group does not exist](#adding-worker-ncn-when-iscsi_sbps-group-does-not-exist)
 * [Adding worker NCN when `iscsi_sbps` group exists](#adding-worker-ncn-when-iscsi_sbps-group-exists)
@@ -344,7 +351,7 @@ for iSCSI can be changed. To do this, use the following procedure:
 1. *Optional:* Verify the iSCSI configuration.
 
     After the CFS node personalization is complete for all of the worker NCNs, administrators may wish to verify the iSCSI configuration.
-    See [Goss tests for SBPS](https://github.com/Cray-HPE/sbps-marshal/blob/main/GOSS_tests_for_sbps.md).
+    See [iSCSI SBPS Verification](iSCSI_SBPS_Verification.md).
 
 ## Manual DNS records update
 

--- a/operations/iscsi_sbps/README.md
+++ b/operations/iscsi_sbps/README.md
@@ -81,181 +81,10 @@ discovery from an initiator node during its boot.
 
 ![iSCSI SBPS workflow](../../img/SBPS_flow_diagram.jpg)
 
-(`ncn-w#`) Example output snippet of `targetcli ls` command on worker node where iSCSI LUNS are created for the images scanned:
-
-```bash
-targetcli ls
-```
-
-```text
-o- / ......................................................................................................................... [...]
-  o- backstores .............................................................................................................. [...]
-  | o- block .................................................................................................. [Storage Objects: 0]
-  | o- fileio ................................................................................................ [Storage Objects: 28]
-  | | o- 0331b9aaef49840 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.03.squashfs (122.2MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 0f3847fd8e25624 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.03.squashfs (114.8MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 1373e69e2028baa ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.11.squashfs (503.4MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 2babe2c96d6f900 ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-23.12.squashfs (1.9GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 380840014ffe295  [/var/lib/cps-local/boot-images/f731d8d5-0fed-41d7-996e-6a0d19b6ff6d/rootfs (10.8GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 719593b460753ac ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.11.squashfs (131.6MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 76e638d3bfc3107 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-23.12.squashfs (64.0KiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 7c0bba5c5301c97  [/var/lib/cps-local/boot-images/5b43428e-4381-4f39-9335-6dababb76d86/rootfs (2.9GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 7cccd5c7adc8cc6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-23.12.squashfs (114.4MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 818ff2c161855b6 ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.03.squashfs (117.9MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 85801b9e9c9cea7 ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.03.squashfs (2.0GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 8edfc76b6dae21f ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.03.squashfs (134.1MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 953aa229aafffa6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.11.squashfs (128.6MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 979b7868c15ee00 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-23.12.squashfs (123.2MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 9de1fe8a016602f ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.07.squashfs (2.0GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- 9f7ee65eadd1d3c ..... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.07.squashfs (272.3MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- a50dd52157e1636 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs (121.9MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- a6db212e5a329fa .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.03.squashfs (2.4GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- aac0f352b7a30d6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.07.squashfs (110.1MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- b91b33a9f98a0be ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.07.squashfs (113.2MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- c1d98cf92b0647f ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-23.12.squashfs (117.9MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- cfaa140ac182849 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.07.squashfs (333.5MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- d265658496338c0 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.07.squashfs (298.2MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- d797313856f7502 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.07.squashfs (2.4GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- da65cccd2e89d0c ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.11.squashfs (555.7MiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- de4cc04e7dacfb9 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.11.squashfs (7.7GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- e41757ef248d642 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-23.12.squashfs (2.4GiB) write-thru activated]
-  | | | o- alua ................................................................................................... [ALUA Groups: 1]
-  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | | o- e837346fddf2004 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.03.squashfs (92.5MiB) write-thru activated]
-  | |   o- alua ................................................................................................... [ALUA Groups: 1]
-  | |     o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
-  | o- pscsi .................................................................................................. [Storage Objects: 0]
-  | o- ramdisk ................................................................................................ [Storage Objects: 0]
-  o- iscsi ............................................................................................................ [Targets: 1]
-  | o- iqn.2023-06.csm.iscsi:ncn-w002 .................................................................................... [TPGs: 1]
-  |   o- tpg1 .................................................................................................. [gen-acls, no-auth]
-  |     o- acls .......................................................................................................... [ACLs: 0]
-  |     o- luns ......................................................................................................... [LUNs: 28]
-  |     | o- lun0 .... [fileio/a50dd52157e1636 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun1 .... [fileio/0331b9aaef49840 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun2 .... [fileio/d265658496338c0 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun3 .... [fileio/1373e69e2028baa (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.11.squashfs) (default_tg_pt_gp)]
-  |     | o- lun4 ... [fileio/c1d98cf92b0647f (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun5 ... [fileio/818ff2c161855b6 (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun6 ... [fileio/b91b33a9f98a0be (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun7 ... [fileio/719593b460753ac (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.11.squashfs) (default_tg_pt_gp)]
-  |     | o- lun8 .. [fileio/2babe2c96d6f900 (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun9 .. [fileio/85801b9e9c9cea7 (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun10 . [fileio/9de1fe8a016602f (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun11 .. [fileio/e41757ef248d642 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun12 .. [fileio/a6db212e5a329fa (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun13 .. [fileio/d797313856f7502 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun14 .. [fileio/de4cc04e7dacfb9 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.11.squashfs) (default_tg_pt_gp)]
-  |     | o- lun15 . [fileio/7cccd5c7adc8cc6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun16 . [fileio/0f3847fd8e25624 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun17 . [fileio/aac0f352b7a30d6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun18 . [fileio/953aa229aafffa6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.11.squashfs) (default_tg_pt_gp)]
-  |     | o- lun19  [fileio/76e638d3bfc3107 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun20  [fileio/e837346fddf2004 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun21  [fileio/9f7ee65eadd1d3c (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun22  [fileio/979b7868c15ee00 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-23.12.squashfs) (default_tg_pt_gp)]
-  |     | o- lun23  [fileio/8edfc76b6dae21f (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.03.squashfs) (default_tg_pt_gp)]
-  |     | o- lun24  [fileio/cfaa140ac182849 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.07.squashfs) (default_tg_pt_gp)]
-  |     | o- lun25  [fileio/da65cccd2e89d0c (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.11.squashfs) (default_tg_pt_gp)]
-  |     | o- lun26  [fileio/7c0bba5c5301c97 (/var/lib/cps-local/boot-images/5b43428e-4381-4f39-9335-6dababb76d86/rootfs) (default_tg_pt_gp)]
-  |     | o- lun27  [fileio/380840014ffe295 (/var/lib/cps-local/boot-images/f731d8d5-0fed-41d7-996e-6a0d19b6ff6d/rootfs) (default_tg_pt_gp)]
-  |     o- portals .................................................................................................... [Portals: 3]
-  |       o- 10.102.104.28:3260 ............................................................................................... [OK]
-  |       o- 10.150.0.4:3260 .................................................................................................. [OK]
-  |       o- 10.252.1.13:3260 ................................................................................................. [OK]
-  o- loopback ......................................................................................................... [Targets: 0]
-  o- vhost ............................................................................................................ [Targets: 0]
-  o- xen-pvscsi ....................................................................................................... [Targets: 0]
-```
-
-The above `targetcli ls` command output shows the following:
-
-* Four `fileio` backing store are created for two `rootfs` images
-* Two iSCSI `LUNs` are created which have the `rootfs` image ID being mapped
-* 26 `PE` or `squashfs` `fileio` backing store are created
-* 26 iSCSI `LUNs` created which have the `PE` or `squashfs` image ID being mapped
-* These iSCSI `LUNs` are ready for projection
-
-(`nid#`) Sample initiator node snippet after the projection:
-
-```bash
-multipath -ll
-```
-
-```text
-11218.831779 | /etc/multipath.conf line 10: ignoring deprecated option "disable_changed_wwids", using built-in value: "yes"
-PE_CPE-base.x86_64-24.11.squashfs (36001405de4cc04e7dacfb9ada0a6b4cc) dm-0 LIO-ORG,de4cc04e7dacfb9
-size=7.7G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
-`-+- policy='round-robin 0' prio=50 status=active
-  |- 1:0:0:14 sdo  8:224  active ready running
-  |- 2:0:0:14 sdaq 66:160 active ready running
-  |- 3:0:0:14 sdbs 68:96  active ready running
-  `- 4:0:0:14 sdcu 70:32  active ready running
-f731d8d5-0fed-41d7-996e-6a0d19b6ff6d_rootfs (36001405380840014ffe295091e8689db) dm-24 LIO-ORG,380840014ffe295
-size=11G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
-`-+- policy='round-robin 0' prio=50 status=active
-  |- 1:0:0:27 sdab 65:176 active ready running
-  |- 2:0:0:27 sdbd 67:112 active ready running
-  |- 3:0:0:27 sdcf 69:48  active ready running
-  `- 4:0:0:27 sddh 70:240 active ready running
-```
-
 ## Steps to achieve SBPS
 
 1. [Worker node personalization](#1-worker-node-personalization)
-1. [Run GOSS test suite](#2-run-goss-test-suite)
+1. [Validate configuration](#2-validate-configuration)
 1. [Create BOS session template](#3-create-bos-session-template)
 1. [IMS image tagging](#4-ims-image-tagging)
 1. [Boot compute nodes or UANs](#5-boot-compute-nodes-or-uans)
@@ -289,17 +118,14 @@ By default worker node personalization of iSCSI SBPS is done during CSM install/
 It is initiated during bootprep (`management-nodes-rollout`) in order to do worker node personalization
 automatically during boot time.
 
-### 2. Run GOSS test suite
+### 2. Validate configuration
 
 In order to verify the readiness of the iSCSI targets before triggering the boot of compute nodes or
-UANs, it is important to run GOSS tests as sanity checks on iSCSI targets.
-
-Refer to [GOSS tests for SBPS](https://github.com/Cray-HPE/sbps-marshal/blob/main/GOSS_tests_for_sbps.md)
-for the details.
+UANs, the iSCSI configuration should be validated. See [iSCSI SBPS Verification](iSCSI_SBPS_Verification.md).
 
 ### 3. Create BOS session template
 
-Once the node personalization is done and GOSS tests are run successfully, create BOS Session Template with SBPS boot parameters.
+Once the node personalization is done and the configuration has been validated, then create BOS Session Templates with SBPS boot parameters.
 
 There are two ways to create BOS session template:
 
@@ -448,7 +274,7 @@ It is necessary to open the console for each node separately.
 In order to monitor iSCSI SBPS target statistics, one may monitor metrics series like aggregate LUN read rate, read rate per LUN, throughput
 statistics on LIO portal network endpoints, and so on.
 
-Refer to [iSCSI Metrics](https://github.com/Cray-HPE/sbps-marshal/blob/main/iscsi_metrics.md) for details.
+Refer to [iSCSI Metrics](iSCSI_SBPS_Metrics.md) for details.
 
 ## Glossary
 

--- a/operations/iscsi_sbps/iSCSI_SBPS_Metrics.md
+++ b/operations/iscsi_sbps/iSCSI_SBPS_Metrics.md
@@ -1,0 +1,110 @@
+# iSCSI SBPS Metrics
+
+The information on this page assumes that
+[Node personalization](iSCSI_SBPS_Verification.md#node-personalization) has completed successfully
+and that the [SBPS Marshal Agent](iSCSI_SBPS_Verification.md#sbps-marshal-agent) is running without
+errors on all [iSCSI-enabled workers](iSCSI_SBPS_Verification.md#iscsi-enabled-workers).
+See [iSCSI SBPS Verification](iSCSI_SBPS_Verification.md) for more details.
+
+* [Overview](#overview)
+* [Metric sources](#metric-sources)
+    * [`sysfs`](#sysfs)
+        * [`sysfs` megabytes read](#sysfs-megabytes-read)
+        * [`sysfs` read IOPS](#sysfs-read-iops)
+    * [`saveconfig.json`](#saveconfigjson)
+* [Retrieve iSCSI metrics](#retrieve-iscsi-metrics)
+    * [Command line](#command-line)
+    * [VictoriaMetrics web UI](#victoriametrics-web-ui)
+    * [Grafana web UI](#grafana-web-ui)
+
+## Overview
+
+iSCSI-based boot content projection is a read-only projection. Metrics related to projection are exported to the node exporter / Prometheus.
+
+* Megabytes read
+* Read I/O per second (IOPs)
+* Number of projected `rootfs` LUNs
+* Number of projected PE LUNs
+* Throughput statistics on LIO portal network endpoints
+
+## Metric sources
+
+### `sysfs`
+
+Megabytes read and read IOPS are retrieved from `sysfs` on each worker node.
+
+#### `sysfs` megabytes read
+
+(`ncn-w#`) Megabytes read are found in the `read_mbytes` files.
+
+```bash
+cat /sys/kernel/config/target/iscsi/iqn.2023-06.csm.iscsi:ncn-w002/tpgt_1/lun/lun_0/statistics/scsi_tgt_port/read_mbytes
+```
+
+Example output:
+
+```text
+137
+```
+
+#### `sysfs` read IOPS
+
+(`ncn-w#`) Read IOPS are found in the `in_cmds` files.
+
+```bash
+cat /sys/kernel/config/target/iscsi/iqn.2023-06.csm.iscsi:ncn-w002/tpgt_1/lun/lun_0/statistics/scsi_tgt_port/in_cmds
+```
+
+Example output:
+
+```text
+2938
+```
+
+### `saveconfig.json`
+
+The number of projected `rootfs` and PE `LUNs` are determined based on the data in `/etc/target/saveconfig.json` on the worker NCNs.
+
+## Retrieve iSCSI metrics
+
+iSCSI metrics can be retrieved on an individual worker node on the command line, or through a web interface.
+
+### Command line
+
+The command line can be used to retrieve any of the metrics listed in the [Overview](#overview) except the throughput statistics.
+The same basic command is used to retrieve each of these metrics, with only the query value changing based on which
+metric is desired.
+
+| *Metric*                   | *Query*                |
+| -------------------------- | ---------------------- |
+| MB read                    | `iscsi_read_mbytes`    |
+| Read IOPS                  | `iscsi_read_rate`      |
+| \# projected `rootfs` LUNs | `iscsi_rootfs_lun_cnt` |
+| \# projected PE LUNs       | `iscsi_pe_lun_cnt`     |
+
+(`ncn-mw#`) For example, show the number of megabytes read.
+
+```bash
+kubectl exec -n services cray-shared-kafka-kafka-0 -it -- curl -G \
+    'http://vmselect-vms.sysmgmt-health.svc.cluster.local:8481/select/0/prometheus/api/v1/query?query=iscsi_read_mbytes' | jq
+```
+
+### VictoriaMetrics web UI
+
+The VictoriaMetrics web UI can be used to retrieve any of the metrics listed in the [Overview](#overview) except the throughput statistics.
+
+In the VictoriaMetrics UI, query for `iscsi` metrics. For details on how to access the UI, see
+[VictoriaMetrics](../system_management_health/Access_System_Management_Health_Services.md#victoriametrics).
+
+### Grafana web UI
+
+Throughput statistics on LIO portal network endpoints can be viewed on Grafana `prometheus` dashboards.
+For details on accessing the Grafana web UI, see
+[Grafana](../system_management_health/Access_System_Management_Health_Services.md#grafana).
+
+In the Grafana web UI, the metrics can be found under General metrics, Node Exporter Full.
+For Job, select `node-exporter`.
+For Host, select any worker NCN (for example, `ncn-w001`).
+Under this, the following metrics may be monitored: `recv hsn0`, `trans hsn0`, `recv nmn0`, and `trans nmn0`.
+
+These metrics can be monitored during iSCSI LUN projection from iSCSI targets to iSCSI initiators during managed node boot time.

--- a/operations/iscsi_sbps/iSCSI_SBPS_Verification.md
+++ b/operations/iscsi_sbps/iSCSI_SBPS_Verification.md
@@ -1,0 +1,513 @@
+# iSCSI SBPS Verification
+
+* [Introduction](#introduction)
+* [Automated tests](#automated-tests)
+* [Node personalization](#node-personalization)
+* [iSCSI-enabled workers](#iscsi-enabled-workers)
+* [SBPS Marshal Agent](#sbps-marshal-agent)
+* [`targetcli` command](#targetcli-command)
+* [`multipath` command](#multipath-command)
+* [DNS SRV and A records](#dns-srv-and-a-records)
+
+## Introduction
+
+Before booting managed nodes, it is important to validate the iSCSI configuration. Most of this configuration is either done
+by the [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+during [Node personalization](#node-personalization), or done periodically by the [SBPS Marshal Agent](#sbps-marshal-agent).
+
+## Automated tests
+
+The fastest way to check the overall readiness of the iSCSI targets is to run the automated Goss health checks.
+
+(`ncn-mw#`) Execute all of the worker automated health checks (including those for iSCSI):
+
+```bash
+ /opt/cray/tests/install/ncn/automated/ncn-healthcheck-worker
+ ```
+
+## Node personalization
+
+The `config_sbps_iscsi_targets.yml` Ansible playbook in the `csm-config-management`
+[Version Control Service (VCS)](../../glossary.md#version-control-service-vcs) repository is responsible for much of the
+iSCSI configuration. During [Management Node Personalization](../configuration_management/Management_Node_Personalization.md),
+this playbook does the following:
+
+* Installs the [SBPS Marshal Agent](#sbps-marshal-agent)
+* Adds Kubernetes labels to the worker NCNs that are designated to be iSCSI targets
+* Removes the labels from workers that are not designated to be iSCSI targets
+* Creates DNS SRV and A records for the workers.
+
+See [Managing Selective Node Personalization](Managing_Selective_Node_Personalization.md) for details on how worker NCNs are
+designated to be iSCSI targets.
+
+## iSCSI-enabled workers
+
+(`ncn-mw#`) List all iSCSI-enabled worker NCNs.
+
+```bash
+kubectl get nodes -l iscsi=sbps
+```
+
+Example output:
+
+```text
+NAME       STATUS   ROLES    AGE    VERSION
+ncn-w001   Ready    <none>   7d2h   v1.32.5
+ncn-w002   Ready    <none>   6d     v1.32.5
+ncn-w003   Ready    <none>   7d1h   v1.32.5
+ncn-w004   Ready    <none>   7d1h   v1.32.5
+```
+
+## SBPS Marshal Agent
+
+The SBPS Marshal Agent runs on the iSCSI-enabled worker NCNs as a Linux `systemd` service.
+Every 180 seconds it looks for `rootfs` and `PE` images in the
+[Image Management Service (IMS)](../../glossary.md#image-management-service-ims)
+and [S3](../../glossary.md#simple-storage-service-s3) storage.
+For any image found, the Marshal Agent creates `fileio` backing stores and corresponding
+iSCSI `LUNs`. This enables the images to be projected.
+
+The following steps should be performed on every iSCSI-enabled worker NCN, in order to ensure that
+the Marshal Agent is running without errors.
+
+1. (`ncn-w#`) Check that the SBPS Marshal Agent is running on every iSCSI-enabled node without any errors.
+
+    ```bash
+    systemctl status sbps-marshal -n 3
+    ```
+
+    The most important thing to verify in the command output is that the service is `active (running)`.
+
+    Example output:
+
+    ```text
+    ● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images similar to PE.
+         Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
+         Active: active (running) since Mon 2025-07-28 20:17:17 UTC; 6 days ago
+       Main PID: 342842 (sbps-marshal)
+          Tasks: 1
+            CPU: 1h 16min 21.251s
+         CGroup: /system.slice/sbps-marshal.service
+                 └─342842 /usr/lib/sbps-marshal/bin/python /usr/lib/sbps-marshal/bin/sbps-marshal
+
+    Aug 04 18:40:34 ncn-w001 sbps-marshal[342842]: agent.py:main:314 INFO 2025-08-04T18:40:34+0000 No sbps-project key value, so image is not marked for projection
+    Aug 04 18:40:34 ncn-w001 sbps-marshal[342842]: agent.py:main:314 INFO 2025-08-04T18:40:34+0000 No sbps-project key value, so image is not marked for projection
+    Aug 04 18:40:34 ncn-w001 sbps-marshal[342842]: agent.py:main:405 INFO 2025-08-04T18:40:34+0000 END SCAN
+    ```
+
+1. (`ncn-w#`) Check for errors in the current Marshal Agent run.
+
+    Any errors shown by this command should be investigated.
+
+    ```bash
+    journalctl -xeu sbps-marshal.service | tac | sed '/START SCAN/q' | grep -i error
+    ```
+
+## `targetcli` command
+
+(`ncn-w#`) On each of the iSCSI-enabled worker NCNs, display information on the `fileio` backing stores, LUNs, and network portals.
+
+> For more details on the information discussed in this section, see [iSCSI SBPS solution details](README.md#iscsi-sbps-solution-details).
+
+```bash
+targetcli ls
+```
+
+### `targetcli` command example 1
+
+Example output:
+
+> Below the example output are guides on how to interpret its contents.
+
+```text
+o- / ......................................................................................................................... [...]
+  o- backstores .............................................................................................................. [...]
+  | o- block .................................................................................................. [Storage Objects: 0]
+  | o- fileio ................................................................................................ [Storage Objects: 14]
+  | | o- 162eec8935d9251  [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-25.09-20250701.squashfs (771.8MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 2b9d303c515911a ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-25.03.squashfs (320.8MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 31fcfe145252d40  [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.09-20250701.squashfs (191.2MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 602f57d78f7162d ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.03.squashfs (117.3MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 7de5e25dcbfeb8e  [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-25.09-20250701.squashfs (748.4MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 7df1b36a366a1a3  [/var/lib/cps-local/boot-images/83f3f34c-b09c-445b-8253-f0708f588328/rootfs (4.2GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 83b09a0062d4edb .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-25.03.squashfs (2.6GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 851b2a42d007322 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-25.03.squashfs (298.1MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 8767f2cfdb49d5f  [/var/lib/cps-local/boot-images/efd2f545-1a08-4f63-bd18-45c2bfcf7efc/rootfs (4.3GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- a1ceab379f1c908  [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-25.09-20250701.squashfs (199.6MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- a78fe7060cf474d  [/var/lib/cps-local/boot-images/5095f83f-b500-4f7c-81be-76b185ad7108/rootfs (2.5GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- d4b0cd14d4625db  [/var/lib/cps-local/boot-images/50256d2c-60a8-41f8-ab37-901515d607e8/rootfs (2.4GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- dc28db97d8d01d5 . [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-25.09-20250701.squashfs (6.7GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- eb63d6793a27096 ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-25.03.squashfs (121.9MiB) write-thru activated]
+  | |   o- alua ................................................................................................... [ALUA Groups: 1]
+  | |     o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | o- pscsi .................................................................................................. [Storage Objects: 0]
+  | o- ramdisk ................................................................................................ [Storage Objects: 0]
+  o- iscsi ............................................................................................................ [Targets: 1]
+  | o- iqn.2023-06.csm.iscsi:ncn-w002 .................................................................................... [TPGs: 1]
+  |   o- tpg1 .................................................................................................. [gen-acls, no-auth]
+  |     o- acls .......................................................................................................... [ACLs: 0]
+  |     o- luns ......................................................................................................... [LUNs: 14]
+  |     | o- lun0 .... [fileio/851b2a42d007322 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun1  [fileio/7de5e25dcbfeb8e (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-25.09-20250701.squashfs) (default_tg_pt_gp)]
+  |     | o- lun2 ... [fileio/eb63d6793a27096 (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun3  [fileio/a1ceab379f1c908 (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-25.09-20250701.squashfs) (default_tg_pt_gp)]
+  |     | o- lun4 ... [fileio/83b09a0062d4edb (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun5  [fileio/dc28db97d8d01d5 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-25.09-20250701.squashfs) (default_tg_pt_gp)]
+  |     | o- lun6 .. [fileio/602f57d78f7162d (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun7  [fileio/31fcfe145252d40 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.09-20250701.squashfs) (default_tg_pt_gp)]
+  |     | o- lun8 . [fileio/2b9d303c515911a (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun9  [fileio/162eec8935d9251 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-25.09-20250701.squashfs) (default_tg_pt_gp)]
+  |     | o- lun10  [fileio/7df1b36a366a1a3 (/var/lib/cps-local/boot-images/83f3f34c-b09c-445b-8253-f0708f588328/rootfs) (default_tg_pt_gp)]
+  |     | o- lun11  [fileio/8767f2cfdb49d5f (/var/lib/cps-local/boot-images/efd2f545-1a08-4f63-bd18-45c2bfcf7efc/rootfs) (default_tg_pt_gp)]
+  |     | o- lun12  [fileio/d4b0cd14d4625db (/var/lib/cps-local/boot-images/50256d2c-60a8-41f8-ab37-901515d607e8/rootfs) (default_tg_pt_gp)]
+  |     | o- lun13  [fileio/a78fe7060cf474d (/var/lib/cps-local/boot-images/5095f83f-b500-4f7c-81be-76b185ad7108/rootfs) (default_tg_pt_gp)]
+  |     o- portals .................................................................................................... [Portals: 2]
+  |       o- 10.252.1.8:3260 .................................................................................................. [OK]
+  |       o- 10.253.0.2:3260 .................................................................................................. [OK]
+  o- loopback ......................................................................................................... [Targets: 0]
+  o- srpt ............................................................................................................. [Targets: 0]
+  o- vhost ............................................................................................................ [Targets: 0]
+  o- xen-pvscsi ....................................................................................................... [Targets: 0]
+```
+
+The following provide examples of how to interpret the command output.
+
+#### PE image
+
+The example output gives information about the PE image `CPE-intel.x86_64-25.03.squashfs`.
+
+* `fileio` backing store
+
+    ```text
+      | | o- 602f57d78f7162d ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.03.squashfs (117.3MiB) write-thru activated]
+    ```
+
+    This line in the example output shows that the `fileio` backing store for the PE image exists and is
+    `/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.03.squashfs`.
+
+* LUN
+
+    ```text
+      |     | o- lun6 .. [fileio/602f57d78f7162d (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-25.03.squashfs) (default_tg_pt_gp)]
+    ```
+
+    This line in the example output shows that the LUN for the PE image exists and is `lun6`.
+
+#### IMS `rootfs` image
+
+The example output also gives information about the `rootfs` for the IMS image with ID `50256d2c-60a8-41f8-ab37-901515d607e8`.
+
+* `fileio` backing store
+
+    ```text
+      | | o- d4b0cd14d4625db  [/var/lib/cps-local/boot-images/50256d2c-60a8-41f8-ab37-901515d607e8/rootfs (2.4GiB) write-thru activated]
+    ```
+
+    This line in the example output shows that the `fileio` backing store for the `rootfs` image exists and is
+    `/var/lib/cps-local/boot-images/50256d2c-60a8-41f8-ab37-901515d607e8/rootfs`.
+
+* LUN
+
+    ```text
+     |     | o- lun12  [fileio/d4b0cd14d4625db (/var/lib/cps-local/boot-images/50256d2c-60a8-41f8-ab37-901515d607e8/rootfs) (default_tg_pt_gp)]
+    ```
+
+    This line in the example output shows that the LUN for the `rootfs` image exists and is `lun12`.
+
+#### Network portals
+
+There should be portals configured for iSCSI projection for the
+[High Speed Network (HSN)](../../glossary.md#high-speed-network-hsn) or the
+[Node Management Network (NMN)](../../glossary.md#node-management-network-nmn), or both.
+If neither of these portals is configured, then managed nodes will be unable to boot.
+
+```text
+ |     o- portals .................................................................................................... [Portals: 2]
+ |       o- 10.252.1.8:3260 .................................................................................................. [OK]
+ |       o- 10.253.0.2:3260 .................................................................................................. [OK]
+```
+
+These lines in the example output show the portals that are configured for iSCSI projection. They consist of the HSN or NMN IP address
+and the iSCSI port number.
+
+(`ncn-w#`) Determining which network the a portal belongs to is done by comparing its IP address to the NMN and HSN network interfaces:
+
+```bash
+ip addr | grep -E 'hsn|nmn'
+```
+
+Example output:
+
+```text
+4: hsn0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    inet 10.253.0.2/16 brd 10.253.255.255 scope global hsn0
+12: bond0.nmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP group default qlen 1000
+    inet 10.252.1.8/17 brd 10.252.127.255 scope global bond0.nmn0
+```
+
+Based on this example output, the portal `10.253.0.2:3260` corresponds to the HSN, and `10.252.1.8:3260` corresponds to the NMN.
+
+### `targetcli` command example 2
+
+(`ncn-w#`) Example output:
+
+```text
+o- / ......................................................................................................................... [...]
+  o- backstores .............................................................................................................. [...]
+  | o- block .................................................................................................. [Storage Objects: 0]
+  | o- fileio ................................................................................................ [Storage Objects: 28]
+  | | o- 0331b9aaef49840 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.03.squashfs (122.2MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 0f3847fd8e25624 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.03.squashfs (114.8MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 1373e69e2028baa ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.11.squashfs (503.4MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 2babe2c96d6f900 ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-23.12.squashfs (1.9GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 380840014ffe295  [/var/lib/cps-local/boot-images/f731d8d5-0fed-41d7-996e-6a0d19b6ff6d/rootfs (10.8GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 719593b460753ac ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.11.squashfs (131.6MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 76e638d3bfc3107 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-23.12.squashfs (64.0KiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 7c0bba5c5301c97  [/var/lib/cps-local/boot-images/5b43428e-4381-4f39-9335-6dababb76d86/rootfs (2.9GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 7cccd5c7adc8cc6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-23.12.squashfs (114.4MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 818ff2c161855b6 ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.03.squashfs (117.9MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 85801b9e9c9cea7 ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.03.squashfs (2.0GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 8edfc76b6dae21f ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.03.squashfs (134.1MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 953aa229aafffa6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.11.squashfs (128.6MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 979b7868c15ee00 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-23.12.squashfs (123.2MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 9de1fe8a016602f ......... [/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.07.squashfs (2.0GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- 9f7ee65eadd1d3c ..... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.07.squashfs (272.3MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- a50dd52157e1636 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs (121.9MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- a6db212e5a329fa .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.03.squashfs (2.4GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- aac0f352b7a30d6 ....... [/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.07.squashfs (110.1MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- b91b33a9f98a0be ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.07.squashfs (113.2MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- c1d98cf92b0647f ........ [/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-23.12.squashfs (117.9MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- cfaa140ac182849 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.07.squashfs (333.5MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- d265658496338c0 ......... [/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.07.squashfs (298.2MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- d797313856f7502 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.07.squashfs (2.4GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- da65cccd2e89d0c ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.11.squashfs (555.7MiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- de4cc04e7dacfb9 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.11.squashfs (7.7GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- e41757ef248d642 .......... [/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-23.12.squashfs (2.4GiB) write-thru activated]
+  | | | o- alua ................................................................................................... [ALUA Groups: 1]
+  | | |   o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | | o- e837346fddf2004 ...... [/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.03.squashfs (92.5MiB) write-thru activated]
+  | |   o- alua ................................................................................................... [ALUA Groups: 1]
+  | |     o- default_tg_pt_gp ....................................................................... [ALUA state: Active/optimized]
+  | o- pscsi .................................................................................................. [Storage Objects: 0]
+  | o- ramdisk ................................................................................................ [Storage Objects: 0]
+  o- iscsi ............................................................................................................ [Targets: 1]
+  | o- iqn.2023-06.csm.iscsi:ncn-w002 .................................................................................... [TPGs: 1]
+  |   o- tpg1 .................................................................................................. [gen-acls, no-auth]
+  |     o- acls .......................................................................................................... [ACLs: 0]
+  |     o- luns ......................................................................................................... [LUNs: 28]
+  |     | o- lun0 .... [fileio/a50dd52157e1636 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun1 .... [fileio/0331b9aaef49840 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun2 .... [fileio/d265658496338c0 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun3 .... [fileio/1373e69e2028baa (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-24.11.squashfs) (default_tg_pt_gp)]
+  |     | o- lun4 ... [fileio/c1d98cf92b0647f (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun5 ... [fileio/818ff2c161855b6 (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun6 ... [fileio/b91b33a9f98a0be (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun7 ... [fileio/719593b460753ac (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-24.11.squashfs) (default_tg_pt_gp)]
+  |     | o- lun8 .. [fileio/2babe2c96d6f900 (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun9 .. [fileio/85801b9e9c9cea7 (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun10 . [fileio/9de1fe8a016602f (/var/lib/cps-local/boot-images/PE/CPE-base.aarch64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun11 .. [fileio/e41757ef248d642 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun12 .. [fileio/a6db212e5a329fa (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun13 .. [fileio/d797313856f7502 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun14 .. [fileio/de4cc04e7dacfb9 (/var/lib/cps-local/boot-images/PE/CPE-base.x86_64-24.11.squashfs) (default_tg_pt_gp)]
+  |     | o- lun15 . [fileio/7cccd5c7adc8cc6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun16 . [fileio/0f3847fd8e25624 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun17 . [fileio/aac0f352b7a30d6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun18 . [fileio/953aa229aafffa6 (/var/lib/cps-local/boot-images/PE/CPE-intel.x86_64-24.11.squashfs) (default_tg_pt_gp)]
+  |     | o- lun19  [fileio/76e638d3bfc3107 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun20  [fileio/e837346fddf2004 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun21  [fileio/9f7ee65eadd1d3c (/var/lib/cps-local/boot-images/PE/CPE-nvidia.aarch64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun22  [fileio/979b7868c15ee00 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+  |     | o- lun23  [fileio/8edfc76b6dae21f (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.03.squashfs) (default_tg_pt_gp)]
+  |     | o- lun24  [fileio/cfaa140ac182849 (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.07.squashfs) (default_tg_pt_gp)]
+  |     | o- lun25  [fileio/da65cccd2e89d0c (/var/lib/cps-local/boot-images/PE/CPE-nvidia.x86_64-24.11.squashfs) (default_tg_pt_gp)]
+  |     | o- lun26  [fileio/7c0bba5c5301c97 (/var/lib/cps-local/boot-images/5b43428e-4381-4f39-9335-6dababb76d86/rootfs) (default_tg_pt_gp)]
+  |     | o- lun27  [fileio/380840014ffe295 (/var/lib/cps-local/boot-images/f731d8d5-0fed-41d7-996e-6a0d19b6ff6d/rootfs) (default_tg_pt_gp)]
+  |     o- portals .................................................................................................... [Portals: 3]
+  |       o- 10.102.104.28:3260 ............................................................................................... [OK]
+  |       o- 10.150.0.4:3260 .................................................................................................. [OK]
+  |       o- 10.252.1.13:3260 ................................................................................................. [OK]
+  o- loopback ......................................................................................................... [Targets: 0]
+  o- vhost ............................................................................................................ [Targets: 0]
+  o- xen-pvscsi ....................................................................................................... [Targets: 0]
+```
+
+The above `targetcli ls` command output shows the following:
+
+* Four `fileio` backing store are created for two `rootfs` images
+* Two iSCSI `LUNs` are created which have the `rootfs` image ID being mapped
+* 26 `PE` or `squashfs` `fileio` backing store are created
+* 26 iSCSI `LUNs` created which have the `PE` or `squashfs` image ID being mapped
+* These iSCSI `LUNs` are ready for projection
+
+## `multipath` command
+
+(`nid#`) Administrators may also view the state of the initiator nodes (i.e. managed nodes using iSCSI LUNs).
+
+> For more details on the information discussed in this section, see [iSCSI SBPS solution details](README.md#iscsi-sbps-solution-details).
+
+```bash
+multipath -ll
+```
+
+Example output:
+
+```text
+11218.831779 | /etc/multipath.conf line 10: ignoring deprecated option "disable_changed_wwids", using built-in value: "yes"
+PE_CPE-base.x86_64-24.11.squashfs (36001405de4cc04e7dacfb9ada0a6b4cc) dm-0 LIO-ORG,de4cc04e7dacfb9
+size=7.7G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
+`-+- policy='round-robin 0' prio=50 status=active
+  |- 1:0:0:14 sdo  8:224  active ready running
+  |- 2:0:0:14 sdaq 66:160 active ready running
+  |- 3:0:0:14 sdbs 68:96  active ready running
+  `- 4:0:0:14 sdcu 70:32  active ready running
+f731d8d5-0fed-41d7-996e-6a0d19b6ff6d_rootfs (36001405380840014ffe295091e8689db) dm-24 LIO-ORG,380840014ffe295
+size=11G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
+`-+- policy='round-robin 0' prio=50 status=active
+  |- 1:0:0:27 sdab 65:176 active ready running
+  |- 2:0:0:27 sdbd 67:112 active ready running
+  |- 3:0:0:27 sdcf 69:48  active ready running
+  `- 4:0:0:27 sddh 70:240 active ready running
+```
+
+## DNS SRV and A records
+
+The DNS records check only needs to be performed on a single worker NCN.
+
+1. (`ncn-w#`) Verify that every iSCSI-enabled worker NCN has DNS SRV and A records.
+
+    1. Get the system domain name.
+
+        ```bash
+        DOMAIN=$(kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' \
+                 | base64 -d | yq4 .spec.network.dns.external); echo "${DOMAIN}"
+        ```
+
+        Example output:
+
+        ```text
+        drax.hpc.amslabs.hpecorp.net
+        ```
+
+    1. List the DNS SRV records for SBPS on the HSN and NMN.
+
+        ```bash
+        dig -t SRV +short "_sbps-hsn._tcp.${DOMAIN}" "_sbps-nmn._tcp.${DOMAIN}"
+        ```
+
+        Example output:
+
+        ```text
+        1 0 3260 iscsi-server-id-002.hsn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-003.hsn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-004.hsn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-001.hsn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-004.nmn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-002.nmn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-003.nmn.drax.hpc.amslabs.hpecorp.net.
+        1 0 3260 iscsi-server-id-001.nmn.drax.hpc.amslabs.hpecorp.net.
+        ```
+
+        Each `iscsi-server-id` number corresponds to a different worker NCN.
+        After that ID comes the network (`hsn` or `nmn` for that record).
+        This example output shows that DNS SRV records exist for four worker NCNs, on both the HSN and NMN.
+
+1. (`ncn-w#`) Verify that a DNS A record exists for each DNS SRV record.
+
+    ```bash
+    dig -t SRV +short "_sbps-hsn._tcp.${DOMAIN}" "_sbps-nmn._tcp.${DOMAIN}" \
+        | awk '{ print $NF }' | xargs dig -t A +short
+    ```
+
+    Example output:
+
+    ```text
+    10.253.0.2
+    10.253.0.8
+    10.253.0.9
+    10.253.0.14
+    10.252.1.7
+    10.252.1.8
+    10.252.1.9
+    10.252.1.10
+    ```
+
+    Confirm that the number of DNS A records listed by this command equals the number of DNS SRV records listed in the previous step.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -82,6 +82,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Issues Related to Trivial File Transfer Protocol (TFTP)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md)
 * [Troubleshooting Using Kubernetes](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Using_Kubernetes.md)
 * [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
+* [iSCSI SBPS Verification](../operations/iscsi_sbps/iSCSI_SBPS_Verification.md)
 
 ## Configuration management
 
@@ -146,6 +147,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Troubleshoot Issues with Large Images](../operations/image_management/Troubleshoot_Large_Image.md)
 * [Troubleshoot Remote Build Node](../operations/image_management/Troubleshoot_Remote_Build_Node.md)
 * [Troubleshoot Interactions with zypper](../operations/image_management/Troubleshoot_zypper_interaction.md)
+* [iSCSI SBPS Verification](../operations/iscsi_sbps/iSCSI_SBPS_Verification.md)
 
 ## Kubernetes
 


### PR DESCRIPTION
# Description
This the documentation section 'post-personalization-verification' that was part of worker node personalization doc.
https://github.com/Cray-HPE/docs-csm/blob/release/1.6/operations/configuration_management/iSCSI_SBPS_Node_Personalization.md#post-personalization-
verification 

This document is removed from CSM 1.7 as it is not applicable due to https://jira-pro.it.hpe.com:8443/browse/CASMPET-7632.
So the section relevant and applicable for CSM 1.7 is 'post-personalization-verification'  of the above doc. So this is now added as separate document named 'Node_Personalization_Verification.md' under 'iscsi_sbps' folder. 

Relates to:
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7632
https://github.com/Cray-HPE/docs-csm/pull/6132

[Partial backport to CSM 1.6](https://github.com/Cray-HPE/docs-csm/pull/6186)

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
