### PR TITLE
CASMPET-7665: Run the remove_psp.sh script to remove unneeded PSP resources

### DIFF
--- a/upgrade/scripts/k8s/remove_psp.sh
+++ b/upgrade/scripts/k8s/remove_psp.sh
@@ -67,7 +67,6 @@ apiserver_has_psp() {
   return "${ret_val}"
 }
 
-
 # A list of known PSPs, taking from system running CSM 1.6
 DEFAULT_PSPS="cray-ceph-csi-cephfs-nodeplugin cray-ceph-csi-cephfs-provisioner"
 DEFAULT_PSPS="${DEFAULT_PSPS} cray-ceph-csi-rbd-nodeplugin cray-ceph-csi-rbd-provisioner"
@@ -84,7 +83,7 @@ DEFAULT_PSPS="${DEFAULT_PSPS} privileged restricted restricted-transition restri
 DEFAULT_PSPS="${DEFAULT_PSPS} sealed-secrets-kube-system sma-vm-cluster spire spire-agent uas-default-psp"
 
 delete_any_psp() {
-  PSPS=$(kubectl get psp -ojsonpath='{.items[*].metadata.name}' 2>/dev/null)
+  PSPS=$(kubectl get psp -ojsonpath='{.items[*].metadata.name}' 2> /dev/null)
   if [ -z "${PSPS}" ]; then
     echo "No existing podsecuritypolices"
     PSPS="${DEFAULT_PSPS}"
@@ -113,22 +112,22 @@ KNOWN_PSP_CR="${KNOWN_PSP_CR} sealed-secrets-kube-system-psp sma-vm-cluster-clus
 #     CLUSTERROLE_MIXED_PSP: ClusterRoles that have a mix of PSP and non-PSP resources
 get_clusterroles() {
   CR=$(kubectl get clusterrole -ojsonpath='{.items[*].metadata.name}')
-  CLUSTERROLES=$(echo ${CR} ${KNOWN_PSP_CR}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+  CLUSTERROLES=$(echo ${CR} ${KNOWN_PSP_CR} | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
   CLUSTERROLE_NO_PSP=""
   CLUSTERROLE_ONLY_PSP=""
   CLUSTERROLE_MIXED_PSP=""
   CLUSTERROLE_NX=""
   for cr in ${CLUSTERROLES}; do
-    if ! resources=$(kubectl get clusterrole "${cr}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+    if ! resources=$(kubectl get clusterrole "${cr}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2> /dev/null); then
       CLUSTERROLE_NX="${CLUSTERROLE_NX} ${cr}"
-      elif [ "${resources}" = podsecuritypolicies ]; then
-        CLUSTERROLE_ONLY_PSP="${CLUSTERROLE_ONLY_PSP} ${cr}"
-      elif echo "${resources}" | grep -q podsecuritypolicies; then
-        CLUSTERROLE_MIXED_PSP="${CLUSTERROLE_MIXED_PSP} ${cr}"
-      else
-        CLUSTERROLE_NO_PSP="${CLUSTERROLE_NO_PSP} ${cr}"
-      fi
+    elif [ "${resources}" = podsecuritypolicies ]; then
+      CLUSTERROLE_ONLY_PSP="${CLUSTERROLE_ONLY_PSP} ${cr}"
+    elif echo "${resources}" | grep -q podsecuritypolicies; then
+      CLUSTERROLE_MIXED_PSP="${CLUSTERROLE_MIXED_PSP} ${cr}"
+    else
+      CLUSTERROLE_NO_PSP="${CLUSTERROLE_NO_PSP} ${cr}"
+    fi
   done
   echo "CLUSTERROLE_NX: ${CLUSTERROLE_NX}"
   echo "CLUSTERROLE_ONLY_PSP: ${CLUSTERROLE_ONLY_PSP}"
@@ -151,11 +150,10 @@ delete_psp_from_clusterroles() {
   for cr in "$@"; do
     #kubectl get clusterrole "${cr}" -o json | jq 'del(.rules[] | select(.resources[0]=="podsecuritypolicies"))' | kubectl apply ${DRY_RUN} -f -
 
-    INDEX=$(kubectl get clusterrole "${cr}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+    INDEX=$(kubectl get clusterrole "${cr}" -o json | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
     kubectl patch ${DRY_RUN} clusterrole "${cr}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
   done
 }
-
 
 KNOWN_PSP_R="ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster sysmgmt-health/cray-sysmgmt-health-grafana"
 
@@ -166,7 +164,7 @@ KNOWN_PSP_R="ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-
 get_roles() {
   # Get a list of Roles
   R=$(kubectl get roles -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
-  ROLES=$(echo ${R} ${KNOWN_PSP_R}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+  ROLES=$(echo ${R} ${KNOWN_PSP_R} | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
   ROLE_NO_PSP=""
   ROLE_ONLY_PSP=""
@@ -174,7 +172,7 @@ get_roles() {
   for nr in ${ROLES}; do
     ns=${nr%/*}
     r=${nr#*/}
-    if ! resources=$(kubectl get role -n "${ns}" "${r}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+    if ! resources=$(kubectl get role -n "${ns}" "${r}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2> /dev/null); then
       ROLE_NX="${ROLE_NX} ${nr}"
     elif [ "${resources}" = podsecuritypolicies ]; then
       ROLE_ONLY_PSP="${ROLE_ONLY_PSP} ${nr}"
@@ -207,7 +205,7 @@ delete_psp_from_roles() {
   for nr in "$@"; do
     ns=${nr%/*}
     r=${nr#*/}
-    INDEX=$(kubectl get role -n "${ns}" "${r}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+    INDEX=$(kubectl get role -n "${ns}" "${r}" -o json | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
     kubectl patch ${DRY_RUN} role -n "${ns}" "${r}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
   done
 }
@@ -319,7 +317,7 @@ get_sa() {
 
   for sa in ${PSP_ONLY_SA}; do
     kind=${sa%%/*}
-    if [[ "${kind}" != ServiceAccount ]]; then
+    if [[ ${kind} != ServiceAccount ]]; then
       continue
     fi
     name_ns=${sa#*/}

--- a/upgrade/scripts/k8s/remove_psp.sh
+++ b/upgrade/scripts/k8s/remove_psp.sh
@@ -1,0 +1,372 @@
+#!/bin/bash
+
+# Overview of the resources for implementing PSP
+#
+# <pod> contains reference to:
+#     <serviceaccount>
+# <role> or <clusterrole> contains reference to
+#     <PSP>
+# <rolebinding> or <clusterrolebinding> link
+#     <serviceaccount>
+# and
+#     <clusterrole>
+#
+# <pod> ==> <serviceaccount> <-- <clusterrolebinding> ==> <clusterrole> ==> <PSP>
+
+# Check for PSP
+#   On each master node, edit
+#     /etc/kubernetes/manifests/kube-apiserver.yaml
+#   and remove the line with:
+#     enable-admission-plugins=PodSecurityPolicy
+#
+# sed -i '/enable-admission-plugins=PodSecurityPolicy/d' /etc/kubernetes/manifests/kube-apiserver.yaml"
+#
+# The kubelet will automatically restart the kube-apiserver pods.  Wait for each kube-apiserver
+# pod to restart and enter Running state before restarting the next one
+
+# DRY_RUN=--dry-run=server
+DRY_RUN=""
+
+apiserver_has_psp()
+{
+    echo "Checking if PSP has been disabled on all control plane nodes"
+    ret_val=1
+    api_servers=$(kubectl get pods -n kube-system -lcomponent=kube-apiserver -ojsonpath='{.items[*].metadata.name}')
+    for server in ${api_servers}; do
+        if kubectl get pod -n kube-system "${server}" -o yaml | grep -q "enable-admission-plugins=.*PodSecurityPolicy"; then
+           ret_val=0
+           echo "${server} has the PodSecurityPolicy plugin  enabled.  Please disable it by running:"
+           echo "    sed -i 's/,*PodSecurityPolicy//' /etc/kubernetes/manifests/kube-apiserver.yaml"
+           echo "    sed -i '/enable-admission-plugins=$/d' /etc/kubernetes/manifests/kube-apiserver.yaml"
+           echo "on ${server#kube-apiserver-}"
+           echo "The kubelet will detect the change and automatically restart ${server}"
+           echo
+        fi
+    done
+    return "${ret_val}"
+}
+
+
+# A list of known PSPs, taking from system running CSM 1.6
+DEFAULT_PSPS="cray-ceph-csi-cephfs-nodeplugin cray-ceph-csi-cephfs-provisioner"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-ceph-csi-rbd-nodeplugin cray-ceph-csi-rbd-provisioner"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-certmanager-cert-manager cray-certmanager-cert-manager-cainjector"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-certmanager-cert-manager-webhook cray-externaldns-external-dns-services"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-kyverno-admission-controller cray-kyverno-background-controller"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-kyverno-cleanup-admission-reports"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-kyverno-post-install-job cray-kyverno-psp cray-kyverno-reports-controller"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-spire cray-spire-agent cray-sysmgmt-health-grafana"
+DEFAULT_PSPS="${DEFAULT_PSPS} cray-sysmgmt-health-kube-state-metrics cray-sysmgmt-health-prometheus-node-exporter"
+DEFAULT_PSPS="${DEFAULT_PSPS} metallb-controller metallb-speaker node-problem-detector"
+DEFAULT_PSPS="${DEFAULT_PSPS} privileged restricted restricted-transition restricted-transition-net-raw"
+DEFAULT_PSPS="${DEFAULT_PSPS} sealed-secrets-kube-system sma-vm-cluster spire spire-agent uas-default-psp"
+
+delete_any_psp()
+{
+    PSPS=$(kubectl get psp -ojsonpath='{.items[*].metadata.name}' 2>/dev/null)
+    if [ -z "${PSPS}" ]; then
+        echo "No existing podsecuritypolices"
+        PSPS="${DEFAULT_PSPS}"
+        return 0
+    fi
+    PSPS=$(echo ${DEFAULT_PSPS} ${PSPS} | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    echo "Deleting all podsecuritypolicies"
+    kubectl delete ${DRY_RUN} psp --all
+    return 0
+}
+
+# A list of known Cluster Roles that point to PSPs, taken from system running CSM 1.6
+KNOWN_PSP_CR="cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} cray-kyverno-admission-controller cray-kyverno-background-controller"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} restricted-psp restricted-transition-net-raw-psp restricted-transition-psp"
+KNOWN_PSP_CR="${KNOWN_PSP_CR} sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp"
+
+# Get 3 list of clusterroles:
+#     CLUSTERROLE_NO_PSP: ClusterRoles that do not have PSP resources
+#     CLUSTERROLE_ONLY_PSP: ClusterRoles that have only PSP resources
+#     CLUSTERROLE_MIXED_PSP: ClusterRoles that have a mix of PSP and non-PSP resources
+get_clusterroles()
+{
+    CR=$(kubectl get clusterrole -ojsonpath='{.items[*].metadata.name}')
+    CLUSTERROLES=$(echo ${CR} ${KNOWN_PSP_CR}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+    CLUSTERROLE_NO_PSP=""
+    CLUSTERROLE_ONLY_PSP=""
+    CLUSTERROLE_MIXED_PSP=""
+    CLUSTERROLE_NX=""
+    for cr in ${CLUSTERROLES}; do
+        if ! resources=$(kubectl get clusterrole "${cr}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+            CLUSTERROLE_NX="${CLUSTERROLE_NX} ${cr}"
+        elif [ "${resources}" = podsecuritypolicies ]; then
+            CLUSTERROLE_ONLY_PSP="${CLUSTERROLE_ONLY_PSP} ${cr}"
+        elif echo "${resources}" | grep -q podsecuritypolicies; then
+            CLUSTERROLE_MIXED_PSP="${CLUSTERROLE_MIXED_PSP} ${cr}"
+        else
+            CLUSTERROLE_NO_PSP="${CLUSTERROLE_NO_PSP} ${cr}"
+        fi
+    done
+    echo "CLUSTERROLE_NX: ${CLUSTERROLE_NX}"
+    echo "CLUSTERROLE_ONLY_PSP: ${CLUSTERROLE_ONLY_PSP}"
+    echo "CLUSTERROLE_MIXED_PSP: ${CLUSTERROLE_MIXED_PSP}"
+}
+
+# Delete a list of clusterroles, specified as a list of:
+#     <clusterrole>
+delete_clusterroles()
+{
+    if [ -n "$*" ]; then
+        kubectl delete ${DRY_RUN} clusterrole "$@"
+    fi
+}
+
+# For clusterroles that have multiple resources, delete just the
+# "podsecuritypolicies" element from the array of resources
+# in the role.  The roles are specified as a list of:
+#     <clusterrole>
+delete_psp_from_clusterroles()
+{
+    for cr in "$@"; do
+        #kubectl get clusterrole "${cr}" -o json | jq 'del(.rules[] | select(.resources[0]=="podsecuritypolicies"))' | kubectl apply ${DRY_RUN} -f -
+
+        INDEX=$(kubectl get clusterrole "${cr}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+        kubectl patch ${DRY_RUN} clusterrole "${cr}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
+    done
+}
+
+
+KNOWN_PSP_R="ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster sysmgmt-health/cray-sysmgmt-health-grafana"
+
+# Get 3 list of roles:
+#     ROLE_NO_PSP: ClusterRoles that do not have PSP resources
+#     ROLE_ONLY_PSP: ClusterRoles that have only PSP resources
+#     ROLE_MIXED_PSP: ClusterRoles that have a mix of PSP and non-PSP resources
+get_roles()
+{
+    # Get a list of Roles
+    R=$(kubectl get roles -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+    ROLES=$(echo ${R} ${KNOWN_PSP_R}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+    ROLE_NO_PSP=""
+    ROLE_ONLY_PSP=""
+    ROLE_MIXED_PSP=""
+    for nr in ${ROLES}; do
+        ns=${nr%/*}
+        r=${nr#*/}
+        if ! resources=$(kubectl get role -n "${ns}" "${r}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+            ROLE_NX="${ROLE_NX} ${nr}"
+        elif [ "${resources}" = podsecuritypolicies ]; then
+            ROLE_ONLY_PSP="${ROLE_ONLY_PSP} ${nr}"
+        elif echo "${resources}" | grep -q podsecuritypolicies; then
+            ROLE_MIXED_PSP="${ROLE_MIXED_PSP} ${nr}"
+        else
+            ROLE_NO_PSP="${ROLE_NO_PSP} ${nr}"
+        fi
+    done
+    echo "ROLE_NX: ${ROLE_NX}"
+    echo "ROLE_ONLY_PSP: ${ROLE_ONLY_PSP}"
+    echo "ROLE_MIXED_PSP: ${ROLE_MIXED_PSP}"
+}
+
+# Delete a list of roles, specified as a list of:
+#     <namespace>/<role>
+delete_roles()
+{
+    for nr in "$@"; do
+        ns=${nr%/*}
+        r=${nr#*/}
+        kubectl delete ${DRY_RUN} role -n "${ns}" "${r}"
+    done
+}
+
+# For roles that have multiple resources, delete just the
+# "podsecuritypolicies" element from the array of resources
+# in the role.  The roles are specified as a list of:
+#     <namespace>/<role>
+delete_psp_from_roles()
+{
+    for nr in "$@"; do
+        ns=${nr%/*}
+        r=${nr#*/}
+        INDEX=$(kubectl get role -n "${ns}" "${r}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+        kubectl patch ${DRY_RUN} role -n "${ns}" "${r}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
+    done
+}
+
+# Get 3 list of clusterrolebindings:
+#     CLUSTERROLEBINDING_NO_SA: ClusterRoleBindings that do not have SA kinds
+#     CLUSTERROLEBINDING_ONLY_SA: ClusterRoleBindings that have only SA kinds
+#     CLUSTERROLEBINDING_MIXED_SA: ClusterRoleBindings that have a mix of SA and non-SA kinds
+get_clusterrolebindings()
+{
+    CLUSTERROLEBINDINGS=$(kubectl get clusterrolebinding -ojsonpath='{.items[*].metadata.name}')
+
+    CLUSTERROLEBINDING_NO_PSP=""
+    CLUSTERROLEBINDING_ONLY_PSP=""
+    CLUSTERROLEBINDING_MIXED_PSP=""
+    for cr in ${CLUSTERROLEBINDINGS}; do
+        kind_name_subj=$(kubectl get clusterrolebinding "${cr}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{" "}{end}{"\n"}')
+        kind_name=${kind_name_subj%@*}
+        kind=${kind_name%/*}
+        name=${kind_name#*/}
+        if [ "${kind}" = ClusterRole ]; then
+           if echo " ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
+               CLUSTERROLEBINDING_ONLY_PSP="${CLUSTERROLEBINDING_ONLY_PSP} ${cr}"
+               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+           elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
+               CLUSTERROLEBINDING_MIXED_PSP="${CLUSTERROLEBINDING_MIXED_PSP} ${cr}"
+           else
+               CLUSTERROLEBINDING_NO_PSP="${CLUSTERROLEBINDING_NO_PSP} ${cr}"
+           fi
+        else
+           CLUSTERROLEBINDING_OTHER="${CLUSTERROLEBINDING_OTHER} ${cr}/${kind}/${name}"
+        fi
+    done
+    echo "CLUSTERROLEBINDING_ONLY_PSP: ${CLUSTERROLEBINDING_ONLY_PSP}"
+    echo "CLUSTERROLEBINDING_MIXED_PSP: ${CLUSTERROLEBINDING_MIXED_PSP}"
+    echo "CLUSTERROLEBINDING_OTHER: ${CLUSTERROLEBINDING_OTHER}"
+}
+
+# Delete a list of clusterrolebindings, specified as a list of:
+#     <clusterrolebinding>
+delete_clusterrolebindings()
+{
+    kubectl delete ${DRY_RUN} clusterrolebindings "$@"
+}
+
+# Get 3 list of rolesbindings:
+#     ROLEBINDING_NO_SA: RoleBindings that do not have SA kinds
+#     ROLEBINDING_ONLY_SA: RoleBindings that have only SA kinds
+#     ROLEBINDING_MIXED_SA: RoleBindings that have a mix of SA and non-SA kinds
+get_rolebindings()
+{
+    # Get a list of Roles
+    ROLEBINDINGS=$(kubectl get rolebindings -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+
+    ROLEBINDING_CLUSTER_ONLY_PSP=""
+    ROLEBINDING_CLUSTER_MIXED_PSP=""
+    ROLEBINDING_CLUSTER_NO_PSP=""
+    ROLEBINDING_ONLY_PSP=""
+    ROLEBINDING_MIXED_PSP=""
+    ROLEBINDING_NO_PSP=""
+    ROLEBINDING_OTHER=""
+    for nr in ${ROLEBINDINGS}; do
+        ns=${nr%/*}
+        r=${nr#*/}
+
+        kind_name_subj=$(kubectl get rolebinding -n "${ns}" "${r}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{":'"${ns}"' "}{end}{"\n"}')
+        kind_name=${kind_name_subj%@*}
+        kind=${kind_name%/*}
+        name=${kind_name#*/}
+        if [ "${kind}" = ClusterRole ]; then
+           if echo "  ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
+               ROLEBINDING_CLUSTER_ONLY_PSP="${ROLEBINDING_CLUSTER_ONLY_PSP} ${nr}"
+               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+           elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
+               ROLEBINDING_CLUSTER_MIXED_PSP="${ROLEBINDING_CLUSTER_MIXED_PSP} ${nr}"
+           else
+               ROLEBINDING_CLUSTER_NO_PSP="${ROLEBINDING_CLUSTER_NO_PSP} ${nr}"
+           fi
+        elif [ "${kind}" = Role ]; then
+           if echo " ${ROLE_NX} ${ROLE_ONLY_PSP} " | grep -q " ${name} "; then
+               ROLEBINDING_ONLY_PSP="${ROLEBINDING_ONLY_PSP} ${nr}"
+               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+           elif echo " ${ROLE_MIXED_PSP} " | grep -q " ${name} "; then
+               ROLEBINDING_MIXED_PSP="${ROLEBINDING_MIXED_PSP} ${nr}"
+           else
+               ROLEBINDING_NO_PSP="${ROLEBINDING_NO_PSP} ${nr}"
+           fi
+        else
+           ROLEBINDING_OTHER="${ROLEBINDING_OTHER} ${nr}/${kind}/${name}"
+        fi
+    done
+    echo "ROLEBINDING_CLUSTER_ONLY_PSP: ${ROLEBINDING_CLUSTER_ONLY_PSP}"
+    echo "ROLEBINDING_CLUSTER_MIXED_PSP: ${ROLEBINDING_CLUSTER_MIXED_PSP}"
+    echo "ROLEBINDING_ONLY_PSP: ${ROLEBINDING_ONLY_PSP}"
+    echo "ROLEBINDING_MIXED_PSP: ${ROLEBINDING_MIXED_PSP}"
+    echo "ROLEBINDING_OTHER: ${ROLEBINDING_OTHER}"
+}
+
+# Delete a list of rolebindings, specified as a list of:
+#     <namespace>/<rolebinding>
+delete_rolebindings()
+{
+    for nr in "$@"; do
+        ns=${nr%/*}
+        r=${nr#*/}
+        kubectl delete ${DRY_RUN} rolebinding -n "${ns}" "${r}"
+    done
+}
+
+get_sa()
+{
+    echo "PSP_ONLY_SA=${PSP_ONLY_SA}"
+    echo
+
+    for sa in ${PSP_ONLY_SA}; do
+        kind=${sa%%/*}
+        if [[ "${kind}" != ServiceAccount ]]; then
+            continue
+        fi
+        name_ns=${sa#*/}
+        name=${name_ns%%/*}
+        # namespace is
+        #     <namespace>[:<namespace>]
+        # If the first one is empty, use the second one
+        ns_tmp=${name_ns#*/}
+        ns=${ns_tmp%:*}
+        if [[ -z ${ns} ]]; then
+            ns=${ns_tmp#*:}
+        fi
+        echo "${sa} ==> kind=${kind} name=${name} ns=${ns}"
+    done
+
+}
+
+delete_sa()
+{
+    echo "delete_sa(): NOP"
+}
+
+
+if apiserver_has_psp; then
+    echo "Please disable PSP on all control plane nodes before running this script"
+    exit 1
+fi
+
+delete_any_psp
+
+get_clusterroles
+
+# shellcheck disable=SC2086
+delete_clusterroles ${CLUSTERROLE_ONLY_PSP}
+
+# shellcheck disable=SC2086
+delete_psp_from_clusterroles ${CLUSTERROLE_MIXED_PSP}
+
+get_roles
+
+# shellcheck disable=SC2086
+delete_roles ${ROLE_ONLY_PSP}
+
+# shellcheck disable=SC2086
+delete_psp_from_roles ${ROLE_MIXED_PSP}
+
+get_clusterrolebindings
+
+# shellcheck disable=SC2086
+delete_clusterrolebindings ${CLUSTERROLEBINDING_ONLY_PSP}
+
+get_rolebindings
+
+# shellcheck disable=SC2086
+delete_rolebindings ${ROLEBINDING_CLUSTER_ONLY_PSP} ${ROLEBINDING_ONLY_PSP}
+
+get_sa
+
+delete_sa

--- a/upgrade/scripts/k8s/remove_psp.sh
+++ b/upgrade/scripts/k8s/remove_psp.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
-
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Overview of the resources for implementing PSP
 #
 # <pod> contains reference to:
@@ -27,23 +49,22 @@
 # DRY_RUN=--dry-run=server
 DRY_RUN=""
 
-apiserver_has_psp()
-{
-    echo "Checking if PSP has been disabled on all control plane nodes"
-    ret_val=1
-    api_servers=$(kubectl get pods -n kube-system -lcomponent=kube-apiserver -ojsonpath='{.items[*].metadata.name}')
-    for server in ${api_servers}; do
-        if kubectl get pod -n kube-system "${server}" -o yaml | grep -q "enable-admission-plugins=.*PodSecurityPolicy"; then
-           ret_val=0
-           echo "${server} has the PodSecurityPolicy plugin  enabled.  Please disable it by running:"
-           echo "    sed -i 's/,*PodSecurityPolicy//' /etc/kubernetes/manifests/kube-apiserver.yaml"
-           echo "    sed -i '/enable-admission-plugins=$/d' /etc/kubernetes/manifests/kube-apiserver.yaml"
-           echo "on ${server#kube-apiserver-}"
-           echo "The kubelet will detect the change and automatically restart ${server}"
-           echo
-        fi
-    done
-    return "${ret_val}"
+apiserver_has_psp() {
+  echo "Checking if PSP has been disabled on all control plane nodes"
+  ret_val=1
+  api_servers=$(kubectl get pods -n kube-system -lcomponent=kube-apiserver -ojsonpath='{.items[*].metadata.name}')
+  for server in ${api_servers}; do
+    if kubectl get pod -n kube-system "${server}" -o yaml | grep -q "enable-admission-plugins=.*PodSecurityPolicy"; then
+      ret_val=0
+      echo "${server} has the PodSecurityPolicy plugin  enabled.  Please disable it by running:"
+      echo "    sed -i 's/,*PodSecurityPolicy//' /etc/kubernetes/manifests/kube-apiserver.yaml"
+      echo "    sed -i '/enable-admission-plugins=$/d' /etc/kubernetes/manifests/kube-apiserver.yaml"
+      echo "on ${server#kube-apiserver-}"
+      echo "The kubelet will detect the change and automatically restart ${server}"
+      echo
+    fi
+  done
+  return "${ret_val}"
 }
 
 
@@ -62,18 +83,17 @@ DEFAULT_PSPS="${DEFAULT_PSPS} metallb-controller metallb-speaker node-problem-de
 DEFAULT_PSPS="${DEFAULT_PSPS} privileged restricted restricted-transition restricted-transition-net-raw"
 DEFAULT_PSPS="${DEFAULT_PSPS} sealed-secrets-kube-system sma-vm-cluster spire spire-agent uas-default-psp"
 
-delete_any_psp()
-{
-    PSPS=$(kubectl get psp -ojsonpath='{.items[*].metadata.name}' 2>/dev/null)
-    if [ -z "${PSPS}" ]; then
-        echo "No existing podsecuritypolices"
-        PSPS="${DEFAULT_PSPS}"
-        return 0
-    fi
-    PSPS=$(echo ${DEFAULT_PSPS} ${PSPS} | tr ' ' '\n' | sort -u | tr '\n' ' ')
-    echo "Deleting all podsecuritypolicies"
-    kubectl delete ${DRY_RUN} psp --all
+delete_any_psp() {
+  PSPS=$(kubectl get psp -ojsonpath='{.items[*].metadata.name}' 2>/dev/null)
+  if [ -z "${PSPS}" ]; then
+    echo "No existing podsecuritypolices"
+    PSPS="${DEFAULT_PSPS}"
     return 0
+  fi
+  PSPS=$(echo ${DEFAULT_PSPS} ${PSPS} | tr ' ' '\n' | sort -u | tr '\n' ' ')
+  echo "Deleting all podsecuritypolicies"
+  kubectl delete ${DRY_RUN} psp --all
+  return 0
 }
 
 # A list of known Cluster Roles that point to PSPs, taken from system running CSM 1.6
@@ -91,52 +111,49 @@ KNOWN_PSP_CR="${KNOWN_PSP_CR} sealed-secrets-kube-system-psp sma-vm-cluster-clus
 #     CLUSTERROLE_NO_PSP: ClusterRoles that do not have PSP resources
 #     CLUSTERROLE_ONLY_PSP: ClusterRoles that have only PSP resources
 #     CLUSTERROLE_MIXED_PSP: ClusterRoles that have a mix of PSP and non-PSP resources
-get_clusterroles()
-{
-    CR=$(kubectl get clusterrole -ojsonpath='{.items[*].metadata.name}')
-    CLUSTERROLES=$(echo ${CR} ${KNOWN_PSP_CR}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+get_clusterroles() {
+  CR=$(kubectl get clusterrole -ojsonpath='{.items[*].metadata.name}')
+  CLUSTERROLES=$(echo ${CR} ${KNOWN_PSP_CR}| tr ' ' '\n' | sort -u | tr '\n' ' ')
 
-    CLUSTERROLE_NO_PSP=""
-    CLUSTERROLE_ONLY_PSP=""
-    CLUSTERROLE_MIXED_PSP=""
-    CLUSTERROLE_NX=""
-    for cr in ${CLUSTERROLES}; do
-        if ! resources=$(kubectl get clusterrole "${cr}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
-            CLUSTERROLE_NX="${CLUSTERROLE_NX} ${cr}"
-        elif [ "${resources}" = podsecuritypolicies ]; then
-            CLUSTERROLE_ONLY_PSP="${CLUSTERROLE_ONLY_PSP} ${cr}"
-        elif echo "${resources}" | grep -q podsecuritypolicies; then
-            CLUSTERROLE_MIXED_PSP="${CLUSTERROLE_MIXED_PSP} ${cr}"
-        else
-            CLUSTERROLE_NO_PSP="${CLUSTERROLE_NO_PSP} ${cr}"
-        fi
-    done
-    echo "CLUSTERROLE_NX: ${CLUSTERROLE_NX}"
-    echo "CLUSTERROLE_ONLY_PSP: ${CLUSTERROLE_ONLY_PSP}"
-    echo "CLUSTERROLE_MIXED_PSP: ${CLUSTERROLE_MIXED_PSP}"
+  CLUSTERROLE_NO_PSP=""
+  CLUSTERROLE_ONLY_PSP=""
+  CLUSTERROLE_MIXED_PSP=""
+  CLUSTERROLE_NX=""
+  for cr in ${CLUSTERROLES}; do
+    if ! resources=$(kubectl get clusterrole "${cr}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+      CLUSTERROLE_NX="${CLUSTERROLE_NX} ${cr}"
+      elif [ "${resources}" = podsecuritypolicies ]; then
+        CLUSTERROLE_ONLY_PSP="${CLUSTERROLE_ONLY_PSP} ${cr}"
+      elif echo "${resources}" | grep -q podsecuritypolicies; then
+        CLUSTERROLE_MIXED_PSP="${CLUSTERROLE_MIXED_PSP} ${cr}"
+      else
+        CLUSTERROLE_NO_PSP="${CLUSTERROLE_NO_PSP} ${cr}"
+      fi
+  done
+  echo "CLUSTERROLE_NX: ${CLUSTERROLE_NX}"
+  echo "CLUSTERROLE_ONLY_PSP: ${CLUSTERROLE_ONLY_PSP}"
+  echo "CLUSTERROLE_MIXED_PSP: ${CLUSTERROLE_MIXED_PSP}"
 }
 
 # Delete a list of clusterroles, specified as a list of:
 #     <clusterrole>
-delete_clusterroles()
-{
-    if [ -n "$*" ]; then
-        kubectl delete ${DRY_RUN} clusterrole "$@"
-    fi
+delete_clusterroles() {
+  if [ -n "$*" ]; then
+    kubectl delete ${DRY_RUN} clusterrole "$@"
+  fi
 }
 
 # For clusterroles that have multiple resources, delete just the
 # "podsecuritypolicies" element from the array of resources
 # in the role.  The roles are specified as a list of:
 #     <clusterrole>
-delete_psp_from_clusterroles()
-{
-    for cr in "$@"; do
-        #kubectl get clusterrole "${cr}" -o json | jq 'del(.rules[] | select(.resources[0]=="podsecuritypolicies"))' | kubectl apply ${DRY_RUN} -f -
+delete_psp_from_clusterroles() {
+  for cr in "$@"; do
+    #kubectl get clusterrole "${cr}" -o json | jq 'del(.rules[] | select(.resources[0]=="podsecuritypolicies"))' | kubectl apply ${DRY_RUN} -f -
 
-        INDEX=$(kubectl get clusterrole "${cr}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
-        kubectl patch ${DRY_RUN} clusterrole "${cr}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
-    done
+    INDEX=$(kubectl get clusterrole "${cr}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+    kubectl patch ${DRY_RUN} clusterrole "${cr}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
+  done
 }
 
 
@@ -146,197 +163,186 @@ KNOWN_PSP_R="ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-
 #     ROLE_NO_PSP: ClusterRoles that do not have PSP resources
 #     ROLE_ONLY_PSP: ClusterRoles that have only PSP resources
 #     ROLE_MIXED_PSP: ClusterRoles that have a mix of PSP and non-PSP resources
-get_roles()
-{
-    # Get a list of Roles
-    R=$(kubectl get roles -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
-    ROLES=$(echo ${R} ${KNOWN_PSP_R}| tr ' ' '\n' | sort -u | tr '\n' ' ')
+get_roles() {
+  # Get a list of Roles
+  R=$(kubectl get roles -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+  ROLES=$(echo ${R} ${KNOWN_PSP_R}| tr ' ' '\n' | sort -u | tr '\n' ' ')
 
-    ROLE_NO_PSP=""
-    ROLE_ONLY_PSP=""
-    ROLE_MIXED_PSP=""
-    for nr in ${ROLES}; do
-        ns=${nr%/*}
-        r=${nr#*/}
-        if ! resources=$(kubectl get role -n "${ns}" "${r}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
-            ROLE_NX="${ROLE_NX} ${nr}"
-        elif [ "${resources}" = podsecuritypolicies ]; then
-            ROLE_ONLY_PSP="${ROLE_ONLY_PSP} ${nr}"
-        elif echo "${resources}" | grep -q podsecuritypolicies; then
-            ROLE_MIXED_PSP="${ROLE_MIXED_PSP} ${nr}"
-        else
-            ROLE_NO_PSP="${ROLE_NO_PSP} ${nr}"
-        fi
-    done
-    echo "ROLE_NX: ${ROLE_NX}"
-    echo "ROLE_ONLY_PSP: ${ROLE_ONLY_PSP}"
-    echo "ROLE_MIXED_PSP: ${ROLE_MIXED_PSP}"
+  ROLE_NO_PSP=""
+  ROLE_ONLY_PSP=""
+  ROLE_MIXED_PSP=""
+  for nr in ${ROLES}; do
+    ns=${nr%/*}
+    r=${nr#*/}
+    if ! resources=$(kubectl get role -n "${ns}" "${r}" -o jsonpath='{.rules[*].resources[*]}{"\n"}' 2>/dev/null); then
+      ROLE_NX="${ROLE_NX} ${nr}"
+    elif [ "${resources}" = podsecuritypolicies ]; then
+      ROLE_ONLY_PSP="${ROLE_ONLY_PSP} ${nr}"
+    elif echo "${resources}" | grep -q podsecuritypolicies; then
+      ROLE_MIXED_PSP="${ROLE_MIXED_PSP} ${nr}"
+    else
+      ROLE_NO_PSP="${ROLE_NO_PSP} ${nr}"
+    fi
+  done
+  echo "ROLE_NX: ${ROLE_NX}"
+  echo "ROLE_ONLY_PSP: ${ROLE_ONLY_PSP}"
+  echo "ROLE_MIXED_PSP: ${ROLE_MIXED_PSP}"
 }
 
 # Delete a list of roles, specified as a list of:
 #     <namespace>/<role>
-delete_roles()
-{
-    for nr in "$@"; do
-        ns=${nr%/*}
-        r=${nr#*/}
-        kubectl delete ${DRY_RUN} role -n "${ns}" "${r}"
-    done
+delete_roles() {
+  for nr in "$@"; do
+    ns=${nr%/*}
+    r=${nr#*/}
+    kubectl delete ${DRY_RUN} role -n "${ns}" "${r}"
+  done
 }
 
 # For roles that have multiple resources, delete just the
 # "podsecuritypolicies" element from the array of resources
 # in the role.  The roles are specified as a list of:
 #     <namespace>/<role>
-delete_psp_from_roles()
-{
-    for nr in "$@"; do
-        ns=${nr%/*}
-        r=${nr#*/}
-        INDEX=$(kubectl get role -n "${ns}" "${r}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
-        kubectl patch ${DRY_RUN} role -n "${ns}" "${r}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
-    done
+delete_psp_from_roles() {
+  for nr in "$@"; do
+    ns=${nr%/*}
+    r=${nr#*/}
+    INDEX=$(kubectl get role -n "${ns}" "${r}" -o json  | jq '.rules | map(.resources[0] == "podsecuritypolicies") | index(true)')
+    kubectl patch ${DRY_RUN} role -n "${ns}" "${r}" --type=json -p="[{'op': 'remove', 'path': '/rules/${INDEX}'}]"
+  done
 }
 
 # Get 3 list of clusterrolebindings:
 #     CLUSTERROLEBINDING_NO_SA: ClusterRoleBindings that do not have SA kinds
 #     CLUSTERROLEBINDING_ONLY_SA: ClusterRoleBindings that have only SA kinds
 #     CLUSTERROLEBINDING_MIXED_SA: ClusterRoleBindings that have a mix of SA and non-SA kinds
-get_clusterrolebindings()
-{
-    CLUSTERROLEBINDINGS=$(kubectl get clusterrolebinding -ojsonpath='{.items[*].metadata.name}')
+get_clusterrolebindings() {
+  CLUSTERROLEBINDINGS=$(kubectl get clusterrolebinding -ojsonpath='{.items[*].metadata.name}')
 
-    CLUSTERROLEBINDING_NO_PSP=""
-    CLUSTERROLEBINDING_ONLY_PSP=""
-    CLUSTERROLEBINDING_MIXED_PSP=""
-    for cr in ${CLUSTERROLEBINDINGS}; do
-        kind_name_subj=$(kubectl get clusterrolebinding "${cr}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{" "}{end}{"\n"}')
-        kind_name=${kind_name_subj%@*}
-        kind=${kind_name%/*}
-        name=${kind_name#*/}
-        if [ "${kind}" = ClusterRole ]; then
-           if echo " ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
-               CLUSTERROLEBINDING_ONLY_PSP="${CLUSTERROLEBINDING_ONLY_PSP} ${cr}"
-               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
-           elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
-               CLUSTERROLEBINDING_MIXED_PSP="${CLUSTERROLEBINDING_MIXED_PSP} ${cr}"
-           else
-               CLUSTERROLEBINDING_NO_PSP="${CLUSTERROLEBINDING_NO_PSP} ${cr}"
-           fi
-        else
-           CLUSTERROLEBINDING_OTHER="${CLUSTERROLEBINDING_OTHER} ${cr}/${kind}/${name}"
-        fi
-    done
-    echo "CLUSTERROLEBINDING_ONLY_PSP: ${CLUSTERROLEBINDING_ONLY_PSP}"
-    echo "CLUSTERROLEBINDING_MIXED_PSP: ${CLUSTERROLEBINDING_MIXED_PSP}"
-    echo "CLUSTERROLEBINDING_OTHER: ${CLUSTERROLEBINDING_OTHER}"
+  CLUSTERROLEBINDING_NO_PSP=""
+  CLUSTERROLEBINDING_ONLY_PSP=""
+  CLUSTERROLEBINDING_MIXED_PSP=""
+  for cr in ${CLUSTERROLEBINDINGS}; do
+    kind_name_subj=$(kubectl get clusterrolebinding "${cr}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{" "}{end}{"\n"}')
+    kind_name=${kind_name_subj%@*}
+    kind=${kind_name%/*}
+    name=${kind_name#*/}
+    if [ "${kind}" = ClusterRole ]; then
+      if echo " ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
+        CLUSTERROLEBINDING_ONLY_PSP="${CLUSTERROLEBINDING_ONLY_PSP} ${cr}"
+        PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+      elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
+        CLUSTERROLEBINDING_MIXED_PSP="${CLUSTERROLEBINDING_MIXED_PSP} ${cr}"
+      else
+        CLUSTERROLEBINDING_NO_PSP="${CLUSTERROLEBINDING_NO_PSP} ${cr}"
+      fi
+    else
+      CLUSTERROLEBINDING_OTHER="${CLUSTERROLEBINDING_OTHER} ${cr}/${kind}/${name}"
+    fi
+  done
+  echo "CLUSTERROLEBINDING_ONLY_PSP: ${CLUSTERROLEBINDING_ONLY_PSP}"
+  echo "CLUSTERROLEBINDING_MIXED_PSP: ${CLUSTERROLEBINDING_MIXED_PSP}"
+  echo "CLUSTERROLEBINDING_OTHER: ${CLUSTERROLEBINDING_OTHER}"
 }
 
 # Delete a list of clusterrolebindings, specified as a list of:
 #     <clusterrolebinding>
-delete_clusterrolebindings()
-{
-    kubectl delete ${DRY_RUN} clusterrolebindings "$@"
+delete_clusterrolebindings() {
+  kubectl delete ${DRY_RUN} clusterrolebindings "$@"
 }
 
 # Get 3 list of rolesbindings:
 #     ROLEBINDING_NO_SA: RoleBindings that do not have SA kinds
 #     ROLEBINDING_ONLY_SA: RoleBindings that have only SA kinds
 #     ROLEBINDING_MIXED_SA: RoleBindings that have a mix of SA and non-SA kinds
-get_rolebindings()
-{
-    # Get a list of Roles
-    ROLEBINDINGS=$(kubectl get rolebindings -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+get_rolebindings() {
+  # Get a list of Roles
+  ROLEBINDINGS=$(kubectl get rolebindings -A -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
 
-    ROLEBINDING_CLUSTER_ONLY_PSP=""
-    ROLEBINDING_CLUSTER_MIXED_PSP=""
-    ROLEBINDING_CLUSTER_NO_PSP=""
-    ROLEBINDING_ONLY_PSP=""
-    ROLEBINDING_MIXED_PSP=""
-    ROLEBINDING_NO_PSP=""
-    ROLEBINDING_OTHER=""
-    for nr in ${ROLEBINDINGS}; do
-        ns=${nr%/*}
-        r=${nr#*/}
+  ROLEBINDING_CLUSTER_ONLY_PSP=""
+  ROLEBINDING_CLUSTER_MIXED_PSP=""
+  ROLEBINDING_CLUSTER_NO_PSP=""
+  ROLEBINDING_ONLY_PSP=""
+  ROLEBINDING_MIXED_PSP=""
+  ROLEBINDING_NO_PSP=""
+  ROLEBINDING_OTHER=""
+  for nr in ${ROLEBINDINGS}; do
+    ns=${nr%/*}
+    r=${nr#*/}
 
-        kind_name_subj=$(kubectl get rolebinding -n "${ns}" "${r}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{":'"${ns}"' "}{end}{"\n"}')
-        kind_name=${kind_name_subj%@*}
-        kind=${kind_name%/*}
-        name=${kind_name#*/}
-        if [ "${kind}" = ClusterRole ]; then
-           if echo "  ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
-               ROLEBINDING_CLUSTER_ONLY_PSP="${ROLEBINDING_CLUSTER_ONLY_PSP} ${nr}"
-               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
-           elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
-               ROLEBINDING_CLUSTER_MIXED_PSP="${ROLEBINDING_CLUSTER_MIXED_PSP} ${nr}"
-           else
-               ROLEBINDING_CLUSTER_NO_PSP="${ROLEBINDING_CLUSTER_NO_PSP} ${nr}"
-           fi
-        elif [ "${kind}" = Role ]; then
-           if echo " ${ROLE_NX} ${ROLE_ONLY_PSP} " | grep -q " ${name} "; then
-               ROLEBINDING_ONLY_PSP="${ROLEBINDING_ONLY_PSP} ${nr}"
-               PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
-           elif echo " ${ROLE_MIXED_PSP} " | grep -q " ${name} "; then
-               ROLEBINDING_MIXED_PSP="${ROLEBINDING_MIXED_PSP} ${nr}"
-           else
-               ROLEBINDING_NO_PSP="${ROLEBINDING_NO_PSP} ${nr}"
-           fi
-        else
-           ROLEBINDING_OTHER="${ROLEBINDING_OTHER} ${nr}/${kind}/${name}"
-        fi
-    done
-    echo "ROLEBINDING_CLUSTER_ONLY_PSP: ${ROLEBINDING_CLUSTER_ONLY_PSP}"
-    echo "ROLEBINDING_CLUSTER_MIXED_PSP: ${ROLEBINDING_CLUSTER_MIXED_PSP}"
-    echo "ROLEBINDING_ONLY_PSP: ${ROLEBINDING_ONLY_PSP}"
-    echo "ROLEBINDING_MIXED_PSP: ${ROLEBINDING_MIXED_PSP}"
-    echo "ROLEBINDING_OTHER: ${ROLEBINDING_OTHER}"
+    kind_name_subj=$(kubectl get rolebinding -n "${ns}" "${r}" -o jsonpath='{.roleRef.kind}/{.roleRef.name}@{range .subjects[*]}{.kind}/{.name}/{.namespace}{":'"${ns}"' "}{end}{"\n"}')
+    kind_name=${kind_name_subj%@*}
+    kind=${kind_name%/*}
+    name=${kind_name#*/}
+    if [ "${kind}" = ClusterRole ]; then
+      if echo "  ${CLUSTERROLE_NX} ${CLUSTERROLE_ONLY_PSP} " | grep -q " ${name} "; then
+        ROLEBINDING_CLUSTER_ONLY_PSP="${ROLEBINDING_CLUSTER_ONLY_PSP} ${nr}"
+        PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+      elif echo " ${CLUSTERROLE_MIXED_PSP} " | grep -q " ${name} "; then
+        ROLEBINDING_CLUSTER_MIXED_PSP="${ROLEBINDING_CLUSTER_MIXED_PSP} ${nr}"
+      else
+        ROLEBINDING_CLUSTER_NO_PSP="${ROLEBINDING_CLUSTER_NO_PSP} ${nr}"
+      fi
+    elif [ "${kind}" = Role ]; then
+      if echo " ${ROLE_NX} ${ROLE_ONLY_PSP} " | grep -q " ${name} "; then
+        ROLEBINDING_ONLY_PSP="${ROLEBINDING_ONLY_PSP} ${nr}"
+        PSP_ONLY_SA="${PSP_ONLY_SA}${kind_name_subj#*@}"
+      elif echo " ${ROLE_MIXED_PSP} " | grep -q " ${name} "; then
+        ROLEBINDING_MIXED_PSP="${ROLEBINDING_MIXED_PSP} ${nr}"
+      else
+        ROLEBINDING_NO_PSP="${ROLEBINDING_NO_PSP} ${nr}"
+      fi
+    else
+      ROLEBINDING_OTHER="${ROLEBINDING_OTHER} ${nr}/${kind}/${name}"
+    fi
+  done
+  echo "ROLEBINDING_CLUSTER_ONLY_PSP: ${ROLEBINDING_CLUSTER_ONLY_PSP}"
+  echo "ROLEBINDING_CLUSTER_MIXED_PSP: ${ROLEBINDING_CLUSTER_MIXED_PSP}"
+  echo "ROLEBINDING_ONLY_PSP: ${ROLEBINDING_ONLY_PSP}"
+  echo "ROLEBINDING_MIXED_PSP: ${ROLEBINDING_MIXED_PSP}"
+  echo "ROLEBINDING_OTHER: ${ROLEBINDING_OTHER}"
 }
 
 # Delete a list of rolebindings, specified as a list of:
 #     <namespace>/<rolebinding>
-delete_rolebindings()
-{
-    for nr in "$@"; do
-        ns=${nr%/*}
-        r=${nr#*/}
-        kubectl delete ${DRY_RUN} rolebinding -n "${ns}" "${r}"
-    done
+delete_rolebindings() {
+  for nr in "$@"; do
+    ns=${nr%/*}
+    r=${nr#*/}
+    kubectl delete ${DRY_RUN} rolebinding -n "${ns}" "${r}"
+  done
 }
 
-get_sa()
-{
-    echo "PSP_ONLY_SA=${PSP_ONLY_SA}"
-    echo
+get_sa() {
+  echo "PSP_ONLY_SA=${PSP_ONLY_SA}"
+  echo
 
-    for sa in ${PSP_ONLY_SA}; do
-        kind=${sa%%/*}
-        if [[ "${kind}" != ServiceAccount ]]; then
-            continue
-        fi
-        name_ns=${sa#*/}
-        name=${name_ns%%/*}
-        # namespace is
-        #     <namespace>[:<namespace>]
-        # If the first one is empty, use the second one
-        ns_tmp=${name_ns#*/}
-        ns=${ns_tmp%:*}
-        if [[ -z ${ns} ]]; then
-            ns=${ns_tmp#*:}
-        fi
-        echo "${sa} ==> kind=${kind} name=${name} ns=${ns}"
-    done
-
+  for sa in ${PSP_ONLY_SA}; do
+    kind=${sa%%/*}
+    if [[ "${kind}" != ServiceAccount ]]; then
+      continue
+    fi
+    name_ns=${sa#*/}
+    name=${name_ns%%/*}
+    # namespace is
+    #     <namespace>[:<namespace>]
+    # If the first one is empty, use the second one
+    ns_tmp=${name_ns#*/}
+    ns=${ns_tmp%:*}
+    if [[ -z ${ns} ]]; then
+      ns=${ns_tmp#*:}
+    fi
+    echo "${sa} ==> kind=${kind} name=${name} ns=${ns}"
+  done
 }
 
-delete_sa()
-{
-    echo "delete_sa(): NOP"
+delete_sa() {
+  echo "delete_sa(): NOP"
 }
-
 
 if apiserver_has_psp; then
-    echo "Please disable PSP on all control plane nodes before running this script"
-    exit 1
+  echo "Please disable PSP on all control plane nodes before running this script"
+  exit 1
 fi
 
 delete_any_psp

--- a/upgrade/scripts/k8s/remove_psp.sh
+++ b/upgrade/scripts/k8s/remove_psp.sh
@@ -41,7 +41,7 @@
 #   and remove the line with:
 #     enable-admission-plugins=PodSecurityPolicy
 #
-# sed -i '/enable-admission-plugins=PodSecurityPolicy/d' /etc/kubernetes/manifests/kube-apiserver.yaml"
+# sed -i '/enable-admission-plugins=PodSecurityPolicy/d' /etc/kubernetes/manifests/kube-apiserver.yaml
 #
 # The kubelet will automatically restart the kube-apiserver pods.  Wait for each kube-apiserver
 # pod to restart and enter Running state before restarting the next one
@@ -64,7 +64,7 @@ apiserver_has_psp() {
       echo
     fi
   done
-  return "${ret_val}"
+  return ${ret_val}
 }
 
 # A list of known PSPs, taking from system running CSM 1.6

--- a/upgrade/scripts/k8s/upgrade_k8s_steps.sh
+++ b/upgrade/scripts/k8s/upgrade_k8s_steps.sh
@@ -119,6 +119,23 @@ else
   fi
 fi
 
+if [[ -f "$DONE_DIR/remove_psp.done" ]]; then
+  echo "INFO Remove unneeded PSP resources already completed, skipping."
+else
+  echo "INFO Remove unneeded PSP resources."
+  /usr/share/doc/csm/upgrade/scripts/k8s/remove_psp.sh
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to remove unneeded PSP resources."
+    exit 1
+  fi
+  touch "$DONE_DIR/remove_psp.done"
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR Failed to create done file for remove PSP resources"
+    exit 1
+  fi
+  echo "INFO Successfully removed unneeded PSP resources."
+fi
+
 if [[ -f "$DONE_DIR/rr_cs_rollout_restart.done" ]]; then
   echo "INFO Rack Resiliency Critical services rollout restart already completed, skipping."
 else


### PR DESCRIPTION
# Description
CASMPET-7665: Run the remove_psp.sh script in the upgrade_k8s_steps.sh script after
deploying manifests to remove PSP resources that are no longer needed

Once Kubernetes is upgraded to 1.32, we no longer use PodSecurityPolicy. There is a bunch of PSP cruft hanging around after upgrading to csm `1.7.0` and `1.7.1`.  Run the `remove_psp.sh` script that David Borman wrote to clean up known PSP resources after upgrade is completed.

# Testing
Upgrades were tested on the vShasta system `molly`.

Upgrade from `1.6.3-beta.3` to `1.7.1-beta.4`
```
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-con
troller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controll
er cray-spire cray-spire-agent-psp node-problem-detector-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-transition-net-raw-psp sealed-secrets-kube-
system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:  privileged-psp restricted-psp restricted-transition-psp
CLUSTERROLE_MIXED_PSP:  cray-kyverno-post-install-job
clusterrole.rbac.authorization.k8s.io "privileged-psp" deleted
clusterrole.rbac.authorization.k8s.io "restricted-psp" deleted
clusterrole.rbac.authorization.k8s.io "restricted-transition-psp" deleted
clusterrole.rbac.authorization.k8s.io/cray-kyverno-post-install-job patched
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:  restricted-transition-psp
CLUSTERROLEBINDING_MIXED_PSP:  cray-kyverno-post-install-job
CLUSTERROLEBINDING_OTHER:
clusterrolebinding.rbac.authorization.k8s.io "restricted-transition-psp" deleted
ROLEBINDING_CLUSTER_ONLY_PSP:  kube-system/kube-system-psp
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "kube-system-psp" deleted
PSP_ONLY_SA=Group/system:authenticated/ Group/system:nodes/:kube-system Group/system:serviceaccounts:kube-system/:kube-system

delete_sa(): NOP
INFO Successfully removed unneeded PSP resources.
Rack Resiliency is not enabled. Skipping restart.
INFO Critical Services rollout restart successfully completed, if it was necessary

ncn-m001:~ # kubectl get rolebinding -A | grep psp
ncn-m001:~ # kubectl get clusterrolebinding | grep psp
ncn-m001:~ # kubectl get clusterrole | grep psp
ncn-m001:~ # 
```

Upgrade from `1.6.3-beta.3` to `1.7.0`
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2501/

```
+ CSM applications and services upgraded
upgrade.sh: OK
INFO Successfully deployed manifests for v1.32
INFO Remove unneeded PSP resources.
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-transition-net-raw-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:  privileged-psp restricted-psp restricted-transition-psp
CLUSTERROLE_MIXED_PSP:  cray-kyverno-post-install-job
clusterrole.rbac.authorization.k8s.io "privileged-psp" deleted
clusterrole.rbac.authorization.k8s.io "restricted-psp" deleted
clusterrole.rbac.authorization.k8s.io "restricted-transition-psp" deleted
clusterrole.rbac.authorization.k8s.io/cray-kyverno-post-install-job patched
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:  restricted-transition-psp
CLUSTERROLEBINDING_MIXED_PSP:  cray-kyverno-post-install-job
CLUSTERROLEBINDING_OTHER:
clusterrolebinding.rbac.authorization.k8s.io "restricted-transition-psp" deleted
ROLEBINDING_CLUSTER_ONLY_PSP:  argo/argo-psp cert-manager/cert-manager-psp istio-system/istio-system-psp kube-system/kube-system-psp loftsman/loftsman-psp operators/operators-psp services/cray-console-operator-psp services/cray-node-discovery services/cray-postgres-operator-psp services/services-default-psp services/sonar-psp spire/tpm-provisioner-psp vault/spire-intermediate-psp vault/tpm-intermediate-psp vault/vault-psp
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "argo-psp" deleted
rolebinding.rbac.authorization.k8s.io "cert-manager-psp" deleted
rolebinding.rbac.authorization.k8s.io "istio-system-psp" deleted
rolebinding.rbac.authorization.k8s.io "kube-system-psp" deleted
rolebinding.rbac.authorization.k8s.io "loftsman-psp" deleted
rolebinding.rbac.authorization.k8s.io "operators-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-console-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-node-discovery" deleted
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "services-default-psp" deleted
rolebinding.rbac.authorization.k8s.io "sonar-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-provisioner-psp" deleted
rolebinding.rbac.authorization.k8s.io "spire-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "vault-psp" deleted
PSP_ONLY_SA=Group/system:authenticated/ Group/system:serviceaccounts:argo/:argo Group/system:serviceaccounts:cert-manager/:cert-manager Group/system:serviceaccounts:istio-system/:istio-system Group/system:nodes/:kube-system Group/system:serviceaccounts:kube-system/:kube-system Group/system:serviceaccounts:loftsman/:loftsman Group/system:serviceaccounts:operators/:operators ServiceAccount/cray-console-operator/services:services ServiceAccount/cray-node-discovery/:services ServiceAccount/cray-postgres-operator/services:services ServiceAccount/default/services:services ServiceAccount/sonar/services:services ServiceAccount/jobs-watcher/services:services ServiceAccount/tpm-provisioner/:spire ServiceAccount/spire-intermediate/vault:vault ServiceAccount/tpm-intermediate/vault:vault Group/system:serviceaccounts:vault/:vault

ServiceAccount/cray-console-operator/services:services ==> kind=ServiceAccount name=cray-console-operator ns=services
ServiceAccount/cray-node-discovery/:services ==> kind=ServiceAccount name=cray-node-discovery ns=services
ServiceAccount/cray-postgres-operator/services:services ==> kind=ServiceAccount name=cray-postgres-operator ns=services
ServiceAccount/default/services:services ==> kind=ServiceAccount name=default ns=services
ServiceAccount/sonar/services:services ==> kind=ServiceAccount name=sonar ns=services
ServiceAccount/jobs-watcher/services:services ==> kind=ServiceAccount name=jobs-watcher ns=services
ServiceAccount/tpm-provisioner/:spire ==> kind=ServiceAccount name=tpm-provisioner ns=spire
ServiceAccount/spire-intermediate/vault:vault ==> kind=ServiceAccount name=spire-intermediate ns=vault
ServiceAccount/tpm-intermediate/vault:vault ==> kind=ServiceAccount name=tpm-intermediate ns=vault
delete_sa(): NOP
INFO Successfully removed unneeded PSP resources.
Rack Resiliency is not enabled. Skipping restart.
INFO Critical Services rollout restart successfully completed, if it was necessary
ncn-m001:~ #
ncn-m001:~ # kubectl get rolebinding -A | grep psp
ncn-m001:~ # kubectl get clusterrolebinding | grep psp
ncn-m001:~ # kubectl get clusterrole | grep psp
ncn-m001:~ #
```

A re-run of `upgrade.sh` on `1.7.0` after removing PSP cruft is successful and recreates rolebindings since it deploys charts that still create them.
```
<snip>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing csm-redfish-interface-emulator v0.1.1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-10-02T13:56:16Z INF Running helm install/upgrade with arguments: upgrade --install csm-redfish-interface-emulator helm/csm-redfish-interface-emulator-0.1.1.tgz --namespace services --create-namespace --set global.chart.name=csm-redfish-interface-emulator --set global.chart.version=0.1.1 --timeout 20m chart=csm-redfish-interface-emulator command=ship namespace=services version=0.1.1
2025-10-02T13:56:21Z INF Release "csm-redfish-interface-emulator" has been upgraded. Happy Helming!
NAME: csm-redfish-interface-emulator
LAST DEPLOYED: Thu Oct  2 13:56:16 2025
NAMESPACE: services
STATUS: deployed
REVISION: 4
TEST SUITE: None
 chart=csm-redfish-interface-emulator command=ship namespace=services version=0.1.1
2025-10-02T13:56:21Z INF Ship status: success. Recording status, manifest to configmap loftsman-vshasta in namespace loftsman command=ship
2025-10-02T13:56:21Z INF Recording log data to configmap loftsman-vshasta-ship-log in namespace loftsman command=ship
+ undeploy -n operators cray-etcd-operator
+ helm status -n operators cray-etcd-operator
Error: release: not found
+ return 0
+ '[' v1.32 = v1.24 ']'
+ set +x
+ CSM applications and services upgraded
upgrade.sh: OK
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 #

ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 # kubectl get pods -A | grep -Ev "Running|Complete"
NAMESPACE         NAME                                                              READY   STATUS      RESTARTS     AGE
rack-resiliency   cray-rrs-6c5585cfdf-6zj96                                         0/2     Init:0/2    0            8h
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 # kubectl get pods -A | grep -Ev "Running|Complete"
NAMESPACE         NAME                                                              READY   STATUS      RESTARTS     AGE
rack-resiliency   cray-rrs-6c5585cfdf-6zj96                                         0/2     Init:0/2    0            8h
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 # kubectl get rolebinding -A | grep psp
argo             argo-psp                                                                   ClusterRole/privileged-psp                                     54m
cert-manager     cert-manager-psp                                                           ClusterRole/privileged-psp                                     54m
istio-system     istio-system-psp                                                           ClusterRole/privileged-psp                                     54m
loftsman         loftsman-psp                                                               ClusterRole/privileged-psp                                     54m
operators        operators-psp                                                              ClusterRole/privileged-psp                                     54m
services         cray-console-operator-psp                                                  ClusterRole/privileged-psp                                     35m
services         cray-node-discovery                                                        ClusterRole/privileged-psp                                     50m
services         cray-postgres-operator-psp                                                 ClusterRole/privileged-psp                                     50m
services         services-default-psp                                                       ClusterRole/privileged-psp                                     54m
services         sonar-psp                                                                  ClusterRole/privileged-psp                                     54m
spire            tpm-provisioner-psp                                                        ClusterRole/restricted-transition-net-raw-psp                  50m
vault            spire-intermediate-psp                                                     ClusterRole/restricted-transition-psp                          50m
vault            tpm-intermediate-psp                                                       ClusterRole/restricted-transition-psp                          50m
vault            vault-psp                                                                  ClusterRole/privileged-psp                                     52m
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 # kubectl get clusterrolebinding | grep psp
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 # kubectl get clusterrole | grep psp
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0 #

ncn-m001:~ # kubectl get pods -A | grep -Ev "Running|Complete"
NAMESPACE         NAME                                                              READY   STATUS      RESTARTS      AGE
rack-resiliency   cray-rrs-6c5585cfdf-6zj96                                         0/2     Init:0/2    0             13h
services          cray-dhcp-kea-helper-29323848-dj5cn                               1/2     NotReady    0             25s
services          cray-dns-unbound-manager-29323848-b7d5t                           1/2     NotReady    0             25s
services          hms-discovery-29323848-mlxjg                                      1/2     NotReady    0             25s
ncn-m001:~ #
```

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
