### PR TITLE
REL_NOTES: Add CASMPET-7575 removal of remaining PSP resources to CSM 1.7.1 release notes

### DIFF
--- a/RELEASE_NOTES_1.7.1.md
+++ b/RELEASE_NOTES_1.7.1.md
@@ -24,6 +24,11 @@ see [CSM 1.7 release notes](RELEASE_NOTES.md).
 
 ## Bug fixes
 
+* After upgrading to Kubernetes 1.32 in CSM 1.7.0, some PodSecurityPolicy (PSP) RoleBindings and Service Accounts still exist.
+
+  Since PSP is not supported in Kubernetes 1.25+, these unneeded RoleBindings and Service Accounts are removed after Kubernetes
+  is upgraded to 1.32.
+
 ## Known issues
 
 * In multi-tenant configurations leveraging Slingshot networking as described in the "HPE Slingshot Network Operator for CSM Multi-Tenancy"

--- a/RELEASE_NOTES_1.7.1.md
+++ b/RELEASE_NOTES_1.7.1.md
@@ -24,9 +24,9 @@ see [CSM 1.7 release notes](RELEASE_NOTES.md).
 
 ## Bug fixes
 
-* After upgrading to Kubernetes 1.32 in CSM 1.7.0, some PodSecurityPolicy (PSP) RoleBindings and Service Accounts still exist.
+* After upgrading to Kubernetes 1.32 in CSM 1.7.0, some Pod Security Policy (PSP) Role Bindings and Service Accounts still exist.
 
-  Since PSP is not supported in Kubernetes 1.25+, these unneeded RoleBindings and Service Accounts are removed after Kubernetes
+  Since PSP is not supported in Kubernetes 1.25+, these unneeded Role Bindings and Service Accounts are removed after Kubernetes
   is upgraded to 1.32.
 
 ## Known issues


### PR DESCRIPTION
# Description
Add removal of remaining PSP resources after upgrade to K8s 1.32 (CASMPET-7575) to CSM 1.7.1 release notes

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
