### PR TITLE
CASMINST-7007 - Add Kubernetes join token information to troubleshooting documentation.

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -183,6 +183,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Disaster Recovery for Postgres](../operations/kubernetes/Disaster_Recovery_Postgres.md)
 * [`etcd` Pods in CLBO State](known_issues/etcd_pods_in_CLBO_state.md)
 * [Cilium Network Troubleshooting Runbook](Cilium_Network_Troubleshooting_Runbook.md)
+* [Node Unable to Join Kubernetes Cluster During NCN Rebuild](known_issues/kubeadm_join_token_missing_during_ncn_rebuild.md)
 
 ## MetalLB
 

--- a/troubleshooting/known_issues/kubeadm_join_token_missing_during_ncn_rebuild.md
+++ b/troubleshooting/known_issues/kubeadm_join_token_missing_during_ncn_rebuild.md
@@ -8,7 +8,7 @@ token list or the `cluster-info` ConfigMap. The join scripts are created during 
 that have since expired or been removed from the cluster.
 
 Bootstrap tokens should be automatically refreshed by the `cray-k8s-token-certs-refresh` cronjob, which runs hourly
-(`0 */1 * * *`) on the first-master node. If this cronjob is not running or has failed, tokens may become stale, causing
+on the first-master node. If this cronjob is not running or has failed, tokens may become stale, causing
 node join failures.
 
 ## Symptoms

--- a/troubleshooting/known_issues/kubeadm_join_token_missing_during_ncn_rebuild.md
+++ b/troubleshooting/known_issues/kubeadm_join_token_missing_during_ncn_rebuild.md
@@ -1,0 +1,146 @@
+# Node Unable to Join Kubernetes Cluster During NCN Rebuild
+
+## Description
+
+During NCN master node rebuild, the node may fail to join the Kubernetes cluster due to a missing or expired bootstrap token.
+This occurs when the token referenced in the join scripts located in `/etc/cray/kubernetes` is no longer present in the cluster's
+token list or the `cluster-info` ConfigMap. The join scripts are created during initial cluster setup and may reference tokens
+that have since expired or been removed from the cluster.
+
+Bootstrap tokens should be automatically refreshed by the `cray-k8s-token-certs-refresh` cronjob, which runs hourly
+(`0 */1 * * *`) on the first-master node. If this cronjob is not running or has failed, tokens may become stale, causing
+node join failures.
+
+## Symptoms
+
+* The node fails to join the Kubernetes cluster during rebuild with a `kubeadm join` error.
+* The error message indicates that a JWS signature cannot be found in the `cluster-info` ConfigMap for the token ID.
+
+Example error output:
+
+```text
+Attempting to join node to the Kubernetes cluster (will continue to retry if it fails)
+kubeadm join 10.252.1.2:6442 --token 770vrq.adapc6m1k68f14r3 --discovery-token-ca-cert-hash sha256:86d0422bb32949fc49fbac28eaf01abe37401f2e93203815c6bd1287403c9af5  --control-plane --certificate-key fa0d08d9b5257c63ae9c3c19c8c766059d46e91454f1325f4f60aac1b7cc6408 --apiserver-advertise-address=10.252.1.17 --apiserver-advertise-address=10.252.1.17...
+[preflight] Running pre-flight checks
+error execution phase preflight: couldn't validate the identity of the API Server: could not find a JWS signature in the cluster-info ConfigMap for token ID "770vrq"
+To see the stack trace of this error execute with --v=5 or higher
+```
+
+## Verification
+
+1. (`ncn-m#`) Identify the first-master node from BSS.
+
+   Command:
+
+   ```bash
+   cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+   ```
+
+   Example output:
+
+   ```toml
+   first-master-hostname = "ncn-m001"
+   ```
+
+1. (`ncn-m#`) Check if the token exists in the cluster's token list.
+
+   Command:
+
+   ```bash
+   kubeadm token list
+   ```
+
+   If the token referenced in the error (e.g., `770vrq`) is not listed, the token has expired or been removed.
+
+1. (`ncn-m#`) Verify the token is missing from the `cluster-info` ConfigMap.
+
+   Command:
+
+   ```bash
+   kubectl -n kube-public get cm cluster-info -o yaml
+   ```
+
+   If the token is not present in the ConfigMap, it needs to be regenerated.
+
+1. (`first-master#`) Check if the `cray-k8s-token-certs-refresh` cronjob is configured and running on the first-master node.
+
+   Command:
+
+   ```bash
+   cat /etc/cron.d/cray-k8s-token-certs-refresh
+   ```
+
+   Expected output:
+
+   ```text
+   0 */1 * * * root /srv/cray/scripts/kubernetes/token-certs-refresh.sh >> /var/log/cray/cron.log 2>&1
+   ```
+
+   Check recent cron log entries:
+
+   ```bash
+   grep token-certs-refresh /var/log/cray/cron.log | tail -10
+   ```
+
+   If the cronjob is missing or not running, this may be why tokens are stale.
+
+## Solution
+
+Rerun the `promote-initial-master.sh` script on the first-master node to regenerate the bootstrap tokens, update the join scripts,
+and restore the `cray-k8s-token-certs-refresh` cronjob.
+
+1. (`ncn-m#`) Identify the first-master node from BSS if not already known.
+
+   Command:
+
+   ```bash
+   cray bss bootparameters list --hosts Global --format toml | grep first-master-hostname
+   ```
+
+   Example output:
+
+   ```toml
+   first-master-hostname = "ncn-m001"
+   ```
+
+1. (`first-master#`) Run the promote initial master script on the first-master node.
+
+   Command:
+
+   ```bash
+   /usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh
+   ```
+
+   This script will:
+   * Create new bootstrap tokens
+   * Update the `cluster-info` ConfigMap with the new tokens
+   * Regenerate the join scripts in `/etc/cray/kubernetes` with valid tokens
+   * Create/update the `cray-k8s-token-certs-refresh` cronjob to run hourly (`0 */1 * * *`)
+
+1. (`first-master#`) Verify the cronjob is now configured.
+
+   Command:
+
+   ```bash
+   cat /etc/cron.d/cray-k8s-token-certs-refresh
+   ```
+
+   Expected output:
+
+   ```text
+   0 */1 * * * root /srv/cray/scripts/kubernetes/token-certs-refresh.sh >> /var/log/cray/cron.log 2>&1
+   ```
+
+1. (`ncn-m#`) Retry the node rebuild process.
+
+   The node should now be able to join the Kubernetes cluster using the updated tokens.
+
+1. (`ncn-m#`) Verify the node has successfully joined the cluster.
+
+   Command:
+
+   ```bash
+   kubectl get nodes
+   ```
+
+   The rebuilt node should appear in the node list with a `Ready` status.


### PR DESCRIPTION
# Description

This PR adds a new troubleshooting document for a known issue where NCN master nodes fail to join the Kubernetes cluster during rebuild due to missing or expired bootstrap tokens.

## Summary of Changes

* **New Document**: Created `kubeadm_join_token_missing_during_ncn_rebuild.md` documenting the issue where nodes fail to join Kubernetes with the error "could not find a JWS signature in the cluster-info ConfigMap for token ID"
* **Updated README**: Added links to the new troubleshooting document.
## Key Content

The new document covers:
- Issue description explaining how bootstrap tokens can become stale when the `cray-k8s-token-certs-refresh` cronjob fails or is missing
- Detailed symptoms including the specific error message customers encounter
- Verification steps including how to identify the first-master node from BSS and check cronjob status
- Solution involving running the `promote-initial-master.sh` script to regenerate tokens and restore the cronjob

Relates to:
- [CASMINST-7007](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7007)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams