### PR TITLE
CASMCMS-9521 - document cray cli console login password visibility.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -844,6 +844,7 @@ waiting_admin
 webUI
 webhook
 webserver
+websocket
 whitespace
 wireshark
 workarea

--- a/operations/conman/Configure_Log_Rotation.md
+++ b/operations/conman/Configure_Log_Rotation.md
@@ -103,7 +103,7 @@ On a regular schedule, the log rotation will execute the following steps:
     subject to rotation.
 
     If the files are larger than the `LOG_ROTATE_FILE_SIZE`, decrease the
-    value of `LOG_ROTATE_SEC_FREQ` so the rotation happens too often.
+    value of `LOG_ROTATE_SEC_FREQ` so the rotation happens more often.
 
 1. Log files are being rotated before a complete boot.
 

--- a/operations/conman/Console_Services_Troubleshooting_Guide.md
+++ b/operations/conman/Console_Services_Troubleshooting_Guide.md
@@ -302,13 +302,41 @@ There are a couple of ways to resolve this situation.
 
         Modify the value of `spec.resources.requests.storage` to increased value required:
 
-        ```text
+        ```yaml
         spec:
-        accessModes:
-        - ReadWriteMany
-        resources:
+          accessModes:
+          - ReadWriteMany
+          resources:
             requests:
-            storage: 150Gi
+              storage: 200Gi
+        ```
+
+    1. Update the customizations.yaml to persist the `pvc` size change.
+
+        Download the customizations.yaml
+
+        ```bash
+        kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+        ```
+
+        Edit customizations.yaml to add cray-console-operator cray-service.persistentVolumeClaims.data-claim.resources.requests.storage
+        to match the new size set in the PVC above. For example, if the new size is 200Gi:
+
+        ```yaml
+        cray-console-operator:
+          cray-service:
+            persistentVolumeClaims:
+              data-claim:
+                resources:
+                  requests:
+                    storage: 200Gi
+        ```
+
+        Save the changed customizations.yaml
+
+        ```bash
+        kubectl delete secret -n loftsman site-init
+        kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
         ```
 
     1. Scale the number of `cray-console-operator` pods to zero.
@@ -334,30 +362,3 @@ There are a couple of ways to resolve this situation.
     When the `cray-console-operator` pod resumes operation it will scale the number
     `cray-console-node` pods back up automatically. After all pods are back up and
     ready, the new increased size of the PVC will be visible from within the pods.
-
-    1. Update the customizations.yaml to persist the `pvc` size change.
-
-    Download the customizations.yaml
-
-    ```bash
-    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-    ```
-
-    Edit customizations.yaml to add cray-console-operator cray-service.persistentVolumeClaims.data-claim.resources.requests.storage
-
-    ```yaml
-      cray-console-operator:
-        cray-service:
-          persistentVolumeClaims:
-            data-claim:
-              resources:
-                requests:
-                  storage: 200Gi
-    ````
-
-    Save the changed customizations.yaml
-
-    ```bash
-    kubectl delete secret -n loftsman site-init
-    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```

