### PR TITLE
CASMCMS-9520: Improve CFS documentation about Ansible verbosity; add v1/v2 option info

### DIFF
--- a/operations/configuration_management/CFS_Global_Options.md
+++ b/operations/configuration_management/CFS_Global_Options.md
@@ -28,23 +28,25 @@ Example output:
 
 The values for all CFS global options can be modified with the `cray cfs options update` command.
 
-The following are the CFS global options, their names in CFS, and their default values.
+The following are the CFS global options, their names in CFS, which CFS API versions support them, and their default values.
 
-| *Option*                                | *CFS name*                  | *Default*                   | *Type*  | *Units/format*                         |
-| --------------------------------------- | --------------------------- | --------------------------- | ------- | -------------------------------------- |
-| [Additional inventory URL][add-url]     | `additionalInventoryUrl`    | `""`                        | string  | Git clone URL                          |
-| [Batch size][bat-siz]                   | `batchSize`                 | `25`                        | integer | Components                             |
-| [Batch window][bat-win]                 | `batchWindow`               | `60`                        | integer | seconds                                |
-| [Batcher check interval][bat-chk]       | `batcherCheckInterval`      | `10`                        | integer | seconds                                |
-| [Batcher maximum backoff][bat-bac]      | `batcherMaxBackoff`         | `3600`                      | integer | seconds                                |
-| [Default Ansible configuration][ancfg]  | `defaultAnsibleConfig`      | `"cfs-default-ansible-cfg"` | string  | ConfigMap name in `services` namespace |
-| [Default batcher retry policy][bat-ret] | `defaultBatcherRetryPolicy` | `3`                         | integer | Component configuration attempts       |
-| [Default clone URL][clo-url]        | `defaultCloneUrl` | `"https://api-gw-service-nmn.local/vcs/cray/config-management.git"` | string | Git clone URL |
-| [Default playbook][pbook]               | `defaultPlaybook`           | `"site.yml"`                | string  | Name of Ansible playbook               |
-| [Hardware synchronization interval][hw] | `hardwareSyncInterval`      | `10`                        | integer | seconds                                |
-| [Session Time-To-Live (TTL)][ses-ttl]   | `sessionTTL`                | `"7d"`                      | string  | Length of time or empty string         |
+| *Option*                                | *CFS name*                  | *API versions* | *Default*                   | *Type*  | *Units/format*                         |
+| --------------------------------------- | --------------------------- | -------------- | --------------------------- | ------- | -------------------------------------- |
+| [Additional inventory URL][add-url]     | `additionalInventoryUrl`    | 2              | `""`                        | string  | Git clone URL                          |
+| [Batch size][bat-siz]                   | `batchSize`                 | 1, 2           | `25`                        | integer | Components                             |
+| [Batch window][bat-win]                 | `batchWindow`               | 1, 2           | `60`                        | integer | seconds                                |
+| [Batcher check interval][bat-chk]       | `batcherCheckInterval`      | 1, 2           | `10`                        | integer | seconds                                |
+| [Batcher maximum backoff][bat-bac]      | `batcherMaxBackoff`         | 2              | `3600`                      | integer | seconds                                |
+| [Default Ansible configuration][ancfg]  | `defaultAnsibleConfig`      | 1, 2           | `"cfs-default-ansible-cfg"` | string  | ConfigMap name in `services` namespace |
+| [Default batcher retry policy][bat-ret] | `defaultBatcherRetryPolicy` | 1, 2           | `3`                         | integer | Component configuration attempts       |
+| [Default clone URL][clo-url]        | `defaultCloneUrl` | 1 | `"https://api-gw-service-nmn.local/vcs/cray/config-management.git"` | string | Git clone URL |
+| [Default playbook][pbook]               | `defaultPlaybook`           | 1, 2           | `"site.yml"`                | string  | Name of Ansible playbook               |
+| [Hardware synchronization interval][hw] | `hardwareSyncInterval`      | 1, 2           | `10`                        | integer | seconds                                |
+| [Session Time-To-Live (TTL)][ses-ttl]   | `sessionTTL`                | 1, 2           | `"7d"`                      | string  | Length of time or empty string         |
 
 ## Additional inventory URL
+
+> **NOTE:** This option is not available in CFS v1.
 
 A Git clone URL to supply additional inventory content to all CFS sessions.
 
