### PR TITLE
CASMTRIAGE-8952: Add note to procedure

### DIFF
--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -242,8 +242,8 @@ While Kubernetes performs rolling restarts to maintain service availability, the
 disruptions as pods are restarted. In-flight requests to these services may fail and require retry.
 
 **Note**: Due to Kubernetes conditions outside the control of Rack Resiliency, some services may fail to restart within
-the timeout period. Retry the `rr_critical_service_restart` script after ensuring that
-the services that failed continue to be imbalanced.
+the timeout period. Retry the [`rr_critical_service_restart.py`](../../upgrade/scripts/k8s/rr_critical_service_restart.py)
+script after ensuring that the services that failed continue to be imbalanced.
 To see the list of imbalanced services, the user can check the logs of `cray-rrs-rms` container
 in `cray-rrs` pod as explained in
 [Steps to view RMS logs](../rack_resiliency/Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting guide](Troubleshooting.md).

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -244,7 +244,7 @@ disruptions as pods are restarted. In-flight requests to these services may fail
 **Note**: Due to Kubernetes conditions outside the control of Rack Resiliency, some services may fail to restart within
 the timeout period. Retry the `rr_critical_service_restart` script after ensuring that
 the services that failed continue to be imbalanced.
-To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container
+To see the list of imbalanced services, the user can check the logs of `cray-rrs-rms` container
 in `cray-rrs` pod as explained in
 [Steps to view RMS logs](../rack_resiliency/Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting guide](Troubleshooting.md).
 

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -246,10 +246,10 @@ the timeout period. Please retry the `rr_critical_service_restart` script after 
 the services that failed continue to be imbalanced.
 To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container
 in `cray-rrs` pod as explained in
-[Steps to view RMS logs](Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting guide](Troubleshooting.md).
+[Steps to view RMS logs](../rack_resiliency/Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting guide](Troubleshooting.md).
 
 For information on how to identify all of the critical services, see
-[List services in ConfigMap](Manage_Critical_Services.md#list-services-in-configmap).
+[List services in ConfigMap](../rack_resiliency/Manage_Critical_Services.md#list-services-in-configmap).
 
 Example usage:
 

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -241,7 +241,7 @@ The script requires the `insert-labels-topology-constraints` cluster policy to b
 While Kubernetes performs rolling restarts to maintain service availability, there may be brief
 disruptions as pods are restarted. In-flight requests to these services may fail and require retry.
 
-**Note**: Due to conditions outside the control of Rack Resiliency, some services may fail to restart within
+**Note**: Due to Kubernetes conditions outside the control of Rack Resiliency, some services may fail to restart within
 the timeout period. Please retry the `rr_critical_service_restart` script after ensuring that
 the services that failed continue to be imbalanced.
 To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -240,6 +240,14 @@ The script requires the `insert-labels-topology-constraints` cluster policy to b
 **Important**: This step restarts critical services (including `cilium-operator`, `coredns`, and other essential CSM services).
 While Kubernetes performs rolling restarts to maintain service availability, there may be brief
 disruptions as pods are restarted. In-flight requests to these services may fail and require retry.
+
+**Note**: Due to conditions outside the control of Rack Resiliency, some services may fail to restart within
+the timeout period. Please retry the `rr_critical_service_restart` script after ensuring that
+the services that failed continue to be imbalanced.
+To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container
+in `cray-rrs` pod as explained in
+[Steps to view RMS logs](Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting.md](Troubleshooting.md).
+
 For information on how to identify all of the critical services, see
 [List services in ConfigMap](Manage_Critical_Services.md#list-services-in-configmap).
 

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -246,7 +246,7 @@ the timeout period. Please retry the `rr_critical_service_restart` script after 
 the services that failed continue to be imbalanced.
 To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container
 in `cray-rrs` pod as explained in
-[Steps to view RMS logs](Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting.md](Troubleshooting.md).
+[Steps to view RMS logs](Troubleshooting.md#steps-to-view-rms-logs) in [Troubleshooting guide](Troubleshooting.md).
 
 For information on how to identify all of the critical services, see
 [List services in ConfigMap](Manage_Critical_Services.md#list-services-in-configmap).

--- a/operations/rack_resiliency/Enabling_RR_on_running_system.md
+++ b/operations/rack_resiliency/Enabling_RR_on_running_system.md
@@ -242,7 +242,7 @@ While Kubernetes performs rolling restarts to maintain service availability, the
 disruptions as pods are restarted. In-flight requests to these services may fail and require retry.
 
 **Note**: Due to Kubernetes conditions outside the control of Rack Resiliency, some services may fail to restart within
-the timeout period. Please retry the `rr_critical_service_restart` script after ensuring that
+the timeout period. Retry the `rr_critical_service_restart` script after ensuring that
 the services that failed continue to be imbalanced.
 To see the list of imbalanced services the user can check the logs of `cray-rrs-rms` container
 in `cray-rrs` pod as explained in


### PR DESCRIPTION

# Description
This PR adds a note to `Enabling_RR_on_a_running_system` about the restart of the critical services.

Resolves: [CASMTRIAGE-8952](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8952)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
