### PR TITLE
CASMHMS-6606: Improve SMD pruning of "Detected" events from hardware inventory history -- 1.6

### DIFF
--- a/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
+++ b/operations/hardware_state_manager/Remove_Duplicate_Detected_Events_From_HSM_Postgres_Database.md
@@ -169,27 +169,133 @@ other component types were affected by this bug.
     Example output:
 
     ```text
+    Batch size:        ALL (ALL = unlimited)
+    Max batches:       0 (0 = unlimited)
+    Replication delay: 1 seconds between batches
+    Vacuum type:       FULL
+
+    Set BATCH_SIZE, MAX_BATCHES, REPLICATION_SLEEP_DELAY, and VACUUM_TYPE variables to override
+
     Determining the postgres leader...
     The SMD postgres leader is cray-smd-postgres-2
-    NOTICE:  hwinv_history table size before pruning:  652 mb
-    NOTICE:  Database size before pruning:             666 mb
+
+    NOTICE:  hwinv_history row count before pruning:    180,857,684
+    NOTICE:  hwinv_history table size before pruning:   79831 mb
+    NOTICE:  Database size before pruning:              79858 mb
     DO
 
     Operations may take considerable time - please do not interrupt
-    
+
     Creating hwinvhist_id_ts_idx index on hwinv_hist table...
     CREATE INDEX
-    
-    Pruning hwinv_hist table...
-    DELETE 1740689
-    
-    Running VACUUM FULL on hwinv_hist table to reclaim disk space...
+
+    Pruning hwinv_hist table .
+    Pruning complete: 180431252 total rows deleted across 1 batches
+
+    Running VACUUM FULL on hwinv_hist table...
     VACUUM
-    
-    NOTICE:  hwinv_history table size after pruning:  268 mb
-    NOTICE:  Database size after pruning:             282 mb
+
+    NOTICE:  hwinv_history row count after pruning:    426,432
+    NOTICE:  hwinv_history table size after pruning:   199 mb
+    NOTICE:  Database size after pruning:              226 mb
     DO
+
+    Total execution time: 0h 17m 32s
     ```
 
     Should any issues arise requiring restoration of the hardware inventory
     history table, please refer back to step 3.
+
+    We have seen cases where the `fru_history_remove_duplicate_detected_events.sh`
+    script can fail if there are too many duplicate "Detected" events
+    present in the database.  Should this occur, see the alternative
+    procedure described further below.
+
+### Alternative Procedure for Large Databases
+
+If the `fru_history_remove_duplicate_detected_events.sh` script fails due to
+an excessive number of duplicate "Detected" events in the database, the pruning
+operation must be broken down into smaller batches. Skip this section if the
+pruning operation in step 4 completed successfully.
+
+This procedure uses environment variables to control the batch size and number
+of iterations. Full descriptions of each variable are provided at the end of
+this section.
+
+The first step is to determine an appropriate batch size through incremental
+testing. Begin with conservative settings: `VACUUM_TYPE` set to `ANALYZE`,
+`MAX_BATCHES` set to 1, and `BATCH_SIZE` set to 100,000:
+
+```bash
+BATCH_SIZE=100000 MAX_BATCHES=1 VACUUM_TYPE=ANALYZE ${HWINV_SCRIPT_DIR}/fru_history_remove_duplicate_detected_events.sh
+```
+
+If successful, increase the batch size to 1,000,000:
+
+```bash
+BATCH_SIZE=1000000 MAX_BATCHES=1 VACUUM_TYPE=ANALYZE ${HWINV_SCRIPT_DIR}/fru_history_remove_duplicate_detected_events.sh
+```
+
+If successful, increase the batch size to 10,000,000:
+
+```bash
+BATCH_SIZE=10000000 MAX_BATCHES=1 VACUUM_TYPE=ANALYZE ${HWINV_SCRIPT_DIR}/fru_history_remove_duplicate_detected_events.sh
+```
+
+If successful, attempt 100,000,000:
+
+```bash
+BATCH_SIZE=100000000 MAX_BATCHES=1 VACUUM_TYPE=ANALYZE ${HWINV_SCRIPT_DIR}/fru_history_remove_duplicate_detected_events.sh
+```
+
+The maximum viable batch size is typically either 10,000,000 or 100,000,000.
+
+Once the maximum batch size has been determined, increase the number of batches
+processed per run by adjusting the `MAX_BATCHES` variable. Continue running the
+script until all duplicate events are pruned.
+
+After all duplicates have been removed, run the script one final time with a
+`FULL` vacuum to reclaim disk space:
+
+```bash
+VACUUM_TYPE=FULL ${HWINV_SCRIPT_DIR}/fru_history_remove_duplicate_detected_events.sh
+```
+
+_Note:_ A `FULL` vacuum is required to return disk space to the operating system.
+
+#### Environment Variables
+
+The following environment variables control the behavior of the pruning script:
+
+##### `BATCH_SIZE`
+
+_Default:_ `ALL` (no limit)
+
+Limits the number of duplicate events to prune per iteration. When tuning
+this variable, start with a low value and increase incrementally until a
+failure occurs, then use the last successful batch size.
+
+##### `MAX_BATCHES`
+
+_Default:_ `0` (no limit)
+
+Limits the number of batches (iterations) to perform. When determining the
+appropriate `BATCH_SIZE`, set this to `1` to test one batch at a time.
+Once an appropriate `BATCH_SIZE` is determined, increase this value to
+process multiple batches per run.
+
+##### `REPLICATION_SLEEP_DELAY`
+
+_Default:_ `1` (second)
+
+Specifies the sleep delay in seconds between batches to allow database
+replication to catch up. Adjusting this value is typically not necessary.
+
+##### `VACUUM_TYPE`
+
+_Default:_ `FULL`
+
+Controls the type of vacuum to perform after pruning. Options are `FULL`
+or `ANALYZE`. Use `ANALYZE` during incremental pruning operations to save
+time. After all duplicates are removed, perform a final `FULL` vacuum to
+reclaim disk space and return it to the operating system.

