### PR TITLE
CASMTRIAGE-8868 - Troubleshoot Compute Node Boot Issues Related to Trivial File Transfer Protocol (TFTP) page doesn't work

### DIFF
--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md
@@ -88,7 +88,7 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
     - DATA packets from server
     - ACK packets from client
 
-    If a pcap file was created, it can be analyzed with:
+    If a `pcap` file was created, it can be analyzed with:
 
     ```bash
     tcpdump -r /tmp/tftp-capture.pcap -nn -vv

--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md
@@ -18,35 +18,109 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
      kubectl get pods -n services -o wide | grep cray-tftp
     ```
 
-1. Start a `tcpdump` session on the NCN.
-
-1. (`ncn-mw#`) Obtain the TFTP pod's ID.
+1. (`ncn-m001#`) Identify the TFTP pods and their worker nodes.
 
     ```bash
-    PODID=$(kubectl get pods -n services --no-headers -o wide | grep cray-tftp | awk '{print $1}')
-    echo $PODID
+    kubectl -n services get pod -l app.kubernetes.io/name=cray-tftp -o wide
     ```
 
-1. (`ncn-mw#`) Enter the TFTP pod using the pod ID.
+    Example output:
 
-    Double check that `PODID` contains only one ID. If there are multiple TFTP pods listed, just choose one as the ID.
+    ```text
+    NAME                         READY   STATUS    RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
+    cray-tftp-58d8648dfd-dx5xk   1/1     Running   0          5d16h   10.32.5.139   ncn-w004   <none>           <none>
+    cray-tftp-58d8648dfd-lgtn9   1/1     Running   0          6d      10.32.2.30    ncn-w001   <none>           <none>
+    cray-tftp-58d8648dfd-wks5l   1/1     Running   0          5d23h   10.32.4.136   ncn-w003   <none>           <none>
+    ```
+
+    Choose one of the pods and note both its name and the worker node it's running on. In this example, we'll use pod `cray-tftp-58d8648dfd-wks5l` running on `ncn-w003`.
+
+1. (`ncn-m001#`) Copy the `pod-tcpdump.sh` script to the worker node running the TFTP pod.
+
+    Replace `ncn-w003` with the actual worker node from the previous step.
 
     ```bash
-    kubectl exec -n services -it $PODID /bin/sh
+    scp /usr/share/doc/csm/scripts/pod-tcpdump.sh ncn-w003:/tmp/
     ```
 
-1. Start a `tcpdump` session from within the TFTP pod.
+1. (`ncn-w#`) SSH to the worker node.
+
+    Replace `ncn-w003` with the actual worker node.
+
+    ```bash
+    ssh ncn-w003
+    ```
+
+1. (`ncn-w#`) Run `tcpdump` on the TFTP pod to capture TFTP traffic (UDP port 69).
+
+    Replace `cray-tftp-58d8648dfd-wks5l` with the actual pod name from step 2.
+
+    ```bash
+    /tmp/pod-tcpdump.sh -n services -p cray-tftp-58d8648dfd-wks5l -f "udp port 69"
+    ```
+
+    This will display live packet capture. Press `Ctrl+C` to stop the capture when done.
+
+    Alternatively, to capture to a file for later analysis:
+
+    ```bash
+    /tmp/pod-tcpdump.sh -n services -p cray-tftp-58d8648dfd-wks5l -f "udp port 69" -w /tmp/tftp-capture.pcap -c 1000
+    ```
 
 1. Open another terminal to perform the following tasks:
 
-    1. Use a TFTP client to issue a TFTP request from either the NCN or a laptop.
+    1. Use a TFTP client to issue a TFTP request from either an NCN or a laptop.
 
-    1. Analyze the NCN `tcpdump` data to ensure that the TFTP discover request is visible.
+    1. Analyze the `tcpdump` data to ensure that the TFTP request is visible.
 
