### PR TITLE
CASMPET-7540: promote first master as needed

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -514,6 +514,46 @@ Before rebooting NCNs:
 
 1. Reboot each of the master nodes (one at a time), going from the highest to lowest number, excluding `ncn-m001`. There are special instructions for `ncn-m001` later, because its console connection is not managed by ConMan.
 
+    1. (`ncn-mw#`) Make sure that the selected node is not set as `first-master-hostname`.
+
+        ```bash
+        cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+        ```
+
+        Example output if `ncn-m002` is set as `first-master-hostname`:
+
+        ```toml
+        first-master-hostname = "ncn-m002"
+        ```
+
+        **`IMPORTANT:`** If the selected node is set as `first-master-hostname`, then change it to
+        another master node; for example, `ncn-m001`.
+
+        ```bash
+        export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | \
+            jq -r '.access_token')
+        promotingMaster=ncn-m001
+        VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster \
+            --limit Global
+        ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
+        ```
+
+    1. (`ncn-mw#`) Verify that the `first-master-hostname` has been updated:
+
+        ```bash
+        cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+        ```
+
+        Example output if `ncn-m001` is now set as `first-master-hostname`:
+
+        ```toml
+        first-master-hostname = "ncn-m001"
+        ```
+
     1. Establish a console session to the master node being rebooted.
 
         See step [Establish a Serial Connection to NCNs](../conman/Establish_a_Serial_Connection_to_NCNs.md) for more information.
@@ -523,7 +563,7 @@ Before rebooting NCNs:
     1. (`ncn-m#`) Reboot the selected node.
 
         ```bash
-         shutdown -r now
+        shutdown -r now
         ```
 
         **`IMPORTANT:`** If the node does not shut down after 5 minutes, then proceed with the power reset below.
@@ -614,6 +654,46 @@ Before rebooting NCNs:
     1. Repeat all of the sub-steps above for the remaining master nodes \(excluding `ncn-m001`\), going from the highest to lowest number, until all master nodes have successfully rebooted.
 
 1. Reboot `ncn-m001`.
+
+    1. (`ncn-mw#`) Make sure that `ncn-m001` is not set as `first-master-hostname`.
+
+        ```bash
+        cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+        ```
+
+        Example output if `ncn-m001` is set as `first-master-hostname`:
+
+        ```toml
+        first-master-hostname = "ncn-m001"
+        ```
+
+        **`IMPORTANT:`** If `ncn-m001` is set as `first-master-hostname`, then change it to another
+        master node, for example, `ncn-m002`.
+
+        ```bash
+        export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | \
+            jq -r '.access_token')
+        promotingMaster=ncn-m002
+        VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster \
+            --limit Global
+        ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
+        ```
+
+    1. (`ncn-mw#`) Verify that the `first-master-hostname` has been updated:
+
+        ```bash
+        cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+        ```
+
+        Example output if `ncn-m002` is now set as `first-master-hostname`:
+
+        ```toml
+        first-master-hostname = "ncn-m002"
+        ```
 
     1. Determine the site/external IP address for one of the other NCNs in the system, in order to establish an SSH session with that NCN.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Before rebooting a master node (e.g., after a firmware upgrade), we need to check if the master node is set as first master hostname. If so, additional commands need to be run to move first master hostname to another one before rebooting it. This PR adds the instructions to move first master hostname as needed.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