--- a/upgrade/scripts/upgrade/smd/fru_history_remove_duplicate_detected_events.sh
+++ b/upgrade/scripts/upgrade/smd/fru_history_remove_duplicate_detected_events.sh
@@ -33,6 +33,53 @@
 
 set -eo pipefail
 
+# Capture start time
+START_TIME=$(date +%s)
+
+# Batch size for DELETE operations - tune based on available memory
+# Smaller batches = slower but safer for memory-constrained environments
+# Larger batches = faster but require more memory
+# Set to a number to limit batch size (e.g., 250000)
+# Default: ALL (process all duplicates in one batch)
+BATCH_SIZE="${BATCH_SIZE:-ALL}"
+
+# Maximum number of batches to process before exiting
+# Useful for processing large datasets incrementally to avoid pod crashes
+# Set to 0 for unlimited (process all duplicates)
+# Default: 0 (unlimited)
+MAX_BATCHES="${MAX_BATCHES:-0}"
+
+# Sleep delay between batches to allow replication to catch up
+# Increase if experiencing replication lag or resource contention
+# Default: 1 second
+REPLICATION_SLEEP_DELAY="${REPLICATION_SLEEP_DELAY:-1}"
+
+# Vacuum type - controls disk space reclamation
+# FULL: Returns disk space to OS, but requires up to 2x table size and blocks writes
+# ANALYZE: Safer for large tables, frees space for reuse but doesn't return to OS
+# Default: FULL
+VACUUM_TYPE="${VACUUM_TYPE:-FULL}"
+
+# Validate VACUUM_TYPE
+case "$VACUUM_TYPE" in
+  FULL | ANALYZE)
+    # Valid option
+    ;;
+  *)
+    echo "Error: Invalid VACUUM_TYPE='$VACUUM_TYPE'" >&2
+    echo "Valid options: FULL or ANALYZE" >&2
+    exit 1
+    ;;
+esac
+
+echo "Batch size:        $BATCH_SIZE (ALL = unlimited)"
+echo "Max batches:       $MAX_BATCHES (0 = unlimited)"
+echo "Replication delay: $REPLICATION_SLEEP_DELAY seconds between batches"
+echo "Vacuum type:       $VACUUM_TYPE"
+echo ""
+echo "Set BATCH_SIZE, MAX_BATCHES, REPLICATION_SLEEP_DELAY, and VACUUM_TYPE variables to override"
+echo ""
+
 # Dig into the secrets store to find all necessary connection data
 #
 # Update SECRET_KEY_REF if it was changed in the SMD chart!
@@ -60,6 +107,7 @@ echo "Determining the postgres leader..."
 POSTGRES_LEADER=$(kubectl exec cray-smd-postgres-0 -n services -c postgres -t -- patronictl list -f json | jq -r '.[] | select(.Role == "Leader").Member')
 
 echo "The SMD postgres leader is $POSTGRES_LEADER"
+echo ""
 
 # Capture and print sizes before pruning and vacuuming
 
@@ -67,14 +115,17 @@ kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "
 	psql \"$PSQL_OPTS\" -c \"
 	DO \\\$\$
 	DECLARE
+		tbl_len_before     bigint := 0;   /* hwinv_history row count before pruning */
 		tbl_size_before    bigint := 0;   /* hwinv_history size before pruning */
 		db_size_before     bigint := 0;   /* DB size before pruning */
 	BEGIN