-1. Go back to the original terminal to analyze the TFTP pod's `tcpdump` data in order to ensure that the TFTP request is visible inside the pod.
+    Example TFTP request from a client:
+
+    ```bash
+    tftp <TFTP_SERVER_IP>
+    tftp> get <filename>
+    tftp> quit
+    ```
+
+1. Review the captured traffic.
+
+    Look for TFTP read requests (RRQ) and responses. Successful TFTP transfers will show:
+    - RRQ (Read Request) from client
+    - DATA packets from server
+    - ACK packets from client
+
+    If a pcap file was created, it can be analyzed with:
+
+    ```bash
+    tcpdump -r /tmp/tftp-capture.pcap -nn -vv
+    ```
 
 ## Troubleshooting
 
-If the TFTP request is not visible on the NCN, it may be caused by a firewall issue. If the TFTP request is not visible inside the pod,
-then double check that the request was issued over the correct interface for the Node Management Network \(NMN\). If it was, then the
-underlying issue could be related to the firewall.
+If the TFTP request is not visible in the packet capture, consider the following:
+
+- **Firewall issues**: The TFTP traffic (UDP port 69) may be blocked by firewall rules on the NCN or network.
+- **Wrong interface**: Ensure the TFTP request was issued over the correct interface for the Node Management Network (NMN).
+- **Network routing**: Verify that routing is configured correctly between the client and the TFTP server.
+- **Pod network issues**: If traffic reaches the worker node but not the pod, there may be issues with the pod network or Kubernetes networking components.
+
+### Additional troubleshooting with the script
+
+Capture all traffic on the pod's network interface (not just TFTP):
+
+```bash
+/tmp/pod-tcpdump.sh -n services -p <POD_NAME> -c 500
+```
+
+Capture on a different interface (if the pod has multiple interfaces):
+
+```bash
+/tmp/pod-tcpdump.sh -n services -p <POD_NAME> -i net1 -f "udp port 69"
+```
+
+For detailed packet inspection with full headers and payload:
+
+```bash
+/tmp/pod-tcpdump.sh -n services -p <POD_NAME> -t "-i eth0 -en -vvv -X udp port 69" -c 100
+```
+
+Replace `<POD_NAME>` with the actual TFTP pod name (e.g., `cray-tftp-58d8648dfd-wks5l`).

