### PR TITLE
CAST-39136: This is adding the scripts for: iSCSI Lun deletion 

### DIFF
--- a/operations/iscsi_sbps/Best_Practices.md
+++ b/operations/iscsi_sbps/Best_Practices.md
@@ -1,0 +1,173 @@
+# Best practices to follow to avoid issues with iSCSI SBPS
+
+This document presents recommended best practices to avoid issues with
+iSCSI SBPS.
+
+Scenario #1: As roots/PE images will be placed in `s3` storage/IMS, there could be unused
+images which user/admin would like to delete. The following are steps to delete unused
+`rootfs/PE` images safely.
+
+## Steps to remove unused `rootfs/PE` images projected by iSCSI SBPS
+
+1. Identify the unused `PE` and `rootfs` images from `targetcli ls` command output from
+   one of the iSCSI target node (worker node) and list them in a file.
+
+   Example command:
+
+   ```bash
+   (`ncn-w#`) targetcli ls
+   ```
+
+   Example command output snippet:
+
+    ```text
+    ...
+
+    |     | o- lun0  [fileio/a50dd52157e1636 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+    ...
+    |     | o- lun5  [fileio/c1d98cf92b0647f (/var/lib/cps-local/boot-images/PE/CPE-aocc.x86_64-23.12.squashfs) (default_tg_pt_gp)]
+    ...
+    |     | o- lun28  [fileio/84c5b467e892c6b (/var/lib/cps-local/boot-images/d114469b-06c6-42ed-b151-05a7f555b3a1/rootfs) (default_tg_pt_gp)]
+    ...
+
+    ```
+
+1. Provide a list of images in a file that are identified for deletion.
+
+   Example:
+
+   ```bash
+   (`ncn-w#`) cat img_list
+   ```
+
+   ```text
+   CPE-amd.x86_64-23.12.squashfs
+   CPE-aocc.x86_64-23.12.squashfs
+   d114469b-06c6-42ed-b151-05a7f555b3a1
+   ```
+
+1. Run the script [`get_img_str.sh`](../../scripts/operations/iscsi_sbps/get_img_str.sh) on one of the worker node (For example, iSCSI target) which takes above file having list of images as an argument.
+
+   Example command:
+
+   ```bash
+   (`ncn-w#`) sh get_img_str.sh img_list
+   ```
+
+   This script will create a output file named `img_str.txt` having list of image identifier
+   strings for which corresponding iSCSI `LUNs` on the iSCSI initiator are to be deleted.
+
+   Example `img_str.txt` file output:
+
+   ```bash
+   (`ncn-w#`) cat img_str.txt
+   ```
+
+   ```text
+   a50dd52157e1636
+   c1d98cf92b0647f
+   84c5b467e892c6b
+   ```
+
+   The first image identifier string above corresponds to the image `CPE-amd.x86_64-23.12.squashfs` in the list
+   and corresponds to `lun0` in the `targetcli ls` output as below:
+
+  ```text
+  |     | o- lun0  [fileio/a50dd52157e1636 (/var/lib/cps-local/boot-images/PE/CPE-amd.x86_64-23.12.squashfs) (default_tg_t_gp)]
+  ```
+
+   Similarly, second (`c1d98cf92b0647f`) and third (`84c5b467e892c6b`) image strings correspond to `lun5` and `lun28` respectively.
+
+1. Login to iSCSI initiator node (compute/UAN) and check the `luns` corresponding to the image
+   identifiers in `img_str.txt`.
+
+   Example command and their outputs:
+
+   (`nid00000#`) or (`uan0#`)
+
+   ```bash
+   (`nid00000#`) lsscsi | grep a50dd52157e1636
+   ```
+
+   ```text
+   [14:0:0:0]   disk    LIO-ORG  a50dd52157e1636  4.0   /dev/sdg
+   [15:0:0:0]   disk    LIO-ORG  a50dd52157e1636  4.0   /dev/sdao
+   [16:0:0:0]   disk    LIO-ORG  a50dd52157e1636  4.0   /dev/sdbw
+   [17:0:0:0]   disk    LIO-ORG  a50dd52157e1636  4.0   /dev/sdde
+   ```
+
+   ```bash
+   (`nid00000#`) lsscsi | grep c1d98cf92b0647f
+   ```
+
+   ```text
+   [14:0:0:5]   disk    LIO-ORG  c1d98cf92b0647f  4.0   /dev/sdl
+   [15:0:0:5]   disk    LIO-ORG  c1d98cf92b0647f  4.0   /dev/sdat
+   [16:0:0:5]   disk    LIO-ORG  c1d98cf92b0647f  4.0   /dev/sdcz
+   [17:0:0:5]   disk    LIO-ORG  c1d98cf92b0647f  4.0   /dev/sddj
+   ```
+
+   ```bash
+   (`nid00000#`) lsscsi | grep 84c5b467e892c6b
+   ```
+
+   ```text
+   [14:0:0:28]  disk    LIO-ORG  84c5b467e892c6b  4.0   /dev/sdai
+   [15:0:0:28]  disk    LIO-ORG  84c5b467e892c6b  4.0   /dev/sdbp
+   [16:0:0:28]  disk    LIO-ORG  84c5b467e892c6b  4.0   /dev/sdcc
+   [17:0:0:28]  disk    LIO-ORG  84c5b467e892c6b  4.0   /dev/sdeg
+   ```
+
+1. Copy `img_str.txt` and `rm_iscsi_luns.sh` onto all iSCSI initiator nodes (compute/UAN nodes)
+   and run the `rm_iscsi_lun.sh` script on compute and UAN nodes with `img_str.txt` as an
+   argument.
+
+   ```bash
+   (`nid00000#`) sh rm_iscsi_luns.sh img_str.txt
+   ```
+
+   This can also be run on multiple iSCSI initiator nodes using `pdsh` command as follows.
+
+   Example:
+
+   ```bash
+   (`ncn-m#`):~ # pdsh -w nid00000[1-4]-nmn "sh rm_iscsi_luns.sh img_str.txt"
+   ```
+
+   Above command runs the script on four compute nodes `nid000001`, `nid000002`, `nid000003`
+   and `nid000004`
+
+1. Verify that the `luns` corresponding to the image identifiers are deleted from iSCSI
+   initiator nodes (compute/UAN).
+
+   (`nid00000#`) or (`uan0#`)
+
+   ```bash
+   lsscsi | grep a50dd52157e1636
+   ```
+
+   ```bash
+   lsscsi | grep c1d98cf92b0647f
+   ```
+
+   ```bash
+   lsscsi | grep 84c5b467e892c6b
+   ```
+
+1. Login to master node and delete the images listed in `img_list` file using `craycli`.
+
+   Example command:
+
+   ```bash
+   cray artifacts delete boot-images PE/CPE-amd.x86_64-23.12.squashfs
+   ```
+
+1. Wait for 180 seconds and verify the iSCSI `luns` corresponding to the images are deleted by  
+   checking the `targetcli ls` output.
+
+   ```bash
+   targetcli ls | grep a50dd52157e1636
+   ```
+
+   This should not list any iSCSI `luns` and `fileio` backing store corresponding to the image
+   identifier string(s).

--- a/scripts/operations/iscsi_sbps/get_img_str.sh
+++ b/scripts/operations/iscsi_sbps/get_img_str.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#  MIT License
+#
+#  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
+# Script to list image identifier strings of images that are going to deleted
+# which are mostly identified as unused images. This script expects a file as
+# an argument which has the list of rootfs/PE image object to be deleted. The
+# output of this script will be list of image identfier strings used to identify
+# corresponding iSCSI luns on the iSCSI iniator.
+
+set -euo pipefail
+
+# output file for this script
+OUTPUT_FILE="img_str.txt"
+
+true > "$OUTPUT_FILE"
+
+#This script takes a file having list of images to be deleted as an argument
+FILE="$1"
+
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 <filename>"
+  echo "Error: No file argument provided."
+  exit 1
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: File not found"
+  exit 1
+fi
+
+while IFS= read -r line; do
+
+  echo "image: $line"
+
+  img_str=$(targetcli ls | grep "lun" | grep $line | awk 'NF-=2' | awk '{print $NF}' | sed "s/\[fileio\///g")
+
+  if [[ -n $img_str ]]; then
+    echo "$img_str" >> "$OUTPUT_FILE"
+  else
+    echo "Warning: No match found for $line" >&2
+  fi
+
+done < "$FILE"

--- a/scripts/operations/iscsi_sbps/rm_iscsi_luns.sh
+++ b/scripts/operations/iscsi_sbps/rm_iscsi_luns.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+#  MIT License
+#
+#  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
+# Script to remove iSCSI Luns on the iSCSI iniator (compute/UAN) for which
+# corresponding rootfs/PE images are going to be deleted. This script
+# expects a file named img_str.txt as an argument which has the list of
+# rootfs/PE image identifiers which is generated as an output of
+# get_img_str.sh script ran before this script on the iSCSI target.
+
+set -euo pipefail
+
+FILE="$1"
+
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 <filename>"
+  echo "Error: No file argument provided."
+  exit 1
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: File not found"
+  exit 1
+fi
+
+while IFS= read -r line; do
+
+  for dev in $(lsscsi | grep $line | awk '{print $NF}'); do
+    blockdev --flushbufs $dev
+  done
+
+  for lun in $(lsscsi | grep $line | awk '{print $1}' | tr -d '[' | tr -d ']'); do
+    echo "Device going to be deleted is $line"
+    echo 1 > /sys/class/scsi_device/$lun/device/delete
+  done
+
+done < "$FILE"
+
+# Cleanup Multipath devices if no active paths
+
+echo "Check for multipath devices with no active paths..."
+
+MULTIPATH_DEVICES=$(multipath -l | grep "dm-*" | awk '{print $1}')
+
+for dev in $MULTIPATH_DEVICES; do
+
+  ACTIVE_PATHS=$(multipath -l "$dev" | grep 'active' | grep 'running' | wc -l)
+
+  if [ "$ACTIVE_PATHS" -eq 0 ]; then
+    echo "Multipath device $dev has 0 active paths. Removing it..."
+    # Flush the I/O and remove the multipath device
+    multipath -f "$dev"
+    if [ $? -eq 0 ]; then
+      echo "Successfully removed $dev."
+    else
+      echo "Failed to remove $dev. It might be in use."
+    fi
+  fi
+done

--- a/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
+++ b/scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#  MIT License
+#
+#  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+
+# Script to remove stale iSCSI LUNs
+
+#set -euo pipefail
+
+lsscsi -t | grep iscsi | awk '{print $4}' > iscsi_devs
+
+input="iscsi_devs"
+
+# Issue Report Luns command to each of the iSCSI Luns.
+# Report Luns command fails if the lun is stale.
+
+while IFS= read -r line; do
+
+  sg_luns --readonly -q "$line" &> /dev/null
+
+  if [ "$?" -ne 0 ]; then
+    blockdev --flushbufs $line
+    echo "report luns command failed for $line"
+    lun=$(lsscsi | grep $line | awk '{print $1}' | tr -d '[' | tr -d ']')
+    echo "stale lun going to be deleted is $lun"
+    echo 1 > /sys/class/scsi_device/$lun/device/delete
+  fi
+
+done < "$input"
+
+rm iscsi_devs
+
+# Cleanup Multipath devices if no active paths
+
+echo "Check for multipath devices with no active paths..."
+
+MULTIPATH_DEVICES=$(multipath -l | grep "dm-*" | awk '{print $1}')
+
+for dev in $MULTIPATH_DEVICES; do
+
+  ACTIVE_PATHS=$(multipath -l "$dev" | grep 'active' | grep 'running' | wc -l)
+
+  if [ "$ACTIVE_PATHS" -eq 0 ]; then
+    echo "Multipath device $dev has 0 active paths. Removing it..."
+    # Flush the I/O and remove the multipath device
+    multipath -f "$dev"
+    if [ $? -eq 0 ]; then
+      echo "Successfully removed $dev."
+    else
+      echo "Failed to remove $dev. It might be in use."
+    fi
+  fi
+done

--- a/troubleshooting/known_issues/remove_stale_iscsi_lun.md
+++ b/troubleshooting/known_issues/remove_stale_iscsi_lun.md
@@ -1,0 +1,27 @@
+# Worker nodes may hang or unresponsive post `rootfs/PE` image deletion
+
+## Symptom  
+
+On CSM 1.7 cluster, where compute/UAN nodes are booted with iSCSI SBPS,
+if any `rootfs/PE` images are deleted say if some of these images are unused,
+then worker nodes may hang or become unresponsive due to flood of following
+messages in the worker nodes `dmesg`.
+
+```text
+[Fri Nov 7 15:06:12 2025] TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x0000000a from iqn.2023-06.csm.iscsi:x1102c5s6b1n0
+```
+
+## Root cause
+
+When the `rootfs/PE` images are deleted, the iSCSI SBPS marshal agent deletes corresponding
+iSCSI `Luns` and `fileio` backing store while it scans `IMS/s3` every 180 secs. So once the iSCSI
+`Luns` are deleted from the iSCSI target (worker node), the corresponding iSCSI `Luns` on the
+iSCSI initiator (compute/UAN) node become stale and iSCSI initiator software looks for
+corresponding `Luns` on the iSCSI target (worker) node repeatedly and above flood of messages
+mentioned in the 'symptom' will be seen in the `dmesg` of worker nodes.
+
+## Resolution
+
+To fix this issue, we need to cleanup these stale iSCSI `Luns` on the iSCSI initiator. Run the
+script [Remove stale iSCSI `Luns`](../../scripts/operations/iscsi_sbps/rm_stale_iscsi_lun.sh)
+to delete stale iSCSI `Luns` from the iscsi initiator(s).


### PR DESCRIPTION
# Description
This is adding the scripts  and document procedural steps to run the scripts for iSCSI Lun deletion for below scenario's:
1. To delete iSCSI luns from the iSCSI clients for which corresponding images are identified as unused and going to be deleted (rm_iscsi_luns.sh, get_img_str.sh).
2. To delete stale iSCSI luns from iSCSI clients post image deletion/corresponding iSCSI lun deletion on iSCSI targets (rm_stale_iscsi_lun.sh).

https://jira-pro.it.hpe.com:8443/browse/CAST-39136

# Checklist

- [NA] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [NA ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
