### PR TITLE
CAST-38539: Warn against setting long passwords on management node BMCs -- 1.7

### DIFF
--- a/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
+++ b/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
@@ -3,6 +3,13 @@
 This procedure describes how to use the System Admin Toolkit's (SAT) `sat bmccreds`
 command to set a global credential for all BMCs on air-cooled nodes.
 
+> **WARNING**: Do not attempt to set a password longer than 20 characters on management node BMCs.
+> The maximum password length supported by `ipmitool` is 20 characters, and `ipmitool` is used
+> during the [System Power On Procedures](../power_management/System_Power_On_Procedures.md) and
+> [System Power Off Procedures](../power_management/System_Power_Off_Procedures.md) to
+> monitor, control, and query management nodes. If a password longer than 20 characters is set on
+> those nodes, the documented steps to power off and power on management nodes will fail.
+
 For more information including alternate methods of using `sat bmccreds`, see: [Set BMC Credentials Using SAT](../../operations/system_configuration_service/Set_BMC_Credentials.md),
 or the `sat-bmccreds(8)` man page by running `sat-man bmccreds`.
 


### PR DESCRIPTION
# Description

Add a warning to the "Change Air-Cooled Node BMC Credentials" procedure
about the negative impact to the system power off/on procedures if the
management node BMCs have their passwords set to a value longer than 20
characters.

https://jira-pro.it.hpe.com:8443/browse/CAST-38539

# Backports

- https://github.com/Cray-HPE/docs-csm/pull/6351
- https://github.com/Cray-HPE/docs-csm/pull/6352

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