@@ -96,6 +98,8 @@ See [Configuration Management with the CFS Batcher](Configuration_Management_wit
 
 ## Batcher maximum backoff
 
+> **NOTE:** This option is not available in CFS v1.
+
 This option specifies the maximum number of seconds that the CFS batcher's back-off will reach.
 
 * Name: `batcherMaxBackoff`
@@ -131,6 +135,8 @@ For more information, see:
 * [Configuration Management of System Components](Configuration_Management_of_System_Components.md)
 
 ## Default clone URL
+
+> **NOTE:** This option is not available in CFS v2.
 
 **NOTE**: This option is deprecated and has no effect. It is removed in CSM 1.2.
 

--- a/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
@@ -1,10 +1,98 @@
 # Change the Ansible Verbosity Logs
 
-It is useful to view the Ansible logs in a Configuration Framework Session \(CFS\) session with greater verbosity than the default. CFS sessions are able to set the Ansible verbosity from the command line when the session is created. The verbosity will apply to all configuration layers in the session.
+* [Overview](#overview)
+* [How Ansible verbosity level is determined](#how-ansible-verbosity-level-is-determined)
+* [Considerations for high verbosity levels](#considerations-for-high-verbosity-levels)
+* [Creating sessions with increased verbosity][create]
+* [Increasing verbosity for sessions that are not created directly][indirect]
 
-Specify an integer using the --ansible-verbosity option, where 1 = `-v`, 2 = `-vv`, and so on. Valid values range from 0 \(default\) to 4. See the `ansible-playbook` help for more information.
+## Overview
 
-It is not recommended to use level 3 or 4 with sessions that target large numbers of hosts. When using --ansible-verbosity to debug Ansible plays or roles, consider also limiting the session targets with --ansible-limit to reduce log output.
+When debugging, it can be useful to view the Ansible logs with greater verbosity than
+the default. The verbosity level is an integer. Valid verbosity levels are integers
+`0` (the default) through `4`, with higher numbers indicating increased verbosity.
+These translate into the number of `-v` arguments passed into the `ansible-playbook`
+command when the playbooks are executed.
 
-**Warning:** Setting the --ansible-verbosity to 4 can cause CFS sessions to hang for unknown reasons. To correct this issue, reduce the verbosity to 3 or lower, or adjust the usage of the `display_ok_hosts` and `display_skipped_hosts` settings in the ansible.cfg file the session is using. Consider also reviewing the Ansible tasks being run and reducing the amount log output from these individual tasks.
+| *Verbosity* | *Argument* |
+|:-----------:| ---------- |
+| `0`         |            |
+| `1`         | `-v`       |
+| `2`         | `-vv`      |
+| `3`         | `-vvv`     |
+| `4`         | `-vvvv`    |
 
+## How Ansible verbosity level is determined
+
+The Ansible verbosity is determined at the time that the CFS session starts.
+The verbosity is applied to all configuration layers in the session.
+The verbosity is set to the first one of the following things that successfully
+specifies a verbosity level.
+
+1. If a verbosity level was specified directly when the session was created (using the
+   CFS API or CLI), then this level is used.
+1. If an Ansible configuration was specified directly when the session was created
+   (using the CFS API or CLI), and if that configuration specifies a verbosity level,
+   then this level is used.
+1. If no Ansible configuration was specified directly when the session was created
+   (using the CFS API or CLI), and if a verbosity level is specified in the
+   [default Ansible configuration][ancfg], then this level is used.
+1. Default to running at a verbosity level of `0`.
+
+For more information on Ansible configurations, see
+[Set the `ansible.cfg` for a Session](Set_the_ansible-cfg_for_a_Session.md).
+
+## Considerations for high verbosity levels
+
+When increasing Ansible verbosity, be aware that it can produce a lot of output, and
+in some cases can even cause problems.
+
+* It is not recommended to use level `3` or `4` with sessions that target a large numbers
+  of hosts. Avoid this by setting an Ansible limit, reducing the number of targets.
+    * See [Creating sessions with increased verbosity][create] for details on
+      how to specify an Ansible limit.
+* Consider reviewing the Ansible tasks being run and altering them, in order to reduce their
+  log output.
+* **WARNING:** Setting the Ansible verbosity to `4` can cause CFS sessions to hang. There
+  are multiple ways to avoid this issue:
+    * Reduce the verbosity to `3` or lower.
+    * Adjust the `display_ok_hosts` and `display_skipped_hosts` settings in the
+      Ansible configuration that the session is using. For more details, see
+      [Set the `ansible.cfg` for a Session](Set_the_ansible-cfg_for_a_Session.md).
+
+## Creating sessions with increased verbosity
+
+When creating a CFS session using the API or CLI, there are several different parameters that
+may be specified. The following table shows the appropriate argument or field to use in
+order to specify the Ansible configuration, limit, or verbosity.
+
+> If no Ansible configuration is directly specified, the session will use the
+> [default Ansible configuration][ancfg].
+
+| *Parameter*             | *CLI*                 | *API*              |
+| ----------------------- | --------------------- | ------------------ |
+| *Ansible configuration* | `--ansible-config`    | `ansibleConfig`    |
+| *Ansible limit*         | `--ansible-limit`     | `ansibleLimit`     |
+| *Ansible verbosity*     | `--ansible-verbosity` | `ansibleVerbosity` |
+
+## Increasing verbosity for sessions that are not created directly
+
+Not all CFS sessions are created directly by an administrator. For example:
+
+* A session may be created indirectly (as part of a script being run,
+  for example).
+* A session may be created by the CFS batcher. For more information,
+  see [Configuration Management with the CFS Batcher](Configuration_Management_with_the_CFS_Batcher.md).
+
+In these cases, an administrator is not able to directly specify these parameters using the
+method described in the previous section. However, these sessions will run using the
+[default Ansible configuration][ancfg]. Any parameters specified in this Ansible
+configuration will be used in these automatic or indirectly-created CFS sessions.
+In particular, this is where an administrator is able to specify an Ansible verbosity
+level for these sessions. For more details, see [Set the `ansible.cfg` for a Session](Set_the_ansible-cfg_for_a_Session.md).
+
+<!--- Define the reference-style Markdown links used to improve readability -->
+
+[ancfg]: CFS_Global_Options.md#default-ansible-configuration
+[create]: #creating-sessions-with-increased-verbosity
+[indirect]: #increasing-verbosity-for-sessions-that-are-not-created-directly

--- a/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
@@ -49,16 +49,16 @@ in some cases can even cause problems.
 
 * It is not recommended to use level `3` or `4` with sessions that target a large numbers
   of hosts. Avoid this by setting an Ansible limit, reducing the number of targets.
-    * See [Creating sessions with increased verbosity][create] for details on
-      how to specify an Ansible limit.
+  * See [Creating sessions with increased verbosity][create] for details on
+    how to specify an Ansible limit.
 * Consider reviewing the Ansible tasks being run and altering them, in order to reduce their
   log output.
 * **WARNING:** Setting the Ansible verbosity to `4` can cause CFS sessions to hang. There
   are multiple ways to avoid this issue:
-    * Reduce the verbosity to `3` or lower.
-    * Adjust the `display_ok_hosts` and `display_skipped_hosts` settings in the
-      Ansible configuration that the session is using. For more details, see
-      [Set the `ansible.cfg` for a Session](Set_the_ansible-cfg_for_a_Session.md).
+  * Reduce the verbosity to `3` or lower.
+  * Adjust the `display_ok_hosts` and `display_skipped_hosts` settings in the
+    Ansible configuration that the session is using. For more details, see
+    [Set the `ansible.cfg` for a Session](Set_the_ansible-cfg_for_a_Session.md).
 
 ## Creating sessions with increased verbosity
 

--- a/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity_Logs.md
@@ -9,7 +9,7 @@
 ## Overview
 
 When debugging, it can be useful to view the Ansible logs with greater verbosity than
-the default. The verbosity level is an integer. Valid verbosity levels are integers
+the default. Valid verbosity levels are the integers
 `0` (the default) through `4`, with higher numbers indicating increased verbosity.
 These translate into the number of `-v` arguments passed into the `ansible-playbook`
 command when the playbooks are executed.


### PR DESCRIPTION
* Backport of https://github.com/Cray-HPE/docs-csm/pull/6290
* Added a few tiny updates to the options page, to indicate which options are available in CFS v1 vs v2