### PR TITLE
CASMINST-7281: Clarify that zero-length CFS ID bug is fixed, but WAR still relevant

### DIFF
--- a/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
+++ b/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
@@ -1,6 +1,7 @@
 # CFS Component With Zero-Length ID
 
-It is possible in some situations for a CFS component to be created with a zero-length string for an `id` field.
+In CSM versions lower than 1.7, it is possible in some situations for a CFS component to be created with a zero-length string for an `id` field.
+In CSM 1.7, the bug that allowed these to be created has been fixed, but such a component could still exist on systems that were upgraded to CSM 1.7.
 Such a component cannot be deleted using the Cray CLI or the CFS API.
 
 ## Symptoms


### PR DESCRIPTION
This PR just adds some additional information to a particular WAR. The bug that caused the problem is gone in CSM 1.7, but the problem would persist through a CSM upgrade. So if the problem happened on the prior CSM version, and then they upgraded, a customer would still need this WAR. That's why this does not remove the WAR, but does at least let folks know that the bug is no more.