### PR TITLE
CASMNET-2336 Removed UAS/UAI references -- 1.7

### DIFF
--- a/operations/network/Gateway_Testing.md
+++ b/operations/network/Gateway_Testing.md
@@ -176,7 +176,6 @@ PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 200
 PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 200
 PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready - 200
 PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 200
-PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 200
 SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -199,7 +198,6 @@ PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 200
 PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 200
 PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 200
 PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 200
-PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 200
 SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -227,7 +225,6 @@ PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
 PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
 PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 404
 PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
-PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
 SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -254,7 +251,6 @@ PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 200
 PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 200
 PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready - 200
 PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 200
-PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 200
 SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -277,7 +273,6 @@ PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 200
 PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 200
 PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 200
 PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 200
-PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 200
 SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -305,7 +300,6 @@ PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
 PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
 PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 404
 PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
-PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
 SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -336,7 +330,6 @@ PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 403
 PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 403
 PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready - 403
 PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 403
-PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 403
 SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -359,7 +352,6 @@ PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 403
 PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 403
 PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 403
 PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 403
-PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 403
 SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
@@ -387,7 +379,6 @@ PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
 PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
 PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v2/service/ready - 404
 PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
-PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
 SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
 SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
 SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found

--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -250,10 +250,6 @@ if __name__ == '__main__':
       reachnets.append("nmnlb")
     elif NODE_TYPE == "outside":
       reachnets.append("cmn")
-    elif NODE_TYPE != "uai":
-      print("Invalid node type {}".format(NODE_TYPE))
-      logging.critical("Invalid node type {}".format(NODE_TYPE))
-      sys.exit(1)
 
     print("Reachable networks: {}".format(reachnets))
 


### PR DESCRIPTION
This fix removes UAS/UAI references in network content of docs-csm

JIRA: https://jira-pro.it.hpe.com:8443/browse/CASMNET-2336

Removed the UAI reference in `gateway-test.py` in **Surtur**  and tested if the script runs fine without the UAI block. Attached the results below:

```shell
ncn-m001:~ # /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py surtur.hpc.amslabs.hpecorp.net outside
auth.cmn.surtur.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

Got 404 for https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/sls/v1/networks/CAN
Reachable networks: ['cmn']

Getting token for hmnlb
auth.hmnlb.surtur.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.hmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

FAIL: Token retrieved for hmnlb network which should be unreachable

Getting token for nmnlb
auth.nmnlb.surtur.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.nmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

FAIL: Token retrieved for nmnlb network which should be unreachable

Getting token for cmn
auth.cmn.surtur.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.surtur.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.surtur.hpc.amslabs.hpecorp.net is reachable
FAIL: hmnlb is reachable

------------- api.nmnlb.surtur.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.surtur.hpc.amslabs.hpecorp.net is reachable
FAIL: nmnlb is reachable

------------- api.cmn.surtur.hpc.amslabs.hpecorp.net -------------------
api.cmn.surtur.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 204
PASS - [cray-bos]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/bos/v2/sessions - 200
PASS - [cray-bss]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200
PASS - [cray-cfs-api]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/cfs/v3/sessions - 200
PASS - [cray-console-data]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 204
PASS - [cray-console-operator]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 204
FAIL - [cray-fas]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 503 (expecting: 200)
PASS - [cray-hbtd]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 200
PASS - [cray-hmnfd]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 200
PASS - [cray-ims]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/ims/images - 200
PASS - [cray-powerdns-manager]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 204
PASS - [cray-scsd]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 200
PASS - [cray-sls]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 200
PASS - [cray-smd]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 200
PASS - [cray-sts]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/sts/healthz - 200
SKIP - [nmdv2-service]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps
SKIP - [slingshot-fabric-manager]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies
SKIP - [sma-telemetry]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping

------------- api.can.surtur.hpc.amslabs.hpecorp.net -------------------
api.can.surtur.hpc.amslabs.hpecorp.net is NOT resolvable
can is not reachable (expected)

Getting token for can
auth.can.surtur.hpc.amslabs.hpecorp.net is NOT resolvable
Could not retrieve token for can (expected)

Overall Gateway Test Status:  FAIL
``` 

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
