### PR TITLE
CASMCMS-9516: cfs session for image customization running on remote node stuck in running status

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -69,6 +69,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Kyverno policy management](../operations/kubernetes/Kyverno.md#known-issues)
 * [PostgreSQL Cluster Upgrades Failing](known_issues/postgres_cluster_upgrade_failure.md)
 * [IMS Image Customization Job Status Stuck at `waiting_on_user`](known_issues/ims_image_customization_job_status_stuck_at_waiting_on_user.md)
+* [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
 
 ## Booting
 
@@ -92,6 +93,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Incrementally Configuring Images](incrementally_configuring_images.md)
 * [CFS-API pods in CLBO state](known_issues/cfs-api_pods_in_CLBO_state.md)
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
+* [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -93,11 +93,11 @@ Note: Do not follow the resolution of the known issue linked above.
 
 (`ncn-mw#`) In order to resolve the problem, delete the CFS session.
 
-    > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name.
+> In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name.
 
-    ```bash
-    cray cfs sessions delete <CFS_SESSION_NAME>
-    ```
+```bash
+cray cfs sessions delete <CFS_SESSION_NAME>
+```
 
 After the CFS session is deleted, a new CFS session for image customization can be created. See
 [Create CFS Session For Image Customization](../../operations/configuration_management/Create_an_Image_Customization_CFS_Session.md).

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -1,0 +1,143 @@
+# CFS Session for Image Customization on remote node Status Stuck at `running`
+
+## Issue description
+
+A CFS session for image customization job on a remote node can get stuck in the `running` state indefinitely.
+This can occur during `image customization` if any of the following things happen:
+
+- The remote node reboots or crashes.
+- The IMS job container on the remote build node is killed or stopped.
+
+## Error identification
+
+A symptom of this problem is following error in `inventory` container's log of CFS pod.
+
+```text
+2025-08-08 15:44:52,299 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
+```
+
+ Follow the steps to view `inventory` container log
+
+1. (`ncn-mw#`) Get the details of the CFS session,
+
+   > In the following command, substitute the actual CFS Session Name being checked.
+
+   ```bash
+   cray cfs sessions describe <CFS_SESSION_NAME> --format json
+   ```
+
+  Example output:
+  
+  ```json
+  {
+  "ansible": {
+    "config": "cfs-default-ansible-cfg",
+    "limit": null,
+    "passthrough": null,
+    "verbosity": 0
+  },
+  "configuration": {
+    "limit": "",
+    "name": "dev-remote-ims-node"
+  },
+  "name": "build-ims-remote-image-x86-cmsdev",
+  "status": {
+    "artifacts": [],
+    "session": {
+      "completionTime": null,
+      "job": "cfs-f7e04dbf-542b-4f22-8c66-537744684db8",
+      "startTime": "2025-08-11T14:51:26",
+      "status": "running",
+      "succeeded": "none"
+    }
+  },
+  "tags": {},
+  "target": {
+    "definition": "image",
+    "groups": [
+      {
+        "members": [
+          "15bacab2-053b-41d6-a7e6-8561cec1bade"
+        ],
+        "name": "Compute"
+      }
+    ],
+    "image_map": [
+      {
+        "result_name": "ims-remote-image-x86-csmdev",
+        "source_id": "15bacab2-053b-41d6-a7e6-8561cec1bade"
+      }
+    ]
+  }
+}
+  ```
+
+1. (`ncn-mw#`) Get the `CFS` pod running in `K8s` cluster,
+
+   > - Perform the following substitutions in the command:
+   >     - Replace `<CFS_SESSIONS_JOB_ID>` with the value of the
+   >       `session.job` field in the CFS sessions detail.
+
+   ```bash
+   kubectl get pods -n services -o name|grep <CFS_SESSIONS_JOB_ID>
+   ```
+
+  Example output:
+  
+  ```text
+  pod/cfs-f7e04dbf-542b-4f22-8c66-537744684db8-4l6wv
+  ```
+
+1. (`ncn-mw#`) Get the `inventory` container's log of CFS pod running in `K8s` cluster,
+
+> - Perform the following substitutions in the command:
+>     - Replace `<CFS_POD>` with the value of previous command.
+
+```bash
+kubectl logs -f <CFS_POD> -n services -c inventory
+```
+
+Example output:
+
+```text
+2025-08-08 15:50:06,023 - INFO    - cray.cfs.inventory - Starting CFS Inventory version=1.31.0, namespace=services
+2025-08-08 15:50:06,108 - INFO    - cray.cfs.inventory - Inventory target=image for cfsession=build-ims-remote-image-x86-cmsdev
+2025-08-08 15:50:06,263 - INFO    - cray.cfs.inventory.image - Uploading public key to IMS for SSH container access.
+2025-08-08 15:50:06,417 - INFO    - cray.cfs.inventory.image - Requesting access to IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade'
+2025-08-08 15:50:07,796 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=0s
+2025-08-08 15:50:12,810 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=5s
+...
+2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
+2025-08-08 15:54:33,722 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=265s
+2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Checking ssh availability
+2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Waiting for SSH to be available at cray-ims-15b7479d-e5f2-405f-971c-405c1fac1152-service.ims.svc.cluster.local:22. Elapsed time=0s
+2025-08-08 15:54:40,753 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
+```
+
+In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for `Error identification`.
+
+```text
+2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
+```
+
+1. Please refer `Error identification` section of [IMS Image Customization Job Stuck](../known_issues/ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) and verify the symptom matches
+ as described in issue description.
+
+Note: Do not follow the `Resolution` of the known issue referred above.
+
+1. If the IMS job container either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution),
+
+   If that is not the case, then the procedure documented here is not applicable.
+
+## Resolution
+
+(`ncn-mw#`) In order to resolve the problem, delete the CFS session.
+
+> In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session ID.
+
+ ```bash
+cray cfs sessions delete <CFS_SESSION_NAME>
+```
+
+After the CFS session is deleted, a new CFS session for image customization can be created. See
+[Create CFS Session For Image Customization](../../operations/configuration_management/Create_an_Image_Customization_CFS_Session.md).

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -23,7 +23,7 @@ Follow these steps to view the `inventory` container log.
     > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name being checked.
 
     ```bash
-    cray cfs sessions describe $CFS_SESSION_NAME --format json | jq '.status.session.job'
+    cray cfs sessions describe <CFS_SESSION_NAME> --format json | jq '.status.session.job'
     ```
 
     Example output:

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -114,18 +114,18 @@ Example output:
 2025-08-08 15:54:40,753 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
 ```
 
-In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for `Error identification`.
+In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for error identification.
 
 ```text
 2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
 ```
 
-1. Please refer `Error identification` section of [IMS Image Customization Job Stuck](../known_issues/ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) and verify the symptom matches
+1. See [Error identification](ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) and verify the symptom matches
  as described in issue description.
 
-Note: Do not follow the `Resolution` of the known issue referred above.
+Note: Do not follow the resolution of the known issue linked above.
 
-1. If the IMS job container either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution),
+1. If the IMS job container either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution).
 
    If that is not the case, then the procedure documented here is not applicable.
 

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -3,7 +3,7 @@
 ## Issue description
 
 A CFS session for image customization job on a remote node can get stuck in the `running` state indefinitely.
-This can occur during `image customization` if any of the following things happen:
+This can occur during image customization if any of the following things happen:
 
 - The remote node reboots or crashes.
 - The IMS job container on the remote build node is killed or stopped.

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -48,7 +48,7 @@ Follow these steps to view the `inventory` container log.
     pod/cfs-f7e04dbf-542b-4f22-8c66-537744684db8-4l6wv
     ```
 
-1. (`ncn-mw#`) Get the `inventory` container's log of CFS pod running in `K8s` cluster,
+1. (`ncn-mw#`) Get the log of the CFS session pod's `inventory` container.
 
     > - Perform the following substitutions in the command:
     >     - Replace `<CFS_POD>` with the value of previous command.
@@ -74,20 +74,20 @@ Follow these steps to view the `inventory` container log.
     2025-08-08 15:54:40,753 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
     ```
 
-    In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for error identification.
+    In the above output following line contains the details about IMS image ID and IMS job ID needed for error identification in the next step.
 
     ```text
     2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
     ```
 
-1. See [Error identification](ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) and verify the symptom matches
- as described in issue description.
+1. Determine whether or not this known issue is the cause of the problem.
 
-Note: Do not follow the resolution of the known issue linked above.
+    Follow the [Error identification](ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) procedure and
+    verify that the symptom matches, but do not follow the resolution steps in the linked page.
 
-1. If the IMS job container on the `remote node` either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution).
+1. If the IMS job container on the remote node either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution).
 
-   If that is not the case, then the procedure documented here is not applicable.
+    If that is not the case, then the procedure documented here is not applicable.
 
 ## Resolution
 

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -10,7 +10,7 @@ This can occur during `image customization` if any of the following things happe
 
 ## Error identification
 
-A symptom of this problem is the following error in the `inventory` container log in the CFS session pod.
+A symptom of this problem is the following error repeated continuously in the `inventory` container log in the CFS session pod.
 
 ```text
 2025-08-08 15:44:52,299 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
@@ -20,112 +20,72 @@ Follow these steps to view the `inventory` container log.
 
 1. (`ncn-mw#`) Get the details of the CFS session.
 
-   > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name being checked.
+    > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name being checked.
 
-   ```bash
-   cray cfs sessions describe <CFS_SESSION_NAME> --format json
-   ```
+    ```bash
+    cray cfs sessions describe $CFS_SESSION_NAME --format json | jq '.status.session.job'
+    ```
 
-  Example output:
-  
-  ```json
-  {
-  "ansible": {
-    "config": "cfs-default-ansible-cfg",
-    "limit": null,
-    "passthrough": null,
-    "verbosity": 0
-  },
-  "configuration": {
-    "limit": "",
-    "name": "dev-remote-ims-node"
-  },
-  "name": "build-ims-remote-image-x86-cmsdev",
-  "status": {
-    "artifacts": [],
-    "session": {
-      "completionTime": null,
-      "job": "cfs-f7e04dbf-542b-4f22-8c66-537744684db8",
-      "startTime": "2025-08-11T14:51:26",
-      "status": "running",
-      "succeeded": "none"
-    }
-  },
-  "tags": {},
-  "target": {
-    "definition": "image",
-    "groups": [
-      {
-        "members": [
-          "15bacab2-053b-41d6-a7e6-8561cec1bade"
-        ],
-        "name": "Compute"
-      }
-    ],
-    "image_map": [
-      {
-        "result_name": "ims-remote-image-x86-csmdev",
-        "source_id": "15bacab2-053b-41d6-a7e6-8561cec1bade"
-      }
-    ]
-  }
-}
-  ```
+    Example output:
+
+    ```text
+    "cfs-4b8a485f-7536-48ca-9fc9-e11a9a555fcd"
+    ```
 
 1. (`ncn-mw#`) Get the name of the CFS pod running in the `services` namespace.
 
-   > - Perform the following substitutions in the command:
-   >     - Replace `<CFS_SESSIONS_JOB_ID>` with the value of the
-   >       `session.job` field in the CFS sessions detail.
+    > - Perform the following substitutions in the command:
+    >     - Replace `<CFS_SESSIONS_JOB_ID>` with the value of the
+    >       previous command.
 
-   ```bash
-   kubectl get pods -n services -o name|grep <CFS_SESSIONS_JOB_ID>
-   ```
+    ```bash
+    kubectl get pods -n services -o name|grep <CFS_SESSIONS_JOB_ID>
+    ```
 
-  Example output:
-  
-  ```text
-  pod/cfs-f7e04dbf-542b-4f22-8c66-537744684db8-4l6wv
-  ```
+    Example output:
+
+    ```text
+    pod/cfs-f7e04dbf-542b-4f22-8c66-537744684db8-4l6wv
+    ```
 
 1. (`ncn-mw#`) Get the `inventory` container's log of CFS pod running in `K8s` cluster,
 
-> - Perform the following substitutions in the command:
->     - Replace `<CFS_POD>` with the value of previous command.
+    > - Perform the following substitutions in the command:
+    >     - Replace `<CFS_POD>` with the value of previous command.
 
-```bash
-kubectl logs -f <CFS_POD> -n services -c inventory
-```
+    ```bash
+    kubectl logs -f <CFS_POD> -n services -c inventory
+    ```
 
-Example output:
+    Example output:
 
-```text
-2025-08-08 15:50:06,023 - INFO    - cray.cfs.inventory - Starting CFS Inventory version=1.31.0, namespace=services
-2025-08-08 15:50:06,108 - INFO    - cray.cfs.inventory - Inventory target=image for cfsession=build-ims-remote-image-x86-cmsdev
-2025-08-08 15:50:06,263 - INFO    - cray.cfs.inventory.image - Uploading public key to IMS for SSH container access.
-2025-08-08 15:50:06,417 - INFO    - cray.cfs.inventory.image - Requesting access to IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade'
-2025-08-08 15:50:07,796 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=0s
-2025-08-08 15:50:12,810 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=5s
-...
-2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
-2025-08-08 15:54:33,722 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=265s
-2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Checking ssh availability
-2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Waiting for SSH to be available at cray-ims-15b7479d-e5f2-405f-971c-405c1fac1152-service.ims.svc.cluster.local:22. Elapsed time=0s
-2025-08-08 15:54:40,753 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
-```
+    ```text
+    2025-08-08 15:50:06,023 - INFO    - cray.cfs.inventory - Starting CFS Inventory version=1.31.0, namespace=services
+    2025-08-08 15:50:06,108 - INFO    - cray.cfs.inventory - Inventory target=image for cfsession=build-ims-remote-image-x86-cmsdev
+    2025-08-08 15:50:06,263 - INFO    - cray.cfs.inventory.image - Uploading public key to IMS for SSH container access.
+    2025-08-08 15:50:06,417 - INFO    - cray.cfs.inventory.image - Requesting access to IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade'
+    2025-08-08 15:50:07,796 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=0s
+    2025-08-08 15:50:12,810 - INFO    - cray.cfs.inventory.image - IMS status=creating for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=5s
+    ...
+    2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
+    2025-08-08 15:54:33,722 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=265s
+    2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Checking ssh availability
+    2025-08-08 15:54:38,739 - INFO    - cray.cfs.inventory.image - Waiting for SSH to be available at cray-ims-15b7479d-e5f2-405f-971c-405c1fac1152-service.ims.svc.cluster.local:22. Elapsed time=0s
+    2025-08-08 15:54:40,753 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
+    ```
 
-In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for error identification.
+    In the above output following line contains the details about `Image ID` and `IMS Job ID` needed for error identification.
 
-```text
-2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
-```
+    ```text
+    2025-08-08 15:54:28,704 - INFO    - cray.cfs.inventory.image - IMS status=fetching_image for IMS image='15bacab2-053b-41d6-a7e6-8561cec1bade' job='15b7479d-e5f2-405f-971c-405c1fac1152'. Elapsed time=260s
+    ```
 
 1. See [Error identification](ims_image_customization_job_status_stuck_at_waiting_on_user.md#error-identification) and verify the symptom matches
  as described in issue description.
 
 Note: Do not follow the resolution of the known issue linked above.
 
-1. If the IMS job container either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution).
+1. If the IMS job container on the `remote node` either does not exist or is in an `exited` state, then proceed to [Resolution](#resolution).
 
    If that is not the case, then the procedure documented here is not applicable.
 
@@ -133,11 +93,11 @@ Note: Do not follow the resolution of the known issue linked above.
 
 (`ncn-mw#`) In order to resolve the problem, delete the CFS session.
 
-> In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name.
+    > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name.
 
- ```bash
-cray cfs sessions delete <CFS_SESSION_NAME>
-```
+    ```bash
+    cray cfs sessions delete <CFS_SESSION_NAME>
+    ```
 
 After the CFS session is deleted, a new CFS session for image customization can be created. See
 [Create CFS Session For Image Customization](../../operations/configuration_management/Create_an_Image_Customization_CFS_Session.md).

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -1,4 +1,4 @@
-# CFS Session for Image Customization on remote node Status Stuck at `running`
+# CFS Session for Image Customization on Remote Node Status Stuck at `running`
 
 ## Issue description
 
@@ -10,17 +10,17 @@ This can occur during `image customization` if any of the following things happe
 
 ## Error identification
 
-A symptom of this problem is following error in `inventory` container's log of CFS pod.
+A symptom of this problem is the following error in the `inventory` container log in the CFS session pod.
 
 ```text
 2025-08-08 15:44:52,299 - INFO    - cray.cfs.inventory.image - Error while waiting for SSH to be available: Error reading SSH protocol banner[Errno 104] Connection reset by peer. Retrying..
 ```
 
- Follow the steps to view `inventory` container log
+Follow these steps to view the `inventory` container log.
 
-1. (`ncn-mw#`) Get the details of the CFS session,
+1. (`ncn-mw#`) Get the details of the CFS session.
 
-   > In the following command, substitute the actual CFS Session Name being checked.
+   > In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name being checked.
 
    ```bash
    cray cfs sessions describe <CFS_SESSION_NAME> --format json
@@ -72,7 +72,7 @@ A symptom of this problem is following error in `inventory` container's log of C
 }
   ```
 
-1. (`ncn-mw#`) Get the `CFS` pod running in `K8s` cluster,
+1. (`ncn-mw#`) Get the name of the CFS pod running in the `services` namespace.
 
    > - Perform the following substitutions in the command:
    >     - Replace `<CFS_SESSIONS_JOB_ID>` with the value of the
@@ -133,7 +133,7 @@ Note: Do not follow the resolution of the known issue linked above.
 
 (`ncn-mw#`) In order to resolve the problem, delete the CFS session.
 
-> In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session ID.
+> In the following command, replace `<CFS_SESSION_NAME>` with the actual CFS session name.
 
  ```bash
 cray cfs sessions delete <CFS_SESSION_NAME>

--- a/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
+++ b/troubleshooting/known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md
@@ -51,7 +51,7 @@ Follow these steps to view the `inventory` container log.
 1. (`ncn-mw#`) Get the log of the CFS session pod's `inventory` container.
 
     > - Perform the following substitutions in the command:
-    >     - Replace `<CFS_POD>` with the value of previous command.
+    >     - Replace `<CFS_POD>` with the output of the command in the previous step.
 
     ```bash
     kubectl logs -f <CFS_POD> -n services -c inventory


### PR DESCRIPTION
CASMCMS-9516: cfs session for image customization running on remote node stuck in running status

A CFS session for image customization job on a remote node can get stuck in the `running` state indefinitely.
This can occur during `image customization` if any of the following things happen:

- The remote node reboots or crashes.
- The IMS job container on the remote build node is killed or stopped.

Backport PRs
1.6: https://github.com/Cray-HPE/docs-csm/pull/6223
1.5: https://github.com/Cray-HPE/docs-csm/pull/6224