### PR TITLE
CASMTRIAGE-8706: Add upgrade-k8s-job check in cilium_migration.sh script -- 1.7

### DIFF
--- a/scripts/cilium_migration.sh
+++ b/scripts/cilium_migration.sh
@@ -31,6 +31,12 @@ if [[ $CNI_VALUE == "cilium" ]]; then
 else
   echo "INFO k8s-primary-cni is '$CNI_VALUE'. Proceeding with migration workflow."
 
+  if ! kubectl get jobs -n argo | grep upgrade-k8s-job | grep Complete; then
+    echo "ERROR Please wait until the upgrade-k8s-job is Complete before running this script."
+    echo "ERROR To check on job status, run 'kubectl get jobs -n argo | grep upgrade-k8s-job'"
+    exit 1
+  fi
+
   echo "INFO Generating Cilium workflow manifest"
 
   if [[ ! -f /usr/share/doc/csm/workflows/cilium/generateCiliumLiveMigration.py ]]; then


### PR DESCRIPTION
# Description
CASMTRIAGE-8706: Add upgrade-k8s-job check in cilium_migration.sh script to verify the upgrade-k8s-job is complete before proceeding

Kubernetes is upgraded to 1.32 in a k8s job that runs at the end of the `deploy-product` workflow as part of the `deploy-product-onexit` hook.   The `upgrade-k8s-job` spins off and continues to run after the `deploy-product` workflow completes.  If the IUF logs and documentation are not read carefully, an admin could miss that they need to monitor the `upgrade-k8s-job` and it needs to complete before moving on to the next stage `cilium-migration`.

If the `cilium_migration.sh` script is started before the `upgrade-k8s-job` is complete, the `cilium_migration.sh` script will eventually fail.

Add a check early in the `cilium_migration.sh` script to verify that the `upgrade-k8s-job` is complete and exit with a message to monitor the `upgrade-k8s-job` if it is not.

# Testing
Did an upgrade on `molly` with the modified `cilium_migration.sh` script.  Manually attempted to run the script during the upgrade process before `deploy-product-onexit` hook ran, while the `upgrade-k8s-job` was running, and after the `upgrade-k8s-job` completed.

Attempted to run `cilium_migration.sh` before `ugprade-k8s-job` was launched.
```
ncn-m001:/usr/share/doc/csm/scripts # kubectl get nodes
NAME       STATUS   ROLES           AGE    VERSION
ncn-m001   Ready    control-plane   3h1m   v1.26.15
ncn-m002   Ready    control-plane   163m   v1.26.15
ncn-m003   Ready    control-plane   115m   v1.26.15
ncn-w001   Ready    <none>          74m    v1.26.15
ncn-w002   Ready    <none>          43m    v1.26.15
ncn-w003   Ready    <none>          12m    v1.26.15
ncn-m001:/usr/share/doc/csm/scripts # kubectl get jobs -n argo | grep upgrade-k8s-job
No resources found in argo namespace.
ncn-m001:/usr/share/doc/csm/scripts #
ncn-m001:/usr/share/doc/csm/scripts # ./cilium_migration.sh
INFO Checking current k8s-primary-cni value in BSS
INFO k8s-primary-cni is 'weave'. Proceeding with migration workflow.
ERROR Please wait until the upgrade-k8s-job is Complete before running this script.
ERROR To check on job status, run 'kubectl get jobs -n argo | grep upgrade-k8s-job'
ncn-m001:/usr/share/doc/csm/scripts #
```

Attempted to run the `cilium_migration.sh` script during the upgrade while the `upgrade-k8s-job` was still running.
```
ncn-m001:/usr/share/doc/csm/scripts # kubectl get nodes
NAME       STATUS   ROLES           AGE     VERSION
ncn-m001   Ready    control-plane   4h8m    v1.32.5
ncn-m002   Ready    control-plane   3h49m   v1.32.5
ncn-m003   Ready    control-plane   3h2m    v1.32.5
ncn-w001   Ready    <none>          141m    v1.32.5
ncn-w002   Ready    <none>          109m    v1.32.5
ncn-w003   Ready    <none>          78m     v1.32.5
ncn-m001:/usr/share/doc/csm/scripts # kubectl get jobs -n argo | grep upgrade-k8s-job
upgrade-k8s-job-6ww6h   Running   0/1           63m        63m
ncn-m001:/usr/share/doc/csm/scripts # ./cilium_migration.sh
INFO Checking current k8s-primary-cni value in BSS
INFO k8s-primary-cni is 'weave'. Proceeding with migration workflow.
ERROR Please wait until the upgrade-k8s-job is Complete before running this script.
ERROR To check on job status, run 'kubectl get jobs -n argo | grep upgrade-k8s-job'
ncn-m001:/usr/share/doc/csm/scripts #
```

Running the script after the `upgrade-k8s-job` completed.
```
12:01:16  ****************************************************************************
12:01:16  ncn-m001: Cilium Migration
12:01:16  ****************************************************************************
12:01:16  INFO Checking current k8s-primary-cni value in BSS
12:01:17  INFO k8s-primary-cni is 'weave'. Proceeding with migration workflow.
12:01:18  upgrade-k8s-job-6ww6h   Complete   1/1           89m        89m
12:01:18  INFO Generating Cilium workflow manifest
12:01:19  Generating workflow for nodes 
12:01:19  ['ncn-m001', 'ncn-m002', 'ncn-m003', 'ncn-w001', 'ncn-w002', 'ncn-w003']
12:01:19  /usr/share/doc/csm/workflows/cilium
12:01:19  Workflow rendered in /usr/share/doc/csm/workflows/cilium/cilium-live-migration.yaml
12:01:19  INFO Applying Cilium workflow manifest
```

Upgrade Control Plane logs: https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2462/execution/node/178/log/
Full upgrade run: https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2462/


# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

