### PR TITLE
CASM-5709: Correct path to RR critical services restart script

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -232,7 +232,7 @@ will generate the full CFS configuration including additional CSM layers and all
 (`ncn-mw#`) Restart the critical services for Rack Resiliency.
 
 ```bash
-python3 /usr/share/doc/csm/upgrade/scripts/upgrade/scripts/k8s/rr_critical_service_restart.py
+python3 /usr/share/doc/csm/upgrade/scripts/k8s/rr_critical_service_restart.py
 ```
 
 ## 11. Proceed to next topic

--- a/operations/rack_resiliency/Manage_Critical_Services.md
+++ b/operations/rack_resiliency/Manage_Critical_Services.md
@@ -329,7 +329,7 @@ This procedure is only necessary after adding critical services to RR.
     > See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 
     ```bash
-    python3 /usr/share/doc/csm/upgrade/scripts/upgrade/scripts/k8s/rr_critical_service_restart.py
+    python3 /usr/share/doc/csm/upgrade/scripts/k8s/rr_critical_service_restart.py
     ```
 
 ### Remove services from Kyverno policy


### PR DESCRIPTION
The path to the script for restarting the RR critical services is incorrect in two places in the docs. This PR corrects those.

No backports needed -- this script only exists in CSM 1.7