### PR TITLE
CASMCMS-9520: Improve CFS documentation about Ansible verbosity

### DIFF
--- a/operations/configuration_management/Change_the_Ansible_Verbosity.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity.md
@@ -9,7 +9,7 @@
 ## Overview
 
 When debugging, it can be useful to view the Ansible logs with greater verbosity than
-the default. The verbosity level is an integer. Valid verbosity levels are integers
+the default. Valid verbosity levels are the integers
 `0` (the default) through `4`, with higher numbers indicating increased verbosity.
 These translate into the number of `-v` arguments passed into the `ansible-playbook`
 command when the playbooks are executed.

--- a/operations/configuration_management/Change_the_Ansible_Verbosity.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity.md
@@ -1,16 +1,100 @@
 # Change the Ansible Verbosity
 
-When debugging, it can be useful to view the Ansible logs with greater verbosity than the default.
-CFS sessions are able to set the Ansible verbosity from the command line when the session is created.
-The verbosity will apply to all configuration layers in the session.
+* [Overview](#overview)
+* [How Ansible verbosity level is determined](#how-ansible-verbosity-level-is-determined)
+* [Considerations for high verbosity levels](#considerations-for-high-verbosity-levels)
+* [Creating sessions with increased verbosity][create]
+* [Increasing verbosity for sessions that are not created directly][indirect]
 
-Specify an integer using the `--ansible-verbosity` option, where 1 = `-v`, 2 = `-vv`.
-Valid values range from 0 \(default\) to 4.
-See the `ansible-playbook` help for more information.
+## Overview
 
-It is not recommended to use level 3 or 4 with sessions that target large numbers of hosts.
-When using `--ansible-verbosity` to debug Ansible plays or roles, consider also limiting the session targets with `--ansible-limit` to reduce log output.
+When debugging, it can be useful to view the Ansible logs with greater verbosity than
+the default. The verbosity level is an integer. Valid verbosity levels are integers
+`0` (the default) through `4`, with higher numbers indicating increased verbosity.
+These translate into the number of `-v` arguments passed into the `ansible-playbook`
+command when the playbooks are executed.
 
-> **WARNING:** Setting the `--ansible-verbosity` to 4 can cause CFS sessions to hang.
-> To correct this issue, reduce the verbosity to 3 or lower, or adjust the usage of the `display_ok_hosts` and `display_skipped_hosts` settings in the `ansible.cfg` file the session is using.
-> Consider also reviewing the Ansible tasks being run and reducing the amount log output from these individual tasks.
+| *Verbosity* | *Argument* |
+|:-----------:| ---------- |
+| `0`         |            |
+| `1`         | `-v`       |
+| `2`         | `-vv`      |
+| `3`         | `-vvv`     |
+| `4`         | `-vvvv`    |
+
+## How Ansible verbosity level is determined
+
+The Ansible verbosity is determined at the time that the CFS session starts.
+The verbosity is applied to all configuration layers in the session.
+The verbosity is set to the first one of the following things that successfully
+specifies a verbosity level.
+
+1. If a verbosity level was specified directly when the session was created (using the
+   CFS API or CLI), then this level is used.
+1. If an Ansible configuration was specified directly when the session was created
+   (using the CFS API or CLI), and if that configuration specifies a verbosity level,
+   then this level is used.
+1. If no Ansible configuration was specified directly when the session was created
+   (using the CFS API or CLI), and if a verbosity level is specified in the
+   [default Ansible configuration][ancfg], then this level is used.
+1. Default to running at a verbosity level of `0`.
+
+For more information on Ansible configurations, see
+[Configure Ansible](Configure_Ansible.md).
+
+## Considerations for high verbosity levels
+
+When increasing Ansible verbosity, be aware that it can produce a lot of output, and
+in some cases can even cause problems.
+
+* It is not recommended to use level `3` or `4` with sessions that target a large numbers
+  of hosts. Avoid this by setting an Ansible limit, reducing the number of targets.
+    * See [Creating sessions with increased verbosity][create] for details on
+      how to specify an Ansible limit.
+* Consider reviewing the Ansible tasks being run and altering them, in order to reduce their
+  log output.
+* **WARNING:** Setting the Ansible verbosity to `4` can cause CFS sessions to hang. There
+  are multiple ways to avoid this issue:
+    * Reduce the verbosity to `3` or lower.
+    * Adjust the `display_ok_hosts` and `display_skipped_hosts` settings in the
+      Ansible configuration that the session is using. For more details, see
+      [Configure Ansible](Configure_Ansible.md).
+
+## Creating sessions with increased verbosity
+
+When creating a CFS session using the API or CLI, there are several different parameters that
+may be specified. The following table shows the appropriate argument or field to use in
+order to specify the Ansible configuration, limit, or verbosity.
+
+> If no Ansible configuration is directly specified, the session will use the
+> [default Ansible configuration][ancfg].
+
+| *Parameter*             | *CLI*                 | *API (v3)*          | *API (v2)*         |
+| ----------------------- | --------------------- | ------------------- | ------------------ |
+| *Ansible configuration* | `--ansible-config`    | `ansible_config`    | `ansibleConfig`    |
+| *Ansible limit*         | `--ansible-limit`     | `ansible_limit`     | `ansibleLimit`     |
+| *Ansible verbosity*     | `--ansible-verbosity` | `ansible_verbosity` | `ansibleVerbosity` |
+
+## Increasing verbosity for sessions that are not created directly
+
+Not all CFS sessions are created directly by an administrator. For example:
+
+* A session may be created indirectly (as part of a [SAT][sat] or [IUF][iuf] operation,
+  for example).
+* A session may be created by the CFS batcher. For more information on the CFS batcher,
+  see [Automatic Configuration Management](Automatic_Configuration_Management.md).
+
+In these cases, an administrator is not able to directly specify these parameters using the
+method described in the previous section. However, these sessions will run using the
+[default Ansible configuration][ancfg]. Any parameters specified in this Ansible
+configuration will be used in these automatic or indirectly-created CFS sessions.
+In particular, this is where an administrator is able to specify an Ansible verbosity
+level for these sessions. For more details, see [Configure Ansible](Configure_Ansible.md).
+
+<!--- Define the reference-style Markdown links used to improve readability -->
+
+[ancfg]: CFS_Global_Options.md#default-ansible-configuration
+[create]: #creating-sessions-with-increased-verbosity
+[indirect]: #increasing-verbosity-for-sessions-that-are-not-created-directly
+[iuf]: ../../glossary.md#install-and-upgrade-framework-iuf
+[sat]: ../../glossary.md#system-admin-toolkit-sat


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This PR is an overhaul of the CFS document describing how to increase the Ansible verbosity. My original motivation was to address the fact that the page implicitly assumed that the CFS session in question was one that the admin was creating directly themselves, even though this is often not the case, with things like batcher, SAT, or IUF starting sessions. So the PR addresses that, but it also attempts to organize all of the information in a more comprehensible way, with relevant links provided for additional information.

For all that, there isn't actually a great deal of totally new content in here -- most of it is just expanding on or linking to things that are already there.

I am planning on making related changes and improvements to other pages, like I did with the options page and now this one. I am just trying to keep each PR as small as possible (while still being able to stand on its own), to help with reviewing.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/6291
1.5: https://github.com/Cray-HPE/docs-csm/pull/6292
1.4: https://github.com/Cray-HPE/docs-csm/pull/6293
1.3: https://github.com/Cray-HPE/docs-csm/pull/6294
1.2: https://github.com/Cray-HPE/docs-csm/pull/6295
1.0: https://github.com/Cray-HPE/docs-csm/pull/6296

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
