### PR TITLE
MTL-2606 -- fix perl regex for PCRE2 compliance

### DIFF
--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -61,8 +61,8 @@ spec:
         exit 1
     fi
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    installed=$(pdsh -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|Nothing to do." | wc -l)
-    if [[ $installed -lt $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | wc -l) ]]; then
+    installed=$(pdsh -w $(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|Nothing to do." | wc -l)
+    if [[ $installed -lt $(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | wc -l) ]]; then
       echo "ERROR installing csi on master nodes. Make sure valid SSH keys exist from ncn-m001 to other master nodes. Manually run - zypper install -y $csi_url on master nodes."
       exit 1
     else

--- a/workflows/templates/storage.before-all.yaml
+++ b/workflows/templates/storage.before-all.yaml
@@ -54,7 +54,7 @@ spec:
                     source /srv/cray/scripts/metal/metal-lib.sh
                     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-noos" \
                       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
-                    pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
+                    pdsh -S -w $(grep -oP 'ncn-m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
           - name: add-admin-label-to-ncn-s002
             templateRef:
               name: ssh-template


### PR DESCRIPTION
# Description

grep >= 3.8 dropped support for PCRE1 (perl compatible regular expressions). "\m" is no longer allowed and produces an error on SLES 15 SP7 / CSM 1.7.1

Relates to:
- https://jira-pro.it.hpe.com:8443/browse/MTL-2606


# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.