--- a/scripts/pod-tcpdump.sh
+++ b/scripts/pod-tcpdump.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#
+# pod-tcpdump.sh - Capture network traffic for a Kubernetes pod
+#
+# This script finds a pod running on the current node and executes
+# tcpdump within its network namespace using nsenter.
+#
+
+set -euo pipefail
+
+# Default values
+NAMESPACE=""
+POD_NAME=""
+LABEL_SELECTOR=""
+INTERFACE="eth0"
+TCPDUMP_ARGS=""
+FILTER_EXPRESSION=""
+PACKET_COUNT=""
+WRITE_FILE=""
+CUSTOM_ARGS=false
+
+# Usage information
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Capture network traffic for a Kubernetes pod running on this node using tcpdump.
+
+OPTIONS:
+    -n, --namespace NAMESPACE       Kubernetes namespace (required)
+    -p, --pod POD_NAME             Specific pod name
+    -l, --label SELECTOR           Label selector (e.g., app=nginx)
+    -i, --interface INTERFACE      Network interface to capture
+                                   (default: "eth0")
+    -c, --count NUMBER             Number of packets to capture
+    -w, --write FILE               Write raw packets to file
+    -f, --filter EXPRESSION        BPF filter expression (e.g., "port 80")
+    -t, --tcpdump-args ARGS        Full tcpdump arguments (overrides defaults)
+    -h, --help                     Show this help message
+
+DEFAULT BEHAVIOR:
+    Without -t, tcpdump is invoked with: -i eth0 -en -vv
+    The -i, -c, -w, and -f options modify this default command.
+
+EXAMPLES:
+    # Capture on default eth0 interface
+    $(basename "$0") -n opa -l app.kubernetes.io/name=cray-opa-ingressgateway
+
+    # Capture 100 packets from specific pod
+    $(basename "$0") -n default -p nginx-abc123 -c 100
+
+    # Capture HTTP traffic only
+    $(basename "$0") -n kube-system -l app=nginx -f "port 80"
+
+    # Capture on specific interface with filter
+    $(basename "$0") -n default -p my-pod -i net1 -f "tcp and port 443"
+
+    # Save to pcap file
+    $(basename "$0") -n opa -l app=ingress -w /tmp/capture.pcap -c 1000
+
+    # Custom tcpdump arguments (full control)
+    $(basename "$0") -n default -p my-pod -t "-i any -nn -vv icmp"
+
+    # Capture DNS traffic
+    $(basename "$0") -n kube-system -l k8s-app=kube-dns -f "port 53" -c 50
+
+NOTES:
+    - This script must be run on the node where the pod is running
+    - Requires root/sudo access to use crictl, nsenter, and tcpdump
+    - Either --pod or --label must be specified
+    - Press Ctrl+C to stop capture (unless -c is specified)
+    - When using -w, tcpdump will be less verbose (use -v in filter for details)
+EOF
+    exit 1
+}
+
+# Error handling
+error() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -p|--pod)
+            POD_NAME="$2"
+            shift 2
+            ;;
+        -l|--label)
+            LABEL_SELECTOR="$2"
+            shift 2
+            ;;
+        -i|--interface)
+            INTERFACE="$2"
+            shift 2
+            ;;
+        -c|--count)
+            PACKET_COUNT="$2"
+            shift 2
+            ;;
+        -w|--write)
+            WRITE_FILE="$2"
+            shift 2
+            ;;
+        -f|--filter)
+            FILTER_EXPRESSION="$2"
+            shift 2
+            ;;
+        -t|--tcpdump-args)
+            TCPDUMP_ARGS="$2"
+            CUSTOM_ARGS=true
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            error "Unknown option: $1. Use -h for help."
+            ;;
+    esac
+done
+
+# Validate required arguments
+[[ -z "$NAMESPACE" ]] && error "Namespace is required. Use -n to specify."
+[[ -z "$POD_NAME" && -z "$LABEL_SELECTOR" ]] && error "Either --pod or --label must be specified."
+
+# Check required commands
+for cmd in kubectl crictl jq nsenter tcpdump; do
+    if ! command -v "$cmd" &> /dev/null; then
+        error "Required command not found: $cmd"
+    fi
+done
+
+# Get the current node name
+NODE_NAME=$(uname -n)
+echo "Running on node: $NODE_NAME"
+
+# Find the pod
+if [[ -n "$POD_NAME" ]]; then
+    echo "Looking for pod: $POD_NAME in namespace: $NAMESPACE"
+    POD=$(kubectl get pod -n "$NAMESPACE" "$POD_NAME" -o json 2>/dev/null | \
+          jq -r "select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" || true)
+    
+    if [[ -z "$POD" ]]; then
+        error "Pod '$POD_NAME' not found in namespace '$NAMESPACE' on this node"
+    fi
+else
+    echo "Looking for pods with label: $LABEL_SELECTOR in namespace: $NAMESPACE"
+    POD=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null | \
+          jq -r ".items[] | select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" | head -n1 || true)
+    
+    if [[ -z "$POD" ]]; then
+        error "No pods found matching label '$LABEL_SELECTOR' in namespace '$NAMESPACE' on this node"
+    fi
+fi
+
+echo "Found pod: $POD"
+
+# Get container IDs for the pod
+echo "Finding container IDs..."
+CONTAINER_IDS=$(crictl ps -o json | \
+                jq -r ".containers[] | select(.labels.\"io.kubernetes.pod.name\" == \"$POD\") | .id")
+
+if [[ -z "$CONTAINER_IDS" ]]; then
+    error "No running containers found for pod '$POD'"
+fi
+
+echo "Found containers:"
+echo "$CONTAINER_IDS" | while read -r cid; do
+    CONTAINER_NAME=$(crictl inspect "$cid" 2>/dev/null | \
+                     jq -r '.status.metadata.name // "unknown"')
+    echo "  - $cid ($CONTAINER_NAME)"
+done
+
+# Get PID for the first container (all containers in pod share network namespace)
+echo ""
+echo "Getting network namespace PID..."
+FIRST_CID=$(echo "$CONTAINER_IDS" | head -n1)
+PID=$(crictl inspect --output go-template --template '{{.info.pid}}' "$FIRST_CID" 2>/dev/null || true)
+
+if [[ -z "$PID" ]]; then
+    error "Could not retrieve PID for container in pod '$POD'"
+fi
+
+echo "PID: $PID"
+echo ""
+
+# Build tcpdump command
+if [[ "$CUSTOM_ARGS" == "true" ]]; then
+    # Use custom arguments directly
+    TCPDUMP_CMD="tcpdump $TCPDUMP_ARGS"
+else
+    # Build command from individual options with defaults
+    TCPDUMP_CMD="tcpdump -i $INTERFACE -en -vv"
+    
+    [[ -n "$PACKET_COUNT" ]] && TCPDUMP_CMD="$TCPDUMP_CMD -c $PACKET_COUNT"
+    [[ -n "$WRITE_FILE" ]] && TCPDUMP_CMD="$TCPDUMP_CMD -w $WRITE_FILE"
+    [[ -n "$FILTER_EXPRESSION" ]] && TCPDUMP_CMD="$TCPDUMP_CMD $FILTER_EXPRESSION"
+fi
+
+echo "========================================"
+echo "Network Capture for pod: $POD"
+echo "Namespace: $NAMESPACE"
+echo "Node: $NODE_NAME"
+echo "PID: $PID"
+echo "Command: $TCPDUMP_CMD"
+echo "========================================"
+echo ""
+
+if [[ -z "$PACKET_COUNT" && -z "$WRITE_FILE" ]]; then
+    echo "Press Ctrl+C to stop capture..."
+    echo ""
+fi
+
+# Execute tcpdump in the container's network namespace
+# Note: We don't redirect stderr so user can see tcpdump's output
+if ! nsenter --target "$PID" --net $TCPDUMP_CMD; then
+    error "Failed to execute tcpdump in network namespace for PID $PID"
+fi
+
+echo ""
+echo "========================================"
+echo "Capture complete"
+[[ -n "$WRITE_FILE" ]] && echo "Output written to: $WRITE_FILE"
+echo "========================================"

