### PR TITLE
CASMTRIAGE-8374/CASMTRIAGE-8454 - Document known issues that can cause Cilium migration to stall

### DIFF
--- a/operations/iuf/workflows/cilium_migration.md
+++ b/operations/iuf/workflows/cilium_migration.md
@@ -4,7 +4,7 @@ This section describes how to migrate your Kubernetes CNI from Weave to Cilium d
 
 ## Steps
 
-1. **Run the migration script:**
+1. (`ncn-m#`) Run the migration script:
 
     ```bash
     /usr/share/doc/csm/scripts/cilium_migration.sh
@@ -15,12 +15,61 @@ This section describes how to migrate your Kubernetes CNI from Weave to Cilium d
     - Migrate the CNI from Weave to Cilium.
     - Continuously monitor the workflow status using `kubectl`.
 
-1. **Monitor the migration workflow:**
+1. (`ncn-mw#`) Monitor the migration workflow:
 
     The workflow status can also be tracked using the Argo CLI:
+
+    The Argo CLI watch function can be used to view the overall progress of the workflow.
 
     ```bash
     argo watch <workflow-name> -n argo
     ```
 
+    The Argo CLI logs function can be used to monitor the workflow in more detail.
+
+    ```bash
+    argo logs <workflow-name> -n argo -f
+    ```
+
     Replace `<workflow-name>` with the actual name of the workflow created by the cilium_migration.sh script.
+
+## Known issues
+
+### Node drain blocked by Kafka
+
+When restarting the pods on the NCN worker nodes it is possible for the workflow to get stuck trying to evict `cray-shared-kafka-kafka` or SMA `cluster-kafka` pods.
+
+Example output:
+
+```console
+evicting pod services/cray-shared-kafka-kafka-1
+error when evicting pods/"cray-shared-kafka-kafka-1" -n "services" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget. 
+```
+
+The issue is that one of the restarted Kafka pods can't communicate with Zookeeper. This is the problem described in
+[`cfs-api` pods in CLBO state during CSM install](../../../troubleshooting/known_issues/cfs-api_pods_in_CLBO_state.md) and has the same workaround.
+
+- (`ncn-mw#`) If the stuck pod is part of `cray-shared-kafka` then restart that Zookeeper instance.
+
+   ```bash
+   kubectl delete pods -n services -l strimzi.io/controller-name=cray-shared-kafka-zookeeper
+   ```
+
+- (`ncn-mw#`) If the stuck pod is a member of SMA `cluster-kafka` then restart the SMA Zookeeper instance.
+
+   ```bash
+   kubectl delete pod -n sma -l strimzi.io/controller-name=cluster-zookeeper
+   ```
+
+### Node drain blocked by an `etcd` cluster
+
+When restarting the pods on the NCN worker nodes it is possible for the workflow to get stuck trying to evict pods from an `etcd` cluster.
+
+Example output:
+
+```console
+evicting pod services/cray-hbtd-bitnami-etcd-2
+error when evicting pods/"cray-hbtd-bitnami-etcd-2" -n "services" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget. 
+```
+
+See [`etcd` Pods in CLBO State](../../../troubleshooting/known_issues/etcd_pods_in_CLBO_state.md) for more information and a workaround.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

There are two known issues that can cause the Cilium migration workflow to stall.

This PR adds this information to the `cilium_migration.md` page so anyone performing the migration is aware.

Relates to:
- [CASMTRIAGE-8374](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8374)
- [CASMTRIAGE-8454](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8454)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
