### PR TITLE
CASMTRIAGE-8958 Fixing an issue found during FM on BM testing

### DIFF
--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -854,7 +854,7 @@ class State:
                         if ip_reservation.ipv4_address() == allocated_ip:
                             fail_sls_network_check = True
                             action_log(action, f'Error found allocated NCN IP {allocated_ip} in subnet {subnet.name()} network {network_name} in SLS: {ip_reservation.to_sls()}')
-                        if not fmn_vip_exists:
+                        if sls_network.name() in ["HMN", "NMN"] and not fmn_vip_exists:
                             # For FMN systems, check both the regular and VIP NCN IP reservations
                             vip_ip = ncn_ips[network_name+"-fmn-vip"].ipv4_address()
                             if ip_reservation.ipv4_address() == vip_ip:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Fixing an issue found during FM on BM testing while adding first fabric manager node. Previously as part of fixing [CASMTRIAGE-8906](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8906), few changes were made and only second FM node addition is tested after this. But these changes had a impact on first FM node addition, which is discovered during the latest test. Now entire flow is tested with this change and everything looks fine.
 
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8958

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
