### PR TITLE
CASMTRIAGE-8851: CSM 1.7.0 workaround or troubleshooting documentation for iuf management-rollout to worker nodes hangs on last worker node DVS errors

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1182,3 +1182,6 @@ Infiniband
 - operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
 FRUID
 FRUIDs
+
+- troubleshooting/known_issues/iuf_management_rollout_last_worker_dvs_errors.md
+cos-prechecks-for-worker-reboots

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -464,6 +464,33 @@ rolling it out to the other NCN worker nodes. Modify the procedure as necessary 
 The images and CFS configurations used are created by the `prepare-images` and `update-cfs-config` stages respectively; see the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation
 for details on how to query the images and CFS configurations and see the [update-cfs-config](../stages/update_cfs_config.md) documentation for details about how the CFS configuration is updated.
 
+### Note when upgrading from CSM 1.6 to CSM 1.7.0 only
+
+- Before starting management rollout for worker nodes, manually check and remove the `cos-prechecks-for-worker-reboots` IUF hook from the cluster as a pre-check step by running the following commands:
+
+    Verify the cos-prechecks-for-worker-reboots hook exists:
+
+    ```bash
+    kubectl -n argo get hooks -l app.kubernetes.io/name=cos-prechecks-for-worker-reboots
+    ```
+
+    Delete the hook:
+
+    ```bash
+    kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
+    ```
+
+    **Example session:**
+
+    ```console
+    root@ncn-m001# kubectl -n argo get hooks
+    NAME                               AGE
+    cos-prechecks-for-worker-reboots   197d
+    ...
+    root@ncn-m001# kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
+    hook.cray-nls.hpe.com "cos-prechecks-for-worker-reboots" deleted
+    ```
+
 **`NOTE`** The `management-nodes-rollout` stage creates additional separate Argo workflows when rebuilding NCN worker nodes. The Argo workflow names will include the string `ncn-lifecycle-rebuild`. If monitoring progress with the Argo UI,
 remember to include these workflows.
 

--- a/troubleshooting/known_issues/iuf_management_rollout_last_worker_dvs_errors.md
+++ b/troubleshooting/known_issues/iuf_management_rollout_last_worker_dvs_errors.md
@@ -1,8 +1,8 @@
-# Troubleshooting guide for IUF management-nodes-rollout to worker nodes hangs on last worker node DVS errors
+# Troubleshooting guide for IUF management-nodes-rollout to worker nodes hangs on final worker node with DVS related errors
 
 ## Description
 
-During upgrades from CSM 1.6.x to 1.7.0, the IUF management-nodes-rollout that targets worker nodes can hang on the final worker node due to `DVS-related` errors.
+During upgrades from CSM 1.6.x to 1.7.0, the IUF management-nodes-rollout that targets worker nodes can hang on the final worker node due to `DVS` related errors.
 The rollout may appear stalled even though most worker nodes have successfully received the new image. IUF logs may repeatedly show errors with DVS modules, as below:
 
 ```console
@@ -14,19 +14,19 @@ ERROR: HA requires at least 1 running DVS server, but there are none
 Pods not running.
 ```
 
-Pods related to DVS may be in an error or `NotReady` state, and Argo Workflows such as `ncn-lifecycle-rebuild` may be in a loop or failing.
+Pods related to DVS may be in an `Error` or `NotReady` state, and Argo Workflows such as `ncn-lifecycle-rebuild` may be in a loop or failing.
+
+## Symptoms
+
+- IUF stops at the last worker node and reports DVS health-check failures.
+- IUF logs reference missing DVS modules or failed health checks.
+- IUF hook object `cos-prechecks-for-worker-reboots` is mentioned in logs.
+- DVS pods may show `NotReady` or `Error` status, e.g. with `kubectl get pods -A | grep dvs`.
 
 ## Impact
 
 - IUF management-nodes-rollout stage for worker nodes may not complete.
 - Automated rebuild workflows (`ncn-lifecycle-rebuild`) can become stuck and require manual intervention.
-
-## Symptoms
-
-- IUF stops at the last worker node and reports DVS health-check failures.
-- IUF Logs reference missing DVS modules or failed health checks.
-- IUF hook object `cos-prechecks-for-worker-reboots` is mentioned in logs.
-- DVS pods may show `NotReady` or Error, e.g. with `kubectl get pods -A | grep dvs`.
 
 ## Root Cause
 
