### PR TITLE
Cast 39136: Add a script to remove stale iSCSI luns

### DIFF
--- a/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
+++ b/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
@@ -31,7 +31,7 @@ rm iscsi_devs
 
 echo "Check for multipath devices with no active paths..."
 
-MULTIPATH_DEVICES=$(multipath -l | grep dm-* | awk '{print $1}')
+MULTIPATH_DEVICES=$(multipath -l | grep "dm-*" | awk '{print $1}')
 
 for dev in $MULTIPATH_DEVICES; do
 

--- a/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
+++ b/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to delete stale iSCSI Lun's which can be seen 
-# in scenario's like after unused image deletion. 
+# in scenario's like after unused image deletion on the cluster. 
 
 # Get the list of iSCSI Luns
 lsscsi -t | grep iscsi | awk '{print $4}' > iscsi_devs

--- a/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
+++ b/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to delete stale iSCSI Lun's which can be seen 
+# in scenario's like after unused image deletion. 
+
+# Get the list of iSCSI Luns
+lsscsi -t | grep iscsi | awk '{print $4}' > iscsi_devs
+	
+input="iscsi_devs"
+
+# For each iSCSI Lun, issue Report Luns command to determine
+# whether it is stale or active lun. Report Luns command fails
+# with Illegal request if it's a stale lun.
+
+while IFS= read -r line
+do
+    sg_luns --readonly -q "$line" &> /dev/null
+
+    if [ "$?" -ne 0 ]; then
+	blockdev --flushbufs $line
+        echo "report luns command failed for $line"
+	lun=$(lsscsi | grep $line | awk '{print $1}' | tr -d '[' | tr -d ']')
+	echo "lun = $lun"
+        echo 1 > /sys/class/scsi_device/$lun/device/delete 
+    fi
+done < "$input"
+
+rm iscsi_devs
+
+# Cleanup Multipath devices if no active paths
+
+echo "Check for multipath devices with no active paths..."
+
+MULTIPATH_DEVICES=$(multipath -l | grep dm-* | awk '{print $1}')
+
+for dev in $MULTIPATH_DEVICES; do
+
+    ACTIVE_PATHS=$(multipath -l "$dev" | grep 'active' | grep 'running' | wc -l)
+
+    if [ "$ACTIVE_PATHS" -eq 0 ]; then
+        echo "Multipath device $dev has 0 active paths. Removing it..."
+        # Flush the I/O and remove the multipath device
+        multipath -f "$dev"
+        if [ $? -eq 0 ]; then
+            echo "Successfully removed $dev."
+        else
+            echo "Failed to remove $dev. It might be in use."
+        fi
+    else
+        echo "Multipath device $dev has $ACTIVE_PATHS active paths. Keeping it."
+    fi
+done


### PR DESCRIPTION
# Description
In the scenario where unused images were deleted from the management nodes, the iSCSI SBPS marshal agent removes iSCSI luns and fileio backing stores during its scan that happens every 180secs.  Due to this, the corresponding iSCSI luns will become stale and need to cleanup. Without cleanup the iSCSI initiator looks for corresponding luns on iSCSI targets and flood of messages on worker nodes console/dmesg will be seen due to which, the worker nodes become unresponsive. This PR is adding a new script to clean such stale iSCSI Luns on the iSCSI initiator.

# Checklist

- [NA] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [NA] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.