### PR TITLE
CASMTRIAGE-8997: Remove use of typing_extensions

### DIFF
--- a/scripts/operations/configuration/python_lib/csm_root_secret.py
+++ b/scripts/operations/configuration/python_lib/csm_root_secret.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@
 import logging
 import traceback
 from typing import NoReturn, Union
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 from . import common
 from . import k8s
@@ -51,12 +51,10 @@ class CsmUserSecretUpdateData(TypedDict, total=False):
     ssh_public_key: Union[str, None]
 
 
-CsmUserSecretFields = Literal['password', 'ssh_config', 'ssh_private_key', 'ssh_public_key']
-
-SSH_CONFIG_FIELD: CsmUserSecretFields = 'ssh_config'
-SSH_PRI_KEY_FIELD: CsmUserSecretFields = 'ssh_private_key'
-SSH_PUB_KEY_FIELD: CsmUserSecretFields = 'ssh_public_key'
-PW_FIELD: CsmUserSecretFields = 'password'
+SSH_CONFIG_FIELD: str = 'ssh_config'
+SSH_PRI_KEY_FIELD: str = 'ssh_private_key'
+SSH_PUB_KEY_FIELD: str = 'ssh_public_key'
+PW_FIELD: str = 'password'
 
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> NoReturn:

--- a/scripts/operations/configuration/python_lib/csm_root_secret.py
+++ b/scripts/operations/configuration/python_lib/csm_root_secret.py
@@ -25,36 +25,27 @@
 
 import logging
 import traceback
-from typing import NoReturn, Union
-from typing_extensions import TypedDict
+from typing import Dict, NoReturn, Union
 
 from . import common
 from . import k8s
 from . import vault
 
 
-class CsmUserSecretData(TypedDict, total=False):
-    password: str
-    ssh_config: str
-    ssh_private_key: str
-    ssh_public_key: str
-
-
-class CsmUserSecretUpdateData(TypedDict, total=False):
-    """
-    A value of None in the update dict means the field should be deleted
-    as part of the update
-    """
-    password: Union[str, None]
-    ssh_config: Union[str, None]
-    ssh_private_key: Union[str, None]
-    ssh_public_key: Union[str, None]
-
-
 SSH_CONFIG_FIELD: str = 'ssh_config'
 SSH_PRI_KEY_FIELD: str = 'ssh_private_key'
 SSH_PUB_KEY_FIELD: str = 'ssh_public_key'
 PW_FIELD: str = 'password'
+
+# Mapping from user secret field names to their string values
+# Valid keys: 'password', 'ssh_config', 'ssh_private_key', 'ssh_public_key'
+CsmUserSecretData = Dict[str, str]
+
+# Mapping from user secret field names to the desired new string values
+# Valid keys: 'password', 'ssh_config', 'ssh_private_key', 'ssh_public_key'
+# If the target value is None, it means the corresponding key should be deleted
+# as part of the update
+CsmUserSecretUpdateData = Dict[str, Union[str, None]]
 
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> NoReturn:
@@ -122,7 +113,7 @@ class CsmUserSecret:
             return
         root_secret = self.get(must_exist=False)
         if root_secret is None:
-            new_root_secret = CsmUserSecretData()
+            new_root_secret: CsmUserSecretData = dict()
             # Get the update fields that are not set to None
             for field, value in secret_update_data.items():
                 if value is not None:

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,6 @@
 import logging
 import traceback
 from typing import List, NoReturn, Optional
-from typing_extensions import Literal
 
 from . import api_requests
 from . import common
@@ -34,8 +33,6 @@ from .types import JSONDecodeError
 
 SMD_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/smd"
 SMD_HSM_COMPONENTS_URL = f"{SMD_BASE_URL}/hsm/v2/State/Components"
-
-MGMT_NCN_HSM_SUBROLE = Literal['Master', 'Storage', 'Worker']
 
 def log_error_raise_exception(msg: str, parent_exception: Optional[Exception] = None) -> NoReturn:
     """
@@ -52,9 +49,11 @@ def log_error_raise_exception(msg: str, parent_exception: Optional[Exception] = 
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_management_ncn_xnames(subrole: Optional[MGMT_NCN_HSM_SUBROLE] = None) -> List[str]:
+def get_management_ncn_xnames(subrole: Optional[str] = None) -> List[str]:
     """
     Return a sorted list of the xnames of the management NCNs
+
+    Valid subrole values: 'Master', 'Storage', 'Worker'
     """
     params = {"type": "Node", "role": "Management"}
     if subrole is not None:

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -212,7 +212,7 @@ def parse_args() -> CsmUserSecretUpdateData:
 
     parsed_args = parser.parse_args()
 
-    field_changes = CsmUserSecretUpdateData()
+    field_changes: CsmUserSecretUpdateData = dict()
 
     if parsed_args.pw_remove:
         # Clear the field in Vault, if it is set

--- a/scripts/operations/configuration/write_ssh_config_to_vault.py
+++ b/scripts/operations/configuration/write_ssh_config_to_vault.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -64,7 +64,7 @@ def parse_args() -> CsmUserSecretUpdateData:
                        dest='ssh_config', default=CONFIG_PATH,
                        help=f"Path to root SSH config file (default: {CONFIG_PATH})")
     parsed_args = parser.parse_args()
-    update = CsmUserSecretUpdateData()
+    update: CsmUserSecretUpdateData = dict()
     update[SSH_CONFIG_FIELD] = None if parsed_args.ssh_config is DELETE else parsed_args.ssh_config
     return update
 


### PR DESCRIPTION
When the changes for CASMPET-7628 were backported, I overlooked the fact that the `typing_extensions` module was not installed on NCNs prior to CSM 1.6. Because of this, some Python scripts fail with import errors when run on those CSM versions.

Fortunately, fixing this is easy, since `typing_extensions` was just used to provide better type annotations. This PR modifies the Python scripts so they no longer import `typing_extensions`, and instead rely on cruder annotations plus code comments to communicate the type information.

This problem was reported on wasp, and I have successfully tested this fix there.

Backports:
1.4: https://github.com/Cray-HPE/docs-csm/pull/6473
1.3: https://github.com/Cray-HPE/docs-csm/pull/6474

No earlier backports needed, as the relevant code did not exist prior to CSM 1.3.
Likewise, this is not needed in CSM 1.6 or later, because the module in question is installed on the NCNs in those releases.