### PR TITLE
CASMTRIAGE-8605 Backup files /etc/motd and /root/.bashrc during ncn-m001 rebuilt #6230

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -114,6 +114,8 @@ spec:
                     ls -d \
                         /root/apply_csm_configuration.* \
                         /root/csm_upgrade.* \
+                        /etc/motd \
+                        /root/.bashrc \
                         /root/output.log 2>/dev/null |
                     sed 's_^/__' |
                     xargs tar -C / -czvf "/root/${BACKUP_TARFILE}"


### PR DESCRIPTION
# Description
Backport of https://github.com/Cray-HPE/docs-csm/pull/6230

CASMTRIAGE-8605 Backup /etc/motd and /root/.bashrc during ncn-m001 rebuilt
* Resolves [CASMTRIAGE-8605](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8605)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.


[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams