### PR TITLE
CASMTRIAGE-8943 - cilium migration failing with k8s primary cni value set as null

### DIFF
--- a/operations/iuf/workflows/cilium_migration.md
+++ b/operations/iuf/workflows/cilium_migration.md
@@ -4,6 +4,7 @@ This describes how to migrate Kubernetes CNI from Weave to Cilium during a CSM u
 
 - [Steps](#steps)
 - [Known issues](#known-issues)
+    - [Missing BSS Global Metadata Parameter](#missing-bss-global-metadata-parameter)
     - [Node drain blocked by Kafka](#node-drain-blocked-by-kafka)
     - [Node drain blocked by an `etcd` cluster](#node-drain-blocked-by-an-etcd-cluster)
 
@@ -41,6 +42,12 @@ This describes how to migrate Kubernetes CNI from Weave to Cilium during a CSM u
     Replace `<workflow-name>` with the actual name of the workflow created by the cilium_migration.sh script.
 
 ## Known issues
+
+### Missing BSS Global Metadata Parameter
+
+On systems originally installed with CSM 1.3 or earlier, the Cilium migration process may fail if the `k8s-primary-cni` BSS Global meta-data parameter is not set.
+
+See [Cilium Migration Failure Due to Missing BSS Global Metadata Parameter](../../../troubleshooting/known_issues/cilium_migration_k8s_primary_cni_not_set.md) for details and resolution steps.
 
 ### Node drain blocked by Kafka
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -80,6 +80,7 @@ to the exiting problem seen into the existing search. (The example searches for 
   made in the [Cray Site Init (CSI)](../glossary.md#cray-site-init-csi) tool.
     * Systems upgrading from CSM 1.6 to CSM 1.7 **may ignore** this issue until the next
       CSM 1.7+ reinstall.
+* [Cilium Migration Failure Due to Missing BSS Global Metadata Parameter](known_issues/cilium_migration_k8s_primary_cni_not_set.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/cilium_migration_k8s_primary_cni_not_set.md
+++ b/troubleshooting/known_issues/cilium_migration_k8s_primary_cni_not_set.md
@@ -1,0 +1,69 @@
+# Cilium Migration Failure Due to Missing BSS Global Metadata Parameter
+
+## Description
+
+On a system that was originally installed with CSM 1.3 or earlier, when upgrading to CSM 1.7,
+the Cilium migration process can fail if the `k8s-primary-cni` BSS Global meta-data parameter is not set.
+
+The `k8s-primary-cni` parameter was added in CSM 1.4. Systems installed at CSM 1.3 or earlier will
+not have this parameter defined, causing the migration script to fail with an unsupported value of `null`.
+
+## Symptoms
+
+During the CSM 1.6 to 1.7 upgrade, the Cilium migration process will fail with an error indicating
+an unsupported `k8s-primary-cni` value.
+
+(`ncn-m#`)
+
+```bash
+/usr/share/doc/csm/scripts/cilium_migration.sh
+```
+
+Example output:
+
+```console
+INFO Checking current k8s-primary-cni value in BSS
+ERROR Unsupported k8s-primary-cni value: 'null'. Only migration from 'weave' to 'cilium' is supported.
+```
+
+## Solution
+
+Set the `k8s-primary-cni` parameter to `weave` in the BSS Global metadata, then re-run the migration process.
+
+1. (`ncn-m#`) Set the `k8s-primary-cni` parameter to `weave`.
+
+   ```bash
+   csi handoff bss-update-cloud-init --limit Global --set meta-data.k8s-primary-cni=weave
+   ```
+
+   Example output:
+
+   ```console
+   2025/12/12 10:57:42 TOKEN was not set. Attempting to read API token from Kubernetes directly ...
+   2025/12/12 10:57:42 Getting management NCNs from SLS...
+   12
+   2025/12/12 10:57:42 Done getting management NCNs from SLS.
+   2025/12/12 10:57:42 Updating NCN cloud-init parameters...
+   2025/12/12 10:57:42 Successfully PUT BSS entry for Global
+   2025/12/12 10:57:42 Done updating NCN cloud-init parameters.
+   ```
+
+1. (`ncn-m#`) Verify the parameter change was successful.
+
+   ```bash
+   cray bss bootparameters list --hosts Global --format json | jq '.[]["cloud-init"]["meta-data"]["k8s-primary-cni"]'
+   ```
+
+   Example output:
+
+   ```console
+   "weave"
+   ```
+
+1. (`ncn-m#`) Re-run the Cilium migration script.
+
+   ```bash
+   /usr/share/doc/csm/scripts/cilium_migration.sh
+   ```
+
+   The migration process should now proceed successfully.


### PR DESCRIPTION
# Description

Added documentation for a known issue where Cilium migration fails on systems originally installed with CSM 1.3 or earlier due to a missing `k8s-primary-cni` BSS Global metadata parameter.

This change includes:
     - New troubleshooting document: `cilium_migration_k8s_primary_cni_not_set.md`
     - Updated `cilium_migration.md` with reference to the new known issue
     - Updated `troubleshooting/README.md` with the new document

Relates to:
     - [CASMTRIAGE-8943](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8943)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.