### PR TITLE
CASMPET-7674: Add note to deploy product about Kubernetes audit log config

### DIFF
--- a/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
+++ b/operations/iuf/workflows/upgrade_csm_and_additional_products_with_iuf.md
@@ -69,7 +69,10 @@ For more detail about about the CSM upgrade hooks, see the section [Description 
 
 1. Deploy product
 
-   > **NOTE** The application of networking changes and CoreDNS anti-affinity changes along with the upgrade of the Kubernetes control plane is performed in a hook automatically executed after `deploy-product`.
+   > **NOTE** The application of networking changes and CoreDNS anti-affinity changes along with the upgrade of
+   the Kubernetes control plane is performed in a hook automatically executed after `deploy-product`.
+   During the Kubernetes control plane upgrade, if Kubernetes audit logging is enabled, local audit log
+   configuration changes will be lost as the audit log configuration will be reset to defaults defined in [Audit Logs](../../security_and_authentication/Audit_Logs.md).
 
    Follow these IUF instructions in order:
 
@@ -104,3 +107,6 @@ The hooks below are automatically executed when CSM is being upgraded with IUF.
 
    The application of networking changes and CoreDNS anti-affinity changes along with the upgrade of the Kubernetes control plane is performed in a hook executed after `deploy-product`.
    The specific scripts executed as part of this hook are `/srv/cray/scripts/common/apply-networking-manifests.sh`, `/usr/share/doc/csm/upgrade/scripts/k8s/apply-coredns-pod-affinity.sh`, and `/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_control_plane.sh`.
+
+   > **NOTE** During the Kubernetes control plane upgrade, if Kubernetes audit logging is enabled, local audit log
+   configuration changes will be lost as the audit log configuration will be reset to defaults defined in [Audit Logs](../../security_and_authentication/Audit_Logs.md).

--- a/upgrade/Upgrade_Only_CSM_with_iuf.md
+++ b/upgrade/Upgrade_Only_CSM_with_iuf.md
@@ -46,6 +46,8 @@ section of the [Upgrade CSM and Additional Products with IUF](../operations/iuf/
 1. Deploy products.
 
    > **NOTE** The application of networking changes and CoreDNS anti-affinity changes along with the upgrade of the Kubernetes control plane is performed in a hook automatically executed after `deploy-product`.
+   During the Kubernetes control plane upgrade, if Kubernetes audit logging is enabled, local audit log
+   configuration changes will be lost as the audit log configuration will be reset to defaults defined in [Audit Logs](../operations/security_and_authentication/Audit_Logs.md).
 
    Follow these IUF instructions in order:
 


### PR DESCRIPTION
# Description
CASMPET-7674: Add note to deploy product about Kubernetes audit log configuration being reset to defaults during Kubernetes control plane upgrade.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
