### PR TITLE
CASMSEC-590: Updated RELEASE_NOTES.md to add a kyverno note worthy note

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,9 +79,9 @@
 
 ## Noteworthy changes
 
-* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed.
-  Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy,
-  how to add exceptions and allow third party signing keys.
+* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are unsigned will not be deployed.
+  For more information on the policy, how to add exceptions, and how to allow third party signing keys, see
+  [What is new in the HPE CSM 1.7 release and above](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above).
 
 ## Test
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,6 +97,7 @@
 * Added [CFS](glossary.md#configuration-framework-service-cfs) node personalization to the barebones image boot test.
     * This tests is part of the procedure to [Validate CSM Health](operations/validate_csm_health.md).
     * For more information, see [Barebones Image Boot Test](troubleshooting/cms_barebones_image_boot.md).
+* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed. Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy, how to add exceptions and allow third party signing keys.
 
 ## Bug fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,6 +79,10 @@
 
 ## Noteworthy changes
 
+* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed.
+  Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy,
+  how to add exceptions and allow third party signing keys.
+
 ## Test
 
 * Modified `adjust k8s_nodes_ready_check.sh` to not fail when a node is in `Ready,SchedulingDisabled` state
@@ -97,9 +101,6 @@
 * Added [CFS](glossary.md#configuration-framework-service-cfs) node personalization to the barebones image boot test.
     * This tests is part of the procedure to [Validate CSM Health](operations/validate_csm_health.md).
     * For more information, see [Barebones Image Boot Test](troubleshooting/cms_barebones_image_boot.md).
-* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed.
-  Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy,
-  how to add exceptions and allow third party signing keys.
 
 ## Bug fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,7 +97,9 @@
 * Added [CFS](glossary.md#configuration-framework-service-cfs) node personalization to the barebones image boot test.
     * This tests is part of the procedure to [Validate CSM Health](operations/validate_csm_health.md).
     * For more information, see [Barebones Image Boot Test](troubleshooting/cms_barebones_image_boot.md).
-* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed. Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy, how to add exceptions and allow third party signing keys.
+* Kyverno image verification policy is being shipped in `Enforce` mode. Container images that are `unsigned` will not be deployed.
+  Please refer the [Kyverno documentation](operations/kubernetes/Kyverno.md#what-is-new-in-the-hpe-csm-17-release-and-above) regarding the policy,
+  how to add exceptions and allow third party signing keys.
 
 ## Bug fixes
 


### PR DESCRIPTION
# Description
Kyverno document is being poined under the noteworthy-changes in  RELEASE_NOTES.md as Image verification Enforcement is a big change being made in CSM 1.7.

Relates to:
[CASMSEC-590](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-590)
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
