### PR TITLE
CASMTRIAGE-8863: Add k8s upgrade time estimate to the deploy_product note

### DIFF
--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -27,11 +27,11 @@ Refer to that table and any corresponding product documents before continuing to
 Once this step has completed:
 
 > **NOTE**  
-> As part of the `deploy-product` stage during upgrades from CSM 1.6 to CSM 1.7:  
->
-> - Kubernetes will be upgraded from version 1.26 to 1.32.5.  
-> - The `deploy-product-onexit` hook will launch a Kubernetes upgrade job that runs outside of IUF, in the `argo` namespace.  
-> - This job must be monitored manually and must complete successfully before proceeding to the next stage.  
+> As part of the `deploy-product` stage during upgrades from CSM 1.6 to CSM 1.7,
+> the `deploy-product-onexit` hook will launch a Kubernetes upgrade job that runs outside of IUF, in the `argo` namespace.
+> - The job will upgrade Kubernetes from version 1.26 to 1.32 in two hops. The first hop will be to version 1.29 and the second hop to version 1.32.
+> - This job must be monitored manually and must complete successfully before proceeding to the next stage.
+> - The job will restart when upgrading the master nodes to 1.32 and kubelet is restarted. The restart will create a new output log.
 >
 > The output from the `deploy-product` stage will look like:
 >
@@ -45,6 +45,19 @@ Once this step has completed:
 > ```bash
 > kubectl wait job -n argo upgrade-k8s-job-zm55x --for=condition=complete --timeout=120m
 > ```
+>
+> The amount of time the `upgrade-k8s-job` runs is directly related to the number of worker nodes in a system.
+> The more worker nodes the longer it takes to complete the Kubernetes upgrade.
+>
+> Below is a table of estimated upgrade time in minutes:
+>
+> | Num Workers | Time (m) |
+> | ----------- | -------- |
+> | 4           | 110      |
+> | 12          | 270      |
+> | 16          | 350      |
+> | 20          | 430      |
+> | 28          | 590      |
 
 - New versions of product microservices have been deployed
 - Per-stage product hooks have executed for the `deploy-product` stage

--- a/operations/iuf/workflows/deploy_product.md
+++ b/operations/iuf/workflows/deploy_product.md
@@ -29,9 +29,10 @@ Once this step has completed:
 > **NOTE**  
 > As part of the `deploy-product` stage during upgrades from CSM 1.6 to CSM 1.7,
 > the `deploy-product-onexit` hook will launch a Kubernetes upgrade job that runs outside of IUF, in the `argo` namespace.
+>
 > - The job will upgrade Kubernetes from version 1.26 to 1.32 in two hops. The first hop will be to version 1.29 and the second hop to version 1.32.
 > - This job must be monitored manually and must complete successfully before proceeding to the next stage.
-> - The job will restart when upgrading the master nodes to 1.32 and kubelet is restarted. The restart will create a new output log.
+> - The job will restart when upgrading the master nodes to 1.32 and `kubelet` restarts. When the job restarts, a new output log will be created.
 >
 > The output from the `deploy-product` stage will look like:
 >
@@ -51,13 +52,13 @@ Once this step has completed:
 >
 > Below is a table of estimated upgrade time in minutes:
 >
-> | Num Workers | Time (m) |
-> | ----------- | -------- |
-> | 4           | 110      |
-> | 12          | 270      |
-> | 16          | 350      |
-> | 20          | 430      |
-> | 28          | 590      |
+> | # Workers | Time (m) |
+> | --------- | -------- |
+> | 4         | 110      |
+> | 12        | 270      |
+> | 16        | 350      |
+> | 20        | 430      |
+> | 28        | 590      |
 
 - New versions of product microservices have been deployed
 - Per-stage product hooks have executed for the `deploy-product` stage


### PR DESCRIPTION
# Description
The `upgrade-k8s-job` launched as part of the `deploy-product-onexit` hook runs outside of IUF in the `argo` namespace. This job needs to be monitored manually and can take a long time to run, especially on a system with a large number of worker nodes. Add a table that shows estimated upgrade times, so that the customer will know approximately how long the `upgrade-k8s-job` will run.  These times are estimated since we have not run on a system with more than 5 workers.

Also, add that the K8s upgrade happens in two hops and the `upgrade-k8s-job` will be restarted by kubelet in the second hop causing a new output file to be created.

This PR resolves [CASMTRIAGE-8863](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8863)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

