### PR TITLE
CASM 5687: Fix function call and remove obsolete RR check in rr_critical_service_restart.py

### DIFF
--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -52,7 +52,7 @@ def err_exit(msg: str) -> NoReturn:
     Prepends "ERROR: " to the message and then prints it to stderr.
     Then exits the script with rc 1
     """
-    print_err(f"ERROR: {msg}")
+    print_stderr(f"ERROR: {msg}")
     sys.exit(1)
 
 def load_configmap(name: str, namespace: str) -> dict:
@@ -74,7 +74,7 @@ def load_configmap(name: str, namespace: str) -> dict:
         )
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
-        print_err(f"Failed to fetch ConfigMap '{name}' from namespace '{namespace}'")
+        print_stderr(f"Failed to fetch ConfigMap '{name}' from namespace '{namespace}'")
         err_exit(e.stderr)
 
 class ServiceDetails(TypedDict):
@@ -105,11 +105,11 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             result = subprocess.run(get_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
             resource_json = json.loads(result.stdout)
         except subprocess.CalledProcessError as e:
-            print_err(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
+            print_stderr(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
             failed_services = True
             continue
         except json.JSONDecodeError as e:
-            print_err(f"Failed to parse JSON for {resource_type}/{name}: {str(e)}")
+            print_stderr(f"Failed to parse JSON for {resource_type}/{name}: {str(e)}")
             failed_services = True
             continue
 
@@ -124,8 +124,8 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
         try:
             subprocess.run(restart_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         except subprocess.CalledProcessError as e:
-            print_err(f"Failed to restart {resource_type}/{name} in namespace {namespace}")
-            print_err(f"Error: {e.stderr}")
+            print_stderr(f"Failed to restart {resource_type}/{name} in namespace {namespace}")
+            print_stderr(f"Error: {e.stderr}")
             failed_services = True
             continue
 
@@ -135,8 +135,8 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             subprocess.run(status_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
             print(f"Restarted {resource_type}/{name} in namespace {namespace}")
         except subprocess.CalledProcessError as e:
-            print_err(f"Rollout status check failed for {resource_type}/{name} in namespace {namespace}")
-            print_err(f"Error: {e.stderr}")
+            print_stderr(f"Rollout status check failed for {resource_type}/{name} in namespace {namespace}")
+            print_stderr(f"Error: {e.stderr}")
             failed_services = True
 
     return failed_services
@@ -170,7 +170,7 @@ def set_rollout_complete(configmap_name: str, namespace: str) -> None:
         subprocess.run(command, check=True)
         print(f"Set rollout_complete=true in ConfigMap '{configmap_name}'")
     except subprocess.CalledProcessError as e:
-        print_err(f"Failed to patch ConfigMap '{configmap_name}'")
+        print_stderr(f"Failed to patch ConfigMap '{configmap_name}'")
         err_exit(e)
 
 def rr_enabled():
@@ -192,10 +192,10 @@ def rr_enabled():
             check=True
         )
     except subprocess.CalledProcessError as e:
-        print_err(f"Error fetching site-init secret: {e.stderr}")
+        print_stderr(f"Error fetching site-init secret: {e.stderr}")
         return False
     except Exception as e:
-        print_err(f"error: {e}")
+        print_stderr(f"error: {e}")
         return False
 
     # Parse JSON output
@@ -207,7 +207,7 @@ def rr_enabled():
         decoded_yaml = base64.b64decode(encoded_yaml).decode("utf-8")
         data = yaml.safe_load(decoded_yaml)
     except Exception as e:
-        print_err(f"Failed to decode or parse customizations.yaml: {e}")
+        print_stderr(f"Failed to decode or parse customizations.yaml: {e}")
         return False
 
     enabled = data.get('spec', {}) \

--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -115,8 +115,8 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
 
         # Check for 'rrflag' label
         labels = resource_json.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {})
-        if "rrflag" not in labels:
-            print(f"Skipping {resource_type}/{name}: 'rrflag' label is not set in namespace {namespace}")
+        if "rrflag" in labels:
+            print(f"Skipping {resource_type}/{name}: 'rrflag' label is already set in namespace {namespace}")
             continue
 
         # Restart the service

--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -256,13 +256,10 @@ def main() -> None:
     Main function to execute the rollout restart of critical services.
     """
     if not rr_enabled():
-        # RR is not enabled
-        if is_cluster_policy_applied("insert-labels-topology-constraints"):
-            # RR is not enabled, but the cluster policy is applied -- this is an error
-            err_exit("Rack Resiliency is not enabled  but ClusterPolicy 'insert-labels-topology-constraints' is applied. Skipping restart.")
-        ## RR is not enabled and the cluster policy is not applied
-        print("Rack Resiliency is not enabled and ClusterPolicy 'insert-labels-topology-constraints' is not applied.Skipping restart.")
+        ## RR is not enabled
+        print("Rack Resiliency is not enabled. Skipping restart.")
         sys.exit(0)
+
     # RR is enabled
     # Check cluster policy
     if not is_cluster_policy_applied("insert-labels-topology-constraints"):


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
This PR fixes two issues in rr_critical_service_restart.py:

1. Corrects the mismatched function call (print_err → print_stderr) introduced as part of [CASM-5679].
2. Removes the obsolete policy check since RR is not enabled and the condition is no longer required.

Why

1. The incorrect function call causes runtime errors.
2. The extra check introduces unnecessary logic and should be removed to simplify the script.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-5687](https://jira-pro.it.hpe.com:8443/browse/CASM-5687)


## Testing

_List the environments in which these changes were tested._

Tested on:

  * `odin`


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
