### PR TITLE
CASM-4543: Modify post install script to dynamically update workflowtemplates 

### DIFF
--- a/docs-csm.spec
+++ b/docs-csm.spec
@@ -54,5 +54,5 @@ cat INSTALLED_FILES | xargs -i sh -c 'test -L {} && exit || test -f $RPM_BUILD_R
 %defattr(-,root,root)
 
 %post
-/usr/share/doc/csm/workflows/update_tags.sh
+/usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -110,14 +110,6 @@ rest of this section can be skipped. Otherwise, follow these steps to enable
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `process-media` or `pre-install-check` stages.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Run `upload-rebuild-templates.sh` to update all the workflows that will be used by IUF and to make sure the workflow templates are the latest versions.
-
-    (`ncn-m001#`) Execute the `upload-rebuild-templates.sh` script.
-
-    ```bash
-    /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
-    ```
-
 1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-e` to execute the [`process-media`](../stages/process_media.md) and [`pre-install-check`](../stages/pre_install_check.md) stages. Perform the upgrade
    using product content found in `${MEDIA_DIR}`.
 


### PR DESCRIPTION
# Description

CASM-4543: Modify post install script to dynamically update workflowtemplates when docs-csm is installed on a CSM environment.

https://jira-pro.it.hpe.com:8443/browse/CASM-4543

Remove manual documention before process-media stage as docs-csm rpm is installed before or along with upload-rebuild-templates.sh script so manual run is not required as rpm install does it 


# Checklist


- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
