### PR TITLE
CASMCMS-9401: IMS - deleted recipe always gets assigned require_dkms=true

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -57,6 +57,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
+* [Soft Deleted IMS recipe always has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
 
 ## Booting
 
@@ -123,6 +124,10 @@ CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0. See [Depre
 ## Grafana dashboards
 
 * [Grafana Dashboards](../operations/system_management_health/Troubleshoot_Grafana_Dashboard.md)
+
+## Image management
+
+* [Soft Deleted IMS recipe always has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
 
 ## Kubernetes
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -57,7 +57,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
-* [Soft Deleted IMS recipe always has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
+* [Soft Deleted IMS Recipe Always Has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
 
 ## Booting
 
@@ -127,7 +127,7 @@ CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0. See [Depre
 
 ## Image management
 
-* [Soft Deleted IMS recipe always has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
+* [Soft Deleted IMS Recipe Always Has `require_dkms=true`](known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md)
 
 ## Kubernetes
 

--- a/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
+++ b/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
@@ -1,104 +1,38 @@
-# Soft deleted IMS recipe always has `require_dkms` value set to `true`
+# Soft Deleted IMS Recipe Always Has `require_dkms=true`
 
 ## Issue description
 
-When IMS recipe is deleted and moves to being classified as a `deleted recipe` it gets assigned `require_dkms=true`
-regardless of the `require_dkms` value of the original recipe. If recipe is restored using operation `undelete`,
-`require_dkms` retains the value `true`. This can be an issue in following scenario:
-
-- IMS recipe attribute `require_dkms` value is set to `false`.
-
-## Error identification
-
-A symptom of the problem is that if operation `delete` is performed  followed by `undelete` on an IMS recipe then recipe
-attribute `require_dkms` value is always set to `true`.
-
-Follow these steps to verify the issue.
-
-1. (`ncn-mw#`) Get the recipe ID with `require_dkms` value set to `false`.
-
-    ```bash
-    cray ims recipes list --format json|jq '.[] | select(.require_dkms == false) | .id'|jq -s '.[0]'
-    ```
-
-    Example output:
-
-    ```text
-    b89827ea-d929-461f-95b6-14cba7983311
-    ```
-
-    If the above command does not return a recipe ID, then the procedure documented here is not applicable.
-
-1. (`ncn-mw#`) Soft delete the recipe.
-
-    > In the following command, replace `<RECIPE_ID>` with the value of previous command.
-
-    ```bash
-    cray ims recipes delete <RECIPE_ID>
-    ```
-
-1. (`ncn-mw#`) Get the details of `soft deleted` recipe and notice the value of `require_dkms` is set to `true`.
-
-    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
-
-    ```bash
-    cray ims deleted recipes describe <RECIPE_ID> --format json|jq '.require_dkms'
-    ```
-
-    Example output:
-
-    ```text
-    true
-    ```
-
-1. (`ncn-mw#`) `undelete` the `soft deleted` IMS recipe.
-
-    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
-
-    ```bash
-    cray ims deleted recipes update <RECIPE_ID> --operation undelete
-    ```
-
-1. (`ncn-mw#`) Get the details of restored recipe and notice the value of `require_dkms` is set to `true`.
-
-    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
-
-    ```bash
-    cray ims recipes describe <RECIPE_ID> --format json|jq '.require_dkms'
-    ```
-
-    Example output:
-
-    ```text
-    true
-    ```
+When an IMS recipe is deleted and becomes a "deleted recipe", its `require_dkms` attribute is set to `true`,
+regardless of its original value. This new value persists even if the recipe is later restored using an `undelete`
+operation.
 
 ## Resolution
 
-1. (`ncn-mw#`) In order to resolve the problem, update the value of `require_dkms` to `false`.
+(`ncn-mw#`) The problem can be worked around by manually updating the `require_dkms` value after the deleted
+has been restored.
 
-    > In the following command, replace `<RECIPE_ID>` with the value used in `Error identification` phase.
+> In the following command, replace `<RECIPE_ID>` with actual IMS recipe ID.
 
-    ```bash
-    cray ims recipes update --require-dkms false <RECIPE_ID> --format json
-    ```
+```bash
+cray ims recipes update --require-dkms false <RECIPE_ID> --format json
+```
 
-    Example output:
+Example output:
 
-    ```json
-    {
-    "arch": "aarch64",
-    "created": "2024-07-18T19:47:03.600611",
-    "id": "b89827ea-d929-461f-95b6-14cba7983311",
-    "link": {
-        "etag": "e07f7f535d886fb9a61130a753a2467b",
-        "path": "s3://ims/recipes/b89827ea-d929-461f-95b6-14cba7983311/recipe.tar.gz",
-        "type": "s3"
-    },
-    "linux_distribution": "sles15",
-    "name": "cray-shasta-csm-sles15sp5-barebones-csm-1.5-aarch64",
-    "recipe_type": "kiwi-ng",
-    "require_dkms": false,
-    "template_dictionary": []
-    }
-    ```
+```json
+{
+  "arch": "aarch64",
+  "created": "2024-07-18T19:47:03.600611",
+  "id": "b89827ea-d929-461f-95b6-14cba7983311",
+  "link": {
+    "etag": "e07f7f535d886fb9a61130a753a2467b",
+    "path": "s3://ims/recipes/b89827ea-d929-461f-95b6-14cba7983311/recipe.tar.gz",
+    "type": "s3"
+  },
+  "linux_distribution": "sles15",
+  "name": "cray-shasta-csm-sles15sp5-barebones-csm-1.5-aarch64",
+  "recipe_type": "kiwi-ng",
+  "require_dkms": false,
+  "template_dictionary": []
+}
+```

--- a/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
+++ b/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
@@ -1,0 +1,104 @@
+# Soft deleted IMS recipe always has `require_dkms` value set to `true`
+
+## Issue description
+
+When IMS recipe is deleted and moves to being classified as a `deleted recipe` it gets assigned `require_dkms=true`
+regardless of the `require_dkms` value of the original recipe. If recipe is restored using operation `undelete`,
+`require_dkms` retains the value `true`. This can be an issue in following scenario:
+
+- IMS recipe attribute `require_dkms` value is set to `false`.
+
+## Error identification
+
+A symptom of the problem is that if operation `delete` is performed  followed by `undelete` on an IMS recipe then recipe
+attribute `require_dkms` value is always set to `true`.
+
+Follow these steps to verify the issue.
+
+1. (`ncn-mw#`) Get the recipe ID with `require_dkms` value set to `false`.
+
+    ```bash
+    cray ims recipes list --format json|jq '.[] | select(.require_dkms == false) | .id'|jq -s '.[0]'
+    ```
+
+    Example output:
+
+    ```text
+    b89827ea-d929-461f-95b6-14cba7983311
+    ```
+
+    If the above command does not return a recipe ID, then the procedure documented here is not applicable.
+
+1. (`ncn-mw#`) Soft delete the recipe.
+
+    > In the following command, replace `<RECIPE_ID>` with the value of previous command.
+
+    ```bash
+    cray ims recipes delete <RECIPE_ID>
+    ```
+
+1. (`ncn-mw#`) Get the details of `soft deleted` recipe and notice the value of `require_dkms` is set to `true`.
+
+    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
+
+    ```bash
+    cray ims deleted recipes describe <RECIPE_ID> --format json|jq '.require_dkms'
+    ```
+
+    Example output:
+
+    ```text
+    true
+    ```
+
+1. (`ncn-mw#`) `undelete` the `soft deleted` IMS recipe.
+
+    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
+
+    ```bash
+    cray ims deleted recipes update <RECIPE_ID> --operation undelete
+    ```
+
+1. (`ncn-mw#`) Get the details of restored recipe and notice the value of `require_dkms` is set to `true`.
+
+    > In the following command, replace `<RECIPE_ID>` with the value used in previous command.
+
+    ```bash
+    cray ims recipes describe <RECIPE_ID> --format json|jq '.require_dkms'
+    ```
+
+    Example output:
+
+    ```text
+    true
+    ```
+
+## Resolution
+
+1. (`ncn-mw#`) In order to resolve the problem, update the value of `require_dkms` to `false`.
+
+    > In the following command, replace `<RECIPE_ID>` with the value used in `Error identification` phase.
+
+    ```bash
+    cray ims recipes update --require-dkms false <RECIPE_ID> --format json
+    ```
+
+    Example output:
+
+    ```json
+    {
+    "arch": "aarch64",
+    "created": "2024-07-18T19:47:03.600611",
+    "id": "b89827ea-d929-461f-95b6-14cba7983311",
+    "link": {
+        "etag": "e07f7f535d886fb9a61130a753a2467b",
+        "path": "s3://ims/recipes/b89827ea-d929-461f-95b6-14cba7983311/recipe.tar.gz",
+        "type": "s3"
+    },
+    "linux_distribution": "sles15",
+    "name": "cray-shasta-csm-sles15sp5-barebones-csm-1.5-aarch64",
+    "recipe_type": "kiwi-ng",
+    "require_dkms": false,
+    "template_dictionary": []
+    }
+    ```

--- a/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
+++ b/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
@@ -7,7 +7,7 @@ regardless of its original value. This new value persists even if the recipe is 
 operation.
 
 For more information on deleting and restoring resources in IMS, see
-[Delete or Recover Deleted IMS Content](../operations/image_management/Delete_or_Recover_Deleted_IMS_Content.md).
+[Delete or Recover Deleted IMS Content](../../operations/image_management/Delete_or_Recover_Deleted_IMS_Content.md).
 
 ## Workaround
 

--- a/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
+++ b/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
@@ -6,6 +6,9 @@ When an IMS recipe is deleted and becomes a "deleted recipe", its `require_dkms`
 regardless of its original value. This new value persists even if the recipe is later restored using an `undelete`
 operation.
 
+For more information on deleting and restoring resources in IMS, see
+[Delete or Recover Deleted IMS Content](../operations/image_management/Delete_or_Recover_Deleted_IMS_Content.md).
+
 ## Workaround
 
 (`ncn-mw#`) The problem can be worked around by manually updating the `require_dkms` value after the deleted

--- a/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
+++ b/troubleshooting/known_issues/ims_soft_deleted_recipe_always_has_require_dkms_true.md
@@ -6,7 +6,7 @@ When an IMS recipe is deleted and becomes a "deleted recipe", its `require_dkms`
 regardless of its original value. This new value persists even if the recipe is later restored using an `undelete`
 operation.
 
-## Resolution
+## Workaround
 
 (`ncn-mw#`) The problem can be worked around by manually updating the `require_dkms` value after the deleted
 has been restored.


### PR DESCRIPTION
When IMS recipe is deleted and moves to being classified as a `deleted recipe` it gets assigned `require_dkms=true` 
regardless of the `require_dkms` value of the original recipe. If recipe is restored using operation `undelete`, 
`require_dkms` retains the value `true`. This can be an issue in following scenario:

- IMS recipe attribute `require_dkms` value is set to `false`.
