### PR TITLE
CASMHMS-6589: Added extra verbiage to describe accuracy of CPU/GPU hardware history

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1161,3 +1161,7 @@ rs232
 S4048-ON
 SmartFabric
 Infiniband
+
+- operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+FRUID
+FRUIDs

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -13,9 +13,17 @@ to issues associated with testing the hardware event history.
 Though this issue is resolved in CSM 1.7.0, this document is retained as
 a reference for removing duplicate events prior to the CSM 1.7.0 upgrade.
 The steps in this document must be completed prior to starting the CSM
-1.7.0 upgrade.
+1.7.0 upgrade.  If your system is running CSM 1.7.0 or later, you should
+no longer perform the actions in this document.
 
 This same material is also present in the CSM 1.5.0 and CSM 1.6.0 docs.
+
+Unfortunately, due to the nature of this bug and capabilities of the pruning
+script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
+1.7.0 release may not be fully accurate.  Once your system is upgraded to CSM
+1.7.0, the accuracy of FRUIDs associated with CPUs and GPUs will be fully
+restored from that point in time and into the future.  No other component
+types were affected by this bug.
 
 ## Prerequisites
 

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -12,17 +12,18 @@ to issues associated with testing the hardware event history.
 
 Though this issue is resolved in CSM 1.7.0, this document is retained as
 a reference for removing duplicate events prior to the CSM 1.7.0 upgrade.
-The steps in this document must be completed prior to starting the CSM
-1.7.0 upgrade.  If your system is running CSM 1.7.0 or later, you should
-no longer perform the actions in this document.
+The steps in this document must be completed prior to starting an upgrade
+from CSM 1.6 to CSM 1.7.  The actions in this document are not required on
+systems running CSM 1.7.0 or later.
 
 This same material is also present in the CSM 1.5.0 and CSM 1.6.0 docs.
 
-Unfortunately, because to the nature of this bug and the capabilities of the pruning
-script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
-1.7.0 release may not be fully accurate. After the system is upgraded to CSM
-1.7, the FRUIDs associations with CPUs and GPUs will be fully accurate from that point on.
-No other component types were affected by this bug.
+Unfortunately, because of the nature of this bug and the capabilities of the
+pruning script, the history of FRUIDs associated with CPUs and GPUs within a
+node may not be fully accurate in systems running CSM releases prior to CSM
+1.7. After the system is upgraded to CSM 1.7, the FRUID associations with
+CPUs and GPUs within a node will be fully accurate from that point on.  No
+other component types were affected by this bug.
 
 ## Prerequisites
 

--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -18,12 +18,11 @@ no longer perform the actions in this document.
 
 This same material is also present in the CSM 1.5.0 and CSM 1.6.0 docs.
 
-Unfortunately, due to the nature of this bug and capabilities of the pruning
+Unfortunately, because to the nature of this bug and the capabilities of the pruning
 script, the history of FRUIDs associated to CPUs and GPUs prior to the CSM
-1.7.0 release may not be fully accurate.  Once your system is upgraded to CSM
-1.7.0, the accuracy of FRUIDs associated with CPUs and GPUs will be fully
-restored from that point in time and into the future.  No other component
-types were affected by this bug.
+1.7.0 release may not be fully accurate. After the system is upgraded to CSM
+1.7, the FRUIDs associations with CPUs and GPUs will be fully accurate from that point on.
+No other component types were affected by this bug.
 
 ## Prerequisites
 


### PR DESCRIPTION
# Description

Provide additional clarification surrounding the accuracy of CPU and GPU hardware history prior to the CSM 1.7.0 release.

* Resolves [CASMHMS-6589](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6589)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.