### PR TITLE
CASMTRIAGE-8644: Adding service not found logic back.

### DIFF
--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -105,10 +105,10 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             result = subprocess.run(get_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
             resource_json = json.loads(result.stdout)
         except subprocess.CalledProcessError as e:
-            print_stderr(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
-            if "not found" in e.stderr.lower():
+            if f"Error from server (NotFound): {resource_type.lower()}s.apps \"{name}\" not found" in e.stderr:
                 print(f"Skipping {resource_type}/{name}: resource not found in namespace {namespace}")
                 continue
+            print(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
             failed_services = True
             continue
         except json.JSONDecodeError as e:
@@ -127,8 +127,7 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
         try:
             subprocess.run(restart_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         except subprocess.CalledProcessError as e:
-            print_stderr(f"Failed to restart {resource_type}/{name} in namespace {namespace}")
-            print_stderr(f"Error: {e.stderr}")
+            print_stderr(f"Failed to restart {resource_type}/{name} in namespace {namespace}: {e.stderr}")
             failed_services = True
             continue
 
@@ -138,8 +137,7 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             subprocess.run(status_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
             print(f"Restarted {resource_type}/{name} in namespace {namespace}")
         except subprocess.CalledProcessError as e:
-            print_stderr(f"Rollout status check failed for {resource_type}/{name} in namespace {namespace}")
-            print_stderr(f"Error: {e.stderr}")
+            print_stderr(f"Rollout status check failed for {resource_type}/{name} in namespace {namespace}: {e.stderr}")
             failed_services = True
 
     return failed_services

--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -108,7 +108,7 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             if f"Error from server (NotFound): {resource_type.lower()}s.apps \"{name}\" not found" in e.stderr:
                 print(f"Skipping {resource_type}/{name}: resource not found in namespace {namespace}")
                 continue
-            print(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
+            print_stderr(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
             failed_services = True
             continue
         except json.JSONDecodeError as e:

--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -106,6 +106,9 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
             resource_json = json.loads(result.stdout)
         except subprocess.CalledProcessError as e:
             print_stderr(f"Failed to get {resource_type}/{name} in namespace {namespace}: {e.stderr}")
+            if "not found" in e.stderr.lower():
+                print(f"Skipping {resource_type}/{name}: resource not found in namespace {namespace}")
+                continue
             failed_services = True
             continue
         except json.JSONDecodeError as e:
@@ -273,7 +276,7 @@ def main() -> None:
     except KeyError as e:
         err_exit(f"Missing expected key in ConfigMap: {e}")
 
-    if not rollout_restart_critical_services(critical_services):
+    if rollout_restart_critical_services(critical_services):
         err_exit(f"RR critical services rollout restart failed.")
 
     print(f"RR critical services rollout restart successful.")

--- a/upgrade/scripts/k8s/rr_critical_service_restart.py
+++ b/upgrade/scripts/k8s/rr_critical_service_restart.py
@@ -91,7 +91,7 @@ def rollout_restart_critical_services(critical_services: Dict[str, ServiceDetail
     Args:
         critical_services (dict): Dictionary of services with their type and namespace.
     Returns:
-        bool: True if successful, False if any service restart failed.
+        bool: False if successful, True if any service restart failed.
     """
     failed_services = False
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This issue is seen due to changes in [this initial script](https://github.com/Cray-HPE/docs-csm/blob/9c07f1b681fca3eb760bbdca512f78069c234a52/upgrade/scripts/k8s/rr_critical_service_restart.py), added the changes back to [the current script](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/upgrade/scripts/k8s/rr_critical_service_restart.py).

Resolves: [CASMTRIAGE-8644](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8644)
Issue caused by: [commit1](https://github.com/Cray-HPE/docs-csm/pull/6236/commits/f9d3324893dce1fa24a3a92b50fff65517b52dd1), [commit2](https://github.com/Cray-HPE/docs-csm/pull/6236/commits/edb048384e74b4719a0795139c147908f63d235e), [commit3](https://github.com/Cray-HPE/docs-csm/pull/6236/commits/a58effd42fa25307e01b3e2fe9ae300999944dc1)

Note: commit3 is followup of commit2
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
