### PR TITLE
CASMTRIAGE-8591 - DOCS: Configure maximum Istio Gateway pods procedure doesn't expand variables

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -445,10 +445,10 @@ the system size.
     ```bash
     for gw in "" -customer-admin -customer-user -hmn; do
       yq write -i ${SITE_INIT}/customizations.yaml \
-        'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax' \
+        "spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax" \
         "$max_amount"
       yq write -i ${SITE_INIT}/customizations.yaml \
-        'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin' \
+        "spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin" \
         "$min_amount"
     done
     ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The following code fragment in `prepare_site_init.md` is incorrectly quoted and causes bad data to be written to customizations.yaml

```
for gw in "" -customer-admin -customer-user -hmn; do
  yq write -i ${SITE_INIT}/customizations.yaml \
    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax' \
    "$max_amount"
  yq write -i ${SITE_INIT}/customizations.yaml \
    'spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin' \
    "$min_amount"
done
```
Output:
```
ncn-m001:~# yq4 .spec.kubernetes.services.cray-istio-ingress.deployments customizations.yaml
istio-ingressgateway${gw}:
  autoscaleMax: 3
  autoscaleMin: 3
```
This PR fixes the scriptlet so it produces the correct output.
```
ncn-m001:~/cspiller # max_amount=3
ncn-m001:~/cspiller # min_amount=3
ncn-m001:~/cspiller # SITE_INIT=~/cspiller/
ncn-m001:~/cspiller # for gw in "" -customer-admin -customer-user -hmn; do
>   yq write -i ${SITE_INIT}/customizations.yaml \
>     "spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMax" \
>     "$max_amount"
>   yq write -i ${SITE_INIT}/customizations.yaml \
>     "spec.kubernetes.services.cray-istio-ingress.deployments.istio-ingressgateway${gw}.autoscaleMin" \
>     "$min_amount"
> done

ncn-m001:~/cspiller # yq4 .spec.kubernetes.services.cray-istio-ingress.deployments customizations.yaml
istio-ingressgateway:
  autoscaleMax: 3
  autoscaleMin: 3
istio-ingressgateway-customer-admin:
  autoscaleMax: 3
  autoscaleMin: 3
istio-ingressgateway-customer-user:
  autoscaleMax: 3
  autoscaleMin: 3
istio-ingressgateway-hmn:
  autoscaleMax: 3
  autoscaleMin: 3
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
