### PR TITLE
CASMNET-2308 - Adjust unbound and kea resource requests for small systems

### DIFF
--- a/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
@@ -83,6 +83,10 @@ yaml_path="$base.cray-dhcp-kea.cray-postgresql.sqlCluster.resources.requests.cpu
 cray_dhcp_kea_postgres_new_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_dhcp_kea_postgres_new_request
 
+yaml_path="$base.cray-dhcp-kea.cray-service.containers.cray-dhcp-kea.resources.requests.cpu"
+cray_dhcp_kea_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_dhcp_kea_new_cpu_request
+
 yaml_path="$base.cray-hms-capmc.cray-service.containers.cray-capmc.resources.requests.cpu"
 cray_capmc_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_capmc_new_cpu_request
@@ -466,6 +470,14 @@ if [[ $crayDnsUnboundDeployed -ne 0 ]]; then
     kubectl rollout status deployment -n services cray-dns-unbound
     echo ""
   fi
+fi
+
+if [ ! -z $cray_dhcp_kea_new_cpu_request ]; then
+  current_req=$(kubectl get deployment -n services cray-dhcp-kea -o json | jq -r '.spec.template.spec.containers[] | select(.name== "cray-dhcp-kea") | .resources.requests.cpu')
+  echo "Patching cray-dhcp-kea deployment with new cpu request of $cray_dhcp_kea_new_cpu_request (from $current_req)"
+  kubectl patch deployment cray-dhcp-kea -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_dhcp_kea_new_cpu_request\" }]"
+  kubectl rollout status deployment -n services cray-dhcp-kea
+  echo ""
 fi
 
 # push updated customizations.yaml to k8s

--- a/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
@@ -171,6 +171,10 @@ yaml_path="$base.cray-opa.opa.resources.requests.cpu"
 cray_opa_new_cpu_request=$(yq r $yaml -pv $yaml_path)
 fail_if_empty $yaml_path $cray_opa_new_cpu_request
 
+yaml_path="$base.cray-dns-unbound.resources.cray-dns-unbound.requests.cpu"
+cray_dns_unbound_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_dns_unbound_new_cpu_request
+
 if kubectl get postgresqls -n spire cray-spire-postgres > /dev/null 2>&1; then
   if [ ! -z $cray_spire_postgres_new_request ]; then
     roll_postgres "spire" "cray-spire-postgres" $cray_spire_postgres_new_request
@@ -449,6 +453,17 @@ if [[ $crayOpaHmnDeployed -ne 0 ]]; then
     echo "Patching cray-opa-ingressgateway-hmn daemonset with new cpu request of $cray_opa_new_cpu_request (from $current_req)"
     kubectl patch daemonset cray-opa-ingressgateway-hmn -n opa --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_opa_new_cpu_request\" }]"
     kubectl rollout status daemonset -n opa cray-opa-ingressgateway-hmn
+    echo ""
+  fi
+fi
+
+crayDnsUnboundDeployed=$(kubectl -n services get deployment cray-dns-unbound --no-headers| wc -l)
+if [[ $crayDnsUnboundDeployed -ne 0 ]]; then
+  if [ ! -z $cray_dns_unbound_new_cpu_request ]; then
+    current_req=$(kubectl -n services get deployment cray-dns-unbound -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dns-unbound") | .resources.requests.cpu')
+    echo "Patching cray-dns-unbound deployment with new cpu request of $cray_dns_unbound_new_cpu_request (from $current_req)"
+    kubectl patch deployment cray-dns-unbound -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_dns_unbound_new_cpu_request\" }]"
+    kubectl rollout status deployment -n services cray-dns-unbound
     echo ""
   fi
 fi

--- a/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
@@ -457,7 +457,7 @@ if [[ $crayOpaHmnDeployed -ne 0 ]]; then
   fi
 fi
 
-crayDnsUnboundDeployed=$(kubectl -n services get deployment cray-dns-unbound --no-headers| wc -l)
+crayDnsUnboundDeployed=$(kubectl -n services get deployment cray-dns-unbound --no-headers | wc -l)
 if [[ $crayDnsUnboundDeployed -ne 0 ]]; then
   if [ ! -z $cray_dns_unbound_new_cpu_request ]; then
     current_req=$(kubectl -n services get deployment cray-dns-unbound -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dns-unbound") | .resources.requests.cpu')

--- a/upgrade/scripts/upgrade/tds_cpu_requests.yaml
+++ b/upgrade/scripts/upgrade/tds_cpu_requests.yaml
@@ -37,6 +37,12 @@ spec:
               requests:
                 cpu: "1"
       cray-dhcp-kea:
+        cray-service:
+          containers:
+            cray-dhcp-kea:
+              resources:
+                requests:
+                  cpu: "500m"
         cray-postgresql:
           sqlCluster:
             resources:

--- a/upgrade/scripts/upgrade/tds_cpu_requests.yaml
+++ b/upgrade/scripts/upgrade/tds_cpu_requests.yaml
@@ -160,3 +160,8 @@ spec:
                   cpu: "100m"
       sma-postgres-cluster:
         pgReqCPU: "500m"
+      cray-dns-unbound:
+        resources:
+          cray-dns-unbound:
+            requests:
+              cpu: "500m"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Shrink amount of CPU requested by `cray-dns-unbound` and `cray-dhcp-kea` on TDS systems from 2 to 500m.

https://jira-pro.it.hpe.com:8443/browse/CASMNET-2308

Tested on `surtur`

Before:
```
ncn-m001:~ # kubectl -n services get deployment cray-dns-unbound -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dns-unbound") | .resources.requests.cpu'
2

ncn-m001:~ # kubectl -n services get deployment cray-dhcp-kea -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dhcp-kea") | .resources.requests.cpu'
2
```
After:
```
ncn-m001:~ # kubectl -n services get deployment cray-dns-unbound -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dns-unbound") | .resources.requests.cpu'
500m

ncn-m001:~ # kubectl -n services get deployment cray-dhcp-kea -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cray-dhcp-kea") | .resources.requests.cpu'
500m
```
Verified `customizations.yaml` has been update correctly with new value.
```
ncn-m001:~ # kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq4 '.spec.kubernetes.services.cray-dns-unbound'
domain_name: '{{ network.dns.external }}'
forwardZones:
  - name: .
    forwardIps:
      - '{{ network.netstaticips.system_to_site_lookups }}'
resources:
  cray-dns-unbound:
    requests:
      cpu: "500m"

ncn-m001:~  # kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq4 '.spec.kubernetes.services.cray-dhcp-kea'
cray-postgresql:
  sqlCluster:
    resources:
      requests:
        cpu: "1"
cray-service:
  containers:
    cray-dhcp-kea:
      resources:
        requests:
          cpu: "500m"
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
