### PR TITLE
CASMCMS-9615: BOS: Refactor main page and services page

### DIFF
--- a/operations/boot_orchestration/BOS_Services.md
+++ b/operations/boot_orchestration/BOS_Services.md
@@ -1,9 +1,10 @@
 # BOS Services
 
-The Boot Orchestration Service \(BOS\) consists of many different micro-services and other components, including the API, operators, and the BOS state reporter.
+The Boot Orchestration Service (BOS) consists of many different micro-services and other components.
 
 * [BOS API](#bos-api)
-* [Boot Orchestration Agent \(BOA\)](#boot-orchestration-agent-boa)
+* [BOS database](#bos-database)
+* [Boot Orchestration Agent (BOA)](#boot-orchestration-agent-boa)
 * [BOS operators](#bos-operators)
     * [`actual-state-cleanup`](#actual-state-cleanup)
     * [`configuration`](#configuration)
@@ -15,20 +16,74 @@ The Boot Orchestration Service \(BOS\) consists of many different micro-services
     * [`session-completion`](#session-completion)
     * [`session-setup`](#session-setup)
     * [`status`](#status)
-* [BOS state reporter](#bos-state-reporter)
+* [BOS reporter](#bos-reporter)
 
 ## BOS API
 
 The API is the point of contact for the user and all other services, including BOS' own services, that want to query or update BOS data.
 
-## Boot Orchestration Agent \(BOA\)
+The BOS API server does not do any of the actual core BOS work -- that is, it does not boot or reboot any nodes, it does not
+coordinate the progress of sessions, and so on. Its essential purpose is to act as a front-end for the
+[BOS database](#bos-database), allowing callers to safely create, read, modify, and delete entries in the database.
+All of the core BOS work is done by the [BOS operators](#bos-operators) and the [BOS reporter](#bos-reporter).
+
+(`ncn-mw#`) The BOS API server runs in multiple Kubernetes pods in the `services` namespace.
+
+```bash
+kubectl get pods -n services -l app.kubernetes.io/name=cray-bos
+```
+
+Example output:
+
+```text
+NAME                       READY   STATUS    RESTARTS   AGE
+cray-bos-994fc7c59-298g8   2/2     Running   0          50d
+cray-bos-994fc7c59-z2r2q   2/2     Running   0          50d
+```
+
+For a user-friendly summary of the BOS API, see [Boot Orchestration Service API](../../api/bos.md).
+For the full BOS API specification and the source for the BOS API server, see the
+[`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) open source GitHub repository.
+
+## BOS database
+
+(`ncn-mw#`) All BOS data is stored in a Redis database running in a pod in the `services` namespace.
+
+```bash
+kubectl get pods -n services -l app.kubernetes.io/name=cray-bos-db
+```
+
+Example output:
+
+```text
+NAME                           READY   STATUS    RESTARTS   AGE
+cray-bos-db-58f4967657-rdj9l   2/2     Running   0          70d
+```
+
+The Helm chart for the BOS database is located in the
+[`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) open source GitHub repository.
+
+## Boot Orchestration Agent (BOA)
 
 BOA was a feature of BOS v1 only. It was a Kubernetes job that was responsible for tracking all of the components in a BOS session and taking actions against them.
+
+The source for BOA is located in the
+[`Cray-HPE/boa`](https://github.com/Cray-HPE/boa/) open source GitHub repository.
 
 ## BOS operators
 
 The BOS operators were introduced in BOS v2.
-Rather than relying on a single actor to handle all components and actions, the actions are broken up against several operators that monitor for components that require a specific action and handle only those components.
+BOS has many different operators, each of which follows the same basic loop:
+
+1. Search the [BOS database](#bos-database) (using the [BOS API](#bos-api))
+   for any potential work for this operator.
+1. Process that work, if any.
+1. Update the [BOS database](#bos-database) (using the [BOS API](#bos-api))
+   based on the work that was done, if applicable.
+1. Sleep for an interval, then go back to the top of the loop.
+
+Each operator is responsible for doing a single basic task -- for example, powering on nodes,
+discovering new nodes on the system, or initializing a new session.
 
 * [`actual-state-cleanup`](#actual-state-cleanup)
 * [`configuration`](#configuration)
@@ -40,6 +95,35 @@ Rather than relying on a single actor to handle all components and actions, the 
 * [`session-completion`](#session-completion)
 * [`session-setup`](#session-setup)
 * [`status`](#status)
+
+The work for a BOS session is done by several different operators, all acting independently of each other.
+These operators are always running, even when no BOS session is actively underway.
+This is a big difference from BOS version 1, where each session created a new dedicated Kubernetes job
+that handled everything associated with that session.
+
+(`ncn-mw#`) The BOS operators run in Kubernetes pods in the `services` namespace.
+
+```bash
+kubectl get pods -n services | grep '^cray-bos-operator-'
+```
+
+Example output:
+
+```text
+cray-bos-operator-actual-state-cleanup-596dc4766c-xsdg2           2/2     Running             0              50d
+cray-bos-operator-configuration-865f95f7d7-2j2tf                  2/2     Running             0              50d
+cray-bos-operator-discovery-698b44f9f9-fhs9c                      2/2     Running             0              50d
+cray-bos-operator-power-off-forceful-666f76c98f-mx5vb             2/2     Running             0              50d
+cray-bos-operator-power-off-graceful-6489689c99-wch2p             2/2     Running             0              50d
+cray-bos-operator-power-on-7d778c67cc-8vbrj                       2/2     Running             0              50d
+cray-bos-operator-session-cleanup-68c4cdbcc-qfvvr                 2/2     Running             0              50d
+cray-bos-operator-session-completion-756b4ddfb5-584bk             2/2     Running             0              50d
+cray-bos-operator-session-setup-654544c589-9t9rr                  2/2     Running             0              50d
+cray-bos-operator-status-7665867877-gcj59                         2/2     Running             0              50d
+```
+
+The source for the BOS operators is located in the
+[`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) open source GitHub repository.
 
 ### `actual-state-cleanup`
 
@@ -70,7 +154,7 @@ This operator calls PCS to power on components for components that have a `power
 
 ### `session-cleanup`
 
-This operator deletes session from BOS that are older than the `cleanup_completed_session_ttl` value.
+This operator deletes sessions from BOS that are older than the `cleanup_completed_session_ttl` value.
 
 ### `session-completion`
 
@@ -86,8 +170,24 @@ Related: [BOS sessions and HSM locks](Sessions.md#bos-sessions-and-hsm-locks).
 
 This operator monitors all components that are enabled in BOS and sets their `phase` based on the components desired and current state in BOS, the components power state as reported by HSM, and the component's configuration status as reported by CFS.
 
-## BOS state reporter
+## BOS reporter
 
-The `bos-state-reporter` was introduced in BOS v2. It runs on all components managed by BOS and periodically reports back the actual state of the component it runs on.
+The `bos-reporter` was introduced in BOS v2.
+It runs on all components managed by BOS and periodically reports back the actual state of the component it runs on.
 This is installed as a package at image customization time.
 See [Options](Options.md) for more information on setting `component_actual_state_ttl` option, which controls how long this data is valid if it is not updated.
+
+The `bos-reporter` RPM must be installed on nodes in order for BOS to operate on them properly.
+It is responsible for reporting the current state and boot artifacts for a node. This is necessary for BOS
+to know when a node has successfully been booted into the correct state.
+
+The reporting is done using the [BOS API](#bos-api). Because of this, the reporting will not work on a node without
+network access to the [BOS API](#bos-api).
+
+The BOS reporter is somewhat analogous to the [CFS](../../glossary.md#configuration-framework-service-cfs) state reporter.
+
+The location of the BOS reporter source code depends on its version. Prior to version 3.0.0,
+the source for the BOS reporter is located in the
+[`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) open source GitHub repository.
+Starting in version 3.0.0, the source for the BOS reporter is located in the
+[`Cray-HPE/bos-reporter`](https://github.com/Cray-HPE/bos-reporter/) open source GitHub repository.

--- a/operations/boot_orchestration/README.md
+++ b/operations/boot_orchestration/README.md
@@ -1,9 +1,11 @@
 # Boot Orchestration Service (BOS)
 
 * [Overview[(#overview)
+* [Terminology](#terminology)
+* [Services](#services)
+* [CLI](#cli)
 * [Versions](#versions)
 * [Dependencies](#dependencies)
-* [CLI commands](#cli-commands)
 * [Source code](#source-code)
 
 ## Overview
@@ -11,19 +13,77 @@
 The Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes.
 This is accomplished using BOS session templates and sessions.
 
-BOS users create a BOS session template using the REST API (or using the [Cray CLI](../../glossary.md#cray-cli-cray), which is a front-end for the REST API).
-A session template is a collection of metadata for a group of nodes and their desired boot artifacts and configuration.
-A BOS session can then be created by applying an action to a session template. The available actions are boot, reboot, and shutdown.
+BOS users create a BOS session template, and then create a BOS session, which applies an action to the session template.
+The available actions are boot, reboot, and shutdown.
 The session can be monitored to determine the status of the request.
 
 For more information, see [BOS Workflows](BOS_Workflows.md).
+
+## Terminology
+
+* [Boot Orchestration Agent (BOA)](BOS_Services.md#boot-Orchestration-agent-boa): A sub-service in BOS version 1 that does not exist in BOS version 2.
+* [Component](Components.md): A node (such as a [compute node](../../glossary.md#compute-node-cn) or [UAN](../../glossary.md#user-access-node-uan)).
+* [Operator](BOS_Services.md#bos-operators): Permanent BOS sub-service responsible for performing a specific task when necessary.
+* [Options](Options.md): Adjustable parameters to control how BOS operates.
+* [Session](Sessions.md): A request for BOS to perform an action on a specified set of components, bringing them to a specified desired state.
+* [Session template](Session_Templates.md): A collection of metadata for a group of nodes and their desired boot artifacts and configuration.
+
+## Services
+
+BOS is made up of a number of different sub-services that combine to provide its functionality.
+For details, see [BOS Services](BOS_Services.md).
+
+## CLI
+
+The [Cray CLI](../../glossary.md#cray-cli-cray) supports BOS commands, providing a more user friendly front-end for the
+[BOS API](BOS_Services.md#bos-api).
+
+The first CLI argument specifies the BOS version.
+For ease of interactive CLI use, specifying the BOS version is optional; it defaults to `v2`.
+However, explicitly specifying the version in scripts or documentation is **highly recommended**,
+because the default BOS version for the CLI is subject to change.
+
+For context-specific usage information, append `--help` to the CLI command. For example:
+
+* `cray bos --help`
+* `cray bos v2 --help`
+* `cray bos sessions --help`
+* `cray bos v2 components list --help`
+
+(`ncn-mw#`) API information, including the version, can be found with the following command:
+
+```bash
+cray bos list --format json
+```
+
+Example output:
+
+```json
+{
+  "links": [
+    {
+      "href": "https://api-gw-service-nmn.local/apis/bos/",
+      "rel": "self"
+    },
+    {
+      "href": "https://api-gw-service-nmn.local/apis/bos/v2",
+      "rel": "versions"
+    }
+  ],
+  "major": "2",
+  "minor": "48",
+  "patch": "2"
+}
+```
+
+For more information, see [BOS Commands Cheat Sheet](Cheatsheet.md).
 
 ## Versions
 
 > BOS v1 is not present starting in CSM 1.6. See [BOS v1 removal](BOS_API_Versions.md#bos-v1-removal) for more information.
 
-There is only one supported API version for BOS -- v2. Compared to BOS v1,
-BOS v2 takes a more flexible approach and relies on a number of permanent operators to guide components through state transitions in an independent manner.
+There is only one supported API version for BOS -- v2. Compared to BOS v1, BOS v2 takes a more flexible approach and relies
+on a number of permanent [operators](BOS_Services.md#bos-operators) to guide components through state transitions in an independent manner.
 The BOS v2 session can be used to track progress of the operation, but there is no centralized Kubernetes pod in which the session resides.
 For more detailed information than is found on this page, see [BOS API Versions](BOS_API_Versions.md).
 
@@ -38,42 +98,13 @@ BOS depends on each of the following services to complete its tasks:
 | [Power Control Service (PCS)](../../glossary.md#power-control-service-pcs) | Used to power nodes on and off, as well as query current power status. |
 | [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm) | Tracks the state of each node, and the node membership of groups and roles. |
 
-## CLI commands
-
-The Cray CLI supports BOS commands. The first argument specifies the BOS version.
-For ease of interactive CLI use, specifying the BOS version is optional; it defaults to v2.
-However, explicitly specifying the version in scripts or documentation is **highly recommended**,
-because the default BOS version for the CLI is subject to change.
-
-(`ncn-mw#`) API information, including the default API version, can be found with the following command:
-
-```bash
-cray bos list --format toml
-```
-
-Example output:
-
-```toml
-[[results]]
-major = "2"
-minor = "0"
-patch = "0"
-[[links]]
-href = "https://api-gw-service-nmn.local/apis/bos/"
-rel = "self"
-
-[[links]]
-href = "https://api-gw-service-nmn.local/apis/bos/v2"
-rel = "versions"
-```
-
 ## Source code
 
 The source code for BOS is located in the following open source GitHub repositories:
 
 | *Repository* | *Contents* |
 | ------------ | ---------- |
-| [`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) | BOS API server |
-| [`Cray-HPE/bos-reporter`](https://github.com/Cray-HPE/bos-reporter/) | `bos-reporter` RPM |
+| [`Cray-HPE/bos`](https://github.com/Cray-HPE/bos/) | BOS API server, API specification, database, and operators. |
+| [`Cray-HPE/bos-reporter`](https://github.com/Cray-HPE/bos-reporter/) | `bos-reporter` RPM. |
 | [`Cray-HPE/craycli`](https://github.com/Cray-HPE/craycli/) | The Cray CLI, including the BOS subcommands. |
 | [`Cray-HPE/cms-tools`](https://github.com/Cray-HPE/cms-tools/) | Health checks and utilities for several CSM services, including BOS. |


### PR DESCRIPTION
This refactors the main BOS page and the BOS services summary page.

Backports:
* CSM 1.6: https://github.com/Cray-HPE/docs-csm/pull/6466
* CSM 1.5: https://github.com/Cray-HPE/docs-csm/pull/6467
* CSM 1.4: https://github.com/Cray-HPE/docs-csm/pull/6468
* CSM 1.3: https://github.com/Cray-HPE/docs-csm/pull/6469
* CSM 1.2: https://github.com/Cray-HPE/docs-csm/pull/6470
* CSM 1.0: https://github.com/Cray-HPE/docs-csm/pull/6471