--- a/scripts/pod-tcpdump.sh
+++ b/scripts/pod-tcpdump.sh
@@ -44,7 +44,7 @@ CUSTOM_ARGS=false
 
 # Usage information
 usage() {
-    cat << EOF
+  cat << EOF
 Usage: $(basename "$0") [OPTIONS]
 
 Capture network traffic for a Kubernetes pod running on this node using tcpdump.
@@ -94,69 +94,69 @@ NOTES:
     - Press Ctrl+C to stop capture (unless -c is specified)
     - When using -w, tcpdump will be less verbose (use -v in filter for details)
 EOF
-    exit 1
+  exit 1
 }
 
 # Error handling
 error() {
-    echo "ERROR: $1" >&2
-    exit 1
+  echo "ERROR: $1" >&2
+  exit 1
 }
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        -n|--namespace)
-            NAMESPACE="$2"
-            shift 2
-            ;;
-        -p|--pod)
-            POD_NAME="$2"
-            shift 2
-            ;;
-        -l|--label)
-            LABEL_SELECTOR="$2"
-            shift 2
-            ;;
-        -i|--interface)
-            INTERFACE="$2"
-            shift 2
-            ;;
-        -c|--count)
-            PACKET_COUNT="$2"
-            shift 2
-            ;;
-        -w|--write)
-            WRITE_FILE="$2"
-            shift 2
-            ;;
-        -f|--filter)
-            FILTER_EXPRESSION="$2"
-            shift 2
-            ;;
-        -t|--tcpdump-args)
-            TCPDUMP_ARGS="$2"
-            CUSTOM_ARGS=true
-            shift 2
-            ;;
-        -h|--help)
-            usage
-            ;;
-        *)
-            error "Unknown option: $1. Use -h for help."
-            ;;
-    esac
+  case $1 in
+    -n | --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    -p | --pod)
+      POD_NAME="$2"
+      shift 2
+      ;;
+    -l | --label)
+      LABEL_SELECTOR="$2"
+      shift 2
+      ;;
+    -i | --interface)
+      INTERFACE="$2"
+      shift 2
+      ;;
+    -c | --count)
+      PACKET_COUNT="$2"
+      shift 2
+      ;;
+    -w | --write)
+      WRITE_FILE="$2"
+      shift 2
+      ;;
+    -f | --filter)
+      FILTER_EXPRESSION="$2"
+      shift 2
+      ;;
+    -t | --tcpdump-args)
+      TCPDUMP_ARGS="$2"
+      CUSTOM_ARGS=true
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      ;;
+    *)
+      error "Unknown option: $1. Use -h for help."
+      ;;
+  esac
 done
 
 # Validate required arguments
