### PR TITLE
DOCS: CASMTRIAGE-9042 CSM 1.7.0 workaround or troubleshooting documentation for iuf management-rollout to worker nodes hangs on last worker node DVS errors

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -519,7 +519,7 @@ for details on how to query the images and CFS configurations and see the [updat
     Verify the cos-prechecks-for-worker-reboots hook exists:
 
     ```bash
-    kubectl -n argo get hooks -l app.kubernetes.io/name=cos-prechecks-for-worker-reboots
+    kubectl get hooks -n argo cos-prechecks-for-worker-reboots
     ```
 
     Delete the hook:


### PR DESCRIPTION
# Description

CASMTRIAGE-9042 DOCS: Modify command for cos-prechecks-for-worker-reboots with IUF worker rebuilds

Analysis:

Modify the kubectl command to verify whether cos-prechecks-for-worker-reboots hook is present

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
