### PR TITLE
CASMTRIAGE-8940 : setting cfs_config and ims_image name 

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-m001-rollout.yaml
@@ -115,6 +115,22 @@ spec:
 
                     HOSTNAME=$(hostname)
 
+                    ### FETCH_CFS_CONFIG_AND_IMAGE
+                    cfs_config="{{=jsonpath(inputs.parameters.global_params,'$.input_params.cfs_configuration_management')}}"
+                    ims_image="{{=jsonpath(inputs.parameters.global_params,'$.input_params.boot_image_management')}}"
+
+                    if [[ -n $cfs_config && -n $ims_image ]]; then
+                      echo "INFO Rebuilding using passed parameters $ims_image and $cfs_config"
+                      CFS_CONFIG_NAME=$cfs_config
+                      IMAGE_ID=$ims_image
+                    else
+                      echo "INFO Starting rebuild using image built in the prepare images stage"
+                      prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                      CFS_CONFIG_NAME=$(echo $prepare_images_output | jq -r '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration')
+                      IMAGE_ID=$(echo $prepare_images_output | jq -r '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id')
+                    fi
+                    echo "DEBUG CFS_CONFIG_NAME=${CFS_CONFIG_NAME}, IMAGE_ID=${IMAGE_ID}"
+
                     ### STEP 1: BACKUP_ARTIFACTS
                     STATE_NAME="BACKUP_ARTIFACTS"
                     state_recorded=$(is_state_recorded "${STATE_NAME}" "${HOSTNAME}")
@@ -142,32 +158,7 @@ spec:
                       echo "INFO ====> ${STATE_NAME} has previously been completed"
                     fi
 
-                    ### STEP 2: FETCH_CFS_AND_IMAGE
-                    STATE_NAME="FETCH_CFS_AND_IMAGE"
-                    state_recorded=$(is_state_recorded "${STATE_NAME}" "${HOSTNAME}")
-                    if [[ "${state_recorded}" == "0" ]]; then
-                      echo "INFO ====> ${STATE_NAME} starting..."
-
-                      cfs_config="{{=jsonpath(inputs.parameters.global_params,'$.input_params.cfs_configuration_management')}}"
-                      ims_image="{{=jsonpath(inputs.parameters.global_params,'$.input_params.boot_image_management')}}"
-
-                      if [[ -n $cfs_config && -n $ims_image ]]; then
-                        echo "INFO Rebuilding $rebuild_set using passed parameters $ims_image and $cfs_config"
-                        CFS_CONFIG_NAME=$cfs_config
-                        IMAGE_ID=$ims_image
-                      else
-                        echo "INFO Starting rebuild of $rebuild_set using image built in the prepare images stage"
-                        prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
-                        CFS_CONFIG_NAME=$(echo $prepare_images_output | jq -r '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration')
-                        IMAGE_ID=$(echo $prepare_images_output | jq -r '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id')
-                      fi
-
-                      record_state "${STATE_NAME}" "${HOSTNAME}"
-                    else
-                      echo "INFO ====> ${STATE_NAME} has previously been completed"
-                    fi
-
-                    ### STEP 3: APPLY_CFS_CONFIGURATION
+                    ### STEP 2: APPLY_CFS_CONFIGURATION
                     STATE_NAME="APPLY_CFS_CONFIGURATION"
                     state_recorded=$(is_state_recorded "${STATE_NAME}" "${HOSTNAME}")
                     if [[ "${state_recorded}" == "0" ]]; then
@@ -190,7 +181,7 @@ spec:
                       echo "INFO ====> ${STATE_NAME} has previously been completed"
                     fi
 
-                    ### STEP 4: BOOTPARAMETERS_UPDATE
+                    ### STEP 3: BOOTPARAMETERS_UPDATE
                     STATE_NAME="BOOTPARAMETERS_UPDATE"
                     state_recorded=$(is_state_recorded "${STATE_NAME}" "${HOSTNAME}")
                     if [[ "${state_recorded}" == "0" ]]; then


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

CFS_CONFIG_NAME and IMAGE_ID needs to be set every time the backup task is run. Hence moving it out of state tracking.

Resolves [CASMTRIAGE-8940](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8940)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
