### PR TITLE
CASMTRIAGE-8597: Re-apply cray-dns-unbound-coredns job

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -110,6 +110,21 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+state_name="RE-APPLY_CRAY_DNS_UNBOUND_JOB"
+#shellcheck disable=SC2046
+state_recorded=$(is_state_recorded "${state_name}" $(hostname))
+if [[ $state_recorded == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    helm -n services get all cray-dns-unbound | yq4 'select(.kind=="Job")' \
+      | grep -v MANIFEST | kubectl -n services apply -f -
+  } >> ${LOG_FILE} 2>&1
+  #shellcheck disable=SC2046
+  record_state ${state_name} $(hostname)
+else
+  echo "====> ${state_name} has been completed"
+fi
+
 state_name="CSM_SERVICE_UPGRADE"
 #shellcheck disable=SC2046
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))


### PR DESCRIPTION
# Description
CASMTRIAGE-8597: Re-apply cray-dns-unbound-coredns job before launching upgrade.sh on k8s 1.24

The "CSM_SERVICES_UPGRADE" state during storage node rollout failed because the `cray-dns-unbound-coredns` job was not found when waiting for the job to complete via the `wait-for-unbound.sh` script.  The job no longer exists because it  has since been cleaned up.  Since we no longer deploy a `cray-dns-unbound` chart in the `core-services-v1.24.yaml` the job isn't applied and running when the `wait-for-unbound.sh` executes.

To get around this, re-apply the `cray-dns-unbound-coredns` job before "CSM_SERVICES_UPGRADE" in `csm-upgrade.sh`, which runs `upgrade.sh` and `wait-for-unbound.sh`, so that the job exists. 

# Testing
Tested on `molly` by deleting the `cray-dns-unbound-coredns` job and then running `csm-upgrade.sh` with the new "RE-APPLY_CRAY_DNS_UNBOUND_JOB" state block.

```
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-rc.4 # kubectl get jobs -n services | grep cray-dns-unbound-coredns
ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-rc.4 #

ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade # ./csm-upgrade.sh

 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log

====> VERIFY_K8S_NODES_UPGRADED has been completed
====> PRE_CEPH_CSI_TARGET_REQUIREMENTS has been completed
====> PRE_CSM_SERVICES_UPGRADE_BUCKETS has been completed
====> RE-APPLY_CRAY_DNS_UNBOUND_JOB ...
====> RE-APPLY_CRAY_DNS_UNBOUND_JOB has been completed
====> CSM_SERVICE_UPGRADE ...
====> CSM_SERVICE_UPGRADE has been completed
====> FIX_SPIRE_ON_STORAGE has been completed

ncn-m001:/etc/cray/upgrade/csm/csm-/ncn-m001 # kubectl get jobs -n services | grep cray-dns-unbound-coredns
cray-dns-unbound-coredns                               Running    0/1           41s        41s
ncn-m001:/etc/cray/upgrade/csm/csm-/ncn-m001 # kubectl get pods -n services | grep cray-dns-unbound
cray-dns-unbound-coredns-h56jq                                    0/2     Completed         0             76s
cray-dns-unbound-dd6857b4c-cw6q7                                  3/3     Running           0             47h
cray-dns-unbound-dd6857b4c-l5dzg                                  3/3     Running           0             47h
cray-dns-unbound-dd6857b4c-pq95t                                  3/3     Running           0             47h
cray-dns-unbound-manager-29244442-kbktx                           0/2     Completed         0             6m3s
cray-dns-unbound-manager-29244444-ghffj                           0/2     Completed         0             4m3s
cray-dns-unbound-manager-29244446-fznrw                           0/2     Completed         0             2m3s
cray-dns-unbound-manager-29244448-vl5f2                           0/2     PodInitializing   0             3s
ncn-m001:/etc/cray/upgrade/csm/csm-/ncn-m001 # kubectl get jobs -n services | grep cray-dns-unbound-coredns
cray-dns-unbound-coredns                               Complete   1/1           67s        87s
ncn-m001:/etc/cray/upgrade/csm/csm-/ncn-m001 #
```

From output.log: 
```
Warning: resource jobs/cray-dns-unbound-coredns is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be u
sed on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
job.batch/cray-dns-unbound-coredns configured
/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0-rc.4 /usr/share/doc/csm/upgrade/scripts/upgrade
++ dirname ./upgrade.sh

<snip>

+ kubectl wait -n services job cray-sls-init-load --for=condition=complete --timeout=20m
job.batch/cray-sls-init-load condition met
+ kubectl wait -n services deployment cray-dns-unbound --for=condition=available --timeout=20m
deployment.apps/cray-dns-unbound condition met
+ kubectl wait -n services job cray-dns-unbound-coredns --for=condition=complete --timeout=20m
job.batch/cray-dns-unbound-coredns condition met
```

On `starlord`
```
ncn-m001:~ # kubectl get jobs -n services | grep cray-dns-unbound
cray-dns-unbound-coredns                               1/1           32s        118m
cray-dns-unbound-manager-29244576                      1/1           18s        5m52s
cray-dns-unbound-manager-29244578                      1/1           46s        3m52s
cray-dns-unbound-manager-29244580                      1/1           20s        112s
ncn-m001:~ #

ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-rc.7/ncn-m001 # cat state
[2025-08-07 13:43:55] BACKUP_SNAPSHOT
[2025-08-07 13:43:55] CHECK_WEAVE
[2025-08-07 13:46:19] UPDATE_SSH_KEYS
[2025-08-07 13:48:07] REPAIR_AND_VERIFY_CHRONY_CONFIG
[2025-08-07 13:48:49] CHECK_CLOUD_INIT_PREREQ

<snip>

[2025-08-08 11:14:07] PRE_CSM_SERVICES_UPGRADE_BUCKETS
[2025-08-08 15:43:13] RE-APPLY_CRAY_DNS_UNBOUND_JOB
[2025-08-08 16:17:54] CSM_SERVICE_UPGRADE
[2025-08-08 16:18:19] FIX_SPIRE_ON_STORAGE
[2025-08-08 16:21:20] UPDATE_TEST_CLI_RPMS
[2025-08-08 16:21:35] POST_UPGRADE_BOS_SNAPSHOT
[2025-08-08 16:22:12] POSTGRES_FIXUP

ncn-m001:/etc/cray/upgrade/csm/csm-1.7.0-rc.7/ncn-m001 # cat ~/output.log | grep -A 5 cray-dns-unbound-coredns
job.batch/cray-dns-unbound-coredns created
/etc/cray/upgrade/csm/media/upgrc7/csm-1.7.0-rc.7 /etc/cray/upgrade/csm/media/upgrc7/csm-1.7.0-rc.7
++ dirname ./upgrade.sh
+ ROOTDIR=.
+ source ./lib/version.sh
++ : csm-1.7.0-rc.7
--
+ kubectl wait -n services job cray-dns-unbound-coredns --for=condition=complete --timeout=20m
job.batch/cray-dns-unbound-coredns condition met
+ export -f poll-saw-completed-job
+ timeout 20m bash -c 'set -exo pipefail; poll-saw-completed-job'
+ poll-saw-completed-job
+ kubectl get pods -n services -l cronjob-name=cray-dns-unbound-manager
+ grep -q Completed
```

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.