### PR TITLE
CASMTRIAGE-8561 - Cilium migration blocked by kafka

### DIFF
--- a/workflows/templates/cilium.deploy.yaml
+++ b/workflows/templates/cilium.deploy.yaml
@@ -119,9 +119,25 @@ spec:
                 value: |
                   echo "Waiting for cilium to start up"
                   cilium status --wait
-        - name: "stash-network-policies"
+        - name: "disable-strimzi-netpol-management"
           dependencies:
             - wait-for-cilium-status
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  echo "Disabling Strimzi Operator NetworkPolicy management"
+                  kubectl -n operators set env deployment/strimzi-cluster-operator STRIMZI_NETWORK_POLICY_GENERATION=false
+                  echo "Waiting for Strimzi Operator to restart"
+                  kubectl -n operators rollout status deployment strimzi-cluster-operator
+        - name: "stash-network-policies"
+          dependencies:
+            - disable-strimzi-netpol-management
           templateRef:
             name: ssh-template
             template: shell-script
@@ -135,8 +151,7 @@ spec:
                   rm -f /tmp/netpol.yaml
                   for i in $(kubectl get netpol -A --no-headers | awk '{print $1}' | sort -u );do
                     echo "--- namespace ${i} ---"
-                    # Not stashing network policies for cray-shared-kafka or SMA kafka because they get recreated by the operator
-                    for j in $(kubectl -n ${i} get netpol --no-headers | egrep -v "cray-shared-kafka|cluster" | awk '{print $1}');do
+                    for j in $(kubectl -n ${i} get netpol --no-headers | awk '{print $1}');do
                       echo "Saving off network policy ${j}"
                       echo "---" >> /tmp/netpol.yaml
                       kubectl -n ${i} get netpol ${j} -o yaml >> /tmp/netpol.yaml

--- a/workflows/templates/cilium.post-migrate.yaml
+++ b/workflows/templates/cilium.post-migrate.yaml
@@ -51,6 +51,22 @@ spec:
                   fi
                   kubectl get netpol -A
                   rm -f /tmp/netpol-out.yaml
+        - name: enable-strimzi-netpol-management
+          dependencies:
+            - restore-network-policies
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  echo "Enabling Strimzi Operator NetworkPolicy management"
+                  kubectl -n operators set env deployment/strimzi-cluster-operator STRIMZI_NETWORK_POLICY_GENERATION-
+                  echo "Waiting for Strimzi Operator to restart"
+                  kubectl -n operators rollout status deployment strimzi-cluster-operator
         - name: update-multus-configmap
           templateRef:
             name: ssh-template
@@ -68,6 +84,7 @@ spec:
           dependencies:
             - restore-network-policies
             - update-multus-configmap
+            - enable-strimzi-netpol-management
           templateRef:
             name: ssh-template
             template: shell-script


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

During Weave to Cilium migration it is possible for the workflow to get stuck because a Kafka pod that restarts on a node that has been migrated to Cilium can no longer communicate with pods running on nodes that are still running Weave.

This appears to be due to the network policies as the kafka policies are left in place. Cilium is configured to not enforce network policy during migration however Weave still enforces them and this appears to be the cause of the issue.

This PR adds a step to the migration procedure that temporarily disables network policy creation by the Strimzi operator. The kafka policies are then backed up and restored with the other network policies before Strimzi network policy management is re-enabled.

While testing on `tyr` I found the already documented workaround of deleting the zookeeper pods is still required however with these changes in place that workaround now works as expected.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