-[[ -z "$NAMESPACE" ]] && error "Namespace is required. Use -n to specify."
-[[ -z "$POD_NAME" && -z "$LABEL_SELECTOR" ]] && error "Either --pod or --label must be specified."
+[[ -z $NAMESPACE ]] && error "Namespace is required. Use -n to specify."
+[[ -z $POD_NAME && -z $LABEL_SELECTOR ]] && error "Either --pod or --label must be specified."
 
 # Check required commands
 for cmd in kubectl crictl jq nsenter tcpdump; do
-    if ! command -v "$cmd" &> /dev/null; then
-        error "Required command not found: $cmd"
-    fi
+  if ! command -v "$cmd" &> /dev/null; then
+    error "Required command not found: $cmd"
+  fi
 done
 
 # Get the current node name
@@ -164,66 +164,66 @@ NODE_NAME=$(uname -n)
 echo "Running on node: $NODE_NAME"
 
 # Find the pod
-if [[ -n "$POD_NAME" ]]; then
-    echo "Looking for pod: $POD_NAME in namespace: $NAMESPACE"
-    POD=$(kubectl get pod -n "$NAMESPACE" "$POD_NAME" -o json 2>/dev/null | \
-          jq -r "select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" || true)
-    
-    if [[ -z "$POD" ]]; then
-        error "Pod '$POD_NAME' not found in namespace '$NAMESPACE' on this node"
-    fi
+if [[ -n $POD_NAME ]]; then
+  echo "Looking for pod: $POD_NAME in namespace: $NAMESPACE"
+  POD=$(kubectl get pod -n "$NAMESPACE" "$POD_NAME" -o json 2> /dev/null \
+    | jq -r "select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" || true)
+
+  if [[ -z $POD ]]; then
+    error "Pod '$POD_NAME' not found in namespace '$NAMESPACE' on this node"
+  fi
 else
-    echo "Looking for pods with label: $LABEL_SELECTOR in namespace: $NAMESPACE"
-    POD=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null | \
-          jq -r ".items[] | select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" | head -n1 || true)
-    
-    if [[ -z "$POD" ]]; then
-        error "No pods found matching label '$LABEL_SELECTOR' in namespace '$NAMESPACE' on this node"
-    fi
+  echo "Looking for pods with label: $LABEL_SELECTOR in namespace: $NAMESPACE"
+  POD=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2> /dev/null \
+    | jq -r ".items[] | select(.spec.nodeName == \"$NODE_NAME\") | .metadata.name" | head -n1 || true)
+
+  if [[ -z $POD ]]; then
+    error "No pods found matching label '$LABEL_SELECTOR' in namespace '$NAMESPACE' on this node"
+  fi
 fi
 
 echo "Found pod: $POD"
 
 # Get container IDs for the pod
 echo "Finding container IDs..."
-CONTAINER_IDS=$(crictl ps -o json | \
-                jq -r ".containers[] | select(.labels.\"io.kubernetes.pod.name\" == \"$POD\") | .id")
+CONTAINER_IDS=$(crictl ps -o json \
+  | jq -r ".containers[] | select(.labels.\"io.kubernetes.pod.name\" == \"$POD\") | .id")
 
-if [[ -z "$CONTAINER_IDS" ]]; then
-    error "No running containers found for pod '$POD'"
+if [[ -z $CONTAINER_IDS ]]; then
+  error "No running containers found for pod '$POD'"
 fi
 
 echo "Found containers:"
 echo "$CONTAINER_IDS" | while read -r cid; do
-    CONTAINER_NAME=$(crictl inspect "$cid" 2>/dev/null | \
-                     jq -r '.status.metadata.name // "unknown"')
-    echo "  - $cid ($CONTAINER_NAME)"
+  CONTAINER_NAME=$(crictl inspect "$cid" 2> /dev/null \
+    | jq -r '.status.metadata.name // "unknown"')
+  echo "  - $cid ($CONTAINER_NAME)"
 done
 
 # Get PID for the first container (all containers in pod share network namespace)
 echo ""
 echo "Getting network namespace PID..."
 FIRST_CID=$(echo "$CONTAINER_IDS" | head -n1)
