### PR TITLE
CASMNET-2345 Include IPv6 in add/remove NCN procedure

### DIFF
--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
@@ -10,6 +10,7 @@
   * [Collect MAC addresses from the NCN](#collect-mac-addresses-from-the-ncn)
     * [Swapping/moving an NCN](#swappingmoving-an-ncn)
     * [Adding a new NCN](#adding-a-new-ncn)
+  * [IPv6](#ipv6)
 * [Next step](#next-step)
 
 ## Description
@@ -534,6 +535,103 @@ The NCN MAC addresses need to be collected using the [Collect NCN MAC Addresses]
     Arch = "X86"
     Class = "River"
     ```
+
+### IPv6
+
+This step is only necessary for systems with IPv6 enabled on their CMN and CHN networks.
+
+#### Determine if IPv6 is enabled
+
+1. (`ncn-mw#`) To preview whether IPv6 has been setup on the current system, dump the `CIDR6` values for the CHN and CMN.
+
+   ```bash
+   cray sls networks list --format json | jq -r '.[] | select([.Name] | inside(["CMN","CHN"])) | .ExtraProperties.CIDR6'
+   ```
+
+   * IPv6 is enabled when IPv6 addresses are printed:
+
+   ```text
+   fdf8:413:de2c:201::/64
+   fdf8:413:de2c:200::/64
+   ```
+
+   * IPv6 is **not** enabled when `null` is printed:
+
+   ```text
+   null
+   null
+   ```
+
+1. If the output was `null`, proceed to [Next step](#next-step). Otherwise, proceed to
+  [Add IPv6 data](#add-ipv6-data).
+
+#### Add IPv6 data
+
+1. (`ncn-mw#`) Install CSI.
+
+   ```bash
+   zypper in cray-site-init
+   ```
+
+1. (`ncn-mw#`) Verify CSI is at version 2.0.5 or higher.
+
+   ```bash
+   csi version
+   ```
+
+   The printed output's `Version` field should have a value of "2.0.5" or higher. If it does not, reach out to CSM to obtain a newer version.
+
+   ```text
+   CRAY-Site-Init build signature...
+   Build Commit   : 5a29f83ed020a7e166b79ca811ccd7827abcc85b-heads-v2.0.5
+   Build Time     : 2025-08-01T15:17:31Z
+   Go Version     : go1.24.5
+   Version        : 2.0.5
+   Platform       : linux/amd64
+   ```
+
+1. (`ncn-mw#`) Fetch the current CIDR values.
+
+    ```bash
+    SLS_NETWORKS="$(cray sls networks list --format json)"
+    CMN_CIDR6="$(jq -r -n --argjson sls_networks "$SLS_NETWORKS" '$sls_networks[] | select(.Name=="CMN") | .ExtraProperties.CIDR6')"
+    CMN_GW6="$(jq -r -n --argjson sls_networks "$SLS_NETWORKS" '$sls_networks[] | select(.Name=="CMN") | .ExtraProperties.Subnets[] | select(.Name=="bootstrap_dhcp").Gateway6')"
+    CHN_CIDR6="$(jq -r -n --argjson sls_networks "$SLS_NETWORKS" '$sls_networks[] | select(.Name=="CHN") | .ExtraProperties.CIDR6')"
+    CHN_GW6="$(jq -r -n --argjson sls_networks "$SLS_NETWORKS" '$sls_networks[] | select(.Name=="CHN") | .ExtraProperties.Subnets[] | select(.Name=="bootstrap_dhcp").Gateway6')"
+    ```
+
+1. (`ncn-mw#`) Perform a dry-run of the IPv6 patch.
+
+   ```bash
+    csi patch csm ipv6 \
+      --chn-cidr6 "$CHN_CIDR6" \
+      --chn-gateway6 "$CHN_GW6" \
+      --cmn-cidr6 "$CMN_CIDR6" \
+      --cmn-gateway6 "$CMN_GW6"
+   ```
+
+   CSI's output will include a directory of changes to be made. Inspect both the output and the files.
+
+1. (`ncn-mw#`) To perform the changes, re-run the same command with the `--commit` flag.
+
+   > ***NOTE*** Both the dry-run and `--commit` run of CSI will create backups of BSS and SLS.
+
+   ```bash
+    csi patch csm ipv6 \
+      --chn-cidr6 "$CHN_CIDR6" \
+      --chn-gateway6 "$CHN_GW6" \
+      --cmn-cidr6 "$CMN_CIDR6" \
+      --cmn-gateway6 "$CMN_GW6" \
+      --commit
+   ```
+
+1. (`ncn-mw#`) Optionally, cleanup and uninstall CSI.
+
+   ```bash
+   zypper remove cray-site-init
+   ```
+
+If everything returned successfully, IPv6 data will exist for the node and the node will configure IPv6 interfaces during its deployment.
 
 ## Next step
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
@@ -5,12 +5,12 @@
 * [Description](#description)
 * [Prerequisites](#prerequisites)
 * [Procedure](#procedure)
-  * [Collect information from the NCN](#collect-information-from-the-ncn)
-    * [Saving/reloading](#savingreloading)
-  * [Collect MAC addresses from the NCN](#collect-mac-addresses-from-the-ncn)
-    * [Swapping/moving an NCN](#swappingmoving-an-ncn)
-    * [Adding a new NCN](#adding-a-new-ncn)
-  * [IPv6](#ipv6)
+    * [Collect information from the NCN](#collect-information-from-the-ncn)
+        * [Saving/reloading](#savingreloading)
+    * [Collect MAC addresses from the NCN](#collect-mac-addresses-from-the-ncn)
+        * [Swapping/moving an NCN](#swappingmoving-an-ncn)
+        * [Adding a new NCN](#adding-a-new-ncn)
+    * [IPv6](#ipv6)
 * [Next step](#next-step)
 
 ## Description
@@ -20,11 +20,11 @@ Add NCN data to the System Layout Service (SLS), Boot Script Service (BSS), and 
 Scenarios where this procedure is applicable:
 
 * Adding a management NCN that has not previously been in the system:
-  * Add an additional NCN to an existing cabinet
-  * Add an NCN that is replacing another NCN of the same type and in the same slot
-  * Add a new NCN that replaces an NCN removed from the system in a different location
+    * Add an additional NCN to an existing cabinet
+    * Add an NCN that is replacing another NCN of the same type and in the same slot
+    * Add a new NCN that replaces an NCN removed from the system in a different location
 * Adding a management NCN that has been present in the system previously:
-  * Add an NCN that was previously removed from the system to move it to a new location
+    * Add an NCN that was previously removed from the system to move it to a new location
 
 ## Prerequisites
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Collect_NCN_MAC_Addresses.md
@@ -47,8 +47,8 @@ See [Check for latest documentation](../../../update_product_stream/README.md#ch
     1. Wait for the updated iPXE binary to be built.
 
         ```bash
-        sleep 30
-        kubectl -n services logs -l app.kubernetes.io/instance=cms-ipxe -f
+        sleep 30 && \
+          kubectl -n services logs -l app.kubernetes.io/instance=cms-ipxe -f
         ```
 
         The following output means that a new iPXE binary has been built:
@@ -67,8 +67,10 @@ See [Check for latest documentation](../../../update_product_stream/README.md#ch
         > `read -s` is used in order to prevent the password from being echoed to the screen or saved in the shell history.
 
         ```bash
-        read -r -s -p "${BMC_IP} root password: " IPMI_PASSWORD
-        export IPMI_PASSWORD
+        read -r -s -p "${BMC_IP} root password: " IPMI_PASSWORD && export IPMI_PASSWORD
+        ```
+
+        ```bash
         ipmitool -I lanplus -U root -E -H "${BMC_IP}" chassis power status
         ```
 
@@ -78,8 +80,13 @@ See [Check for latest documentation](../../../update_product_stream/README.md#ch
 
         ```bash
         BMC_IP=BMC_IP_ADDRESS
-        read -r -s -p "${BMC_IP} root password: " IPMI_PASSWORD
-        export IPMI_PASSWORD
+        ```
+
+        ```bash
+        read -r -s -p "${BMC_IP} root password: " IPMI_PASSWORD && export IPMI_PASSWORD
+        ```
+
+        ```bash
         ipmitool -I lanplus -U root -E -H "${BMC_IP}" sol activate
         ```
 

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python3
+
+#  MIT License
 #
-# MIT License
+#  (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
 #
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
 #pylint: disable=missing-docstring, C0301, C0103, C0302
 
 import subprocess
@@ -43,7 +43,7 @@ import urllib3
 
 from sls_utils.Managers import NetworkManager
 from sls_utils.Networks import Subnet as SLSSubnet
-from sls_utils.Reservations import Reservation as IPReservation
+from sls_utils.Reservations import Reservation
 from sls_utils import ipam
 
 # Global variables for service URLs. These get set in main.
@@ -617,7 +617,7 @@ def create_update_etc_hosts_actions(existing_management_ncns, ncn_alias, ncn_xna
 
     # NCN IPs
     for network_name, ip in ncn_ips.items():
-        line = f'{str(ip):15} {ncn_alias}.{network_name.lower()}'
+        line = f'{str(ip.ipv4_address()):15} {ncn_alias}.{network_name.lower()}'
         if network_name == "NMN":
             line += f' {ncn_alias}'
 
@@ -683,7 +683,7 @@ class State:
                     tokens = alias.split('.', 2)
                     network_name = tokens[1].upper()
                     action_log(action, f'Found existing NCN IP address for NCN {self.ncn_alias} in BSS Global Bootparameters: {host_record}')
-                    ncn_ips[network_name] = ip
+                    ncn_ips[network_name] = Reservation(name=self.ncn_alias, ipv4_address=ip, comment=self.ncn_xname)
 
         if bmc_ip is None:
             action_log(action, f'Failed to find existing NCN BMC IP address for {self.bmc_alias} in BSS Global Bootparameters')
@@ -692,7 +692,7 @@ class State:
 
         # Validate each network that has a bootstrap_dhcp subnet that an IP Reservation exists for this NCN
         failed_to_find_ip = False
-        for network_name, ncn_ip in ncn_ips.items():
+        for network_name, ip_reservation in ncn_ips.items():
             network = self.sls_networks[network_name]
 
             if "bootstrap_dhcp" not in network.subnets():
@@ -701,9 +701,11 @@ class State:
 
             reservation_found = False
             for name, reservation in dhcp_bootstrap.reservations().items():
-                if str(ncn_ip) == str(reservation.ipv4_address()):
+                if str(ip_reservation.ipv4_address()) == str(reservation.ipv4_address()):
                     reservation_found = True
-                    action_log(action, f'Removing existing IP Reservation with NCN IP {ncn_ip} in the bootstrap_dhcp subnet of the {network_name} network: {reservation.name()} {reservation.ipv4_address()} {reservation.aliases()} {reservation.comment()}')
+                    action_log(action, f'Removing existing IP Reservation with NCN IP {ip_reservation.ipv4_address()} in the bootstrap_dhcp subnet of the {network_name} network: {reservation.name()} {reservation.ipv4_address()} {reservation.aliases()} {reservation.comment()}')
+                    if reservation.ipv6_address:
+                        ip_reservation.ipv6_address(reservation.ipv6_address())
                     del dhcp_bootstrap.reservations()[name]
                     break
 
@@ -748,7 +750,7 @@ class State:
 
         # Add BMC IP reservation to the HMN network.
         # Example: {"Aliases":["ncn-s001-mgmt"],"Comment":"x3000c0s13b0","IPAddress":"10.254.1.31","Name":"x3000c0s13b0"}
-        bmc_ip_reservation = IPReservation(self.bmc_xname, bmc_ip, comment=self.bmc_xname, aliases=[self.bmc_alias])
+        bmc_ip_reservation = Reservation(self.bmc_xname, bmc_ip, comment=self.bmc_xname, aliases=[self.bmc_alias])
         action_log(action, f"Temporally adding NCN BMC IP reservation to bootstrap_dhcp subnet in the HMN network: {bmc_ip_reservation.to_sls()}")
 
         self.sls_networks["HMN"].subnets()["bootstrap_dhcp"].reservations().update(
@@ -764,12 +766,13 @@ class State:
         action_log(action, "Allocating NCN IP addresses")
 
         ncn_ips = {}
-        for network_name in ["CAN", "CHN", "CMN", "HMN", "MTL", "NMN"]:
+        for network_name in NETWORKS:
             if network_name not in self.sls_networks:
                 continue
 
             try:
-                ncn_ips[network_name] = allocate_ip_address_in_subnet(action, self.sls_networks, network_name, "bootstrap_dhcp", self.networks_allowed_in_dhcp_range)
+                new_ip = allocate_ip_address_in_subnet(action, self.sls_networks, network_name, "bootstrap_dhcp", self.networks_allowed_in_dhcp_range)
+                ncn_ips[network_name] = Reservation(name=self.ncn_alias, ipv4_address=new_ip, comment=self.ncn_xname)
             except (AllocatedIPIsOutsideStaticRange, ExhaustedAvailableIPAddressSpace):
                 print_action(action)
                 sys.exit(1)
@@ -801,7 +804,7 @@ class State:
 
                     # Verify no IP Reservations exist with any NCN IP
                     if sls_network.name() in ncn_ips:
-                        allocated_ip = ncn_ips[network_name]
+                        allocated_ip = ncn_ips[network_name].ipv4_address()
                         if ip_reservation.ipv4_address() == allocated_ip:
                             fail_sls_network_check = True
                             action_log(action, f'Error found allocated NCN IP {allocated_ip} in subnet {subnet.name()} network {network_name} in SLS: {ip_reservation.to_sls()}')
@@ -828,7 +831,7 @@ class State:
         action_log(action, "Network | IP Address")
         action_log(action, "--------|-----------")
         for network in sorted(self.ncn_ips):
-            ip = self.ncn_ips[network]
+            ip = self.ncn_ips[network].ipv4_address()
             action_log(action, f'{network:<8}| {ip}')
 
         action_log(action, "")
@@ -850,7 +853,7 @@ class State:
         print("        Network | IP Address")
         print("        --------|-----------")
         for network in sorted(self.ncn_ips):
-            ip = self.ncn_ips[network]
+            ip = self.ncn_ips[network].ipv4_address()
             print(f'        {network:<8}| {ip}')
 
         print("")
@@ -877,7 +880,7 @@ class State:
                 # Check for if this IP is one of our allocated IPs
                 for network, ip in self.ncn_ips.items():
                     if host_record["ip"] == ip:
-                        action_log(action, f'Error found {network} IP Address {ip} in Global host_records in BSS: {host_record}')
+                        action_log(action, f'Error found {network} IP Address {ip.ipv4_address()} in Global host_records in BSS: {host_record}')
                         fail_host_records = True
 
 
@@ -898,7 +901,7 @@ class State:
                 for network_name, ip in self.ncn_ips.items():
                     # Verify each NCN IP is associated with correct NCN
                     expected_alias = f'{self.ncn_alias}.{network_name.lower()}'
-                    if str(ip) == host_record["ip"]:
+                    if str(ip.ipv4_address()) == host_record["ip"]:
                         expected_aliases = [expected_alias]
                         alternate_aliases = [] # ncn-m001 on the NMN can have an alternate host record for the PIT
                         if network_name == "NMN":
@@ -906,18 +909,18 @@ class State:
                             alternate_aliases = ["pit", "pit.nmn"]
 
                         if expected_aliases == host_record["aliases"] or alternate_aliases == host_record["aliases"]:
-                            action_log(action, f"Pass found existing host_record with the IP address {ip} which contains the expected aliases of {expected_aliases}")
+                            action_log(action, f"Pass found existing host_record with the IP address {ip.ipv4_address()} which contains the expected aliases of {expected_aliases}")
                         else:
                             fail_host_records = True
-                            action_log(action, f'Error existing host_record with IP address {ip} with aliases {host_record["aliases"]}, instead of {expected_aliases}')
+                            action_log(action, f'Error existing host_record with IP address {ip.ipv4_address()} with aliases {host_record["aliases"]}, instead of {expected_aliases}')
 
                     # Verify each NCN alias is associated with the correct IP
                     if expected_alias in host_record["aliases"]:
-                        if str(ip) == host_record["ip"]:
-                            action_log(action, f"Pass found existing host_record for alias {expected_alias} which has the expected IP address of {ip}")
+                        if str(ip.ipv4_address()) == host_record["ip"]:
+                            action_log(action, f"Pass found existing host_record for alias {expected_alias} which has the expected IP address of {ip.ipv4_address()}")
                         else:
                             fail_host_records = True
-                            action_log(action, f'Error existing host_record for alias {expected_alias} has the IP address of {host_record["ip"]}, instead of the expected {ip}')
+                            action_log(action, f'Error existing host_record for alias {expected_alias} has the IP address of {host_record["ip"]}, instead of the expected {ip.ipv4_address()}')
 
 
 
@@ -957,7 +960,7 @@ class State:
 
     def update_sls_networking(self, session: requests.Session):
         # Add IP Reservations for all of the networks that make sense
-        for network_name, ip in self.ncn_ips.items():
+        for network_name, ip_reservation in self.ncn_ips.items():
             sls_network = self.sls_networks[network_name]
             # CAN
             # Master:  {"Aliases":["ncn-m002-can","time-can","time-can.local"],"Comment":"x3000c0s3b0n0","IPAddress":"10.101.5.134","Name":"ncn-m002"}
@@ -1005,12 +1008,6 @@ class State:
             #   - No reservations
             #   - have IP reservations with the node xname for the reservation name
 
-            # All networks except for the CHN have the NCNs alias as the name for the reservation. The CHN has the node xname.
-            name = self.ncn_alias
-
-            # All NCN types have their xname as the comment for their IP reservation
-            comment = self.ncn_xname
-
             # For all networks except the CHN the following aliases are present
             #   - ncn-{*}-{network}
             #   - time-{network}
@@ -1032,8 +1029,7 @@ class State:
                 aliases.append(self.ncn_xname)
                 aliases.append(f'{self.ncn_alias}.local')
 
-            ip_reservation = IPReservation(name, ip, aliases=aliases, comment=comment)
-
+            ip_reservation.aliases(aliases)
             print(f"Adding NCN IP reservation to bootstrap_dhcp subnet in the {network_name} network")
             print(json.dumps(ip_reservation.to_sls(), indent=2))
 
@@ -1047,7 +1043,7 @@ class State:
             if network_name == "HMN":
                 # Add BMC IP reservation to the HMN network.
                 # Example: {"Aliases":["ncn-s001-mgmt"],"Comment":"x3000c0s13b0","IPAddress":"10.254.1.31","Name":"x3000c0s13b0"}
-                bmc_ip_reservation = IPReservation(self.bmc_xname, self.bmc_ip, comment=self.bmc_xname, aliases=[self.bmc_alias])
+                bmc_ip_reservation = Reservation(self.bmc_xname, self.bmc_ip, comment=self.bmc_xname, aliases=[self.bmc_alias])
                 print("Adding NCN BMC IP reservation to bootstrap_dhcp subnet in the HMN network")
                 print(json.dumps(bmc_ip_reservation.to_sls(), indent=2))
 
@@ -1085,7 +1081,7 @@ class State:
 
             host_record = {
                 "aliases": [f'{self.ncn_alias}.{network_name.lower()}'],
-                "ip": str(ip),
+                "ip": str(ip.ipv4_address()),
             }
 
             if network_name == "NMN":
@@ -1245,9 +1241,9 @@ def allocate_ips_command(session: requests.Session, args, state: State):
 
     # Validate allocated IPs are not in use in the HSM EthernetInterfaces table
     for network, ip in state.ncn_ips.items():
-        action, found_ethernet_interfaces = search_hsm_inventory_ethernet_interfaces(session, ip_address=ip)
+        action, found_ethernet_interfaces = search_hsm_inventory_ethernet_interfaces(session, ip_address=ip.ipv4_address())
         if len(found_ethernet_interfaces) == 0:
-            action_log(action, f"Pass {network} IP address {ip} is not currently in use in HSM Ethernet Interfaces")
+            action_log(action, f"Pass {network} IP address {ip.ipv4_address()} is not currently in use in HSM Ethernet Interfaces")
         else:
             # An IP address that has been allocated for the NCN is present in HSM.
             # If the component ID is not set, then this is not a real IP reservation and can be removed, as it is most likely
@@ -1260,7 +1256,7 @@ def allocate_ips_command(session: requests.Session, args, state: State):
                     else:
                         print("Skipping due to dry run!")
                 else:
-                    action_log(action, f'Error found EthernetInterfaces with allocated IP address {ip} in HSM: {found_ie}')
+                    action_log(action, f'Error found EthernetInterfaces with allocated IP address {ip.ipv4_address()} in HSM: {found_ie}')
                     print_action(action)
                     sys.exit(1)
 
@@ -1545,9 +1541,9 @@ def ncn_data_command(session: requests.Session, args, state: State):
 
     # Validate allocated IPs are not in use in the HSM EthernetInterfaces table
     for network, ip in state.ncn_ips.items():
-        action, found_ethernet_interfaces = search_hsm_inventory_ethernet_interfaces(session, ip_address=ip)
+        action, found_ethernet_interfaces = search_hsm_inventory_ethernet_interfaces(session, ip_address=ip.ipv4_address())
         if len(found_ethernet_interfaces) == 0:
-            action_log(action, f"Pass {network} IP address {ip} is not currently in use in HSM Ethernet Interfaces")
+            action_log(action, f"Pass {network} IP address {ip.ipv4_address()} is not currently in use in HSM Ethernet Interfaces")
         else:
             # An IP address that has been allocated for the NCN is present in HSM.
             # If the component ID is not set, then this is not a real IP reservation and can be removed, as it is most likely
@@ -1560,7 +1556,7 @@ def ncn_data_command(session: requests.Session, args, state: State):
                     else:
                         print("Skipping due to dry run!")
                 else:
-                    action_log(action, f'Error found EthernetInterfaces with allocated IP address {ip} in HSM: {found_ie}')
+                    action_log(action, f'Error found EthernetInterfaces with allocated IP address {ip.ipv4_address()} in HSM: {found_ie}')
                     print_action(action)
                     sys.exit(1)
 
@@ -1697,7 +1693,7 @@ def ncn_data_command(session: requests.Session, args, state: State):
     ncn_cidrs = {}
     for network_name, ip in state.ncn_ips.items():
         bootstrap_dhcp_subnet = sls_networks[network_name].subnets()["bootstrap_dhcp"]
-        ncn_cidrs[network_name] = f'{ip}/{bootstrap_dhcp_subnet.ipv4_network().prefixlen}'
+        ncn_cidrs[network_name] = f'{ip.ipv4_address()}/{bootstrap_dhcp_subnet.ipv4_network().prefixlen}'
 
     bootparams = copy.deepcopy(donor_bootparameters)
     bootparams["hosts"] = [state.ncn_xname]
@@ -1868,7 +1864,7 @@ def ncn_data_command(session: requests.Session, args, state: State):
             ei["Description"] = "- kea"
             for network in CLOUD_INIT_NETWORKS:
                 if network in state.ncn_ips:
-                    ei["IPAddresses"].append({"IPAddress": str(state.ncn_ips[network])})
+                    ei["IPAddresses"].append({"IPAddress": str(state.ncn_ips[network].ipv4_address())})
 
         print(f"Adding MAC Addresses {mac} to HSM Inventory EthernetInterfaces")
         print(json.dumps(ei, indent=2))

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -2051,7 +2051,7 @@ def main():
     if not os.path.exists(log_directory):
         os.makedirs(log_directory)
 
-    # Start the actual process of adding a NCN...
+    # Start the actual process of adding an NCN...
     state = State(
         ncn_xname=args.xname,
         ncn_alias=args.alias,

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -52,6 +52,9 @@ HSM_URL = None
 SLS_URL = None
 KEA_URL = None
 
+CLOUD_INIT_NETWORKS = ["NMN", "CAN", "CMN", "MTL", "HMN"]
+NETWORKS = CLOUD_INIT_NETWORKS + ["CHN"]
+
 #
 # HTTP Action stuff
 #
@@ -1717,7 +1720,7 @@ def ncn_data_command(session: requests.Session, args, state: State):
         # This is a CSM 1.2 Specific thing
         bootparams["cloud-init"]["meta-data"]["ipam"] = {}
         for network_name, ip_cidr in ncn_cidrs.items():
-            if network_name not in ["CAN", "CMN", "HMN", "MTL", "NMN"]:
+            if network_name not in CLOUD_INIT_NETWORKS:
                 # This network is not managed by cloud-init
                 continue
 
@@ -1864,7 +1867,7 @@ def ncn_data_command(session: requests.Session, args, state: State):
 
         if interface == "mgmt0":
             ei["Description"] = "- kea"
-            for network in ["NMN", "CAN", "CMN", "MTL", "HMN"]:
+            for network in CLOUD_INIT_NETWORKS:
                 if network in state.ncn_ips:
                     ei["IPAddresses"].append({"IPAddress": str(state.ncn_ips[network])})
 

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -1717,7 +1717,6 @@ def ncn_data_command(session: requests.Session, args, state: State):
     # bootparams["cloud-init"]["meta-data"]["shasta-role"] # This will remain the same for the particular node type. ncn-master, ncn-storage, ncn-worker
     bootparams["cloud-init"]["meta-data"]["xname"] = state.ncn_xname
     if "ipam" in bootparams["cloud-init"]["meta-data"]:
-        # This is a CSM 1.2 Specific thing
         bootparams["cloud-init"]["meta-data"]["ipam"] = {}
         for network_name, ip_cidr in ncn_cidrs.items():
             if network_name not in CLOUD_INIT_NETWORKS:

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/mac_collection_script.ipxe
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/mac_collection_script.ipxe
@@ -6,10 +6,20 @@
 # for a nodes state (e.g. interface names, and available hardware such as HSN).
 set mgmt_vid0 15b3 # Mellanox
 set mgmt_vid1 1077 # QLogic
-#set mgmt_vid2 8086 # Intel
+set mgmt_vid2 1924 # Solarflare
+set mgmt_vid3 14e4 # Broadcomm
 set hsn_did0 1017 # Mellanox CX-5
-#set hsn_did1 1015 # Mellanox CX-4
+set hsn_did1 101b # Mellanox CX-6
 set ignore ffff
+
+:nics_scan
+echo === NIC DISCOVERY ==================================
+# Must start at 0; uint does not start at 0.
+set idx:int8 0
+:check isset ${net${idx}/mac} || goto checked
+  echo net${idx} MAC ${net${idx}/mac} PCI.DeviceID ${pci/${net${idx}/busloc}.2.2} PCI.VendorID ${pci/${net${idx}/busloc}.0.2}
+  inc idx && goto check
+:checked
 
 :nic_naming
 echo === DEVICE NAMING ==================================
@@ -66,14 +76,12 @@ set odd 0
 # HSN-config is handled up the stack.
 :hsn
   echo net${idx} is hsn${idx_hsn}
-  set net-hsn-udev-params ifname=hsn${idx_hsn}:${net${idx}/mac} ip=hsn${idx_hsn}:auto6 ${net-hsn-udev-params}
+  set net-hsn-udev-params ifname=hsn${idx_hsn}:${net${idx}/mac} ${net-hsn-udev-params}
   inc idx && inc idx_hsn && goto loop
 
 # bare interfaces used for bonds or stand-alones
 :mgmt
 
-  # Logic to setup redundant PCIe connections (Port1 of PCIe1 with Port1 of PCIe2 and so on and so forth)
-  iseq mgmt0 mgmt${idx_mgmt} && set ipsrc dhcp || set ipsrc auto6
   # Set dual-bond now that we've maybe incremented idx_mgmt to 2.
   iseq mgmt2 mgmt${idx_mgmt} && set dual-bond 1 ||
   iseq mgmt2 mgmt${idx_mgmt} && clear notice || set notice (or mgmt1 on single-bond servers)
@@ -81,7 +89,6 @@ set odd 0
   # Tell the kernel which MACs get sun or mgmt names.
   iseq ${odd} 1 && echo net${idx} is sun${idx_sun} ${notice} ||
   iseq ${odd} 1 && inc idx_sun ||
-  iseq ${odd} 1 && iseq ${dual-bond} 0 ||
   iseq ${odd} 0 && echo net${idx} is mgmt${idx_mgmt} ||
   iseq ${odd} 0 && inc idx_mgmt ||
 

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/sls_utils/Networks.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/sls_utils/Networks.py
@@ -1,24 +1,24 @@
-# MIT License
+#  MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#  (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
 """Classes for management of SLS Networks and Subnets."""
 from collections import defaultdict
 import ipaddress
@@ -33,18 +33,22 @@ from .Reservations import Reservation
 class Network:
     """Represent a Network from and SLS data structure."""
 
-    def __init__(self, name, network_type, ipv4_address):
+    _ipv6_address = None
+
+    def __init__(self, name, network_type, ipv4_address, ipv6_address = None):
         """Create a Network.
 
         Args:
             name (str): Short name of the network
             network_type (str): Type of the network: ethernet, etc.
             ipv4_address: (str): IPv4 CIDR of the network
+            ipv6_address: (str): IPv6 CIDR of the network
         """
         self._name = name
         self._full_name = ""
         self._ipv4_address = ipaddress.IPv4Interface(ipv4_address)  # IPRanges
-
+        if ipv6_address is not None:
+            self._ipv6_address = ipaddress.IPv6Interface(ipv6_address)  # IPRanges
         self.__type = network_type
         self.__mtu = None
         self.__subnets = defaultdict()
@@ -146,6 +150,27 @@ class Network:
         """
         return self._ipv4_address.network
 
+    def ipv6_address(self, network_address=None):
+        """IPv6 network addressing.
+
+        Args:
+            network_address: IPv6 address of the network for the setter
+
+        Returns:
+            ipv4_address: IPv6 address of the network for the getter
+        """
+        if network_address is not None:
+            self._ipv6_address = ipaddress.IPv6Interface(network_address)
+        return self._ipv6_address
+
+    def ipv6_network(self):
+        """IPv6 network of the CIDR, Ranges, etc.
+
+        Returns:
+            ipv6_address.network: IPv6 network address of the Network.
+        """
+        return self._ipv6_address.network
+
     def mtu(self, network_mtu=None):
         """MTU of the network.
 
@@ -224,6 +249,8 @@ class Network:
                 "Subnets": subnets,
             },
         }
+        if self._ipv6_address:
+            sls["ExtraProperties"]["CIDR6"] = str(self._ipv6_address)
 
         if self.__bgp_asns[0] and self.__bgp_asns[1]:
             sls["ExtraProperties"]["MyASN"] = self.__bgp_asns[0]
@@ -277,7 +304,9 @@ class BicanNetwork(Network):
 class Subnet(Network):
     """Subnets are Networks with extra metadata: DHCP info, IP reservations, etc..."""
 
-    def __init__(self, name, ipv4_address, ipv4_gateway, vlan):
+    __ipv6_gateway = None
+
+    def __init__(self, name, ipv4_address, ipv4_gateway, vlan, ipv6_address = None, ipv6_gateway = None):
         """Create a new Subnet.
 
         Args:
@@ -285,9 +314,13 @@ class Subnet(Network):
             ipv4_address (str): IPv4 CIDR of the subnet
             ipv4_gateway (str): IPv4 address of the network gateway
             vlan (int): VLAN ID of the subnet
+            ipv6_address (str): IPv6 CIDR of the subnet
+            ipv6_gateway (str): IPv6 address of the network gateway
         """
-        super().__init__(name=name, network_type=None, ipv4_address=ipv4_address)
+        super().__init__(name=name, network_type=None, ipv4_address=ipv4_address, ipv6_address=ipv6_address)
         self.__ipv4_gateway = ipaddress.IPv4Address(ipv4_gateway)
+        if ipv6_gateway is not None:
+            self.__ipv6_gateway = ipaddress.IPv6Address(ipv6_gateway)
         self.__vlan = int(vlan)
         self.__ipv4_dhcp_start_address = None
         self.__ipv4_dhcp_end_address = None
@@ -309,7 +342,9 @@ class Subnet(Network):
         sls_subnet = cls(
             name=sls_data.get("Name"),
             ipv4_address=sls_data.get("CIDR"),
+            ipv6_address=sls_data.get("CIDR6"),
             ipv4_gateway=sls_data.get("Gateway"),
+            ipv6_gateway=sls_data.get("Gateway6"),
             vlan=sls_data.get("VlanID"),
         )
 
@@ -357,6 +392,7 @@ class Subnet(Network):
                     reservation.get("Name"): Reservation(
                         name=reservation.get("Name"),
                         ipv4_address=reservation.get("IPAddress"),
+                        ipv6_address=reservation.get("IPAddress6"),
                         aliases=list(reservation.get("Aliases", [])),
                         comment=reservation.get("Comment"),
                     ),
@@ -390,6 +426,19 @@ class Subnet(Network):
         if subnet_ipv4_gateway is not None:
             self.__ipv4_gateway = subnet_ipv4_gateway
         return self.__ipv4_gateway
+
+    def ipv6_gateway(self, subnet_ipv6_gateway=None):
+        """IPv6 Gateway of the subnet.
+
+        Args:
+            subnet_ipv6_gateway (str): IPv6 gateway of the subnet for the setter
+
+        Returns:
+            ipv4_gateway (xxx): IPv6 gateway of the subnet for the getter
+        """
+        if subnet_ipv6_gateway is not None:
+            self.__ipv6_gateway = subnet_ipv6_gateway
+        return self.__ipv6_gateway
 
     def dhcp_start_address(self, subnet_dhcp_start_address=None):
         """IPv4 starting address if DHCP is used in the subnet.
@@ -488,6 +537,11 @@ class Subnet(Network):
             "Gateway": str(self.__ipv4_gateway),
             "VlanID": self.__vlan,
         }
+        if self._ipv6_address:
+            sls.update({"CIDR6": str(self._ipv6_address)})
+
+        if self.__ipv6_gateway:
+            sls.update({"Gateway6": str(self.__ipv6_gateway)})
 
         if self.__ipv4_dhcp_start_address and self.__ipv4_dhcp_end_address:
             dhcp = {

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/sls_utils/Reservations.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/sls_utils/Reservations.py
@@ -1,24 +1,24 @@
-# MIT License
+#  MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#  (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
 """Class for managing SLS Reservations."""
 import ipaddress
 
@@ -26,17 +26,22 @@ import ipaddress
 class Reservation:
     """Name, IPv4 address and list of aliases to create A Records and CNAMEs."""
 
-    def __init__(self, name, ipv4_address, aliases=list, comment=""):
+    __ipv6_address = None
+
+    def __init__(self, name, ipv4_address, ipv6_address = None, aliases=list, comment=""):
         """Create a Reservation class.
 
         Args:
             name (str): Name of the reservation
-            ipv4_address (str): IPv4 address of the reservation
+            ipv4_address (str or ipaddress.IPv4Address): IPv4 address of the reservation
+            ipv6_address (str or ipaddress.IPv6Address): IPv6 address of the reservation
             aliases (list): List of strings for reservation alternate names
             comment (str): Arbitrary comment on the reservation
         """
         self.__name = name
         self.__ipv4_address = ipaddress.IPv4Address(ipv4_address)
+        if ipv6_address is not None:
+            self.__ipv6_address = ipaddress.IPv6Address(ipv6_address)
         self.__aliases = aliases
         self.__comment = comment
 
@@ -57,14 +62,31 @@ class Reservation:
         """IPv4 Address of the host.
 
         Args:
-            reservation_ipv4_address: IPv4 address of the reservation
+            reservation_ipv4_address (str or ipaddress.IPv4Address): IPv4 address of the reservation
 
         Returns:
             ipv4_address (ipaddress.IPv4Address):  IPv4 CIDR of the reservation.
         """
-        if reservation_ipv4_address:
+        if isinstance(reservation_ipv4_address, ipaddress.IPv4Address):
+            self.__ipv4_address = reservation_ipv4_address
+        elif isinstance(reservation_ipv4_address, str):
             self.__ipv4_address = ipaddress.IPv4Address(reservation_ipv4_address)
         return self.__ipv4_address
+
+    def ipv6_address(self, reservation_ipv6_address=None):
+        """IPv4 Address of the host.
+
+        Args:
+            reservation_ipv6_address (str or ipaddress.IPv6Address): IPv4 address of the reservation
+
+        Returns:
+            ipv4_address (ipaddress.IPv6Address):  IPv4 CIDR of the reservation.
+        """
+        if isinstance(reservation_ipv6_address, ipaddress.IPv6Address):
+            self.__ipv6_address = reservation_ipv6_address
+        elif isinstance(reservation_ipv6_address, str):
+            self.__ipv6_address = ipaddress.IPv6Address(reservation_ipv6_address)
+        return self.__ipv6_address
 
     def comment(self, reservation_comment=None):
         """Arbitrary descriptive text.
@@ -102,6 +124,8 @@ class Reservation:
             "Name": self.__name,
             "IPAddress": str(self.__ipv4_address),
         }
+        if self.__ipv6_address:
+            sls.update({"IPAddress6": str(self.__ipv6_address)})
         if self.__aliases:
             sls.update({"Aliases": [str(a) for a in self.__aliases]})
         if self.__comment is not None:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

This PR amends the add/remove NCN procedure with updates for adding IPv6 data on systems using IPv6.

* A new step for adding IPv6 data was amended to the Add NCN Data procedure
* Bugfixes and enhancements to the `add_management_ncn.py` script were necessary to prevent the _deletion_ of IPv6 data, the script as it was written was purging any and all IPv6 data from SLS during the add remove NCN procedure

This includes a few, additional changes to the add/remove NCN procedure:

* A few copy-paste friendly updates for the add/remove procedure, fixing snippets that fail to run to completion when copied to clipboard from github.com
* Updates the `mac_collection_script.ipxe` iPXE script, replacing the CSM 1.2 copy with a CSM 1.7 version. This version includes a "NIC discovery" printout for easier scrutiny of interface hardware, as well as a wider range of applicable IDs for eligible mgmt and HSN hardware. This script was tested as part of the add/remove procedure changes in this pull-request

    ```text
    Features: DNS HTTP HTTPS iSCSI TFTP VLAN SRP AoE EFI Menu
    === NIC DISCOVERY ==================================
    net0 MAC 00:62:0b:a3:ad:72 PCI.DeviceID 16d7 PCI.VendorID 14e4
    net1 MAC 00:62:0b:a3:ad:73 PCI.DeviceID 16d7 PCI.VendorID 14e4
    net2 MAC 04:32:01:22:fe:40 PCI.DeviceID 16d8 PCI.VendorID 14e4
    net3 MAC 04:32:01:22:fe:41 PCI.DeviceID 16d8 PCI.VendorID 14e4
    net4 MAC 00:62:0b:a4:21:64 PCI.DeviceID 16d7 PCI.VendorID 14e4
    net5 MAC 00:62:0b:a4:21:65 PCI.DeviceID 16d7 PCI.VendorID 14e4
    === DEVICE NAMING ==================================
    net0 MAC 00:62:0b:a3:ad:72
    net0 is mgmt0
    net1 MAC 00:62:0b:a3:ad:73
    net1 is sun0 (or mgmt1 on single-bond servers)
    net2 MAC 04:32:01:22:fe:40
    net2 is mgmt1
    net3 MAC 04:32:01:22:fe:41
    net3 is sun1
    net4 MAC 00:62:0b:a4:21:64
    net4 is mgmt2
    net5 MAC 00:62:0b:a4:21:65
    net5 is sun2 (or mgmt1 on single-bond servers)
    ```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
