### PR TITLE
CASMTRIAGE-8604 :adding disk space check before node drain

### DIFF
--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -53,10 +53,10 @@ spec:
                   THRESHOLD=80
                   NAME_WORKER_REGEX='^ncn-w[0-9]+$'
 
-                  echo "DEBUG Checking /var/lib/containerd usage (threshold ${THRESHOLD}%) excluding ${TARGET}"
+                  echo "INFO Checking /var/lib/containerd usage (threshold ${THRESHOLD}%) excluding ${TARGET}"
                   workers=$(kubectl get nodes --no-headers 2>/dev/null | awk '{print $1}' | grep -E "${NAME_WORKER_REGEX}" | grep -v "^${TARGET}$" || true)
                   if [ -z "${workers}" ]; then
-                    echo "INFO No other worker nodes found; continuing."
+                    echo "DEBUG No other worker nodes found; continuing drain for ${TARGET}."
                     exit 0
                   fi
                   risk_nodes=()
@@ -77,8 +77,10 @@ spec:
                     echo "INFO Refer to operations > kubernetes > containerd section of the CSM documentation to cleanup /var/lib/containerd on the affected nodes and then re-run the IUF stage"
                     exit 1
                   fi
-                  echo "INFO All checked workers below ${THRESHOLD}%"
+                  echo "INFO All checked workers $(echo "$workers" | paste -sd',' -) below ${THRESHOLD}%"
         - name: drain
+          dependencies:
+            - check-disk-space
           templateRef:
             name: kubectl-and-curl-template
             template: shell-script

--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,6 +38,46 @@ spec:
           - name: desiredCfsConfig
       dag:
         tasks:
+        - name: check-disk-space
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  set -euo pipefail
+                  TARGET="{{inputs.parameters.targetNcn}}"
+                  THRESHOLD=80
+                  NAME_WORKER_REGEX='^ncn-w[0-9]+$'
+
+                  echo "DEBUG Checking /var/lib/containerd usage (threshold ${THRESHOLD}%) excluding ${TARGET}"
+                  workers=$(kubectl get nodes --no-headers 2>/dev/null | awk '{print $1}' | grep -E "${NAME_WORKER_REGEX}" | grep -v "^${TARGET}$" || true)
+                  if [ -z "${workers}" ]; then
+                    echo "INFO No other worker nodes found; continuing."
+                    exit 0
+                  fi
+                  risk_nodes=()
+                  for worker in $workers; do
+                    disk_usage_percentage=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@"$worker" "df -P /var/lib/containerd 2>/dev/null | tail -1 | awk '{print \$5}'" 2>/dev/null || true)
+                    disk_usage_percentage=${disk_usage_percentage%\%}
+                    if [ -z "$disk_usage_percentage" ] || ! [[ "$disk_usage_percentage" =~ ^[0-9]+$ ]]; then
+                      echo "WARN Unable to determine usage on $worker"
+                      continue
+                    fi
+                    if [ "$disk_usage_percentage" -ge "$THRESHOLD" ]; then
+                      echo "DEBUG Node $worker at ${disk_usage_percentage}% (>= ${THRESHOLD}%)"
+                      risk_nodes+=("$worker")
+                    fi
+                  done
+                  if [ "${#risk_nodes[@]}" -gt 0 ]; then
+                    echo "ERROR Threshold exceeded on: ${risk_nodes[*]}"
+                    echo "INFO Refer to operations > kubernetes > containerd section of the CSM documentation to cleanup /var/lib/containerd on the affected nodes and then re-run the IUF stage"
+                    exit 1
+                  fi
+                  echo "INFO All checked workers below ${THRESHOLD}%"
         - name: drain
           templateRef:
             name: kubectl-and-curl-template


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

This PR adds a disk space check before draining the node so all services are up after a successful drain.
Resolves- [CASMTRIAGE-8604](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8604)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
