### PR TITLE
CASMPET-7674: Add audit logging note to Kubernetes Upgrade documentation

### DIFF
--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -257,6 +257,8 @@ Run the following script to apply anti-affinity to `coredns` pods:
 ```
 
 > **`NOTE`**: `kubelet` has been upgraded already, ignore the warning to upgrade it.
+Additionally, if Kubernetes audit logging is enabled, local configuration changes will be lost as the
+audit logging configuration will be reset to defaults defined in [Audit Logs](../operations/security_and_authentication/Audit_Logs.md)
 
 - Uninstall the deprecated `etcd-operator`.
 


### PR DESCRIPTION
# Description
CASMPET-7674: Add audit logging note to Kubernetes Upgrade documentation that local audit logging configuration changes will be lost when reset to defaults.

I will be adding a similar note to release/1.6 and release/1.7 deploy product workflow, where `upgrade_control_plane.sh` is executed.

This note was requested by LANL in CAST-38647.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
