### PR TITLE
CASMHMS-6600: Add new SMD subrole "FabricManager" to docs

### DIFF
--- a/install/create_application_node_config_yaml.md
+++ b/install/create_application_node_config_yaml.md
@@ -121,7 +121,7 @@ Example `hmn_connections.json` row representing an application node with SourceN
 
     To add additional HSM SubRole for a given prefix, add a new mapping under the `prefix_hsm_subroles` field. Where the key is the application node prefix and the value is the HSM SubRole.
 
-    Valid HSM SubRoles values are: `Worker`, `Master`, `Storage`, `UAN`, `Gateway`, `LNETRouter`, `Visualization`, and `UserDefined`.
+    Valid HSM SubRoles values are: `Worker`, `Master`, `Storage`, `UAN`, `Gateway`, `LNETRouter`, `Visualization`, `UserDefined`, and `FabricManager`.
 
     From the HMN example above, the following additional prefix HSM SubRole mappings are required:
 

--- a/operations/hardware_state_manager/HSM_Roles_and_Subroles.md
+++ b/operations/hardware_state_manager/HSM_Roles_and_Subroles.md
@@ -39,6 +39,7 @@ The following is a list of all pre-defined subroles:
 * `LNETRouter`
 * `Visualization`
 * `UserDefined`
+* `FabricManager`
 
 The `Master`, `Worker`, and `Storage` subroles are generally used with the `Management` role to indicate NCN types.
 
@@ -78,7 +79,8 @@ data:
              "Gateway",
              "LNETRouter",
              "Visualization",
-             "UserDefined"
+             "UserDefined",
+             "FabricManager"
           ]
        }
     }


### PR DESCRIPTION
### Summary and Scope

Add new SMD subrole "FabricManager" to the documentation.

### Issues and Related PRs

* Resolves [CASMHMS-6600](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6600)d any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).

## Pull Request Checklist

- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.