### PR TITLE
CASMHMS-6589: Added extra verbiage to describe accuracy of CPU/GPU hardware history

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1264,3 +1264,7 @@ Init
 
 - upgrade/1.5.2/README.md
 Multitenancy
+
+- operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+FRUID
+FRUIDs

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -19,6 +19,13 @@ time should the database continue to grow too large.
 The steps in this document must be also be completed immediately prior to
 starting a CSM 1.6.0 upgrade.
 
+Unfortunately, due to the nature of this bug and capabilities of the pruning
+script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
+1.7.0 release may not be fully accurate.  Once your system is upgraded to CSM
+1.7.0, the accuracy of FRUIDs associated with CPUs and GPUs will be fully
+restored from that point in time and into the future.  No other component
+types were affected by this bug.
+
 ## Prerequisites
 
 - Healthy HSM Postgres Cluster.

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -19,12 +19,11 @@ time should the database continue to grow too large.
 The steps in this document must be also be completed immediately prior to
 starting a CSM 1.6.0 upgrade.
 
-Unfortunately, due to the nature of this bug and capabilities of the pruning
+Unfortunately, because to the nature of this bug and the capabilities of the pruning
 script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
-1.7.0 release may not be fully accurate.  Once your system is upgraded to CSM
-1.7.0, the accuracy of FRUIDs associated with CPUs and GPUs will be fully
-restored from that point in time and into the future.  No other component
-types were affected by this bug.
+1.7.0 release may not be fully accurate. After the system is upgraded to CSM
+1.7, the FRUIDs associations with CPUs and GPUs will be fully accurate from that point on.
+No other component types were affected by this bug.
 
 ## Prerequisites
 

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -17,13 +17,14 @@ The steps outlined here are repeatable and the scripts can be rerun at any
 time should the database continue to grow too large.
 
 The steps in this document must be also be completed immediately prior to
-starting a CSM 1.6.0 upgrade.
+starting an upgrade from CSM 1.5 to CSM 1.6.
 
-Unfortunately, because to the nature of this bug and the capabilities of the pruning
-script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
-1.7.0 release may not be fully accurate. After the system is upgraded to CSM
-1.7, the FRUIDs associations with CPUs and GPUs will be fully accurate from that point on.
-No other component types were affected by this bug.
+Unfortunately, because of the nature of this bug and the capabilities of the
+pruning script, the history of FRUIDs associated with CPUs and GPUs within a
+node may not be fully accurate in systems running CSM releases prior to CSM
+1.7. After the system is upgraded to CSM 1.7, the FRUID associations with
+CPUs and GPUs within a node will be fully accurate from that point on.  No
+other component types were affected by this bug.
 
 ## Prerequisites
 


### PR DESCRIPTION
# Description

Provide additional clarification surrounding the accuracy of CPU and GPU hardware history prior to the CSM 1.7.0 release.

* Resolves [CASMHMS-6589](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6589)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.