### PR TITLE
CASMINST-7411:saving upgrade-k8s pod logs

### DIFF
--- a/upgrade/scripts/k8s/upgrade_k8s_job.yaml
+++ b/upgrade/scripts/k8s/upgrade_k8s_job.yaml
@@ -42,7 +42,9 @@ spec:
         args:
         - |
           ssh -i /myssh/id_rsa -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null root@ncn-m001 "/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_steps.sh"
+              -o UserKnownHostsFile=/dev/null root@ncn-m001 \
+              "ts=\$(date +'%Y-%m-%d_%H-%M-%S'); \
+               /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_steps.sh >> /root/upgrade_k8s_output_\$ts.log 2>&1"
         volumeMounts:
         - mountPath: /myssh
           name: ssh


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

This PR ensures that the output of the Kubernetes upgrade script executed via the k8s-upgrade-job (triggered by the deploy-product-onexit hook) is persisted for future reference.

**Change Summary**

- Captures the output of the upgrade script and saves it to a timestamped log file under /root on the target node (ncn-m001).
- This ensures that logs are retained even after the Job pod is deleted.

Resolves [CASMINST-7411](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7411)

For testing a dummy command was run in the job 
 `ssh -i /myssh/id_rsa -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null root@ncn-m001 \
              "ts=\$(date +'%Y-%m-%d_%H-%M-%S'); \
               echo 'Test log at \$ts' >> /root/upgrade_k8s_output_\$ts.log 2>&1"
 `

After completion of job , log could be seen in this file

`ncn-m001:/mnt/developer/pankhuri # cat /root/upgrade_k8s_output_2025-08-04_09-01-12.log`
`Test log at $ts
`

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