--- a/operations/conman/Console_Services_Troubleshooting_Guide.md
+++ b/operations/conman/Console_Services_Troubleshooting_Guide.md
@@ -311,33 +311,37 @@ There are a couple of ways to resolve this situation.
               storage: 200Gi
         ```
 
-    1. Update the customizations.yaml to persist the `pvc` size change.
+    1. Update `customizations.yaml` to persist the PVC size change.
 
-        Download the customizations.yaml
+        1. Download `customizations.yaml`
 
-        ```bash
-        kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-        ```
+            ```bash
+            kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+            ```
 
-        Edit customizations.yaml to add cray-console-operator cray-service.persistentVolumeClaims.data-claim.resources.requests.storage
-        to match the new size set in the PVC above. For example, if the new size is 200Gi:
+        1. Edit `customizations.yaml`.
 
-        ```yaml
-        cray-console-operator:
-          cray-service:
-            persistentVolumeClaims:
-              data-claim:
-                resources:
-                  requests:
-                    storage: 200Gi
-        ```
+            Add `cray-console-operator cray-service.persistentVolumeClaims.data-claim.resources.requests.storage`
+            to match the new size set in the PVC above.
 
-        Save the changed customizations.yaml
+            For example, if the new size is `200Gi`:
 
-        ```bash
-        kubectl delete secret -n loftsman site-init
-        kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-        ```
+            ```yaml
+            cray-console-operator:
+              cray-service:
+                persistentVolumeClaims:
+                  data-claim:
+                    resources:
+                      requests:
+                        storage: 200Gi
+            ```
+
+        1. Save the changed `customizations.yaml`
+
+            ```bash
+            kubectl delete secret -n loftsman site-init
+            kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+            ```
 
     1. Scale the number of `cray-console-operator` pods to zero.
 

--- a/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
+++ b/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
@@ -83,14 +83,7 @@ The user performing these procedures needs to have access permission to the `cra
 
 1. (`ncn-mw#`) Establish a serial console session with the desired NCN.
 
-    ```bash
-    cray console interact $XNAME
-    ```
-
-    The console session log files for each NCN are located in a shared volume in the `cray-console-node` pods.
-    In those pods, the log files are in the `/var/log/conman/` directory and are named `console.<xname>`.
-
-1. Exit the connection to the console by entering `&.``[Enter]`.
+    Follow the instructions in [Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md).
 
 ## Evacuation procedure
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -13,12 +13,12 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 * Tenant access restriction requires use of the Cray CLI method. Direct access to ConMan within a K8S pod does not restrict access by tenant.
 * If the user is a member of a tenant, then only the consoles for that tenant are available.
 
-## Procedure to Log in using the Cray CLI
+## Procedure to log in using the Cray CLI
 
-> **`IMPORTANT`** When using the `cray` CLI for access and a password is required it will be visible on the
+> **`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the
 > screen as it is being typed. The websocket connection is secure and the password will not be recorded
-> in the console logs but it will be visible to anyone looking at your screen. If this is a concern, use
-> the procedure below to log in using ConMan directly within a K8S pod.
+> in the console logs but it will be visible on the screen and will be captured by a `screen` session. If this is a concern, use
+> the [procedure to log in using ConMan directly within a Kubernetes pod](#procedure-to-log-in-using-conman-directly-within-a-kubernetes-pod).
 >
 > **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
@@ -54,7 +54,7 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
     Connection closed by the server.
     ```
 
-## Procedure to Log in using ConMan Directly Within a K8S Pod
+## Procedure to log in using ConMan directly within a Kubernetes pod
 
 > **`NOTE`** this procedure has changed since the CSM 0.9 release.
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -21,7 +21,7 @@ These procedures show how to connect to the node's Serial Over LAN (SOL) via Con
 
 **`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the screen as it is
 being typed. The websocket connection is secure and the password will not be recorded in the console logs, but it will be
-visible on the screen and will be captured by a `screen` session. If this is a concern, use the procedure to
+visible on the screen and will be captured by a `screen` session, if one is running. If this is a concern, use the procedure to
 [log in using ConMan directly within a Kubernetes pod](#log-in-using-conman-directly-within-a-kubernetes-pod).
 
 ### Procedure to log in using Cray CLI

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -10,8 +10,8 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* Tenant access restriction requires use of the Cray CLI method. Direct access to ConMan within a K8S pod does not restrict access by tenant.
-* If the user is a member of a tenant, then only the consoles for that tenant are available.
+* Tenant access restriction requires use of the Cray CLI method. Direct access to ConMan within a Kubernetes pod does not restrict access by tenant.
+* If the user is a member of a tenant, then only the consoles for that tenant are available when using the CLI.
 
 ## Log in using the Cray CLI
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -10,10 +10,16 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 ## Limitations
 
 * Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
-* If the user is a member of a tenant, then only the logs for that tenant are available.
+* Tenant access restriction requires use of the Cray CLI method. Direct access to ConMan within a K8S pod does not restrict access by tenant.
+* If the user is a member of a tenant, then only the consoles for that tenant are available.
 
-## Procedure
+## Procedure to Log in using the Cray CLI
 
+> **`IMPORTANT`** When using the `cray` CLI for access and a password is required it will be visible on the
+> screen as it is being typed. The websocket connection is secure and the password will not be recorded
+> in the console logs but it will be visible to anyone looking at your screen. If this is a concern, use
+> the procedure below to log in using ConMan directly within a K8S pod.
+>
 > **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
 1. Log on to a Kubernetes master or worker node.
@@ -28,7 +34,6 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 
     ```text
     Connected to wss://api-gw-service-nmn.local/apis/console-operator/console-operator/interact/x3000c0s19b1n0
