### PR TITLE
CASMTRIAGE-8826: Add Nexus prune steps to upgrade docs -- 1.7

### DIFF
--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -53,7 +53,7 @@ See [Check for latest documentation](../update_product_stream/README.md#check-fo
 
 ### 3. Prune Nexus data
 
-Over time, it's possible for the persistent volume that stores Nexus data to fill up with old and unnecessary files, which can cause the upgrade to fail if disk utilization gets to 100%. Please see [Nexus Space Cleanup](../operations/package_repository_management/Nexus_Space_Cleanup.md) for specific steps.
+Over time, it's possible for the persistent volume that stores Nexus data to fill up with old and unnecessary files, which can cause the upgrade to fail if not enough disk space is available. Please see [Nexus Space Cleanup](../operations/package_repository_management/Nexus_Space_Cleanup.md) for specific steps.
 
 ### 4. Export Nexus data
 

--- a/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
+++ b/upgrade/Prepare_for_Upgrade_to_Next_CSM_Major_Version.md
@@ -20,12 +20,13 @@ completes its upgrade, then quorum would be lost.
 
 1. [Start typescript](#1-start-typescript)
 1. [Ensure latest documentation installed](#2-ensure-latest-documentation-is-installed)
-1. [Export Nexus data](#3-export-nexus-data)
-1. [Adding switch admin password to Vault](#4-adding-switch-admin-password-to-vault)
-1. [Ensure SNMP is configured on the management network switches](#5-ensure-snmp-is-configured-on-the-management-network-switches)
-1. [Running sessions](#6-running-sessions)
-1. [Health validation](#7-health-validation)
-1. [Stop typescript](#8-stop-typescript)
+1. [Prune Nexus data](#3-prune-nexus-data)
+1. [Export Nexus data](#4-export-nexus-data)
+1. [Adding switch admin password to Vault](#5-adding-switch-admin-password-to-vault)
+1. [Ensure SNMP is configured on the management network switches](#6-ensure-snmp-is-configured-on-the-management-network-switches)
+1. [Running sessions](#7-running-sessions)
+1. [Health validation](#8-health-validation)
+1. [Stop typescript](#9-stop-typescript)
 
 ### 1. Start typescript
 
@@ -50,7 +51,11 @@ CSM version on the system -- not the target version of the upgrade.
 
 See [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation) for instructions.
 
-### 3. Export Nexus data
+### 3. Prune Nexus data
+
+Over time, it's possible for the persistent volume that stores Nexus data to fill up with old and unnecessary files, which can cause the upgrade to fail if disk utilization gets to 100%. Please see [Nexus Space Cleanup](../operations/package_repository_management/Nexus_Space_Cleanup.md) for specific steps.
+
+### 4. Export Nexus data
 
 **Warning:** This process can take multiple hours where Nexus is unavailable and should be done
 during scheduled maintenance periods.
@@ -62,13 +67,13 @@ If there is no maintenance period available, then skip this step until after the
 Reference [Nexus Export and Restore Procedure](../operations/package_repository_management/Nexus_Export_and_Restore.md)
 for details.
 
-### 4. Adding switch admin password to Vault
+### 5. Adding switch admin password to Vault
 
 If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
 See [Adding switch admin password to Vault](../operations/network/management_network/README.md#adding-switch-admin-password-to-vault).
 
-### 5. Ensure SNMP is configured on the management network switches
+### 6. Ensure SNMP is configured on the management network switches
 <!-- snmp-authentication-tag -->
 <!-- When updating this information, search the docs for the snmp-authentication-tag to find related content -->
 <!-- These comments can be removed once we adopt HTTP/lw-dita/Generated docs with re-usable snippets -->
@@ -106,7 +111,7 @@ contains the following relevant information:
 
 Return here after verifying that SNMP is properly configured on the management network switches.
 
-### 6. Running sessions
+### 7. Running sessions
 
 [Boot Orchestration Service (BOS)](../glossary.md#boot-orchestration-service-bos),
 [Configuration Framework Service (CFS)](../glossary.md#configuration-framework-service-cfs),
@@ -144,7 +149,7 @@ Return here after verifying that SNMP is properly configured on the management n
    There is currently no method to prevent new sessions from being created as long as the service
    APIs are accessible on the API gateway.
 
-### 7. Health validation
+### 8. Health validation
 
 1. Validate CSM health.
 
@@ -159,6 +164,6 @@ Return here after verifying that SNMP is properly configured on the management n
    If a Lustre file system is being used, then see the ClusterStor documentation for details on how
    to validate Lustre health.
 
-### 8. Stop typescript
+### 9. Stop typescript
 
 For any typescripts that were started during this preparation stage, stop them with the `exit` command.


### PR DESCRIPTION
Insert a link in the upgrade preparation documentation to the Nexus volume pruning documentation, as subsequent upgrades cause Nexus to use large amounts of disk space, and maxing out that volume will cause the upgrade to fail.

[CASMTRIAGE-8826](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8826)

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
