### PR TITLE
CASMINST-7513 - DOCS: Add steps to deploy fmn nodes during CSM install

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -74,6 +74,7 @@ shown here with numbered topics.
     1. [Kubernetes encryption](#1-kubernetes-encryption)
     1. [Export Nexus data](#2-export-nexus-data)
 - [Installation of additional HPE Cray EX software products](#installation-of-additional-hpe-cray-ex-software-products)
+- [Fabric Manager Node redeployment](#fabric-manager-node-redeployment)
 
 > **`NOTE`** If problems are encountered during the installation,
 > [Troubleshooting installation problems](#12-troubleshooting-installation-problems) and
@@ -336,3 +337,11 @@ See the [Install or upgrade additional products with IUF](../operations/iuf/work
 procedure to continue with the installation of additional HPE Cray EX software products.
 
 For additional information on the IUF, see [Install and Upgrade Framework](../operations/iuf/IUF.md).
+
+## Fabric Manager Node redeployment
+
+> **OPTIONAL:** This section is only applicable if Fabric Manager nodes were deployed during the CSM installation.
+
+After additional HPE Cray EX software products have been installed, Fabric Manager nodes need to be redeployed with a new customized image.
+
+See [Redeploy Fabric Manager Nodes](../operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md).

--- a/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
+++ b/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
@@ -436,6 +436,14 @@ Repository priorities are without effect. All enabled repositories share the sam
  ...
 ```
 
+#### Join Fabric Manager nodes to Spire
+
+After the Fabric Manager nodes have been deployed and are running, join them to Spire to avoid issues with Spire tokens.
+
+```bash
+ncn-m001:~ # /opt/cray/platform-utils/spire/fix-spire-on-fmn.sh
+```
+
 ### Install Fabric Manager on FM baremetal nodes
 
 For install/ upgrade Fabric Manager on the FMNs please refer [FabricManager Install/ Upgrade](...)

--- a/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
+++ b/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
@@ -100,39 +100,17 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
 
 ### 3. Redeploy the FMNs
 
-After updating BSS with the new image and setting `metal.no-wipe=0`, reboot the FMNs to apply the new image.
+After updating BSS with the new image and setting `metal.no-wipe=0`, redeploy the FMNs to apply the new image.
 
-See [Reboot NCNs](../node_management/Reboot_NCNs_manual.md) for the procedure to reboot management nodes.
+Follow the [Boot NCN](../node_management/Add_Remove_Replace_NCNs/Boot_NCN.md) procedure for each Fabric Manager node. This procedure will:
 
-### 4. Set `metal.no-wipe=1` after redeployment
+- Set the PXE boot option and power on the node
+- Monitor the boot process
+- Set `metal.no-wipe=1` after successful boot to preserve data on future reboots
 
-After the Fabric Manager nodes have been successfully redeployed and are running with the new image, set `metal.no-wipe=1` to preserve data on future reboots.
+**Note:** Skip the sections in Boot NCN that are specific to master, worker, or storage nodes (such as verifying cluster membership or Ceph operations).
 
-1. (`ncn-mw#`) For each Fabric Manager node, set `metal.no-wipe=1`:
-
-    ```bash
-    TARGET_XNAME=<fmn-xname>
-    csi handoff bss-update-param --set metal.no-wipe=1 --limit ${TARGET_XNAME}
-    ```
-
-    For example:
-
-    ```bash
-    TARGET_XNAME=x3000c0s28b0n0
-    csi handoff bss-update-param --set metal.no-wipe=1 --limit ${TARGET_XNAME}
-    ```
-
-    Repeat for each Fabric Manager node.
-
-1. (`ncn-mw#`) Verify the change:
-
-    ```bash
-    cray bss bootparameters list --name ${TARGET_XNAME} --format=json | jq -r '.[0].params' | grep metal.no-wipe
-    ```
-
-    The output should show `metal.no-wipe=1`.
-
-### 5. Join Fabric Manager nodes to Spire
+### 4. Join Fabric Manager nodes to Spire
 
 After the Fabric Manager nodes have been redeployed and are running with the new image, join them to Spire to avoid issues with Spire tokens.
 

--- a/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
+++ b/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
@@ -2,7 +2,7 @@
 
 > **OPTIONAL:** This procedure is only applicable if Fabric Manager nodes were deployed during the CSM installation.
 
-Although Fabric Manager nodes (FMNs) were deployed during the CSM installation, the initial deployment did not include the final image with all necessary components. Once the other HPE Cray EX software products have been installed via the Install and Upgrade Framework (IUF), the Fabric Manager nodes need to be redeployed with the new customized image.
+Although Fabric Manager Nodes (FMNs) were deployed during the CSM installation, the initial deployment did not include the final image with all necessary components. Once the other HPE Cray EX software products have been installed via the Install and Upgrade Framework (IUF), the FMNs need to be redeployed with the new customized image.
 
 ## Prerequisites
 
@@ -25,7 +25,7 @@ This procedure will:
 
 ### 2. Update BSS with the new FMN image
 
-Once the new FMN image has been built and uploaded to S3, update the boot parameters in the Boot Script Service (BSS) to point the Fabric Manager nodes to the new image.
+Once the new FMN image has been built and uploaded to S3, update the boot parameters in the Boot Script Service (BSS) to point the FMNs to the new image.
 
 1. (`ncn-mw#`) Set an environment variable for the new IMS image ID.
 
@@ -35,7 +35,7 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
     NEW_IMS_IMAGE_ID="<IMS_IMAGE_ID_FROM_BOOTPREP>"
     ```
 
-1. (`ncn-mw#`) Determine the component names (xnames) of the Fabric Manager nodes.
+1. (`ncn-mw#`) Determine the component names (xnames) of the FMNs.
 
     ```bash
     cray hsm state components list --role Management --subrole FabricManager --format json | jq -r '.Components[].ID'
@@ -48,9 +48,9 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
     x3000c0s29b0n0
     ```
 
-1. (`ncn-mw#`) Update the boot parameters for the Fabric Manager nodes.
+1. (`ncn-mw#`) Update the boot parameters for the FMNs.
 
-    Replace the `<xname>` placeholders with the actual xnames of the Fabric Manager nodes:
+    Replace the `<xname>` placeholders with the actual xnames of the FMNs.
 
     ```bash
     /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
@@ -74,7 +74,7 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
 
 1. (`ncn-mw#`) Set `metal.no-wipe=0` to allow the disk to be wiped during redeployment.
 
-    For each Fabric Manager node, set `metal.no-wipe=0`:
+    For each FMN, set `metal.no-wipe=0`:
 
     ```bash
     TARGET_XNAME=<fmn-xname>
@@ -88,7 +88,7 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
     csi handoff bss-update-param --set metal.no-wipe=0 --limit ${TARGET_XNAME}
     ```
 
-    Repeat for each Fabric Manager node.
+    Repeat for each FMN.
 
 1. (`ncn-mw#`) Verify the change:
 
@@ -98,9 +98,9 @@ Once the new FMN image has been built and uploaded to S3, update the boot parame
 
     The output should show `metal.no-wipe=0`.
 
-### 3. Redeploy the Fabric Manager nodes
+### 3. Redeploy the FMNs
 
-After updating BSS with the new image and setting `metal.no-wipe=0`, reboot the Fabric Manager nodes to apply the new image.
+After updating BSS with the new image and setting `metal.no-wipe=0`, reboot the FMNs to apply the new image.
 
 See [Reboot NCNs](../node_management/Reboot_NCNs_manual.md) for the procedure to reboot management nodes.
 

--- a/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
+++ b/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
@@ -136,6 +136,8 @@ After the Fabric Manager nodes have been successfully redeployed and are running
 
 After the Fabric Manager nodes have been redeployed and are running with the new image, join them to Spire to avoid issues with Spire tokens.
 
-```bash
-/opt/cray/platform-utils/spire/fix-spire-on-fmn.sh
-```
+1. (`ncn-mw#`) Join Spire on the Fabric Manager nodes.
+
+    ```bash
+    /opt/cray/platform-utils/spire/fix-spire-on-fmn.sh
+    ```

--- a/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
+++ b/operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md
@@ -1,0 +1,141 @@
+# Redeploy Fabric Manager Nodes
+
+> **OPTIONAL:** This procedure is only applicable if Fabric Manager nodes were deployed during the CSM installation.
+
+Although Fabric Manager nodes (FMNs) were deployed during the CSM installation, the initial deployment did not include the final image with all necessary components. Once the other HPE Cray EX software products have been installed via the Install and Upgrade Framework (IUF), the Fabric Manager nodes need to be redeployed with the new customized image.
+
+## Prerequisites
+
+- CSM installation has been completed
+- Additional HPE Cray EX software products have been installed via IUF
+- The Cray CLI is configured and authenticated
+- SAT is configured and authenticated
+
+## Procedure
+
+### 1. Build the FMN image
+
+Follow the procedure in the **FMN Base Image Creation** section of [Configure FM (Fabric Manager) On Baremetal](Configure_FM_On_Baremetal.md#fmn-base-image-creation) to build the new FMN base image.
+
+This procedure will:
+
+- Create a `sat bootprep` configuration file for FMN
+- Execute `sat bootprep run` to generate the new FMN image and upload it to S3
+- Produce a new IMS image ID for the customized FMN image
+
+### 2. Update BSS with the new FMN image
+
+Once the new FMN image has been built and uploaded to S3, update the boot parameters in the Boot Script Service (BSS) to point the Fabric Manager nodes to the new image.
+
+1. (`ncn-mw#`) Set an environment variable for the new IMS image ID.
+
+    After running `sat bootprep run`, obtain the IMS resultant image ID from the output or from the CFS session:
+
+    ```bash
+    NEW_IMS_IMAGE_ID="<IMS_IMAGE_ID_FROM_BOOTPREP>"
+    ```
+
+1. (`ncn-mw#`) Determine the component names (xnames) of the Fabric Manager nodes.
+
+    ```bash
+    cray hsm state components list --role Management --subrole FabricManager --format json | jq -r '.Components[].ID'
+    ```
+
+    Example output:
+
+    ```text
+    x3000c0s28b0n0
+    x3000c0s29b0n0
+    ```
+
+1. (`ncn-mw#`) Update the boot parameters for the Fabric Manager nodes.
+
+    Replace the `<xname>` placeholders with the actual xnames of the Fabric Manager nodes:
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+       -p "${NEW_IMS_IMAGE_ID}" <xname1> <xname2>
+    ```
+
+    For example:
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/node_management/assign-ncn-images.sh \
+       -p "${NEW_IMS_IMAGE_ID}" x3000c0s28b0n0 x3000c0s29b0n0
+    ```
+
+1. (`ncn-mw#`) Verify the boot parameters have been updated.
+
+    ```bash
+    cray bss bootparameters list --name <xname> --format json | jq -r '.[0].params' | grep metal.server
+    ```
+
+    The output should show the new IMS image ID in the `metal.server` parameter.
+
+1. (`ncn-mw#`) Set `metal.no-wipe=0` to allow the disk to be wiped during redeployment.
+
+    For each Fabric Manager node, set `metal.no-wipe=0`:
+
+    ```bash
+    TARGET_XNAME=<fmn-xname>
+    csi handoff bss-update-param --set metal.no-wipe=0 --limit ${TARGET_XNAME}
+    ```
+
+    For example:
+
+    ```bash
+    TARGET_XNAME=x3000c0s28b0n0
+    csi handoff bss-update-param --set metal.no-wipe=0 --limit ${TARGET_XNAME}
+    ```
+
+    Repeat for each Fabric Manager node.
+
+1. (`ncn-mw#`) Verify the change:
+
+    ```bash
+    cray bss bootparameters list --name ${TARGET_XNAME} --format=json | jq -r '.[0].params' | grep metal.no-wipe
+    ```
+
+    The output should show `metal.no-wipe=0`.
+
+### 3. Redeploy the Fabric Manager nodes
+
+After updating BSS with the new image and setting `metal.no-wipe=0`, reboot the Fabric Manager nodes to apply the new image.
+
+See [Reboot NCNs](../node_management/Reboot_NCNs_manual.md) for the procedure to reboot management nodes.
+
+### 4. Set `metal.no-wipe=1` after redeployment
+
+After the Fabric Manager nodes have been successfully redeployed and are running with the new image, set `metal.no-wipe=1` to preserve data on future reboots.
+
+1. (`ncn-mw#`) For each Fabric Manager node, set `metal.no-wipe=1`:
+
+    ```bash
+    TARGET_XNAME=<fmn-xname>
+    csi handoff bss-update-param --set metal.no-wipe=1 --limit ${TARGET_XNAME}
+    ```
+
+    For example:
+
+    ```bash
+    TARGET_XNAME=x3000c0s28b0n0
+    csi handoff bss-update-param --set metal.no-wipe=1 --limit ${TARGET_XNAME}
+    ```
+
+    Repeat for each Fabric Manager node.
+
+1. (`ncn-mw#`) Verify the change:
+
+    ```bash
+    cray bss bootparameters list --name ${TARGET_XNAME} --format=json | jq -r '.[0].params' | grep metal.no-wipe
+    ```
+
+    The output should show `metal.no-wipe=1`.
+
+### 5. Join Fabric Manager nodes to Spire
+
+After the Fabric Manager nodes have been redeployed and are running with the new image, join them to Spire to avoid issues with Spire tokens.
+
+```bash
+/opt/cray/platform-utils/spire/fix-spire-on-fmn.sh
+```


### PR DESCRIPTION
# Description
     
This PR adds documentation for deploying Fabric Manager (FM) nodes during CSM installation.

**Changes include:**
     - Added steps to deploy FM nodes during CSM install in `install/README.md`
     - Updated `operations/fm_on_baremetal/Configure_FM_On_Baremetal.md` with additional configuration details
     - Created new procedure document `operations/fm_on_baremetal/Redeploy_Fabric_Manager_Nodes.md` for redeploying Fabric Manager nodes

# Checklist

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.