### PR TITLE
CASMTRIAGE-8315: Updating firmware on m001 doc release/1.6

### DIFF
--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -8,11 +8,11 @@ Retrieve the model name and firmware image required to update an HPE or Gigabyte
 > - The commands in the procedure must be run on `ncn-m001`.
 
 - [Prerequisites](#prerequisites)
-- [Find the model name](#find-the-model-name)
-- [Get the firmware images](#get-the-firmware-images)
+- [Setup](#setup)
 - [Flash the firmware](#flash-the-firmware)
     - [Flash Gigabyte `ncn-m001`](#flash-gigabyte-ncn-m001)
-    - [Flash HPE `ncn-m001`](#flash-hpe-ncn-m001)
+    - [Flash HPE `ncn-m001` using web interface](#flash-hpe-ncn-m001-using-web-interface)
+    - [Flash HPE `ncn-m001` using `ilorest`](#flash-hpe-ncn-m001-using-ilorest)
 
 ## Prerequisites
 
@@ -21,37 +21,59 @@ Retrieve the model name and firmware image required to update an HPE or Gigabyte
 
 The following information is needed:
 
-- IP address of `ncn-m001` BMC
 - IP address of `ncn-m001`
 - Root password for `ncn-m001` BMC
 
-## Find the model name
+## Setup
 
-Use one of the following commands to find the model name for the node type in use.
-
-- (`ncn-m001#`) Find HPE model name.
+1. (`ncn-m001#`) Set variables for `USERNAME` and `BMC_PASSWORD`
 
     ```bash
-    curl -k -u root:password https://ipaddressOfBMC/redfish/v1/Systems/1 | jq .Model
+    USERNAME=root
+    read -r -s -p "NCN BMC ${USERNAME} password: " BMC_PASSWORD
     ```
 
-- (`ncn-m001#`) Find Gigabyte model name.
+1. (`ncn-m001#`) Get the IP address of `ncn-m001's` BMC (on the external/campus network)
 
     ```bash
-    curl -k -u root:password https://ipaddressOfBMC/redfish/v1/Systems/Self | jq .Model
+    BMC_ADDRESS=$(ipmitool lan print | grep "IP Address  " | cut -f2 -d: | sed 's/ //g')
+    echo $BMC_ADDRESS
     ```
 
-## Get the firmware images
+1. (`ncn-m001#`) Find the model name
 
-1. (`ncn-m001#`) View a list of images stored in FAS that are ready to be flashed.
-
-    In the following example, `ModelName` is the name found in the previous section.
+- For HPE nodes:
 
     ```bash
-    cray fas images list --format json | jq '.[] | .[] | select(.models | index("ModelName"))'
+    MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/Systems/1 | jq -r .Model)
+    echo $MODEL
+    export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
+    ```
+
+- For Gigabyte nodes:
+
+    ```bash
+    MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}ipaddressOfBMC/redfish/v1/Systems/Self | jq -r .Model)
+    echo $MODEL
+    export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
+    ```
+
+1. Get the firmware images
+
+- (`ncn-m001#`) View a list of images stored in FAS that are ready to be flashed.
+
+    ```bash
+    cray fas images list --format json | jq '.[] | .[] | select(.models | index($ENV.MODEL))'
     ```
 
     Locate the images in the returned output for the `ncn-m001` firmware and/or BIOS.
+    Make sure to select the correct firmware/BIOS version as several versions may be installed in FAS.
+    - For HPE nodes:
+        - iLO firmware will be `ilo5_xxx.bin` or `ilo6_xxx.bin`
+        - BIOS wil be a `.signed.flash` file
+    - For Gigabyte nodes:
+        - BMC firmware will be `rom.ima_enc`
+        - BIOS will be `image.RBU`
 
     Look for the returned `s3URL`. For example:
 
@@ -59,7 +81,7 @@ Use one of the following commands to find the model name for the node type in us
     "s3URL": "s3:/fw-update/4e5f569a603311eb96b582a8e219a16d/image.RBU"
     ```
 
-1. (`ncn-m001#`) Get the firmware images using the `s3URL` path from the previous step.
+- (`ncn-m001#`) Get the firmware images using the `s3URL` path from the previous step.
 
     In the following example command, `4e5f569a603311eb96b582a8e219a16d/image.RBU` is the path in the `s3URL`,
     and the image will be saved to the file `image.RBU` in the current directory.
@@ -71,7 +93,9 @@ Use one of the following commands to find the model name for the node type in us
 ## Flash the firmware
 
 - [Flash Gigabyte `ncn-m001`](#flash-gigabyte-ncn-m001)
-- [Flash HPE `ncn-m001`](#flash-hpe-ncn-m001)
+- HPE nodes can be updated using two different methods
+    - [Flash HPE `ncn-m001` using web interface](#flash-hpe-ncn-m001-using-web-interface)
+    - [Flash HPE `ncn-m001` using `ilorest`](#flash-hpe-ncn-m001-using-ilorest)
 
 ### Flash Gigabyte `ncn-m001`
 
@@ -85,13 +109,11 @@ Use one of the following commands to find the model name for the node type in us
 
     Be sure to substitute the correct values for the following strings in the example command:
 
-    - `passwd` = Root password of `ncn-m001` BMC
-    - `ipaddressOfBMC` = IP address of `ncn-m001` BMC
     - `ipaddressOfM001` = IP address of `ncn-m001` node
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
+    curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
         -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
     ```
 
@@ -99,26 +121,24 @@ Use one of the following commands to find the model name for the node type in us
 
     ```bash
     sleep 200
-    ping ipaddressOfBMC
+    ping ${BMC_ADDRESS}
     ```
 
     When the `ping` returns that the node has rebooted, check that the firmware version is at the expected value:
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/FirmwareInventory/BMC
+    curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/UpdateService/FirmwareInventory/BMC
     ```
 
 1. (`ncn-m001#`) Update BIOS.
 
     Be sure to substitute the correct values for the following strings in the example command:
 
-    - `passwd` = Root password of `ncn-m001` BMC
-    - `ipaddressOfBMC` = IP address of `ncn-m001` BMC
     - `ipaddressOfM001` = IP address of `ncn-m001` node
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
+    curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
         -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
     ```
 
@@ -139,7 +159,7 @@ Use one of the following commands to find the model name for the node type in us
      Using the task number (596 in the above example), check the state of the task:
 
      ```bash
-     curl -sku root:password https://ipaddressOfBMC/redfish/v1/TaskService/Tasks/596 | jq .TaskState
+    curl -sk -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/TaskService/Tasks/596 | jq .TaskState
      ```
 
      State should be "Running" until BIOS update is finished.
@@ -148,11 +168,11 @@ Use one of the following commands to find the model name for the node type in us
 
     > After updating BIOS, `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
 
-### Flash HPE `ncn-m001`
+### Flash HPE `ncn-m001` using web interface
 
 The web interface will be used to update iLO 5 or iLO 6 (BMC) firmware and/or System ROM (BIOS) on the HPE `ncn-m001` node.
 
-1. (`linux#`) Copy the iLO 5 or iLO 6 firmware and/or System ROM files to a local computer from `ncn-m001` using `scp` or other secure copy tools.
+1. (`linux/win/mac#`) Copy the iLO 5 or iLO 6 firmware and/or System ROM files to a local computer from `ncn-m001` using `scp` or other secure copy tools.
 
     ```bash
     scp root@ipaddressOfM001Node:pathToFile/filename .
@@ -170,3 +190,59 @@ The web interface will be used to update iLO 5 or iLO 6 (BMC) firmware and/or Sy
     1. Click `"Flash"`.
 
     > After updating System ROM (BIOS), `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
+
+### Flash HPE `ncn-m001` using `ilorest`
+
+1. (`ncn-m001#`) Install `ilorest` rpm on `ncn-m001`.
+
+    ```bash
+    zypper install ilorest
+    ```
+
+1. {`ncn-m001#`) Check firmware versions before making changes on `ncn-m001`.
+
+    ```bash
+    ilorest serverinfo  |grep "Firmware:" -A3
+    Firmware: 
+    ------------------------------------------------
+    iLO 5 : 3.02 Feb 22 2024
+    System ROM : A43 v3.60 (01/21/2025)
+    ```
+
+1. {`ncn-m001#`) Update BIOS on `ncn-m001` using the downloaded System ROM file.
+
+    ```bash
+    ilorest uploadcomp --component=A43_3.70_03_21_2025.signed.flash --update_target
+    sleep 90
+    ```
+
+1. {`ncn-m001#`) Update BMC on `ncn-m001` using the downloaded iLO file.
+
+    ```bash
+    ilorest uploadcomp --component=ilo5_311.bin --forceupload --update_target
+    sleep 60
+    ```
+
+1. {`ncn-m001#`) Using `ipmitool`, login to the `ncn-m001` console, using the correct user, password, and BMC IP address so that you can watch the console log as the node boots
+
+    ```bash
+    ipmitool -I lanplus -U $USERNAME -P $BMC_PASSWORD -H $BMC_ADDRESS sol activate
+    ncn-m001 login: root
+    Password:
+    ```
+
+1. {`ncn-m001#`) Reboot `ncn-m001`. Do not accidentally issue this command on another node!
+
+    ```bash
+    shutdown -r now
+    ```
+
+1. {`ncn-m001#`) Once the node is back up check firmware versions.
+
+    ```bash
+    ilorest serverinfo  |grep "Firmware:" -A3
+    Firmware: 
+    ------------------------------------------------
+    iLO 5 : 3.11 Feb 25 2025
+    System ROM : A43 v3.70 (03/21/2025)
+    ```

--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -26,69 +26,70 @@ The following information is needed:
 
 ## Setup
 
-1. (`ncn-m001#`) Set variables for `USERNAME` and `BMC_PASSWORD`
+1. (`ncn-m001#`) Set variables for `USERNAME` and `BMC_PASSWORD`.
 
     ```bash
     USERNAME=root
     read -r -s -p "NCN BMC ${USERNAME} password: " BMC_PASSWORD
     ```
 
-1. (`ncn-m001#`) Get the IP address of `ncn-m001's` BMC (on the external/campus network)
+1. (`ncn-m001#`) Get the IP address of `ncn-m001's` BMC (on the external/campus network).
 
     ```bash
     BMC_ADDRESS=$(ipmitool lan print | grep "IP Address  " | cut -f2 -d: | sed 's/ //g')
     echo $BMC_ADDRESS
     ```
 
-1. (`ncn-m001#`) Find the model name
+1. (`ncn-m001#`) Find the model name.
 
-- For HPE nodes:
-
-    ```bash
-    MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/Systems/1 | jq -r .Model)
-    echo $MODEL
-    export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
-    ```
-
-- For Gigabyte nodes:
-
-    ```bash
-    MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}ipaddressOfBMC/redfish/v1/Systems/Self | jq -r .Model)
-    echo $MODEL
-    export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
-    ```
-
-1. Get the firmware images
-
-- (`ncn-m001#`) View a list of images stored in FAS that are ready to be flashed.
-
-    ```bash
-    cray fas images list --format json | jq '.[] | .[] | select(.models | index($ENV.MODEL))'
-    ```
-
-    Locate the images in the returned output for the `ncn-m001` firmware and/or BIOS.
-    Make sure to select the correct firmware/BIOS version as several versions may be installed in FAS.
     - For HPE nodes:
-        - iLO firmware will be `ilo5_xxx.bin` or `ilo6_xxx.bin`
-        - BIOS wil be a `.signed.flash` file
+
+        ```bash
+        MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/Systems/1 | jq -r .Model)
+        echo $MODEL
+        export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
+        ```
+
     - For Gigabyte nodes:
-        - BMC firmware will be `rom.ima_enc`
-        - BIOS will be `image.RBU`
 
-    Look for the returned `s3URL`. For example:
+        ```bash
+        MODEL=$(curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}ipaddressOfBMC/redfish/v1/Systems/Self | jq -r .Model)
+        echo $MODEL
+        export BMC_PASSWORD USERNAME BMC_ADDRESS MODEL
+        ```
 
-    ```text
-    "s3URL": "s3:/fw-update/4e5f569a603311eb96b582a8e219a16d/image.RBU"
-    ```
+1. (`ncn-m001#`) Get the firmware images.
 
-- (`ncn-m001#`) Get the firmware images using the `s3URL` path from the previous step.
+    1. View a list of images stored in FAS that are ready to be flashed.
 
-    In the following example command, `4e5f569a603311eb96b582a8e219a16d/image.RBU` is the path in the `s3URL`,
-    and the image will be saved to the file `image.RBU` in the current directory.
+        ```bash
+        cray fas images list --format json | jq '.[] | .[] | select(.models | index($ENV.MODEL))'
+        ```
 
-    ```bash
-    cray artifacts get fw-update 4e5f569a603311eb96b582a8e219a16d/image.RBU image.RBU
-    ```
+        Locate the images in the returned output for the `ncn-m001` firmware and/or BIOS.
+        Make sure to select the correct firmware/BIOS version as several versions may be installed in FAS.
+
+        - For HPE nodes:
+            - iLO firmware will be `ilo5_xxx.bin` or `ilo6_xxx.bin`
+            - BIOS wil be a `.signed.flash` file
+        - For Gigabyte nodes:
+            - BMC firmware will be `rom.ima_enc`
+            - BIOS will be `image.RBU`
+
+        Look for the returned `s3URL`. For example:
+
+        ```text
+        "s3URL": "s3:/fw-update/4e5f569a603311eb96b582a8e219a16d/image.RBU"
+        ```
+
+    1. Get the firmware images using the `s3URL` path from the previous step.
+
+        In the following example command, `4e5f569a603311eb96b582a8e219a16d/image.RBU` is the path in the `s3URL`,
+        and the image will be saved to the file `image.RBU` in the current directory.
+
+        ```bash
+        cray artifacts get fw-update 4e5f569a603311eb96b582a8e219a16d/image.RBU image.RBU
+        ```
 
 ## Flash the firmware
 
@@ -117,14 +118,14 @@ The following information is needed:
         -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
     ```
 
-    Wait for the BMC to update and reboot
+1. (`ncn-m001#`) Wait for the BMC to update and reboot.
 
     ```bash
     sleep 200
     ping ${BMC_ADDRESS}
     ```
 
-    When the `ping` returns that the node has rebooted, check that the firmware version is at the expected value:
+1. (`ncn-m001#`) After the reboot completes, check that the firmware version is at the expected value.
 
     ```bash
     curl -k -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/UpdateService/FirmwareInventory/BMC
@@ -132,7 +133,7 @@ The following information is needed:
 
 1. (`ncn-m001#`) Update BIOS.
 
-    Be sure to substitute the correct values for the following strings in the example command:
+    Be sure to substitute the correct values for the following strings in the example command.
 
     - `ipaddressOfM001` = IP address of `ncn-m001` node
     - `filename` = Filename of the downloaded image
@@ -142,31 +143,37 @@ The following information is needed:
         -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
     ```
 
-    This will return a json packet simular to:
+    Example output:
 
      ```json
      {"@odata.type":"#UpdateService.v1_5_0.UpdateService","Messages":[{"@odata.type":"#Message.v1_0_7.Message","Message":"A new task /redfish/v1/TaskService/Tasks/596 was created.","MessageArgs":["/redfish/v1/TaskService/Tasks/596"],"MessageId":"Task.1.0.New","Resolution":"None","Severity":"OK"},{"@odata.type":"#Message.v1_0_7.Message","Message":"Device is prepareing flash firmware for action SimpleUpdate.","MessageArgs":["SimpleUpdate"],"MessageId":"UpdateService.1.0.PrepareUpdate","Resolution":"None","Severity":"OK"}]}
      ```
 
+1. Verify successful update.
+
      When updating the Gigabyte BIOS, the BIOS version number will not change until the node is rebooted.
      To verify a successful update, check the task that was created.
-     Using the return json packet, find the line:
 
-     ```text
-     "A new task /redfish/v1/TaskService/Tasks/596 was created."  
-     ```
+     1. In the JSON response from the previous step, find the text that resembles the following.
 
-     Using the task number (596 in the above example), check the state of the task:
+         ```text
+         "A new task /redfish/v1/TaskService/Tasks/596 was created."  
+         ```
 
-     ```bash
-    curl -sk -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/TaskService/Tasks/596 | jq .TaskState
-     ```
+     1. (`ncn-m001#`) Using the task number (`596` in the above example), check the state of the task.
 
-     State should be "Running" until BIOS update is finished.
-     Once finished, the state will be "Completed".
-     If you receive a state other than "Running" or "Completed", check the task for other messages.
+         ```bash
+         curl -sk -u ${USERNAME}:${BMC_PASSWORD} https://${BMC_ADDRESS}/redfish/v1/TaskService/Tasks/596 | jq .TaskState
+         ```
 
-    > After updating BIOS, `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
+     The state should be `Running` until the BIOS update is finished.
+     Once finished, the state will be `Completed`.
+     If a state other than `Running` or `Completed` is shown, then check the task for other messages.
+
+1. Reboot `ncn-m001`.
+
+    After updating BIOS, `ncn-m001` must be rebooted.
+    Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
 
 ### Flash HPE `ncn-m001` using web interface
 
@@ -189,11 +196,14 @@ The web interface will be used to update iLO 5 or iLO 6 (BMC) firmware and/or Sy
     1. Click `"Confirm TPM override"`.
     1. Click `"Flash"`.
 
-    > After updating System ROM (BIOS), `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
+1. Reboot `ncn-m001`.
+
+    After updating System ROM (BIOS), `ncn-m001` must be rebooted.
+    Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.
 
 ### Flash HPE `ncn-m001` using `ilorest`
 
-1. (`ncn-m001#`) Install `ilorest` rpm on `ncn-m001`.
+1. (`ncn-m001#`) Install `ilorest` RPM on `ncn-m001`.
 
     ```bash
     zypper install ilorest
@@ -203,6 +213,11 @@ The web interface will be used to update iLO 5 or iLO 6 (BMC) firmware and/or Sy
 
     ```bash
     ilorest serverinfo  |grep "Firmware:" -A3
+    ```
+
+    Example output:
+
+    ```text
     Firmware: 
     ------------------------------------------------
     iLO 5 : 3.02 Feb 22 2024
@@ -223,24 +238,45 @@ The web interface will be used to update iLO 5 or iLO 6 (BMC) firmware and/or Sy
     sleep 60
     ```
 
-1. {`ncn-m001#`) Using `ipmitool`, login to the `ncn-m001` console, using the correct user, password, and BMC IP address so that you can watch the console log as the node boots
+1. Reboot `ncn-m001`.
 
-    ```bash
-    ipmitool -I lanplus -U $USERNAME -P $BMC_PASSWORD -H $BMC_ADDRESS sol activate
-    ncn-m001 login: root
-    Password:
-    ```
+    1. (`linux/win/mac#`) Open a console to `ncn-m001` and log in as `root`.
 
-1. {`ncn-m001#`) Reboot `ncn-m001`. Do not accidentally issue this command on another node!
+        > - **IMPORTANT**: Do not open the console from `ncn-m001` itself, or in a terminal that connected through `ncn-m001`.
+        > - Update the example command to specify the correct user, password, and BMC IP address.
 
-    ```bash
-    shutdown -r now
-    ```
+        ```bash
+        ipmitool -I lanplus -U <BMC_USERNAME> -P <BMC_PASSWORD> -H <BMC_ADDRESS> sol activate
+        ```
 
-1. {`ncn-m001#`) Once the node is back up check firmware versions.
+        Example console:
+
+        ```console
+        ncn-m001 login: root
+        Password:
+        ```
+
+    1. {`ncn-m001#`) Reboot `ncn-m001`.
+
+        **IMPORTANT** Do not accidentally issue this command on another node!
+
+        ```bash
+        shutdown -r now
+        ```
+
+    1. Watch the console until `ncn-m001` reboots and is back up.
+
+        The console can be closed at this point. It is no longer needed for this procedure.
+
+1. {`ncn-m001#`) Check firmware versions.
 
     ```bash
     ilorest serverinfo  |grep "Firmware:" -A3
+    ```
+
+    Example output:
+
+    ```text
     Firmware: 
     ------------------------------------------------
     iLO 5 : 3.11 Feb 25 2025


### PR DESCRIPTION
# Description

Updated the document "Updating Firmware on m001" for ease of use and document the ilorest commands which can optionally be used to do the update on HPE nodes.

Relates to:
CASMTRIAGE-8315


# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
