### PR TITLE
CASMTRIAGE-8829 - nexus-export.sh missing path to nexus-helper.sh

### DIFF
--- a/scripts/nexus-export.sh
+++ b/scripts/nexus-export.sh
@@ -25,6 +25,8 @@
 
 set -eo pipefail
 
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+
 availRGW=$(ceph df -f json | jq '.stats.total_avail_bytes' | awk '{printf "%.0f", ($1/1024/1024/1024)}')
 echo "Gibibytes available in cluster: $availRGW"
 
@@ -82,7 +84,7 @@ EOF
   fi
 fi
 
-source nexus_helper.sh
+source ${SCRIPT_DIR}/nexus_helper.sh
 alpine_version=$(get_latest_alpine)
 echo "Pulling the latest alpine version: $alpine_version"
 cache_alpine

--- a/scripts/nexus-export.sh
+++ b/scripts/nexus-export.sh
@@ -25,7 +25,7 @@
 
 set -eo pipefail
 
-SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+SCRIPT_DIR=$(dirname "$(realpath ${BASH_SOURCE[0]})")
 
 availRGW=$(ceph df -f json | jq '.stats.total_avail_bytes' | awk '{printf "%.0f", ($1/1024/1024/1024)}')
 echo "Gibibytes available in cluster: $availRGW"

--- a/scripts/nexus-restore.sh
+++ b/scripts/nexus-restore.sh
@@ -25,12 +25,14 @@
 
 set -exo pipefail
 
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+
 if [[ "Bound" != $(kubectl get pvc -n nexus nexus-bak -o jsonpath='{.status.phase}') ]]; then
   echo "Error no backup PVC was found\nPlease run nexus-backup.sh before trying to restore"
   exit 1
 fi
 
-source nexus_helper.sh
+source ${SCRIPT_DIR}/nexus_helper.sh
 alpine_version=$(get_latest_alpine)
 
 kubectl -n nexus scale deployment nexus --replicas=0

--- a/scripts/nexus-restore.sh
+++ b/scripts/nexus-restore.sh
@@ -25,7 +25,7 @@
 
 set -exo pipefail
 
-SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+SCRIPT_DIR=$(dirname "$(realpath ${BASH_SOURCE[0]})")
 
 if [[ "Bound" != $(kubectl get pvc -n nexus nexus-bak -o jsonpath='{.status.phase}') ]]; then
   echo "Error no backup PVC was found\nPlease run nexus-backup.sh before trying to restore"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The `nexus-export.sh` script has an error in both docs-csm 1.6 and docs-csm 1.7 versions of the script where it assumes the `nexus_helper.sh` script will be in the current working directory. However, this documentation here expects the script to be run with an absolute path from any directory.

This PR addresses the issue by forcing it to source `nexus_helper.sh` from the same directory as `nexus-export.sh`

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8829

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
