### PR TITLE
CASMPET-7651: Add k8s cert validity period to RELEASE_NOTES

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -732,7 +732,6 @@ sysfs
 syslog
 system_unit
 teardown
-time.Duration
 timeframes
 timestamp
 timezone

--- a/.spelling
+++ b/.spelling
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -732,6 +732,7 @@ sysfs
 syslog
 system_unit
 teardown
+time.Duration
 timeframes
 timestamp
 timezone

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,7 +80,8 @@
 ## Noteworthy changes
 
 * The default Kubernetes certificate validity period increased from 1 year to 3 years.
-  For more details on the certificate validity period and how to modify it, see [Modify Certificate Validity Period](operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#modify-certificate-validity-period)
+  For more details on the certificate validity period and how to modify it, see
+  [Modify certificate validity period](operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#modify-certificate-validity-period).
 
 ## Test
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,6 +79,9 @@
 
 ## Noteworthy changes
 
+* The default Kubernetes certificate validity period increased from 1 year to 3 years.
+  For more details on the certificate validity period and how to modify it, see [Modify Certificate Validity Period](operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#modify-certificate-validity-period)
+
 ## Test
 
 * Modified `adjust k8s_nodes_ready_check.sh` to not fail when a node is in `Ready,SchedulingDisabled` state

--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -15,6 +15,7 @@ Procedures for Certificate Renewal:
 - [File Locations](#file-locations)
 - [Check Certificates](#check-certificates)
 - [Backup Existing Certificates](#backup-existing-certificates)
+- [Modify Certificate Validity Period](#modify-certificate-validity-period)
 - [Renew All Certificates](#renew-all-certificates)
 - [Renew Etcd Certificate](#renew-etcd-certificate)
 - [Update Client Secrets](#update-client-secrets)
@@ -131,6 +132,42 @@ Client (master and worker nodes):
     ncn-w003: /var/lib/kubelet/pki/kubelet.crt
 
     [...]
+    ```
+
+## Modify Certificate Validity Period
+
+With Kubernetes 1.32 and `kubeadm.k8s.io/vbeta4`, the Kubernetes certificate validity period, or expiry, can be configured in the `/etc/kubernetes/kubeadmcfg.yaml` file. In CSM 1.7, the default certificate validity period is `26280h` or **3 years**.
+
+If you wish to keep the certificate validity period at 3 years, you can skip this section and jump to the [Renew All Certificates](#renew-all-certificates) section.
+
+To adjust the validity period before renewing certificates, modify the `certificateValidityPeriod` value in the `/etc/kubernetes/kubeadmcfg.yaml` configuration file. The field value follows Go's time.Duration values format, with hours (h) being the longest supported unit.
+
+For example, the value for 5 years (365 days * 24 hours * 5 years) is `43800h`.
+
+Run the following steps on each master node.
+
+1. Make copy of `/etc/kubernetes/kubeadmcfg.yaml`.
+
+    ```bash
+    cp /etc/kubernetes/kubeadmcfg.yaml /etc/kubernetes/kubeadmcfg.yaml.bak
+    ```
+
+1. Edit the `certificateValidityPeriod` value.
+
+    ```bash
+    yq4 eval -i -P '.certificateValidityPeriod = "43800h"' "/etc/kubernetes/kubeadmcfg.yaml"
+    ```
+
+1. Check `certificateValidityPeriod` value.
+
+    ```bash
+    cat /etc/kubernetes/kubeadmcfg.yaml | grep certificateValidityPeriod
+    ```
+
+    Example output:
+
+    ```text
+    certificateValidityPeriod: 43800h
     ```
 
 ## Renew All Certificates

--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -15,7 +15,7 @@ Procedures for Certificate Renewal:
 - [File Locations](#file-locations)
 - [Check Certificates](#check-certificates)
 - [Backup Existing Certificates](#backup-existing-certificates)
-- [Modify Certificate Validity Period](#modify-certificate-validity-period)
+- [Modify certificate validity period](#modify-certificate-validity-period)
 - [Renew All Certificates](#renew-all-certificates)
 - [Renew Etcd Certificate](#renew-etcd-certificate)
 - [Update Client Secrets](#update-client-secrets)
@@ -134,11 +134,12 @@ Client (master and worker nodes):
     [...]
     ```
 
-## Modify Certificate Validity Period
+## Modify certificate validity period
 
 With Kubernetes 1.32 and `kubeadm.k8s.io/vbeta4`, the Kubernetes certificate validity period, or expiry, can be configured in the `/etc/kubernetes/kubeadmcfg.yaml` file. In CSM 1.7, the default certificate validity period is `26280h` or **3 years**.
 
-If you wish to keep the certificate validity period at 3 years, you can skip this section and jump to the [Renew All Certificates](#renew-all-certificates) section.
+Administrators who wish to keep the certificate validity period at 3 years should skip this section and jump to
+[Renew all certificates](#renew-all-certificates).
 
 To adjust the validity period before renewing certificates, modify the `certificateValidityPeriod` value in the `/etc/kubernetes/kubeadmcfg.yaml` configuration file.
 
@@ -148,19 +149,21 @@ For example, the value for 5 years is `43800h`.
 
 Run the following steps on each master node.
 
-1. Make copy of `/etc/kubernetes/kubeadmcfg.yaml`.
+1. (`ncn-m#`) Make copy of `/etc/kubernetes/kubeadmcfg.yaml`.
 
     ```bash
-    cp /etc/kubernetes/kubeadmcfg.yaml /etc/kubernetes/kubeadmcfg.yaml.bak
+    cp -v /etc/kubernetes/kubeadmcfg.yaml /etc/kubernetes/kubeadmcfg.yaml.bak
     ```
 
-1. Edit the `certificateValidityPeriod` value.
+1. (`ncn-m#`) Edit the `certificateValidityPeriod` value.
+
+   > Modify the following example command to replace `43800h` with the desired value.
 
     ```bash
     yq4 eval -i -P '.certificateValidityPeriod = "43800h"' "/etc/kubernetes/kubeadmcfg.yaml"
     ```
 
-1. Check `certificateValidityPeriod` value.
+1. (`ncn-m#`) Check the `certificateValidityPeriod` value.
 
     ```bash
     cat /etc/kubernetes/kubeadmcfg.yaml | grep certificateValidityPeriod

--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -140,9 +140,11 @@ With Kubernetes 1.32 and `kubeadm.k8s.io/vbeta4`, the Kubernetes certificate val
 
 If you wish to keep the certificate validity period at 3 years, you can skip this section and jump to the [Renew All Certificates](#renew-all-certificates) section.
 
-To adjust the validity period before renewing certificates, modify the `certificateValidityPeriod` value in the `/etc/kubernetes/kubeadmcfg.yaml` configuration file. The field value follows Go's time.Duration values format, with hours (h) being the longest supported unit.
+To adjust the validity period before renewing certificates, modify the `certificateValidityPeriod` value in the `/etc/kubernetes/kubeadmcfg.yaml` configuration file.
 
-For example, the value for 5 years (365 days * 24 hours * 5 years) is `43800h`.
+The `certificateValidityPeriod` field value follows Go's `time.Duration` values format, with hours being the longest supported unit.
+
+For example, the value for 5 years is `43800h`.
 
 Run the following steps on each master node.
 


### PR DESCRIPTION
# Description
CASMPET-7651: Add k8s cert validity period to RELEASE_NOTES
* Add Modify Certificate Validity Period section to cert renewal instructions

# Testing
Tested `Modify Certificate Validity Period` on `beau`

```
ncn-m001:~ # kubeadm certs check-expiration
[check-expiration] Reading configuration from the "kubeadm-config" ConfigMap in namespace "kube-system"...
[check-expiration] Use 'kubeadm init phase upload-config --config your-config.yaml' to re-upload it.

CERTIFICATE                  EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
admin.conf                   Jun 28, 2028 00:36 UTC   2y327d          ca                      no
apiserver                    Jun 28, 2028 00:36 UTC   2y327d          ca                      no
apiserver-kubelet-client     Jun 28, 2028 00:36 UTC   2y327d          ca                      no
controller-manager.conf      Jun 28, 2028 00:36 UTC   2y327d          ca                      no
front-proxy-client           Jun 28, 2028 00:36 UTC   2y327d          front-proxy-ca          no
scheduler.conf               Jun 28, 2028 00:36 UTC   2y327d          ca                      no
!MISSING! super-admin.conf

CERTIFICATE AUTHORITY   EXPIRES                  RESIDUAL TIME   EXTERNALLY MANAGED
ca                      Jun 27, 2028 23:00 UTC   2y327d          no
front-proxy-ca          Jun 27, 2028 23:00 UTC   2y327d          no
ncn-m001:~ #

ncn-m001:/etc/kubernetes # cp /etc/kubernetes/kubeadmcfg.yaml /etc/kubernetes/kubeadmcfg.yaml.bak
ncn-m001:/etc/kubernetes # ls
admin.conf  controller-manager.conf  etcd-node-ca-csr.json  kubeadmcfg.yaml  kubeadmcfg.yaml.bak  kubelet.conf	manifests  pki	scheduler.conf	super-admin.conf  tenant-admin.conf
ncn-m001:/etc/kubernetes # yq4 eval -i -P '.certificateValidityPeriod = "43800h"' "/etc/kubernetes/kubeadmcfg.yaml"
ncn-m001:/etc/kubernetes # cat /etc/kubernetes/kubeadmcfg.yaml | grep certificateValidityPeriod
certificateValidityPeriod: 43800h
ncn-m001:/etc/kubernetes #

<snip>

ncn-m001:/etc/kubernetes # kubeadm certs renew all --config /etc/kubernetes/kubeadmcfg.yaml
W0805 20:13:37.978750 4076261 validation.go:79] WARNING: certificateValidityPeriod: the value 43800h0m0s is more than the recommended default for certificate expiration: 8760h0m0s
certificate embedded in the kubeconfig file for the admin to use and for kubeadm itself renewed
certificate for serving the Kubernetes API renewed
certificate the apiserver uses to access etcd renewed
certificate for the API server to connect to kubelet renewed
certificate embedded in the kubeconfig file for the controller manager to use renewed
certificate for liveness probes to healthcheck etcd renewed
certificate for etcd nodes to communicate with each other renewed
certificate for serving etcd renewed
certificate for the front proxy client renewed
certificate embedded in the kubeconfig file for the scheduler manager to use renewed
MISSING! certificate embedded in the kubeconfig file for the super-admin

Done renewing certificates. You must restart the kube-apiserver, kube-controller-manager, kube-scheduler and etcd, so that they can use the new certificates.
ncn-m001:/etc/kubernetes # kubeadm certs check-expiration --config /etc/kubernetes/kubeadmcfg.yaml
W0805 20:14:23.696474 4079102 validation.go:79] WARNING: certificateValidityPeriod: the value 43800h0m0s is more than the recommended default for certificate expiration: 8760h0m0s
CERTIFICATE                  EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
admin.conf                   Aug 04, 2030 20:13 UTC   4y364d          ca                      no
apiserver                    Aug 04, 2030 20:13 UTC   4y364d          ca                      no
apiserver-etcd-client        Aug 04, 2030 20:13 UTC   4y364d          etcd-ca                 no
apiserver-kubelet-client     Aug 04, 2030 20:13 UTC   4y364d          ca                      no
controller-manager.conf      Aug 04, 2030 20:13 UTC   4y364d          ca                      no
etcd-healthcheck-client      Aug 04, 2030 20:13 UTC   4y364d          etcd-ca                 no
etcd-peer                    Aug 04, 2030 20:13 UTC   4y364d          etcd-ca                 no
etcd-server                  Aug 04, 2030 20:13 UTC   4y364d          etcd-ca                 no
front-proxy-client           Aug 04, 2030 20:13 UTC   4y364d          front-proxy-ca          no
scheduler.conf               Aug 04, 2030 20:13 UTC   4y364d          ca                      no
!MISSING! super-admin.conf

CERTIFICATE AUTHORITY   EXPIRES                  RESIDUAL TIME   EXTERNALLY MANAGED
ca                      Jun 27, 2028 23:00 UTC   2y327d          no
etcd-ca                 Jun 26, 2035 22:59 UTC   9y              no
front-proxy-ca          Jun 27, 2028 23:00 UTC   2y327d          no
ncn-m001:/etc/kubernetes #
```

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
