### PR TITLE
CASMTRIAGE-8626: Absolute Path for Critical Services Restart Script

### DIFF
--- a/upgrade/scripts/k8s/upgrade_k8s_steps.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s_steps.sh
@@ -123,7 +123,7 @@ if [[ -f "$DONE_DIR/rr_cs_rollout_restart.done" ]]; then
   echo "INFO Rack Resiliency Critical services rollout restart already completed, skipping."
 else
   # For each CS in static ConfigMap, perform rollout restart of the critical service
-  python3 rr_critical_service_restart.py || {
+  python3 /usr/share/doc/csm/upgrade/scripts/k8s/rr_critical_service_restart.py || {
     echo "ERROR Critical Services rollout restart failed."
     exit 1
   }


### PR DESCRIPTION
Description: Absolute Path for Critical Services Restart Script in upgrade_k8s_steps.sh.

The current script has relative path which does not work when from Argo Pods. This has to be changed to absolute path.

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8626 

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