@@ -37,45 +37,18 @@ The upgrade workflow template `before-each-hooks` lists and executes hook object
 kubectl get hooks -n argo -l before-each=true
 ```
 
-When the leftover IUF hook object is executed but its script is no longer present on nodes, the DVS NCN health check can fail and block the worker rebuild, causing IUF to hang on the last worker node.
-
-## Pre-check Resolution (Recommended)
-
-**Before starting the upgrade:**
-
-- Check for and remove the `cos-prechecks-for-worker-reboots` Argo hook object from the cluster as a pre-check step:
-
-  Verify the cos-prechecks-for-worker-reboots hook exists:
-
-  ```bash
-  kubectl -n argo get hooks -l app.kubernetes.io/name=cos-prechecks-for-worker-reboots
-  ```
-
-  Delete the hook:
-
-  ```bash
-  kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
-  ```
-
-**Example session:**
-
-```console
-root@ncn-m001# kubectl -n argo get hooks
-NAME                               AGE
-cos-prechecks-for-worker-reboots   197d
-...
-root@ncn-m001# kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
-hook.cray-nls.hpe.com "cos-prechecks-for-worker-reboots" deleted
-```
+When the obsolete IUF hook object is executed, the DVS NCN health check can fail and block the worker rebuild, causing IUF to hang on the last worker node.
 
 ## Workaround
 
 If you encounter the issue during the upgrade, perform the following steps to recover and proceed:
 
-1. **Find and delete the `cos-prechecks-for-worker-reboots` IUF hook:**  
-   See commands above.
+1. Find and delete the `cos-prechecks-for-worker-reboots` IUF hook:
 
-2. **If Argo shows a stuck workflow (e.g., `upgrade-recipe-25-9-0-management-nodes-rollout`), remove it:**
+   Refer to the [note](../../operations/iuf/workflows/management_rollout.md#note-when-upgrading-from-csm-16-to-csm-170-only) under [Management Rollout for NCN worker nodes](../../operations/iuf/workflows/management_rollout.md#23-ncn-worker-nodes)
+   for details on how to manually check and remove the `cos-prechecks-for-worker-reboots` IUF hook from the cluster.
+
+2. If Argo shows a stuck workflow (e.g., `upgrade-recipe-25-9-0-management-nodes-rollout`), remove it:
 
    ```bash
    kubectl -n argo get wf
@@ -84,9 +57,9 @@ If you encounter the issue during the upgrade, perform the following steps to re
 
    Or delete via the Argo UI.
 
-   *Note:* After deleting the hook, the workflow may attempt to run the hook and report `NotFound`. If the IUF process is unresponsive, interrupt with Ctrl-C and force exit.
+   *Note:* After deleting the hook, the workflow may attempt to run the hook and report `NotFound`. If the IUF process is unresponsive, interrupt with **Ctrl-C** and force exit.
 
-3. **Mark worker nodes that already received the image so subsequent IUF runs skip them:**
+3. Label worker nodes that have already received the image so subsequent IUF runs skip them:
 
    ```bash
    kubectl label node <node-name> iuf-prevent-rollout=true --overwrite
@@ -99,12 +72,8 @@ If you encounter the issue during the upgrade, perform the following steps to re
    kubectl get nodes --show-labels | grep iuf-prevent-rollout
    ```
 
-4. **Restart the IUF operation for the remaining worker nodes:**
+4. Restart the IUF operation for the remaining worker nodes:
 
    ```bash
-   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout <label-or-list>
+   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout <worker>
    ```
-
-## Resolution
-
-- Remove the `cos-prechecks-for-worker-reboots` IUF hook object from clusters as a pre-upgrade check before upgrading to CSM 1.7.0.

