### PR TITLE
CASM-5743: Return zero as exit code to avoid failures when installing docs-csm on PIT node  

### DIFF
--- a/docs-csm.spec
+++ b/docs-csm.spec
@@ -55,4 +55,6 @@ cat INSTALLED_FILES | xargs -i sh -c 'test -L {} && exit || test -f $RPM_BUILD_R
 
 %post
 /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+# Return zero as exit code to avoid failures when installing docs-csm on PIT node
+exit 0
 


### PR DESCRIPTION
# Description

CASM-5743: Add zero exit code to post-install script to maintain compatibility to install docs-csm on PIT node during fresh install, when other nodes are not initialized yet .As, Absence of running Kubernetes cluster should not cause docs-csm installer to fail.

https://jira-pro.it.hpe.com:8443/browse/CASM-5743



# Checklist


- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
