### PR TITLE
CASMTRIAGE-8928 - During installation of csm + products unable to add switch admin password to vault -- 1.7

### DIFF
--- a/operations/network/management_network/README.md
+++ b/operations/network/management_network/README.md
@@ -41,6 +41,16 @@ including `goss-switch-bgp-neighbor-aruba-or-mellanox` use these credentials to 
 is not required to configure the management network. If Vault is unavailable, this step can be temporarily skipped. Any
 automated tests that depend on the switch credentials being in Vault will fail until they are added.
 
+**`NOTE`** For fresh installations, this script should be run on one of the deployed master or worker nodes (e.g., `ncn-m002`, `ncn-w001`),
+**NOT** on the PIT (Pre-Install Toolkit) node. The PIT does not have access to Vault. You may need to install the `docs-csm` RPM on the
+target node first if the script is not already present.
+
+(`ncn-mw#`) If needed, install the `docs-csm` RPM to make the script available:
+
+```bash
+zypper install -y docs-csm
+```
+
 (`ncn-mw#`) The following script will prompt for the password, write it to Vault, and then read it back
 to verify that it was written correctly.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This change adds a note and installation instructions for the management network switch password documentation. It clarifies that the script for adding switch admin passwords to Vault should be run on deployed master or worker nodes **NOT** on the PIT node, since the PIT does not have access to Vault.

Additionally, it includes instructions for installing the `docs-csm` RPM on the target node if the script is not already present.

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8928

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
