### PR TITLE
CASMNET-2368 - Procedures to replace an NCN NIC and boot an NCN using its secondary NIC -- 1.7

### DIFF
--- a/operations/node_management/NCN_NIC_Replacement.md
+++ b/operations/node_management/NCN_NIC_Replacement.md
@@ -4,6 +4,11 @@ This procedure is for re-adding a non-compute node (NCN) after NIC replacement. 
 [Replace NCN procedure](Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#replace-ncn-procedure) but many of
 the steps can be skipped because only the NIC and its MAC addresses changed.
 
+This procedure can also be used to boot an NCN using the second interface if the primary NIC has failed. The
+DHCP service only assigns the designated IP address to the `mgmt0` interface. If it becomes necessary to boot
+the node using the other NIC, use this procedure to swap the MAC addresses of the `mgmt0` and `mgmt1` interfaces
+in the boot parameters.
+
 * [Prerequisites](#prerequisites)
 * [Procedure](#procedure)
   1. [Collect the new MAC addresses](#1-collect-the-new-mac-addresses)


### PR DESCRIPTION
# Description

Add note to `NCN_NIC_Replacement.md` indicating it can also be used to reconfigure the node to boot from its secondary NIC in the event that the primary NIC has failed.

Relates to:
- [CASMNET-2368](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2368)
- [CAST-38898](https://jira-pro.it.hpe.com:8443/browse/CAST-38898)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
