### PR TITLE
CASMINST-6761: add Postgres SyncFailed known issue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -246,5 +246,8 @@ see [Removals](introduction/deprecated_features/README.md#removals)
 * `sat bootprep` image customization error
     * The SAT product should be upgraded to 2.6.23 to avoid this issue.
     * For more information, including a workaround, see [sat bootprep image customization error](troubleshooting/known_issues/sat_bootprep_image_customization_error.md).
+* PostgreSQL clusters may fall into `SyncFailed` state after upgrade from CSM 1.4 to 1.5 due to Kyverno webhook conflicts
+    * This issue can be resolved by temporarily removing Kyverno webhook configurations and restarting the Kyverno deployment.
+    * For more information, including a workaround, see [PostgreSQL Clusters in `SyncFailed` State Due to Kyverno Webhook](troubleshooting/known_issues/postgres_syncfailed_kyverno_webhook.md).
 
 For a full list of known issues, see [Known issues](troubleshooting/README.md#known-issues).

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -80,6 +80,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
 * [PostgreSQL Cluster Upgrades Failing](known_issues/postgres_cluster_upgrade_failure.md)
+* [PostgreSQL Clusters in `SyncFailed` State Due to Kyverno Webhook](known_issues/postgres_syncfailed_kyverno_webhook.md)
 * [Remove Duplicate Detected Events From the HSM Postgres Database](../operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md)
 * [IMS Image Customization Job Status Stuck at `waiting_on_user`](known_issues/ims_image_customization_job_status_stuck_at_waiting_on_user.md)
 * [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)

--- a/troubleshooting/known_issues/postgres_syncfailed_kyverno_webhook.md
+++ b/troubleshooting/known_issues/postgres_syncfailed_kyverno_webhook.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Sometimes after PostgreSQL clusters upgrade from version 11 to 14 (CSM 1.4 to CSM 1.5), most
+Sometimes after PostgreSQL clusters upgrade from version 11 to 14 (CSM 1.4 to CSM 1.5),
 clusters fall into a `SyncFailed` state due to admission webhook conflicts with Kyverno policies.
 The issue occurs when the Kyverno mutating webhook `mutate.kyverno.svc-fail` denies requests
 during PostgreSQL pod updates, preventing the clusters from maintaining their healthy state.

--- a/troubleshooting/known_issues/postgres_syncfailed_kyverno_webhook.md
+++ b/troubleshooting/known_issues/postgres_syncfailed_kyverno_webhook.md
@@ -1,0 +1,106 @@
+# PostgreSQL Clusters in `SyncFailed` State Due to Kyverno Webhook
+
+## Description
+
+Sometimes after PostgreSQL clusters upgrade from version 11 to 14 (CSM 1.4 to CSM 1.5), most
+clusters fall into a `SyncFailed` state due to admission webhook conflicts with Kyverno policies.
+The issue occurs when the Kyverno mutating webhook `mutate.kyverno.svc-fail` denies requests
+during PostgreSQL pod updates, preventing the clusters from maintaining their healthy state.
+
+## Symptoms
+
+PostgreSQL clusters display `SyncFailed` state instead of `Running` after upgrade completion.
+
+Command:
+
+```bash
+kubectl get postgresql -A
+```
+
+Example output:
+
+```text
+NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
+argo        cray-nls-postgres            cray-nls            14        3      2Gi                                     12h   Running
+services    cfs-ara-postgres             cfs-ara             14        3      50Gi     100m          100Mi            12h   SyncFailed
+services    cray-console-data-postgres   cray-console-data   14        3      2Gi      100m          256Mi            12h   SyncFailed
+services    cray-dns-powerdns-postgres   cray-dns-powerdns   14        3      10Gi     100m          100Mi            12h   SyncFailed
+services    cray-sls-postgres            cray-sls            14        3      1Gi      100m          128Mi            12h   SyncFailed
+services    cray-smd-postgres            cray-smd            14        3      100Gi    1             100Mi            12h   SyncFailed
+services    gitea-vcs-postgres           gitea-vcs           14        3      50Gi     100m          256Mi            12h   SyncFailed
+services    keycloak-postgres            keycloak            14        3      10Gi                                    12h   SyncFailed
+spire       cray-spire-postgres          cray-spire          14        3      60Gi     1             1Gi              9h    SyncFailed
+spire       spire-postgres               spire               14        3      60Gi     1             4Gi              12h   SyncFailed
+```
+
+In addition, Postgres pod logs show errors related to Kyverno admission webhook failures.
+
+Command:
+
+```bash
+kubectl -n spire logs -f spire-postgres-0 -c postgres
+```
+
+Example output:
+
+```text
+HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \\"mutate.kyverno.svc-fail\\" denied the request: mutation policy pod-sec-ctxt-spire error: failed to validate resource mutated by policy pod-sec-ctxt-spire: ValidationError(io.k8s.api.core.v1.Pod.metadata.managedFields[1]): unknown field \\"subresource\\" in io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry\\n\\nValidationError(io.k8s.api.core.v1.Pod.metadata.managedFields[2]): unknown field \\"subresource\\" in io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry","code":400}\n'
+```
+
+## Solution
+
+The issue can be resolved by temporarily removing Kyverno webhook configurations and restarting
+the Kyverno deployment to reset the webhook state.
+
+1. (`ncn-mw#`) Remove the Kyverno webhook configurations.
+
+   Commands:
+
+   ```bash
+   kubectl delete validatingwebhookconfiguration kyverno-resource-validating-webhook-cfg
+   kubectl delete mutatingwebhookconfiguration kyverno-resource-mutating-webhook-cfg
+   ```
+
+1. (`ncn-mw#`) Scale down the Kyverno deployment.
+
+   Command:
+
+   ```bash
+   kubectl scale deploy cray-kyverno -n kyverno --replicas 0
+   ```
+
+1. (`ncn-mw#`) Scale up the Kyverno deployment.
+
+   Command:
+
+   ```bash
+   kubectl scale deploy cray-kyverno -n kyverno --replicas 3
+   ```
+
+1. (`ncn-mw#`) Wait approximately 5 minutes and verify that PostgreSQL clusters return to
+   `Running` state.
+
+   Command:
+
+   ```bash
+   kubectl get postgresql -A
+   ```
+
+   Example output:
+
+   ```text
+   NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
+   argo        cray-nls-postgres            cray-nls            14        3      2Gi                                     12h   Running
+   services    cfs-ara-postgres             cfs-ara             14        3      50Gi     100m          100Mi            12h   Running
+   services    cray-console-data-postgres   cray-console-data   14        3      2Gi      100m          256Mi            12h   Running
+   services    cray-dns-powerdns-postgres   cray-dns-powerdns   14        3      10Gi     100m          100Mi            12h   Running
+   services    cray-sls-postgres            cray-sls            14        3      1Gi      100m          128Mi            12h   Running
+   services    cray-smd-postgres            cray-smd            14        3      100Gi    1             100Mi            12h   Running
+   services    gitea-vcs-postgres           gitea-vcs           14        3      50Gi     100m          256Mi            12h   Running
+   services    keycloak-postgres            keycloak            14        3      10Gi                                    12h   Running
+   spire       cray-spire-postgres          cray-spire          14        3      60Gi     1             1Gi              9h    Running
+   spire       spire-postgres               spire               14        3      60Gi     1             4Gi              12h   Running
+   ```
+
+This workaround is based on the [Kyverno troubleshooting guide](https://kyverno.io/docs/troubleshooting/)
+and will be resolved in a future CSM release.


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When upgrading CSM from 1.4 to 1.5, sometimes Postgres clusters could be stuck in SyncFailed state due to kyverno policy conflicts. This PR adds a known issue and updates the release note.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
