### PR TITLE
CASMTRIAGE-8993 - apply_csm_configuration.sh needs to be updated to ignore fabric manager nodes

### DIFF
--- a/operations/fm_on_baremetal/README.md
+++ b/operations/fm_on_baremetal/README.md
@@ -56,7 +56,7 @@ In CSM versions < 1.7.0, the deployment of the Fabric Manager within CSM uses na
 
 In theory, this model should satisfy HA requirements: if the pod fails (or needs to be moved during an upgrade), Kubernetes can detect the fault and recreate the Fabric Manager on another node, providing continuity.
 
-In practice, however, this approach does not meet the contractual HA obligations. Because of Kubernetes “best‑effort” scheduling and the resource demands of the Fabric Manager, real service outages can exceed 5 minutes.
+In practice, however, this approach does not meet the contractual HA obligations. Because of Kubernetes "best‑effort" scheduling and the resource demands of the Fabric Manager, real service outages can exceed 5 minutes.
 
 To address these issues, CSM 1.7.1 includes FM on baremetal support, which provides the necessary base OS image, networking, and storage configurations for running the Slingshot Fabric Manager natively within the CSM environment to achieve HA.
 

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -196,7 +196,8 @@ BACKUP_NCN_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "backup-${CONFIG_NAME}-
 
 if [[ -z ${XNAMES} ]]; then
   echo "Retrieving a list of all management node component names (xnames)"
-  XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+  echo "NOTE: FabricManager nodes are excluded from configuration"
+  XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(select(.SubRole != "FabricManager")) | map(.ID) | join(",")')
   [[ -n ${XNAMES} ]] || err_exit "No management nodes found in HSM"
 fi
 XNAME_LIST=${XNAMES//,/ }


### PR DESCRIPTION
# Description

This change updates the `apply_csm_configuration.sh` script to exclude FabricManager nodes from CSM configuration during installation.

This change is needed because FabricManager nodes are not ready for configuration during initial installation:
- The required SUSE repositories for Ansible are not yet available
- The nodes have not been deployed with their final images

The script now filters out nodes with SubRole "FabricManager" when retrieving the list of management nodes from HSM, preventing configuration attempts on these nodes until they are properly prepared.

Relates to:
- CASMTRIAGE-8993

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.