### PR TITLE
CASMTRIAGE-6297: Update  IUF update-vcs-config stage documentation a Note about Resolving VCS merge conflicts -- 1.7

### DIFF
--- a/operations/iuf/workflows/configuration.md
+++ b/operations/iuf/workflows/configuration.md
@@ -78,6 +78,8 @@ file found in `${ADMIN_DIR}`.
     iuf -a ${ACTIVITY_NAME} run --site-vars "${ADMIN_DIR}/site_vars.yaml" -bpcd "${ADMIN_DIR}" -r update-vcs-config
     ```
 
+    > **WARNING:** If the `update-vcs-config` stage of IUF fails due to git merge conflicts, they must be resolved manually as described in the [`Resolving VCS merge conflicts documentation`](../../configuration_management/VCS_Branching_Strategy.md#resolving-vcs-merge-conflicts).
+
 Once this step has completed:
 
 - Product configuration content has been merged to VCS branches as described in the [update-vcs-config stage documentation](../stages/update_vcs_config.md)


### PR DESCRIPTION

# Description

CASMTRIAGE-6297: Update  IUF update-vcs-config stage documentation a Note about Resolving VCS merge conflicts

1. Add a warning note If the IUF update-vcs-config stage fails due to git merge conflicts, they must be resolved manually.

2. Ensure that there is a link from the IUF update-vcs-config section to the procedure for handling merge conflicts.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