+		SELECT COUNT(*) FROM hwinv_hist INTO tbl_len_before;
 		SELECT pg_total_relation_size('hwinv_hist') INTO tbl_size_before;
 		SELECT pg_database_size(current_database()) INTO db_size_before;
 
-		RAISE NOTICE 'hwinv_history table size before pruning:  % mb', tbl_size_before / 1024 / 1024;
-		RAISE NOTICE 'Database size before pruning:             % mb', db_size_before / 1024 / 1024;
+		RAISE NOTICE 'hwinv_history row count before pruning:    %', to_char(tbl_len_before, 'FM999,999,999,999');
+		RAISE NOTICE 'hwinv_history table size before pruning:   % mb', tbl_size_before / 1024 / 1024;
+		RAISE NOTICE 'Database size before pruning:              % mb', db_size_before / 1024 / 1024;
 	END;
 	\\\$\$ LANGUAGE plpgsql;\"
 "
@@ -97,35 +148,95 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-# Run the pruning logic
+# Run the pruning logic in batches to avoid memory exhaustion
+# This approach processes data in chunks to prevent OOM issues
 
 echo ""
-echo "Pruning hwinv_hist table... "
+echo -n "Pruning hwinv_hist table "
 
-kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "
-	psql \"$PSQL_OPTS\" -c \"
-	WITH ordered AS (
-		SELECT ctid, id, \"timestamp\", event_type,
-			LAG(event_type) OVER (PARTITION BY id ORDER BY \"timestamp\") AS prev_type
-		FROM hwinv_hist
-		WHERE id IN (
-			SELECT loc.id
-			FROM hwinv_by_loc loc
-			WHERE loc.type IN ('Processor', 'NodeAccel')
-		)
-	),
-	dups AS (
-		SELECT ctid
-		FROM ordered
-		WHERE event_type = 'Detected' AND prev_type = 'Detected'
-	)
-	DELETE FROM hwinv_hist
-	WHERE ctid IN (SELECT ctid FROM dups);\"
-"
+BATCH_COUNT=0
+TOTAL_DELETED=0
 
-if [[ $? -ne 0 ]]; then
-  echo "Error executing SQL command" >&2
-  exit 1
+while true; do
+  BATCH_COUNT=$((BATCH_COUNT + 1))
+
+  # Run the delete (limited to BATCH_SIZE) and capture full output
+  OUTPUT=$(kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "
+		psql \"$PSQL_OPTS\" -c \"
+		DO \\\$\\\$
+		DECLARE
+			rows_deleted INTEGER;
+		BEGIN
+			WITH ordered AS (
+				SELECT ctid, id, \"timestamp\", event_type,
+					LAG(event_type) OVER (PARTITION BY id ORDER BY \"timestamp\") AS prev_type
+				FROM hwinv_hist
+				WHERE id IN (
+					SELECT loc.id
+					FROM hwinv_by_loc loc
+					WHERE loc.type IN ('Processor', 'NodeAccel')
+				)
+			),
+			dups AS (
+				SELECT ctid
+				FROM ordered
+				WHERE event_type = 'Detected' AND prev_type = 'Detected'
+				LIMIT $BATCH_SIZE
+			)
+			DELETE FROM hwinv_hist
+			WHERE ctid IN (SELECT ctid FROM dups);
+
+			GET DIAGNOSTICS rows_deleted = ROW_COUNT;
+			RAISE NOTICE '%', rows_deleted;
+		END;
+		\\\$\\\$;\"
+	" 2>&1)
+
+  # Check for errors
+  if [[ $? -ne 0 ]]; then
+    echo ""
+    echo "$OUTPUT"
+    echo ""
+    echo "Error executing SQL command" >&2
+    exit 1
+  fi
+
+  # Extract the row count from NOTICE output (last NOTICE line only)
+  DELETED=$(echo "$OUTPUT" | grep "NOTICE:" | tail -1 | grep -oE '[0-9]+')
+
+  # If nothing deleted then we're done
+  if [[ -z $DELETED || $DELETED -eq 0 ]]; then
+    BATCH_COUNT=$((BATCH_COUNT - 1))
+    break
+  fi
+
+  TOTAL_DELETED=$((TOTAL_DELETED + DELETED))
+
+  # Print progress indicator
+  echo -n "."
+
+  # If batch size is ALL, we are done after one iteration
+  if [[ $BATCH_SIZE == "ALL" ]]; then
+    break
+  fi
+
+  # Check if we've reached the maximum batch limit
+  if [[ $MAX_BATCHES -gt 0 && $BATCH_COUNT -ge $MAX_BATCHES ]]; then
+    echo ""
+    echo "Reached maximum batch limit of $MAX_BATCHES batches"
+    break
+  fi
+
+  # Small delay to allow replication to catch up and resources to be freed
+  sleep $REPLICATION_SLEEP_DELAY
+done
+
+echo ""
+if [[ $MAX_BATCHES -gt 0 && $TOTAL_DELETED -gt 0 && $BATCH_COUNT -ge $MAX_BATCHES ]]; then
+  echo "Partial pruning complete: $TOTAL_DELETED rows deleted across $BATCH_COUNT batches (limit reached)"
+  echo "Run script again to continue processing remaining duplicates"
+else
+  echo "Pruning complete: $TOTAL_DELETED total rows deleted across $BATCH_COUNT batches"
 fi
 
 # The pruning logic above removed a large part of the hwinv_hist table. This
@@ -134,26 +245,30 @@ fi
 #
 #     1. Do nothing
 #            * Standard vacuum will eventually run but could be days or weeks
-#     2. Standard vacuum
+#     2. VACUUM ANALYZE
 #            * Non-blocking
-#            * Frees internal space
+#            * Frees internal space for reuse
 #            * Does not return disk space to the OS
-#     3. Full vacuum
+#            * Much less memory-intensive than VACUUM FULL
+#            * Safer for large tables
+#     3. VACUUM FULL
 #            * Blocking - no updates allowed to table until complete
-#            * Frees internal space
+#            * Frees internal space for reuse
 #            * Returns disk space to the OS
+#            * Requires up to 2x table size in free disk space
+#            * Very memory-intensive and can crash pods on large tables
 #
-# So, run a full vacuum
+# The VACUUM_TYPE variable controls which approach is used
 
 echo ""
-echo "Running VACUUM FULL on hwinv_hist table to reclaim disk space..."
+echo "Running VACUUM $VACUUM_TYPE on hwinv_hist table..."
 
 kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "
-	psql \"$PSQL_OPTS\" -c \"VACUUM FULL hwinv_hist;\"
+	psql \"$PSQL_OPTS\" -c \"VACUUM $VACUUM_TYPE hwinv_hist;\"
 "
 
 if [[ $? -ne 0 ]]; then
-  echo "Error running VACUUM FULL" >&2
+  echo "Error running VACUUM $VACUUM_TYPE" >&2
   exit 1
 fi
 
@@ -165,14 +280,28 @@ kubectl -n services exec "$POSTGRES_LEADER" -c postgres -it -- bash -c "
 	psql \"$PSQL_OPTS\" -c \"
 	DO \\\$\$
 	DECLARE
+		tbl_len_after     bigint := 0;   /* hwinv_history row count after pruning */
 		tbl_size_after    bigint := 0;   /* hwinv_history size after pruning */
 		db_size_after     bigint := 0;   /* DB size after pruning */
 	BEGIN
+		SELECT COUNT(*) FROM hwinv_hist INTO tbl_len_after;
 		SELECT pg_total_relation_size('hwinv_hist') INTO tbl_size_after;
 		SELECT pg_database_size(current_database()) INTO db_size_after;
 
-		RAISE NOTICE 'hwinv_history table size after pruning:  % mb', tbl_size_after / 1024 / 1024;
-		RAISE NOTICE 'Database size after pruning:             % mb', db_size_after / 1024 / 1024;
+		RAISE NOTICE 'hwinv_history row count after pruning:    %', to_char(tbl_len_after, 'FM999,999,999,999');
+		RAISE NOTICE 'hwinv_history table size after pruning:   % mb', tbl_size_after / 1024 / 1024;
+		RAISE NOTICE 'Database size after pruning:              % mb', db_size_after / 1024 / 1024;
 	END;
 	\\\$\$ LANGUAGE plpgsql;\"
 "
+
+# Calculate and display total execution time
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+
+HOURS=$((ELAPSED / 3600))
+MINUTES=$(((ELAPSED % 3600) / 60))
+SECONDS=$((ELAPSED % 60))
+
+echo ""
+echo "Total execution time: ${HOURS}h ${MINUTES}m ${SECONDS}s"


### PR DESCRIPTION
# Description

Improvements to SMD's pruning script for "Detected" events.  Prior script was causing SMD's postgres cluster to OOM on a customer system where the database size was quite substantial.  The improvements here break the pruning into chunks to reduce memory pressure.  There are also doc changes included to describe how to use the updated script.

* Resolves [CASMHMS-6606](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6606)

# Testing

Most testing was done locally on my laptop.  I uploaded database dumps from mug, tyr, and from the customer system in question into a simulated SMD on my laptop and successfully performed the new pruning operation, using all possible new configuration options.

Also tested on the `mug` and `tyr` internal systems.

The updated script was also sent to the customer to test on their system, where it ran successfully.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.