### PR TITLE
CASMPET-7653: Remove iSCSI selective worker personalization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,13 +12,6 @@
     * This feature **can only be enabled during an upgrade from CSM 1.6 to CSM 1.7 or an install of CSM 1.7**.
     * See [Enabling Rack Resiliency](operations/rack_resiliency/Enabling_Rack_Resiliency.md) for more details.
 
-### iSCSI SBPS
-
-* The [iSCSI SBPS feature](operations/iscsi_sbps/README.md) is enhanced to allow administrators
-  to select which worker NCNs are enabled as iSCSI targets. This is a change from CSM 1.6, where
-  all worker NCNs are enabled as iSCSI targets. For more information, see
-  [Managing Selective Node Personalization](operations/iscsi_sbps/Managing_Selective_Node_Personalization.md).
-
 ### Monitoring
 
 ### Networking

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -21,9 +21,8 @@ and BMC/controller passwords.
 1. [Set up passwordless SSH](#5-set-up-passwordless-ssh)
 1. [Configure the root password and SSH keys in Vault](#6-configure-the-root-password-and-ssh-keys-in-vault)
 1. [Add switch admin password to Vault](#7-add-switch-admin-password-to-vault)
-1. [iSCSI SBPS configuration](#8-iscsi-sbps-configuration)
-1. [Configure management nodes with CFS](#9-configure-management-nodes-with-cfs)
-1. [Proceed to next topic](#10-proceed-to-next-topic)
+1. [Configure management nodes with CFS](#8-configure-management-nodes-with-cfs)
+1. [Proceed to next topic](#9-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.
@@ -129,7 +128,7 @@ to managed nodes.
 
 This procedure sets up resources in Kubernetes (a Kubernetes Secret and ConfigMap) which are later
 applied to the management nodes by the [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs)
-during node personalization in section [9. Configure management nodes with CFS](#9-configure-management-nodes-with-cfs) below.
+during node personalization in section [9. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
 
 ## 6. Configure the root password and SSH keys in Vault
 
@@ -138,7 +137,7 @@ for the procedure to configure the `root` password and SSH keys in Vault.
 
 This procedure writes the `root` password hash and SSH keys to Vault which are later
 applied to the management nodes by CFS during node personalization in section
-[9. Configure management nodes with CFS](#9-configure-management-nodes-with-cfs) below.
+[9. Configure management nodes with CFS](#8-configure-management-nodes-with-cfs) below.
 
 ## 7. Add switch admin password to Vault
 
@@ -163,25 +162,7 @@ Password read from Vault matches what was written
 SUCCESS
 ```
 
-## 8. iSCSI SBPS configuration
-
-In CSM 1.6, all the worker nodes were configured and enabled as iSCSI SBPS targets. Starting in CSM 1.7.0, selective
-node personalization is supported. All worker nodes are still **configured** for iSCSI, but selective node
-personalization gives administrators control over which worker nodes are actually enabled as iSCSI SBPS targets.
-The default behavior is still the same as in CSM 1.6, so if no action is taken to use this feature, then all
-worker nodes will be enabled as iSCSI targets.
-
-For administrators who do not wish to use this feature, no action is required, and this step can be skipped.
-Otherwise, before proceeding with the install, follow the procedure in the
-[CSM install](../operations/iscsi_sbps/Managing_Selective_Node_Personalization.md#csm-install) section of
-[Managing Selective Node Personalization](../operations/iscsi_sbps/Managing_Selective_Node_Personalization.md).
-
-Later in the install process, [SAT Bootprep](../operations/system_admin_toolkit/usage/SAT_Bootprep.md) adds the
-iSCSI configuration layer to the NCN CFS configurations. If the above procedure to enable this feature has not
-been done when that CFS configuration is applied to the NCNs, then all of the worker nodes will be enabled as
-iSCSI targets.
-
-## 9. Configure management nodes with CFS
+## 8. Configure management nodes with CFS
 
 Management nodes need to be configured after booting for administrative access, security, and other
 purposes. The [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs)
@@ -223,7 +204,7 @@ will generate the full CFS configuration including additional CSM layers and all
     The number reported should match the number of management nodes in the system.
     If there are failures, see [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md).
 
-## 10. Proceed to next topic
+## 9. Proceed to next topic
 
 After completing the operational procedures above which configure administrative access, the next
 step is to validate the health of management nodes and CSM services.

--- a/operations/README.md
+++ b/operations/README.md
@@ -891,6 +891,5 @@ these backups.
 Below are the documents related to iSCSI-based boot content projection.
 
 - [iSCSI SBPS](iscsi_sbps/README.md)
-- [Managing Selective Node Personalization](iscsi_sbps/Managing_Selective_Node_Personalization.md)
 - [iSCSI SBPS Verification](iscsi_sbps/iSCSI_SBPS_Verification.md)
 - [iSCSI SBPS Metrics](iscsi_sbps/iSCSI_SBPS_Metrics.md)

--- a/operations/iscsi_sbps/README.md
+++ b/operations/iscsi_sbps/README.md
@@ -14,8 +14,7 @@ is a boot content projection solution that replaces the Cray
 SBPS projects boot content like `rootfs` and [Cray Programming Environment (CPE)](../../glossary.md#cray-programming-environment-cpe) images.
 SBPS is aimed to offer better reliability, availability, security, ease and speed of deployment and ease of management than CPS/DVS.
 SBPS was introduced in CSM 1.6. In CSM 1.7.0, support is removed for projecting root filesystems and PE images using
-CPS and DVS. Also in CSM 1.7.0, the iSCSI SBPS [selective worker node personalization](#selective-worker-node-personalization)
-feature is introduced.
+CPS and DVS.
 
 The SBPS solution is spread across different components, including:
 
@@ -92,31 +91,10 @@ discovery from an initiator node during its boot.
 
 ### 1. Worker node personalization
 
-Node personalization is the prerequisite step of SBPS solution where worker nodes are configured as iSCSI targets (servers)
-with necessary provisioning. The required RPMs for the `targetcli` command and LIO are part of the NCN node image.
-The SBPS Marshal Agent gets installed during node personalization using CFS.
-
-#### Selective worker node personalization
-
-In CSM 1.6, all worker nodes are configured and enabled as iSCSI SBPS targets using
-[Management Node Personalization](../configuration_management/Management_Node_Personalization.md)
-
-Starting in CSM 1.7.0, selective iSCSI worker node personalization is introduced.
-All worker nodes are still **configured** for iSCSI, but selective node personalization gives
-administrators control over which worker nodes are enabled as iSCSI SBPS targets.
-
-The default behavior is still the same as in CSM 1.6, so if no action is taken to use this
-feature, then all worker nodes will continue to be enabled as iSCSI targets.
-
-For details on iSCSI selective worker node personalization,
-see [Managing Selective Node Personalization](Managing_Selective_Node_Personalization.md).
-
-#### Automatic setup with bootprep
-
-By default worker node personalization of iSCSI SBPS is done during CSM install/upgrade
-(using the [Install and Upgrade Framework (IUF)](../../glossary.md#install-and-upgrade-framework-iuf)).
-It is initiated during bootprep (`management-nodes-rollout`) in order to do worker node personalization
-automatically during boot time.
+Worker nodes are configured for SBPS during [Management Node Personalization](../configuration_management/Management_Node_Personalization.md).
+This is the prerequisite step of the SBPS solution, where worker nodes are configured as iSCSI targets (servers)
+with necessary provisioning. The SBPS Marshal Agent is also installed (the required RPMs for the `targetcli`
+command and LIO are part of the NCN image).
 
 ### 2. Validate configuration
 

--- a/operations/iscsi_sbps/iSCSI_SBPS_Verification.md
+++ b/operations/iscsi_sbps/iSCSI_SBPS_Verification.md
@@ -33,12 +33,8 @@ iSCSI configuration. During [Management Node Personalization](../configuration_m
 this playbook does the following:
 
 * Installs the [SBPS Marshal Agent](#sbps-marshal-agent)
-* Adds Kubernetes labels to the worker NCNs that are designated to be iSCSI targets
-* Removes the labels from workers that are not designated to be iSCSI targets
-* Creates DNS SRV and A records for the workers.
-
-See [Managing Selective Node Personalization](Managing_Selective_Node_Personalization.md) for details on how worker NCNs are
-designated to be iSCSI targets.
+* Adds Kubernetes labels to all worker NCNs, designating them as iSCSI-enabled targets
+* Creates DNS SRV and A records for the workers
 
 ## iSCSI-enabled workers
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -5,7 +5,6 @@ This section updates the software running on management NCNs.
 - [1. Update management host firmware (FAS)](#1-update-management-host-firmware-fas)
 - [2. Execute the IUF `management-nodes-rollout` stage](#2-execute-the-iuf-management-nodes-rollout-stage)
     - [Configure optional CSM features](#configure-optional-csm-features)
-        - [Selective iSCSI worker node personalization](#selective-iscsi-worker-node-personalization)
         - [Rack Resiliency](#rack-resiliency)
         - [IPv6](#ipv6)
     - [`management-nodes-rollout` overview](#management-nodes-rollout-overview)
@@ -32,23 +31,6 @@ Once this step has completed:
 > If this IUF procedure is not part of an upgrade from CSM 1.6 to CSM 1.7, then this section should be skipped.
 
 Several CSM features can be enabled and configured as part of the upgrade process.
-This has to be done at this point in the upgrade; unless otherwise noted in the specific section,
-these choices cannot be changed later.
-
-#### Selective iSCSI worker node personalization
-
-> If this IUF procedure is not part of an upgrade from CSM 1.6 to CSM 1.7, then this section should be skipped.
-
-In CSM 1.6, all the worker nodes are configured and enabled as iSCSI SBPS targets. Starting in CSM 1.7.0, selective worker node
-personalization is supported. All worker nodes are still **configured** for iSCSI, but selective node personalization
-gives administrators control over which worker nodes are actually enabled as iSCSI SBPS targets. The default behavior
-is still the same as in CSM 1.6, so if no action is taken to use this feature, then all worker nodes will remain
-enabled as iSCSI targets.
-
-For administrators who do not wish to use this feature, no action is required, and this step can be skipped.
-Otherwise, before proceeding, follow the procedure in the
-[CSM upgrade from 1.6 to 1.7](../../iscsi_sbps/Managing_Selective_Node_Personalization.md#csm-upgrade-from-16-to-17)
-section of [Managing Selective Node Personalization](../../iscsi_sbps/Managing_Selective_Node_Personalization.md).
 
 #### Rack Resiliency
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md
@@ -28,9 +28,6 @@ All activities required for site maintenance are complete.
 
 The latest CSM documentation has been installed on the master nodes. See [Check for Latest Documentation](../../../update_product_stream/README.md#check-for-latest-documentation).
 
-**IMPORTANT**: Before beginning a procedure to add or remove a worker NCN, see
-[Adding or removing worker NCN](../../iscsi_sbps/Managing_Selective_Node_Personalization.md#adding-or-removing-worker-ncn).
-
 1. (`ncn-m#`) Run `ncn_add_pre-req.py` to adjust the network.
 
    ```bash


### PR DESCRIPTION
Because [CASMPET-7649](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7649) is being deferred until CSM 1.7.1, this means that the iSCSI selective worker node personalization feature is not ready for customer use in the majority of cases (such as CSM upgrades from 1.6).

Fortunately, the feature defaults to being disabled and requires manual steps to be enabled. And if the feature is not enabled, then CSM will continue to work as it already did. So if we just remove documentation about the feature,. then customers will encounter no problems related to it.