### PR TITLE
CASMHMS-6597: Lint and refactor HSM groups/partitions docs

### DIFF
--- a/operations/hardware_state_manager/Component_Group_Members.md
+++ b/operations/hardware_state_manager/Component_Group_Members.md
@@ -1,42 +1,62 @@
 # Component Group Members
 
-The members object in the group definition has additional actions available for managing the members after the group has been created.
+The members object in the group definition has actions available for managing the
+members after the group has been created.
 
-The following is an example of group members:
+* [Prerequisites](#prerequisites)
+* [Retrieve group members](#retrieve-group-members)
+* [Add group members](#add-group-members)
+* [Remove group members](#remove-group-members)
+* Related links
+    * [Component Groups and Partitions](Component_Groups_and_Partitions.md)
+    * [Manage Component Groups](Manage_Component_Groups.md)
+    * [Component Partition Members](Component_Partition_Members.md)
+    * [Component Membership](Component_Memberships.md)
 
-```json
-{
-    "ids" : [
-        "x0c0s0b0n0","x0c0s0b0n1","x0c0s0b1n0"
-    ]
-}
-```
+## Prerequisites
 
-### Retrieve Group Members
+The commands on this page will not work unless the Cray CLI has been initialized on the node where
+the commands are being run. For more information, see
+[Configure the Cray CLI](../configure_cray_cli.md).
 
-Retrieve just the members array for a group:
+## Retrieve group members
 
-```bash
-cray hsm groups members list GROUP_LABEL
-```
+* (`ncn-mw#`) Retrieve just the members array for a group:
 
-Retrieve only the members of a group that are also in a specific partition:
+    ```bash
+    cray hsm groups members list GROUP_LABEL  --format json
+    ```
 
-```bash
-cray hsm groups members list --partition PARTITION_NAME GROUP_LABEL
-```
+    Example output:
 
-Retrieve only the members of a group that are not in any partition currently:
+    ```json
+    {
+        "ids" : [
+            "x0c0s0b0n0","x0c0s0b0n1","x0c0s0b1n0"
+        ]
+    }
+    ```
 
-```bash
-cray hsm groups members list --partition NULL GROUP_LABEL
-```
+* (`ncn-mw#`) Retrieve only the members of a group that are also in a specific partition:
 
-### Add Group Members
+    ```bash
+    cray hsm groups members list --partition PARTITION_NAME GROUP_LABEL
+    ```
 
-Add a single component to a group. The only time this is not permitted is if the component already exists, or the group has an exclusiveGroup label and the component is already a member of a group with that exclusive label.
+* (`ncn-mw#`) Retrieve only the members of a group that are not in any partition currently:
 
-Add a component to a group:
+    ```bash
+    cray hsm groups members list --partition NULL GROUP_LABEL
+    ```
+
+## Add group members
+
+Only a single component at a time may be added to a group. The only times this is not permitted are
+if the component already exists in the group, or if the group has an `exclusiveGroup` label and the
+component is already a member of another group with that same exclusive label. For more information
+on exclusive group labels, see [Groups](Component_Groups_and_Partitions.md#groups).
+
+(`ncn-mw#`) Add a component to a group:
 
 ```bash
 cray hsm groups members create --id MEMBER_ID GROUP_LABEL
@@ -48,11 +68,12 @@ For example:
 cray hsm groups members create --id x1c0s0b0n0 blue
 ```
 
-### Remove Group Members
+## Remove group members
 
-Single members with the specified component name (xname) are removed from the given group.
+Single components may be removed from a given group, assuming that they are currently a member
+of that group.
 
-Remove a member from a group:
+(`ncn-mw#`) Remove a member from a group:
 
 ```bash
 cray hsm groups members delete MEMBER_ID GROUP_LABEL
@@ -63,4 +84,3 @@ For example:
 ```bash
 cray hsm groups members delete x1c0s0b0n0 blue
 ```
-

--- a/operations/hardware_state_manager/Component_Groups_and_Partitions.md
+++ b/operations/hardware_state_manager/Component_Groups_and_Partitions.md
@@ -1,16 +1,38 @@
 # Component Groups and Partitions
 
-The Hardware State Manager \(HSM\) provides the group and partition services. Both are means of grouping \(also known as labeling\) system components that are tracked by HSM. Components include the nodes, blades, controllers, and more on a system.
+The Hardware State Manager \(HSM\) provides the group and partition services. Both are means of
+grouping \(also known as labeling\) system components that are tracked by HSM. Components
+include the nodes, blades, controllers, and other hardware on a system.
 
-There is no limit to the number of members a group or partition contains. The only limitation is that all members must be actual members of the system. The HSM needs to know that the components exist.
+There is no limit to the number of members a group or partition contains. The only limitation
+is that all members must be actual members of the system. The HSM needs to know that the
+components exist.
 
-### Groups
+## Groups
 
-Groups are collections of components \(primarily nodes\) in /hsm/v2/State/Components. Components can be members of any number of groups. Groups can be created freely, and HSM does not assign them any predetermined meaning.
+Groups are collections of components \(primarily nodes\) in `/hsm/v2/State/Components`.
+Components can be members of any number of groups. Groups can be created freely, and HSM
+does not assign them any predetermined meaning.
 
-If a group has `exclusiveGroup=EXCLUSIVE_LABEL_NAME` set, then a component may only be a member of one group that matches that exclusive label. For example, if the exclusive group label colors is associated with groups blue, red, and green, then a node that is part of the green group could not also be placed in the red group.
+If a group has `exclusiveGroup=EXCLUSIVE_LABEL_NAME` set, then a component may only be a
+member of one group that matches that exclusive label. For example, if the exclusive group
+label `colors` is associated with groups `blue`, `red`, and `green`, then a node that is part of
+the `green` group could not also be placed in the `red` group.
 
-### Partitions
+Related links:
 
-Partitions are isolated, non-overlapping groups. Each component can be a member of only one partition at a time, and partitions are used as an access control mechanism. Partitions have a specific predefined meaning, intended to provide logical divisions of a single physical system.
+* [Manage Component Groups](Manage_Component_Groups.md)
+* [Component Group Members](Component_Group_Members.md)
+* [Component Membership](Component_Memberships.md)
 
+## Partitions
+
+Partitions are isolated, non-overlapping groups. Each component can be a member of only one
+partition at a time, and partitions are used as an access control mechanism. Partitions have
+a specific predefined meaning, intended to provide logical divisions of a single physical system.
+
+Related links:
+
+* [Manage Component Partitions](Manage_Component_Partitions.md)
+* [Component Partition Members](Component_Partition_Members.md)
+* [Component Membership](Component_Memberships.md)

--- a/operations/hardware_state_manager/Component_Memberships.md
+++ b/operations/hardware_state_manager/Component_Memberships.md
@@ -4,10 +4,35 @@ Memberships are a read-only resource that is generated automatically by changes 
 in `/hsm/v2/State/Components` is represented. Filter options are available to prune the list, or a specific component name
 (xname) can be given. All groups and the partition \(if any\) of each component are listed.
 
-At this point in time, only information about node components is needed. The `--type` node filter option is used in the
-commands below to retrieve information about node memberships only.
+Membership information is only needed for node components. The `--type` node filter option is used in the
+commands on this page to retrieve information about node memberships only.
 
-The following is an example membership:
+* [Prerequisites](#prerequisites)
+* [Retrieve membership data for a component](#retrieve-membership-data-for-a-component)
+* [List component membership data](#list-component-membership-data)
+* Related links
+    * [Component Groups and Partitions](Component_Groups_and_Partitions.md)
+    * [Component Group Members](Component_Group_Members.md)
+    * [Component Partition Members](Component_Partition_Members.md)
+
+## Prerequisites
+
+The commands on this page will not work unless the Cray CLI has been initialized on the node where
+the commands are being run. For more information, see
+[Configure the Cray CLI](../configure_cray_cli.md).
+
+## Retrieve membership data for a component
+
+Any components in `/hsm/v2/State/Components` can have its group and memberships looked up with its
+individual component name (xname).
+
+(`ncn-mw#`) Retrieve membership information for a component.
+
+```bash
+cray hsm memberships describe MEMBER_ID --format json
+```
+
+Example output:
 
 ```json
 {
@@ -21,29 +46,20 @@ The following is an example membership:
 }
 ```
 
-**Troubleshooting:** If the Cray CLI has not been initialized, the CLI commands will not work.
+## List component membership data
 
-## Retrieve Group and Partition Memberships
+By default, the memberships collection contains all components, regardless of if they are in a
+group. However, a filtered subset is desired more frequently. Querying the memberships collection
+supports the same query options as `/hsm/v2/State/Components`.
 
-By default, the memberships collection contains all components, regardless of if they are in a group. However, a filtered subset
-is desired more frequently. Querying the memberships collection supports the same query options as `/hsm/v2/State/Components`.
+* (`ncn-mw#`) Retrieve all node memberships:
 
-Retrieve all node memberships:
+    ```bash
+    cray hsm memberships list --type Node
+    ```
 
-```bash
-cray hsm memberships list --type Node
-```
+* (`ncn-mw#`) Retrieve only nodes not in a partition:
 
-Retrieve only nodes not in a partition:
-
-```bash
-cray hsm memberships list --type Node --partition NULL
-```
-
-## Retrieve Membership Data for a Given Component
-
-Any components in `/hsm/v2/State/Components` can have its group and memberships looked up with its individual component component name (xname).
-
-```bash
-cray hsm memberships describe MEMBER_ID
-```
+    ```bash
+    cray hsm memberships list --type Node --partition NULL
+    ```

--- a/operations/hardware_state_manager/Component_Partition_Members.md
+++ b/operations/hardware_state_manager/Component_Partition_Members.md
@@ -1,8 +1,39 @@
 # Component Partition Members
 
-The members object in the partition definition has additional actions available for managing the members after the partition has been created.
+The members object in the partition definition has actions\
+available for managing the members after the partition has been created.
 
-The following is an example of partition members:
+* [Prerequisites](#prerequisites)
+* [Retrieve partition members](#retrieve-partition-members)
+* [Add partition members](#add partition members)
+* [Remove partition members](#remove-partition-members)
+* Related links
+    * [Component Groups and Partitions](Component_Groups_and_Partitions.md)
+    * [Manage Component Partitions](Manage_Component_Partitions.md)
+    * [Component Group Members](Component_Group_Members.md)
+    * [Component Membership](Component_Memberships.md)
+
+## Prerequisites
+
+The commands on this page will not work unless the Cray CLI has been initialized on the node where
+the commands are being run. For more information, see
+[Configure the Cray CLI](../configure_cray_cli.md).
+
+## Retrieve partition members
+
+Retrieving members of a partition is very similar to how group members are
+retrieved and modified. No filtering options are available in partitions.
+However, there are partition and group filtering parameters for the
+`/hsm/v2/State/Components` and `/hsm/v2/memberships` collections, with
+both essentially working the same way.
+
+(`ncn-mw#`) Retrieve only the members array for a single partition:
+
+```bash
+cray hsm partitions members list PARTITION_NAME --format json
+```
+
+Example output:
 
 ```json
 {
@@ -12,43 +43,37 @@ The following is an example of partition members:
 }
 ```
 
-### Retrieve Partition Members
+## Add partition members
 
-Retrieving members of a partition is very similar to how group members are retrieved and modified. No filtering options are available in partitions. However, there are partition and group filtering parameters for the /hsm/v2/State/Components and /hsm/v2/memberships collections, with both essentially working the same way.
+Components can be added to a partition's member list, assuming that the
+component is not already a member of any partition.
 
-Retrieve only the members array for a single partition:
+(`ncn-mw#`) Add a component to a partition:
 
-```screen
-cray hsm partitions members list PARTITION_NAME
-```
-
-### Add a Component to Partition
-
-Components can be added to a partition's member list, assuming it is not already a member or in another partition. This can be verified by looking at the membership information.
-
-Add a component to a partition:
-
-```screen
+```bash
 cray hsm partitions members create --id COMPONENT_ID PARTITION_NAME
 ```
 
 For example:
 
-```screen
+```bash
 cray hsm partitions members create --id x1c0s0b0n0 partition1
 ```
 
-### Remove a Partition Member
+### Remove partition members
 
-Remove a single component from a partition, assuming it is a current member. It will no longer be in any partition and is free to be assigned to a new one.
+Single components may be removed from a given partition, assuming that they are currently a member
+of that partition. After being removed, the component will no longer be in any partition and is
+free to be assigned to a new one.
 
-```screen
+(`ncn-mw#`) Remove a member from a partition:
+
+```bash
 cray hsm partitions members delete MEMBER_ID PARTITION_NAME
 ```
 
 For example:
 
-```screen
+```bash
 cray hsm partitions members delete x1c0s0b0n0 partition1
 ```
-

--- a/operations/hardware_state_manager/Manage_Component_Groups.md
+++ b/operations/hardware_state_manager/Manage_Component_Groups.md
@@ -1,6 +1,7 @@
 # Manage Component Groups
 
-The creation, deletion, and modification of groups is enabled by the Hardware State Manager \(HSM\) APIs.
+The creation, deletion, and modification of groups is enabled by the Hardware State Manager
+\(HSM\) APIs.
 
 * [Example group](#example-group)
 * [Prerequisites](#prerequisites)
@@ -8,7 +9,13 @@ The creation, deletion, and modification of groups is enabled by the Hardware St
     * [Create a group](#create-a-group)
     * [Modify a group](#modify-a-group)
 * [Retrieve a group](#retrieve-a-group)
+* [List groups](#list-groups)
 * [Delete a group](#delete-a-group)
+* Related links
+    * [Component Groups and Partitions](Component_Groups_and_Partitions.md)
+    * [Component Group Members](Component_Group_Members.md)
+    * [Manage Component Partitions](Manage_Component_Partitions.md)
+    * [Component Membership](Component_Memberships.md)
 
 ## Example group
 
@@ -36,14 +43,18 @@ The following is an example group that contains the optional fields tags and `ex
 
 ## Prerequisites
 
-The commands on this page will not work unless the Cray CLI has been initialized on the node where the commands
-are being run. For more information, see [Configure the Cray CLI](../configure_cray_cli.md).
+The commands on this page will not work unless the Cray CLI has been initialized on the node where
+the commands are being run. For more information, see
+[Configure the Cray CLI](../configure_cray_cli.md).
 
 ## Create and modify a group
 
-A group is defined by its members list and identifying label. It is also possible to add a description and a free form set of tags to help organize groups.
+A group is defined by its members list and identifying label. It is also possible to add a
+description and a free form set of tags to help organize groups.
 
-The members list may be set initially with the full list of member IDs, or can begin empty and have components added individually.
+The members list may be set initially with the full list of member IDs, or can begin empty and have
+components added individually.
+
 The following examples show different ways to create and modify a group.
 
 ### Create a group
@@ -73,7 +84,7 @@ The following examples show different ways to create and modify a group.
 
 ### Modify a group
 
-* (`ncn-mw#`) Add a description of a group:
+* (`ncn-mw#`) Add a description to a group:
 
     ```bash
     cray hsm groups update test_group --description "Description of group"
@@ -81,11 +92,15 @@ The following examples show different ways to create and modify a group.
 
 * (`ncn-mw#`) Add a new component to a group:
 
+    > For more information, see [Component Group Members](Component_Group_Members.md).
+
     ```bash
     cray hsm groups members create --id XNAME GROUP_LABEL
     ```
 
 * (`ncn-mw#`) Remove a component from a group:
+
+    > For more information, see [Component Group Members](Component_Group_Members.md).
 
     ```bash
     cray hsm groups members delete XNAME GROUP_LABEL
@@ -93,19 +108,37 @@ The following examples show different ways to create and modify a group.
 
 ## Retrieve a group
 
-Retrieve the complete group object to learn more about a group. This is also submitted when the group is created, except it is up-to-date with any additions or deletions from the members set.
+Retrieve the complete group object to learn more about a group. This is also submitted when the
+group is created, except it is up-to-date with any additions or deletions from the members set.
 
-(`ncn-mw#`) Retrieve all fields for a group, including the members list:
+* (`ncn-mw#`) Retrieve all fields for a group, including the members list:
+
+    ```bash
+    cray hsm groups describe GROUP_LABEL
+    ```
+
+* (`ncn-mw#`) Retrieve only the members list for a group:
+
+    > For more information, see [Component Group Members](Component_Group_Members.md).
+
+    ```bash
+    cray hsm groups members list GROUP_LABEL
+    ```
+
+## List groups
+
+(`ncn-mw#`) Retrieve a listing of all groups, including all fields of those groups.
 
 ```bash
-cray hsm groups describe GROUP_LABEL
+cray hsm groups list
 ```
 
 ## Delete a group
 
-Entire groups can be removed. The group label is deleted and removed from all members who were formerly a part of the group.
+Entire groups can be removed. The group label is deleted and removed from all members that were
+formerly a part of the group.
 
-(`ncn-mw#`) Delete a group with the following command:
+(`ncn-mw#`) Delete a group:
 
 ```bash
 cray hsm groups delete GROUP_LABEL

--- a/operations/hardware_state_manager/Manage_Component_Partitions.md
+++ b/operations/hardware_state_manager/Manage_Component_Partitions.md
@@ -2,6 +2,22 @@
 
 The creation, deletion, and modification of partitions is enabled by the Hardware State Manager \(HSM\) APIs.
 
+* [Example partition](#example-partition)
+* [Prerequisites](#prerequisites)
+* [Create and modify a partition](#create-and-modify-a-partition)
+    * [Create a partition](#create-a-partition)
+    * [Modify a partition](#modify-a-partition)
+* [Retrieve a partition](#retrieve-a-partition)
+* [List partitions](#list-partitions)
+* [Delete a partition](#delete-a-partition)
+* Related links
+    * [Component Groups and Partitions](Component_Groups_and_Partitions.md)
+    * [Component Partition Members](Component_Partition_Members.md)
+    * [Manage Component Groups](Manage_Component_Groups.md)
+    * [Component Membership](Component_Memberships.md)
+
+## Example partition
+
 The following is an example partition that contains the optional tags field:
 
 ```json
@@ -21,63 +37,100 @@ The following is an example partition that contains the optional tags field:
 }
 ```
 
-**Troubleshooting:** If the Cray CLI has not been initialized, the CLI commands will not work.
+## Prerequisites
 
-### Create a New Partition
+The commands on this page will not work unless the Cray CLI has been initialized on the node where
+the commands are being run. For more information, see
+[Configure the Cray CLI](../configure_cray_cli.md).
 
-Creating a partition is very similar to creating a group. Members can either be provided in an initial list, or the list can be initially empty and added to later. There is no exclusiveGroups field because partition memberships are always exclusive. The following are two different ways to create a partition.
+## Create and modify a partition
 
-Create a new partition with an empty members list and two optional tags:
+Members can either be provided in an initial list, or the list can be initially empty and added to
+later. There is no `exclusiveGroups` field because partition memberships are always exclusive.
 
-```screen
-cray hsm partitions create --name PARTITION_NAME \
---tags TAG1,TAG2 \
---description DESCRIPTION_OF_PARTITION_NAME
-```
+The following examples show different ways to create and modify a partition.
 
-Create a new partition with a pre-set members list:
+### Create a partition
 
-```screen
-cray hsm partitions create --name PARTITION_NAME \
---description DESCRIPTION OF PARTITION_NAME \
---members-ids MEMBER_ID,MEMBER_ID,MEMBER_ID,MEMBER_ID
-```
+* (`ncn-mw#`) Create a new partition with an empty members list and two optional tags:
 
-Create a new partition:
+    ```bash
+    cray hsm partitions create --name PARTITION_NAME \
+        --tags TAG1,TAG2 \
+        --description DESCRIPTION_OF_PARTITION_NAME
+    ```
 
-```screen
-cray hsm partitions create -v --label PARTITION_LABEL
-```
+* (`ncn-mw#`) Create a new partition with a specified members list:
 
-Add a description of the partition:
+    ```bash
+    cray hsm partitions create --name PARTITION_NAME \
+        --description DESCRIPTION OF PARTITION_NAME \
+        --members-ids MEMBER_ID,MEMBER_ID,MEMBER_ID,MEMBER_ID
+    ```
 
-```screen
-cray hsm partitions update test_group --description "Description of partition"
-```
+* (`ncn-mw#`) Create a new partition:
 
-Add a new component to the partition:
+    ```bash
+    cray hsm partitions create -v --label PARTITION_NAME
+    ```
 
-```screen
-cray hsm partitions members create --id XNAME PARTITION_LABEL
-```
+### Modify a partition
 
-### Retrieve Partition Information
+* (`ncn-mw#`) Add a description to a partition:
+
+    ```bash
+    cray hsm partitions update test_group --description "Description of partition"
+    ```
+
+* (`ncn-mw#`) Add a new component to a partition:
+
+    > For more information, see [Component Partition Members](Component_Partition_Members.md).
+
+    ```bash
+    cray hsm partitions members create --id XNAME PARTITION_NAME
+    ```
+
+* (`ncn-mw#`) Remove a component from a partition:
+
+    > For more information, see [Component Partition Members](Component_Partition_Members.md).
+
+    ```bash
+    cray hsm partitions members delete XNAME PARTITION_NAME
+    ```
+
+## Retrieve a partition
 
 Information about a partition is retrieved with the partition name.
 
-Retrieve all fields for a partition, including the members list:
+* (`ncn-mw#`) Retrieve all fields for a partition, including the members list:
 
-```screen
-cray hsm partitions describe PARTITION_NAME
+    ```bash
+    cray hsm partitions describe PARTITION_NAME
+    ```
+
+* (`ncn-mw#`) Retrieve only the members list for a partition:
+
+    > For more information, see [Component Partition Members](Component_Partition_Members.md).
+
+    ```bash
+    cray hsm partitions members list PARTITION_NAME
+    ```
+
+## List partitions
+
+(`ncn-mw#`) Retrieve a listing of all partitions, including all fields of those partitions.
+
+```bash
+cray hsm partitions list
 ```
 
-### Delete a Partition
+## Delete a partition
 
-Once a partition is deleted, the former members will not have a partition assigned to them and are ready to be assigned to a new partition.
+Once a partition is deleted, the former members will not have a partition assigned to them and are
+ready to be assigned to a new partition.
 
-Delete a partition so all members are no longer in it:
+(`ncn-mw#`) Delete a partition:
 
-```screen
+```bash
 cray hsm partitions delete PARTITION_NAME
 ```
-


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
This started when I noticed some low-hanging fruit linting errors on some of the HSM pages. But then I noticed that all of the group/partition pages are somewhat related, but none of them link to each other, and they are each organized slightly differently. 

This PR included the following changes:

* Fixes linter errors
* Adds appropriate links between the pages
* Reorganizes the pages so they are more consistent
* Add in a few missing commands from some of the pages (which was part of making them consistent, as well)

There still isn't much in the way of actual meaningful content changes here. Almost all of this PR is just reorganizing the existing data for clarity and consistency.

Backports:

1.6: https://github.com/Cray-HPE/docs-csm/pull/6322
1.5: https://github.com/Cray-HPE/docs-csm/pull/6323
1.4: https://github.com/Cray-HPE/docs-csm/pull/6324
1.3: https://github.com/Cray-HPE/docs-csm/pull/6325
1.2: https://github.com/Cray-HPE/docs-csm/pull/6326
1.0: https://github.com/Cray-HPE/docs-csm/pull/6327

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Resolves CASMHMS-6597.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
