### PR TITLE
CASMINIST-7445 Included IPV6 nieghbor cache table

### DIFF
--- a/operations/configuration_management/ARP_cache_tuning.md
+++ b/operations/configuration_management/ARP_cache_tuning.md
@@ -74,16 +74,17 @@ net.ipv4.neigh.default.gc_thresh3 = 75000
 net.ipv4.neigh.default.gc_stale_time = 240
 net.ipv4.neigh.default.base_reachable_time_ms = 1500000
 ```
+
 ## IPv6 Considerations
 
 If your environment uses IPv6, you may also want to set the equivalent IPv6 neighbor cache settings. Just like the IPv4 ARP cache, IPv6 maintains a Neighbor Cache table to map IPv6 addresses to MAC addresses.  
 The following parameters can be set using the same calculated values from the IPv4 ARP cache settings:
 
 ```ini
-net.ipv6.neigh.default.gc_thresh1 = 2048
-net.ipv6.neigh.default.gc_thresh2 = 4096
-net.ipv6.neigh.default.gc_thresh3 = 8192
-net.ipv6.route.gc_thresh = -1
+net.ipv6.neigh.default.gc_thresh1 = 25000
+net.ipv6.neigh.default.gc_thresh2 = 37500
+net.ipv6.neigh.default.gc_thresh3 = 75000
+net.ipv6.route.gc_thresh = 1024
 net.ipv6.xfrm6_gc_thresh = 32768
 ```
 
@@ -147,6 +148,7 @@ The following steps describe how to use the Configuration Framework Service (CFS
      - name: net.ipv4.neigh.default.base_reachable_time_ms
        value: 1500000
    ```
+   
    > **`NOTE`** If IPv6 neighbor cache table is also required for a system, add them to the `sysctl_config` list as well.
 
 1. Commit the change and push it back up to the VCS.
@@ -301,6 +303,7 @@ The following steps describe how to use the Configuration Framework Service (CFS
       ncn-m001: net.ipv4.neigh.default.gc_thresh2 = 4096
       ncn-m001: net.ipv4.neigh.default.gc_thresh3 = 8192
       ```
+   
 2. (`ncn-m001`) Verify IPv6 neighbor table cache settings (if configured).
 
       ```bash

--- a/operations/configuration_management/ARP_cache_tuning.md
+++ b/operations/configuration_management/ARP_cache_tuning.md
@@ -74,6 +74,18 @@ net.ipv4.neigh.default.gc_thresh3 = 75000
 net.ipv4.neigh.default.gc_stale_time = 240
 net.ipv4.neigh.default.base_reachable_time_ms = 1500000
 ```
+## IPv6 Considerations
+
+If your environment uses IPv6, you may also want to set the equivalent IPv6 neighbor cache settings. Just like the IPv4 ARP cache, IPv6 maintains a Neighbor Cache table to map IPv6 addresses to MAC addresses.  
+The following parameters can be set using the same calculated values from the IPv4 ARP cache settings:
+
+```ini
+net.ipv6.neigh.default.gc_thresh1 = 2048
+net.ipv6.neigh.default.gc_thresh2 = 4096
+net.ipv6.neigh.default.gc_thresh3 = 8192
+net.ipv6.route.gc_thresh = -1
+net.ipv6.xfrm6_gc_thresh = 32768
+```
 
 ## Host configuration
 
@@ -135,6 +147,7 @@ The following steps describe how to use the Configuration Framework Service (CFS
      - name: net.ipv4.neigh.default.base_reachable_time_ms
        value: 1500000
    ```
+   > **`NOTE`** If IPv6 neighbor cache table is also required for a system, add them to the `sysctl_config` list as well.
 
 1. Commit the change and push it back up to the VCS.
 
@@ -287,6 +300,24 @@ The following steps describe how to use the Configuration Framework Service (CFS
       ncn-m001: net.ipv4.neigh.default.gc_thresh1 = 2048
       ncn-m001: net.ipv4.neigh.default.gc_thresh2 = 4096
       ncn-m001: net.ipv4.neigh.default.gc_thresh3 = 8192
+      ```
+2. (`ncn-m001`) Verify IPv6 neighbor table cache settings (if configured).
+
+      ```bash
+      pdsh -w ${NCNS} "sysctl -a | grep -E 'net.ipv6.neigh.default.gc_thresh[1-3]|net.ipv6.route.gc_thresh|net.ipv6.xfrm6_gc_thresh'" | dshbak -c
+      ```
+
+      Example output:
+
+      ```ini
+      ----------------
+      ncn-m[001-003],ncn-s[001-003],ncn-w[001-006]
+      ----------------
+      net.ipv6.neigh.default.gc_thresh1 = 128
+      net.ipv6.neigh.default.gc_thresh2 = 512
+      net.ipv6.neigh.default.gc_thresh3 = 1024
+      net.ipv6.route.gc_thresh = 1024
+      net.ipv6.xfrm6_gc_thresh = 32768
       ```
 
 ## Troubleshooting

--- a/operations/configuration_management/ARP_cache_tuning.md
+++ b/operations/configuration_management/ARP_cache_tuning.md
@@ -148,7 +148,7 @@ The following steps describe how to use the Configuration Framework Service (CFS
      - name: net.ipv4.neigh.default.base_reachable_time_ms
        value: 1500000
    ```
-   
+
    > **`NOTE`** If IPv6 neighbor cache table is also required for a system, add them to the `sysctl_config` list as well.
 
 1. Commit the change and push it back up to the VCS.
@@ -303,8 +303,8 @@ The following steps describe how to use the Configuration Framework Service (CFS
       ncn-m001: net.ipv4.neigh.default.gc_thresh2 = 4096
       ncn-m001: net.ipv4.neigh.default.gc_thresh3 = 8192
       ```
-   
-2. (`ncn-m001`) Verify IPv6 neighbor table cache settings (if configured).
+
+1. (`ncn-m001`) Verify IPv6 neighbor table cache settings (if configured).
 
       ```bash
       pdsh -w ${NCNS} "sysctl -a | grep -E 'net.ipv6.neigh.default.gc_thresh[1-3]|net.ipv6.route.gc_thresh|net.ipv6.xfrm6_gc_thresh'" | dshbak -c


### PR DESCRIPTION
The IPv6 cache size sysctls are still set to the SUSE defaults. This fix updates ARP cache tuning guidance to set the IPv6 neighbor cache values to be the same size as the IPv4 ARP cache.

Relates to: https://github.com/Cray-HPE/node-images/pull/1326

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

https://jira-pro.it.hpe.com:8443/browse/CASMINST-7445
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs: 

Relates to:
- pr-link-1 
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