-PID=$(crictl inspect --output go-template --template '{{.info.pid}}' "$FIRST_CID" 2>/dev/null || true)
+PID=$(crictl inspect --output go-template --template '{{.info.pid}}' "$FIRST_CID" 2> /dev/null || true)
 
-if [[ -z "$PID" ]]; then
-    error "Could not retrieve PID for container in pod '$POD'"
+if [[ -z $PID ]]; then
+  error "Could not retrieve PID for container in pod '$POD'"
 fi
 
 echo "PID: $PID"
 echo ""
 
 # Build tcpdump command
-if [[ "$CUSTOM_ARGS" == "true" ]]; then
-    # Use custom arguments directly
-    TCPDUMP_CMD="tcpdump $TCPDUMP_ARGS"
+if [[ $CUSTOM_ARGS == "true" ]]; then
+  # Use custom arguments directly
+  TCPDUMP_CMD="tcpdump $TCPDUMP_ARGS"
 else
-    # Build command from individual options with defaults
-    TCPDUMP_CMD="tcpdump -i $INTERFACE -en -vv"
-    
-    [[ -n "$PACKET_COUNT" ]] && TCPDUMP_CMD="$TCPDUMP_CMD -c $PACKET_COUNT"
-    [[ -n "$WRITE_FILE" ]] && TCPDUMP_CMD="$TCPDUMP_CMD -w $WRITE_FILE"
-    [[ -n "$FILTER_EXPRESSION" ]] && TCPDUMP_CMD="$TCPDUMP_CMD $FILTER_EXPRESSION"
+  # Build command from individual options with defaults
+  TCPDUMP_CMD="tcpdump -i $INTERFACE -en -vv"
+
+  [[ -n $PACKET_COUNT ]] && TCPDUMP_CMD="$TCPDUMP_CMD -c $PACKET_COUNT"
+  [[ -n $WRITE_FILE ]] && TCPDUMP_CMD="$TCPDUMP_CMD -w $WRITE_FILE"
+  [[ -n $FILTER_EXPRESSION ]] && TCPDUMP_CMD="$TCPDUMP_CMD $FILTER_EXPRESSION"
 fi
 
 echo "========================================"
@@ -235,19 +235,19 @@ echo "Command: $TCPDUMP_CMD"
 echo "========================================"
 echo ""
 
-if [[ -z "$PACKET_COUNT" && -z "$WRITE_FILE" ]]; then
-    echo "Press Ctrl+C to stop capture..."
-    echo ""
+if [[ -z $PACKET_COUNT && -z $WRITE_FILE ]]; then
+  echo "Press Ctrl+C to stop capture..."
+  echo ""
 fi
 
 # Execute tcpdump in the container's network namespace
 # Note: We don't redirect stderr so user can see tcpdump's output
 if ! nsenter --target "$PID" --net $TCPDUMP_CMD; then
-    error "Failed to execute tcpdump in network namespace for PID $PID"
+  error "Failed to execute tcpdump in network namespace for PID $PID"
 fi
 
 echo ""
 echo "========================================"
 echo "Capture complete"
-[[ -n "$WRITE_FILE" ]] && echo "Output written to: $WRITE_FILE"
+[[ -n $WRITE_FILE ]] && echo "Output written to: $WRITE_FILE"
 echo "========================================"


### PR DESCRIPTION
This PR fixes the "Troubleshoot Compute Node Boot Issues Related to Trivial File Transfer Protocol (TFTP)" documentation page by providing a working procedure for capturing and analyzing TFTP traffic.

**Changes:**
- Rewrote the TFTP troubleshooting procedure with clear, step-by-step instructions
- Added a new `pod-tcpdump.sh` script to simplify network packet capture for Kubernetes pods
- Expanded troubleshooting guidance with additional diagnostic options
- Fixed incorrect/outdated commands in the original documentation

The new procedure uses the `pod-tcpdump.sh` utility to run tcpdump inside the TFTP pod's network namespace, making it easier for administrators to diagnose TFTP-related boot issues.

Relates to:
- [CASMTRIAGE-8868](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8868)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.