--- a/troubleshooting/known_issues/iuf_management_rollout_last_worker_dvs_errors.md
+++ b/troubleshooting/known_issues/iuf_management_rollout_last_worker_dvs_errors.md
@@ -1,0 +1,110 @@
+# Troubleshooting guide for IUF management-nodes-rollout to worker nodes hangs on last worker node DVS errors
+
+## Description
+
+During upgrades from CSM 1.6.x to 1.7.0, the IUF management-nodes-rollout that targets worker nodes can hang on the final worker node due to `DVS-related` errors.
+The rollout may appear stalled even though most worker nodes have successfully received the new image. IUF logs may repeatedly show errors with DVS modules, as below:
+
+```console
+INFO Running before each hook: cos-prechecks-for-worker-reboots
+dvs module is not loaded on x3000c0s8b0n0
+dvs module is not loaded on x3000c0s9b0n0
+dvs module is not loaded on x3000c0s10b0n0
+ERROR: HA requires at least 1 running DVS server, but there are none
+Pods not running.
+```
+
+Pods related to DVS may be in an error or `NotReady` state, and Argo Workflows such as `ncn-lifecycle-rebuild` may be in a loop or failing.
+
+## Impact
+
+- IUF management-nodes-rollout stage for worker nodes may not complete.
+- Automated rebuild workflows (`ncn-lifecycle-rebuild`) can become stuck and require manual intervention.
+
+## Symptoms
+
+- IUF stops at the last worker node and reports DVS health-check failures.
+- IUF Logs reference missing DVS modules or failed health checks.
+- IUF hook object `cos-prechecks-for-worker-reboots` is mentioned in logs.
+- DVS pods may show `NotReady` or Error, e.g. with `kubectl get pods -A | grep dvs`.
+
+## Root Cause
+
+An IUF hook (`cos-prechecks-for-worker-reboots`) was removed from the `docs-csm` CSM 1.7.0 rpm. However, the corresponding Kubernetes IUF hook object created by the 1.6.x rpm can remain in the cluster.
+The upgrade workflow template `before-each-hooks` lists and executes hook objects in the `argo` namespace:
+
+```bash
+kubectl get hooks -n argo -l before-each=true
+```
+
+When the leftover IUF hook object is executed but its script is no longer present on nodes, the DVS NCN health check can fail and block the worker rebuild, causing IUF to hang on the last worker node.
+
+## Pre-check Resolution (Recommended)
+
+**Before starting the upgrade:**
+
+- Check for and remove the `cos-prechecks-for-worker-reboots` Argo hook object from the cluster as a pre-check step:
+
+  Verify the cos-prechecks-for-worker-reboots hook exists:
+
+  ```bash
+  kubectl -n argo get hooks -l app.kubernetes.io/name=cos-prechecks-for-worker-reboots
+  ```
+
+  Delete the hook:
+
+  ```bash
+  kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
+  ```
+
+**Example session:**
+
+```console
+root@ncn-m001# kubectl -n argo get hooks
+NAME                               AGE
+cos-prechecks-for-worker-reboots   197d
+...
+root@ncn-m001# kubectl -n argo delete hook cos-prechecks-for-worker-reboots --ignore-not-found=true
+hook.cray-nls.hpe.com "cos-prechecks-for-worker-reboots" deleted
+```
+
+## Workaround
+
+If you encounter the issue during the upgrade, perform the following steps to recover and proceed:
+
+1. **Find and delete the `cos-prechecks-for-worker-reboots` IUF hook:**  
+   See commands above.
+
+2. **If Argo shows a stuck workflow (e.g., `upgrade-recipe-25-9-0-management-nodes-rollout`), remove it:**
+
+   ```bash
+   kubectl -n argo get wf
+   kubectl -n argo delete wf upgrade-recipe-25-9-0-management-nodes-rollout
+   ```
+
+   Or delete via the Argo UI.
+
+   *Note:* After deleting the hook, the workflow may attempt to run the hook and report `NotFound`. If the IUF process is unresponsive, interrupt with Ctrl-C and force exit.
+
+3. **Mark worker nodes that already received the image so subsequent IUF runs skip them:**
+
+   ```bash
+   kubectl label node <node-name> iuf-prevent-rollout=true --overwrite
+   ```
+
+   Example:
+
+   ```bash
+   kubectl label nodes ncn-w002 ncn-w003 --overwrite iuf-prevent-rollout=true
+   kubectl get nodes --show-labels | grep iuf-prevent-rollout
+   ```
+
+4. **Restart the IUF operation for the remaining worker nodes:**
+
+   ```bash
+   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r management-nodes-rollout --limit-management-rollout <label-or-list>
+   ```
+
+## Resolution
+
+- Remove the `cos-prechecks-for-worker-reboots` IUF hook object from clusters as a pre-upgrade check before upgrading to CSM 1.7.0.


### PR DESCRIPTION
# Description

CASMTRIAGE-8851: workaround or troubleshooting documentation for iuf management-rollout to worker nodes hangs on last worker node DVS errors

Analysis:

cos-prechecks-for-worker-reboots hook script is currently removed as part of docs-csm CSM 1.7.0 [USS-4838](https://jira-pro.it.hpe.com:8443/browse/USS-4838) DVS ncn health check doesn't allow worker rebuild
but hook(k8s object) which was installed as part of 1.6 docs-csm rpm remains on cluster while Upgrading to CSM 1.7 and as  before-each-hooks uses  kubectl get hooks -n argo -l before-each=true  and run . so, cos-prechecks-for-worker-reboots gets executed as part of Upgrade
https://github.com/Cray-HPE/docs-csm/blob/release/1.7/workflows/templates/before-each-hooks.yaml#L48

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