-
     <ConMan> Connection to console [x3000c0s19b1n0] opened.
 
     nid000001 login:
@@ -48,3 +53,58 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
     <ConMan> Connection to console [x3000c0s19b1n0] closed.
     Connection closed by the server.
     ```
+
+## Procedure to Log in using ConMan Directly Within a K8S Pod
+
+> **`NOTE`** this procedure has changed since the CSM 0.9 release.
+
+1. Log on to a Kubernetes master or worker node.
+
+1. (`ncn-mw#`) Find the `cray-console-operator` pod.
+
+    ```bash
+    OP_POD=$(kubectl get pods -n services -o wide|grep cray-console-operator|awk '{print $1}'); echo $OP_POD
+    ```
+
+    Example output:
+
+    ```text
+    cray-console-operator-6cf89ff566-kfnjr
+    ```
+
+1. (`ncn-mw#`) Set the `XNAME` variable to the component name (xname) of the node whose console is to be opened.
+
+    ```bash
+    XNAME=x123456789s0c0n0
+    ```
+
+1. (`ncn-mw#`) Find the `cray-console-node` pod that is connected to that node.
+
+    ```bash
+    NODEPOD=$(kubectl -n services exec $OP_POD -c cray-console-operator -- sh -c "/app/get-node $XNAME" | jq .podname | sed 's/"//g')
+    echo $NODEPOD
+    ```
+
+    Example output:
+
+    ```text
+    cray-console-node-1
+    ```
+
+1. (`ncn-mw#`) Connect to the node's console using ConMan on the `cray-console-node` pod which was found.
+
+    ```bash
+    kubectl exec -it -n services $NODEPOD -c cray-console-node -- conman -j $XNAME
+    ```
+
+    Example output:
+
+    ```text
+    <ConMan> Connection to console [x3000c0s25b1] opened.
+
+    nid000009 login:
+    ```
+
+    Using the command above, a user can also attach to an already active SOL session that is being used by another user, so both can access the node's SOL simultaneously.
+
+1. Exit the connection to the console with the `&.` command.

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -1,6 +1,8 @@
 # Log in to a Node Using ConMan
 
-This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConMan.
+These procedures show how to connect to the node's Serial Over LAN (SOL) via ConMan.
+
+> **`NOTE`** These procedures have changed since the CSM 1.6 release.
 
 ## Prerequisites
 
@@ -23,8 +25,6 @@ visible on the screen and will be captured by a `screen` session. If this is a c
 [log in using ConMan directly within a Kubernetes pod](#log-in-using-conman-directly-within-a-kubernetes-pod).
 
 ### Procedure to log in using Cray CLI
-
-> **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
 1. Log on to a Kubernetes master or worker node.
 
@@ -60,7 +60,7 @@ visible on the screen and will be captured by a `screen` session. If this is a c
 
 ## Log in using ConMan directly within a Kubernetes pod
 
-> **`NOTE`** this procedure has changed since the CSM 0.9 release.
+> **`NOTE`** This procedure has changed since the CSM 0.9 release.
 
 1. Log on to a Kubernetes master or worker node.
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -17,7 +17,6 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 
 ### Sensitive input echoed when using CLI to access console
 
-
 **`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the screen as it is
 being typed. The websocket connection is secure and the password will not be recorded in the console logs but it will be
 visible on the screen and will be captured by a `screen` session. If this is a concern, use the procedure to

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -13,13 +13,18 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
 * Tenant access restriction requires use of the Cray CLI method. Direct access to ConMan within a K8S pod does not restrict access by tenant.
 * If the user is a member of a tenant, then only the consoles for that tenant are available.
 
-## Procedure to log in using the Cray CLI
+## Log in using the Cray CLI
 
-> **`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the
-> screen as it is being typed. The websocket connection is secure and the password will not be recorded
-> in the console logs but it will be visible on the screen and will be captured by a `screen` session. If this is a concern, use
-> the [procedure to log in using ConMan directly within a Kubernetes pod](#procedure-to-log-in-using-conman-directly-within-a-kubernetes-pod).
->
+### Sensitive input echoed when using CLI to access console
+
+
+**`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the screen as it is
+being typed. The websocket connection is secure and the password will not be recorded in the console logs but it will be
+visible on the screen and will be captured by a `screen` session. If this is a concern, use the procedure to
+[log in using ConMan directly within a Kubernetes pod](#log-in-using-conman-directly-within-a-kubernetes-pod).
+
+### Procedure to log in using Cray CLI
+
 > **`NOTE`** this procedure has changed since the CSM 1.6.x releases.
 
 1. Log on to a Kubernetes master or worker node.
@@ -54,7 +59,7 @@ This procedure shows how to connect to the node's Serial Over LAN (SOL) via ConM
     Connection closed by the server.
     ```
 
-## Procedure to log in using ConMan directly within a Kubernetes pod
+## Log in using ConMan directly within a Kubernetes pod
 
 > **`NOTE`** this procedure has changed since the CSM 0.9 release.
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -20,7 +20,7 @@ These procedures show how to connect to the node's Serial Over LAN (SOL) via Con
 ### Sensitive input echoed when using CLI to access console
 
 **`IMPORTANT`** When using the `cray` CLI for access and a password is required, it will be visible on the screen as it is
-being typed. The websocket connection is secure and the password will not be recorded in the console logs but it will be
+being typed. The websocket connection is secure and the password will not be recorded in the console logs, but it will be
 visible on the screen and will be captured by a `screen` session. If this is a concern, use the procedure to
 [log in using ConMan directly within a Kubernetes pod](#log-in-using-conman-directly-within-a-kubernetes-pod).
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -70,6 +70,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [PostgreSQL Cluster Upgrades Failing](known_issues/postgres_cluster_upgrade_failure.md)
 * [IMS Image Customization Job Status Stuck at `waiting_on_user`](known_issues/ims_image_customization_job_status_stuck_at_waiting_on_user.md)
 * [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
+* [Sensitive input echoed when using CLI to access console](../operations/conman/Log_in_to_a_Node_Using_ConMan.md#sensitive-input-echoed-when-using-cli-to-access-console)
 * Systems running CSM 1.6 or earlier that fresh install CSM 1.7 must regenerate their
   management switch configuration because of the
   [Other behavior changes](../introduction/csi_Tool_Changes.md#other-behavior-changes)
@@ -109,6 +110,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [ConMan Failing to Connect to a Console](../operations/conman/Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
 * [ConMan Asking for Password on SSH Connection](../operations/conman/Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
 * [Console Node Pod Stuck in Terminating State](../operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
+* [Sensitive input echoed when using CLI to access console](../operations/conman/Log_in_to_a_Node_Using_ConMan.md#sensitive-input-echoed-when-using-cli-to-access-console)
 
 ## Customer Management Network (CMN)
 


### PR DESCRIPTION
# Description

Document that limitation that if using the cray CLI to interact with a node console and a password is required, that password will be visible to people that can view the screen. It is not logged, but is visible.

Plus a little general cleanup of the console docs while I was in there.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
