### PR TITLE
CASMCMS-9626: BOS/BSS improvements

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -52,6 +52,7 @@ Glossary of terms used in CSM documentation.
 * [NCN Lifecycle Service (NLS)](#ncn-lifecycle-service-nls)
 * [NIC Mezzanine Card (NMC)](#nic-mezzanine-card-nmc)
 * [Node Controller (nC)](#node-controller-nc)
+* [Node ID (NID)](#node-id-nid)
 * [Node Management Network (NMN)](#node-management-network-nmn)
 * [Node Memory Dump (NMD)](#node-memory-dump-nmd)
 * [Non-Compute Node (NCN)](#non-compute-node-ncn)
@@ -501,6 +502,21 @@ node card.
 Each compute blade node card includes an embedded node controller (nC) and REST
 endpoint to manage the node environmental conditions, power, HMS nFPGA interface, and
 firmware.
+
+## Node ID (NID)
+
+A numerical identifier for a node. Nodes can be uniquely identified using NIDs or [xnames](#xname),
+although not all CSM services support the use of NIDs for node identification. The NID for a node
+can be found using the [Boot Script Service (BSS)](#boot-script-service-bss), the
+[Hardware State Manager (HSM)](#hardware-state-manager-hsm), or the
+[System Admin Toolkit (SAT)](#system-admin-toolkit-sat).
+
+See also:
+
+* [Defragment NID Numbering](operations/node_management/Defragment_NID_Numbering.md)
+* [Power control and query by NID](operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md#power-control-and-query-by-nid)
+* [`reject_nids` option](operations/boot_orchestration/Options.md#reject_nids) in the
+  [Boot Orchestration Service (BOS)](#boot-orchestration-service-bos)
 
 ## Node Management Network (NMN)
 

--- a/operations/boot_orchestration/API.md
+++ b/operations/boot_orchestration/API.md
@@ -3,6 +3,8 @@
 * [Overview](#overview)
 * [Server](#server)
 * [Kubernetes deployment](#kubernetes-deployment)
+* [Options](#options)
+* [Migration job](#migration-job)
 * [Specification](#specification)
 * [Source](#source)
 
@@ -18,10 +20,23 @@ coordinate the progress of sessions, and so on. Its essential purpose is to act 
 [BOS database](Database.md), allowing callers to safely create, read, modify, and delete entries in the database.
 All of the core BOS work is done by the [BOS operators](Operators.md) and the [BOS reporter](Reporter.md).
 
-> Other than the API server, the only other part of BOS that directly accesses the database is
-> the [`power-on` operator](Operators.md#power-on).
+> Other than the API server, there are only two parts of BOS that ever directly access the BOS databases.
+> See [BOS database access](Database.md#access) for details.
 
 ## Kubernetes deployment
+
+(`ncn-mw#`) The BOS API server is a Kubernetes deployment in the `services` namespace:
+
+```bash
+kubectl get deployments -n services -l app.kubernetes.io/name=cray-bos
+```
+
+Example output:
+
+```text
+NAME       READY   UP-TO-DATE   AVAILABLE   AGE
+cray-bos   2/2     2            2           11d
+```
 
 (`ncn-mw#`) The BOS API server runs in multiple Kubernetes pods in the `services` namespace.
 
@@ -36,6 +51,46 @@ NAME                       READY   STATUS    RESTARTS   AGE
 cray-bos-994fc7c59-298g8   2/2     Running   0          50d
 cray-bos-994fc7c59-z2r2q   2/2     Running   0          50d
 ```
+
+## Options
+
+Although many of the [BOS Options](Options.md) do not impact the behavior of the API server,
+the following options do:
+
+* [`logging_level`](Options.md#logging_level)
+    * This option determines the verbosity of BOS logging, including the BOS API server.
+    * The server logs can be viewed by looking at the logs of the pods in the server
+      [Kubernetes deployment](#kubernetes-deployment).
+* [`ims_read_timeout`](Options.md#ims_read_timeout)
+    * This option determines how long the BOS API server will wait for a response to API requests to IMS.
+    * BOS has other service-specific timeout options; these options would also apply to the BOS API server,
+      but the API server does not make calls to any of those other services.
+* [`ims_errors_fatal`](Options.md#ims_errors_fatal) and
+  [`ims_images_must_exist`](Options.md#ims_images_must_exist)
+    * These options control how BOS deals with IMS issues during
+      [boot set validation](Session_Templates.md#boot-set-validation).
+* [`session_limit_required`](Options.md#session_limit_required)
+    * This option determines whether or not a [session limit](Limit_the_Scope_of_a_BOS_Session.md)
+      is required when creating a new [session](Sessions.md).
+* [`reject_nids`](Options.md#reject_nids)
+    * During [boot set validation](Session_Templates.md#boot-set-validation), this option controls whether
+      [NIDs](../../glossary.md#node-id-nid) in the [`node_list`](Session_Templates.md#node-list)
+      field is a fatal error.
+    * This option controls whether NIDs in the [session limit](Limit_the_Scope_of_a_BOS_Session.md)
+      is a fatal error when creating a new [session](Sessions.md).
+
+See [Options](Options.md) for more information.
+
+## Migration job
+
+When the `cray-bos` [Kubernetes deployment](#kubernetes-deployment) is upgraded, the `cray-bos-migration`
+job runs in the `services` namespace. It checks data in the [BOS databases](Database.md) and fixes some
+cases of invalid data (for example, session template names that are not legal under the API
+[Specification](#specification).
+
+The migration job pods first wait until all of the databases are accessible. In some cases, this will time
+out before the databases are ready, and the pod will exit in failure. The job migration automatically
+retries when the pod fails; in most cases, the databases are ready in time when the next migration job pod runs.
 
 ## Specification
 

--- a/operations/boot_orchestration/Database.md
+++ b/operations/boot_orchestration/Database.md
@@ -1,13 +1,31 @@
 # BOS database
 
 * [Overview](#overview)
+* [Kubernetes deployment](#kubernetes-deployment)
 * [Data organization](#data-organization)
 * [Access](#access)
 * [Source](#source)
 
 ## Overview
 
-(`ncn-mw#`) All BOS data is stored in Redis databases running in a pod in the `services` namespace.
+All BOS data is stored in Redis databases.
+
+## Kubernetes deployment
+
+(`ncn-mw#`) The BOS databases are a Kubernetes deployment in the `services` namespace.
+
+```bash
+kubectl get deployments -n services -l app.kubernetes.io/name=cray-bos-db
+```
+
+Example output:
+
+```text
+NAME          READY   UP-TO-DATE   AVAILABLE   AGE
+cray-bos-db   1/1     1            1           11d
+```
+
+(`ncn-mw#`) The database pod runs in the `services` namespace.
 
 ```bash
 kubectl get pods -n services -l app.kubernetes.io/name=cray-bos-db
@@ -26,7 +44,7 @@ Within the Redis pod, the BOS data is divided into 6 databases:
 
 | *Database*                                                                 | *Key*                                                               |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [Components](Components.md)                                                | Node xname                                                          |
+| [Components](Components.md)                                                | Component name ([xname](../../glossary.md#xname))                   |
 | Boot artifacts (`initrd`, kernel, and kernel parameters)                   | [BSS](../../glossary.md#boot-script-service-bss) token              |
 | [Options](Options.md)                                                      | `options`                                                           |
 | [Session templates](Session_Templates.md)                                  | Hash based on [tenant](Multi_tenancy_with_BOS.md) and template name |
@@ -39,8 +57,11 @@ Within the Redis pod, the BOS data is divided into 6 databases:
 
 ## Access
 
-All access to the BOS databases is done by the [BOS API server](API.md), with a single exception;
-The [`power-on` operator](Operators.md#power-on) directly writes to the boot artifacts database.
+All access to the BOS databases is done by the [BOS API server](API.md), with two exceptions:
+
+* The [`power-on` operator](Operators.md#power-on) directly writes to the boot artifacts database.
+* The [migration job](API.md#migration-job) directly reads from and writes to most of the databases.
+    * The migration job only runs when the `cray-bos` deployment is upgraded.
 
 ## Source
 

--- a/operations/boot_orchestration/Limit_the_Scope_of_a_BOS_Session.md
+++ b/operations/boot_orchestration/Limit_the_Scope_of_a_BOS_Session.md
@@ -33,7 +33,7 @@ then the `limit` parameter is not optional when creating a session.
 However, even if this option is enabled, it is still possible to use
 [Advanced session limit syntax](#advanced-session-limit-syntax) to effectively create a
 session with no limit; a session can be limited to all nodes on the system by specifying
-`*` as the limit parameter (if this is done on the command line, it must be quoted it in
+`*` as the limit parameter (if this is done on the command line, it must be quoted in
 order to prevent it from being interpreted by the shell).
 
 ## Limiting tenant sessions

--- a/operations/boot_orchestration/Limit_the_Scope_of_a_BOS_Session.md
+++ b/operations/boot_orchestration/Limit_the_Scope_of_a_BOS_Session.md
@@ -20,7 +20,8 @@ For more details on creating a session, see [Create a session](Manage_a_BOS_Sess
 
 ## Rejecting NIDs in session limits
 
-When specifying nodes, component names (xnames) must be used. The use of NIDs is not supported.
+When specifying nodes, component names ([xnames](../../glossary.md#xname)) must be used. The use of
+[NIDs](../../glossary.md#node-id-nid) is not supported.
 In order to prevent the accidental creation of sessions attempting to use NIDs, the
 [`reject_nids` option](Options.md#reject_nids) may be enabled.
 
@@ -28,6 +29,12 @@ In order to prevent the accidental creation of sessions attempting to use NIDs, 
 
 If the [`session_limit_required` option](Options.md#session_limit_required) is enabled,
 then the `limit` parameter is not optional when creating a session.
+
+However, even if this option is enabled, it is still possible to use
+[Advanced session limit syntax](#advanced-session-limit-syntax) to effectively create a
+session with no limit; a session can be limited to all nodes on the system by specifying
+`*` as the limit parameter (if this is done on the command line, it must be quoted it in
+order to prevent it from being interpreted by the shell).
 
 ## Limiting tenant sessions
 

--- a/operations/boot_orchestration/Multi_tenancy_with_BOS.md
+++ b/operations/boot_orchestration/Multi_tenancy_with_BOS.md
@@ -6,6 +6,7 @@
     * [Tenant administrators](#tenant-administrators)
 * [Components](#components)
 * [Sessions and session templates](#sessions-and-session-templates)
+    * [Tenant name-spacing](#tenant-name-spacing)
     * [Session templates with tenancy](#session-templates-with-tenancy)
         * [Tenant-owned session templates](#tenant-owned-session-templates)
         * [Session templates not owned by tenants](#session-templates-not-owned-by-tenants)

--- a/operations/boot_orchestration/Multi_tenancy_with_BOS.md
+++ b/operations/boot_orchestration/Multi_tenancy_with_BOS.md
@@ -37,11 +37,12 @@ resources specific to that tenant.
 
 A tenant administrator is a role that is only able to manage resources belonging to a specific tenant.
 
-[Tenant administrators](../multi-tenancy/TenantAdminConfig.md) should be able to view their
+[Tenant administrators](../multi-tenancy/TenantAdminConfig.md) are able to view their
 [components](Components.md), [session templates](Session_Templates.md), and [sessions](Sessions.md) normally.
+Tenant administrators are also able to create sessions using their session templates.
 Tenant administrators are not able to view the resources of another tenant.
 Tenant administrators have restricted or no access to some BOS endpoints, such as the components endpoint
-(which can be viewed but not patched), and the options endpoint (which is blocked entirely).
+(which can be viewed but not patched), and the [options](Options.md) endpoint (which is blocked entirely).
 
 ## Components
 

--- a/operations/boot_orchestration/Operators.md
+++ b/operations/boot_orchestration/Operators.md
@@ -3,7 +3,7 @@
 * [Overview](#overview)
 * [Execution loop](#execution-loop)
 * [Options](#options)
-* [Kubernetes pods](#kubernetes-pods)
+* [Kubernetes deployment](#kubernetes-deployment)
 * [Operator list](#operator-list)
     * [`actual-state-cleanup`](#actual-state-cleanup)
     * [`configuration`](#configuration)
@@ -49,7 +49,9 @@ the relevant operator descriptions in the [Operator list](#operator-list).
 The following BOS options apply to operators generally:
 
 * [`logging_level`](Options.md#logging_level)
-    * This option determines the verbosity of the [BOS operator Kubernetes pod](#kubernetes-pods) logs.
+    * This option determines the verbosity of BOS logging, including the BOS operator logs.
+    * The operator logs can be viewed by looking at the logs of the pods in the operator
+      [Kubernetes deployment](#kubernetes-deployment).
 * [`polling_frequency`](Options.md#polling_frequency)
     * This option determines how long the sleep interval is in the [execution loop](#execution-loop).
     * The only operator which is an exception to this is the [`discovery`](#discovery) operator, which
@@ -68,9 +70,30 @@ The following BOS options apply to operators generally:
 
 See [Options](Options.md) for more information.
 
-## Kubernetes pods
+## Kubernetes deployment
 
-(`ncn-mw#`) The BOS operators run in Kubernetes pods in the `services` namespace.
+(`ncn-mw#`) Each BOS operator has its own Kubernetes deployment in the `services` namespace.
+
+```bash
+kubectl get deployments -n services -l app.kubernetes.io/instance=cray-bos | grep '^cray-bos-operator-'
+```
+
+Example output:
+
+```text
+cray-bos-operator-actual-state-cleanup   1/1     1            1           11d
+cray-bos-operator-configuration          1/1     1            1           11d
+cray-bos-operator-discovery              1/1     1            1           11d
+cray-bos-operator-power-off-forceful     1/1     1            1           11d
+cray-bos-operator-power-off-graceful     1/1     1            1           11d
+cray-bos-operator-power-on               1/1     1            1           11d
+cray-bos-operator-session-cleanup        1/1     1            1           11d
+cray-bos-operator-session-completion     1/1     1            1           11d
+cray-bos-operator-session-setup          1/1     1            1           11d
+cray-bos-operator-status                 1/1     1            1           11d
+```
+
+(`ncn-mw#`) The BOS operator pods run in the `services` namespace.
 
 ```bash
 kubectl get pods -n services | grep '^cray-bos-operator-'
@@ -162,7 +185,7 @@ For each enabled BOS component that has a `power-on-pending` status, this operat
 
 1. Calls PCS to power on the node.
 
-> Unlike all parts of BOS other than the [API server](API.md), this operator directly accesses a
+> Unlike almost all parts of BOS other than the [API server](API.md), this operator directly accesses a
 > [BOS database](Database.md). Specifically, after the BSS step in the above procedure,
 > the operator writes an entry in the boot artifacts database. The key for the entry is the BSS
 > token. The value of the entry is a dictionary containing the kernel, kernel, parameters, and `initrd`.

--- a/operations/boot_orchestration/Options.md
+++ b/operations/boot_orchestration/Options.md
@@ -254,6 +254,6 @@ This can be helpful in avoiding accidental reboots of more components than inten
 
 If this option is enabled, it is still possible to effectively create a session with no limit
 by specifying `*` as the limit parameter (if this is done on the command line, it must be
-quoted it in order to prevent it from being interpreted by the shell).
+quoted in order to prevent it from being interpreted by the shell).
 
 This option does NOT have an effect on sessions that were created prior to it being enabled (even if they have not yet started).

--- a/operations/boot_orchestration/Options.md
+++ b/operations/boot_orchestration/Options.md
@@ -169,7 +169,8 @@ After this time, the request will time out. The default is 20 seconds.
 
 ### `ims_errors_fatal`
 
-This option modifies how BOS behaves when validating the architecture of a boot image in a [boot set](Session_Templates.md#boot-sets).
+This option modifies how BOS behaves when validating the architecture of a boot image
+during [boot set validation](Session_Templates.md#boot-set-validation).
 Specifically, this option comes into play when BOS needs data from the
 [Image Management Service (IMS)](../../glossary.md#image-management-service-ims)
 in order to do this validation, but IMS is unreachable.
@@ -178,12 +179,10 @@ In the above situation, if this option is true, then the validation will fail.
 Otherwise, if the option is false, then a warning will be logged, but the validation will not
 be failed because of this.
 
-This boot set validation happens when creating a session template, validating a session
-template, or creating a session.
-
 ### `ims_images_must_exist`
 
-This option modifies how BOS behaves when validating a boot set whose boot image appears to be from IMS.
+This option modifies how BOS behaves when performing [boot set validation](Session_Templates.md#boot-set-validation)
+on a [boot set](Session_Templates.md#boot-sets) whose boot image appears to be from IMS.
 Specifically, this option comes into play when the image does not actually exist in IMS.
 
 In the above situation, if this option is true, then the validation will fail.
@@ -192,9 +191,6 @@ be failed because of this.
 
 Note: If `ims_images_must_exist` is true but `ims_errors_fatal` is false, then
 a failure to determine whether or not an image is in IMS will NOT result in a fatal error.
-
-This boot set validation happens when creating a [session template](Session_Templates.md),
-validating a session template, or creating a session.
 
 ### `ims_read_timeout`
 
@@ -235,21 +231,29 @@ How frequently the BOS operators check component state for needed actions (in se
 
 ### `reject_nids`
 
-BOS does not support the use of NIDs to identify nodes -- only xnames.
-If the `reject_nids` option is enabled, BOS will prevent creation of sessions and session templates that appear to reference NIDs.
+Regardless of the value of this option,
+BOS does not support the use of [NIDs](../../glossary.md#node-id-nid) to identify nodes -- only
+component names ([xnames](../../glossary.md#xname)).
+If the `reject_nids` option is enabled, then BOS will prevent creation of [sessions](Sessions.md) and
+[session templates](Session_Templates.md) that appear to reference NIDs.
 Specifically, if this option is enabled, then:
 
-* When creating a session template, if it has any boot sets with a `node_list` that appears to contain a NID, then the creation will fail.
-* When validating a session template, if it has any boot sets with a `node_list` that appears to contain a NID, then the validation will fail.
-* When creating a session, if the specified session template has any boot sets with a `node_list` that appears to contain a NID, then the session creation will fail.
-* When creating a session, if the session limit appears to contain NID values, then the creation will fail.
+* During [boot set validation](Session_Templates.md#boot-set-validation), if a
+  [boot set](Session_Templates.md#boot-sets) has
+  a [`node_list`](Session_Templates.md#node-list) that appears to contain a NID, then the validation will fail.
+* When creating a session, if the [session limit](Limit_the_Scope_of_a_BOS_Session.md) appears to contain NID
+  values, then the creation will fail.
 
 This option does NOT have an effect on sessions that were created prior to it being enabled (even if they have not yet started).
 
 ### `session_limit_required`
 
-If enabled, BOS sessions cannot be created without specifying the `limit` parameter.
+If enabled, then BOS sessions cannot be created without specifying a
+[session limit](Limit_the_Scope_of_a_BOS_Session.md).
 This can be helpful in avoiding accidental reboots of more components than intended.
+
 If this option is enabled, it is still possible to effectively create a session with no limit
 by specifying `*` as the limit parameter (if this is done on the command line, it must be
 quoted it in order to prevent it from being interpreted by the shell).
+
+This option does NOT have an effect on sessions that were created prior to it being enabled (even if they have not yet started).

--- a/operations/boot_orchestration/Session_Templates.md
+++ b/operations/boot_orchestration/Session_Templates.md
@@ -15,6 +15,7 @@ Session templates can be created via the API by providing JSON data or via the C
     * [`rootfs` providers](#rootfs-providers)
         * [`root` kernel parameter example](#root-kernel-parameter-example)
     * [Overriding configuration](#overriding-configuration)
+    * [Boot set validation](#boot-set-validation)
 
 ## Session template structure
 
@@ -59,7 +60,7 @@ The following is an example BOS session template:
 ```
 
 * The `description` field is an optional text description of the template.
-* The `node_list` field (under `boot_sets`) is a list of individual node component names (xnames).
+* The `node_list` field (under `boot_sets`) is a list of individual node component names ([xnames](../../glossary.md#xname)).
 * The `etag` field is used to identify the version of the `manifest.json` file in S3.
 * The `path` field is the path to the `manifest.json` file in S3.
 * The `type` field is the type of storage where the boot image resides.
@@ -109,6 +110,7 @@ This boot artifact information from the files stored in S3 is then written to th
 
 Each boot set also specifies a set of nodes that are the targets of the boot set.
 There are three different fields used to specify the nodes: `node_list`, `node_groups`, and `node_roles_groups`.
+These are called the hardware-specifier fields of the boot set.
 The total set of nodes targeted by the boot set is the union of the nodes specified by these fields.
 
 > Related:
@@ -119,7 +121,7 @@ The total set of nodes targeted by the boot set is the union of the nodes specif
 
 #### Node list
 
-`node_list` maps to a list of nodes identified by component names (xnames).
+`node_list` maps to a list of nodes identified by component names ([xnames](../../glossary.md#xname)).
 
 For example:
 
@@ -127,7 +129,7 @@ For example:
 "node_list": ["x3000c0s19b1n0", "x3000c0s19b1n1", "x3000c0s19b2n0"]
 ```
 
-NIDs are not supported.
+[NIDs](../../glossary.md#node-id-nid) are not supported.
 The [`reject_nids` option](Options.md#reject_nids) can be enabled in order to prevent accidental creation of session templates that reference NIDs.
 
 If the session template belongs to a tenant, any nodes listed in this field should belong to that tenant in TAPMS.
@@ -231,3 +233,40 @@ The following table explains the different pieces in the preceding example.
 It is also possible to specify CFS configuration in the boot set. This is done by setting the `cfs` field inside the boot set.
 It follows the same format as the `cfs` field at the top level of the session template.
 If specified, this will override (for that boot set entry) whatever value is set in the base session template.
+
+### Boot set validation
+
+Boot set validation is performed by the [BOS API server](API.md) in the following operations:
+
+* A [session template](Session_Templates.md) is being created
+* A session template is being validated.
+* A [session](Sessions.md) is being created.
+    * In the case that the session operation is a shutdown, then
+      not all of the boot set validation occurs. See below for details.
+
+If a boot set fails validation, then the associated operation also fails. The following
+things are checked when a boot set is validated:
+
+* Verify that at least one non-empty hardware-specifier field is set.
+    * See [Specifying nodes](#specifying-nodes) for details on hardware-specifier fields.
+* Verify that the [`rootfs_provider`](#rootfs-providers) field is either unset or is set to a supported value.
+* Verify that the [boot artifacts](#boot-artifacts) exist in [S3](../../glossary.md#simple-storage-service-s3).
+    * This check is not performed in the case that the boot set validation is being
+      done when creating a shutdown session.
+* If the [`ims_images_must_exist` option](Options.md#ims_images_must_exist) is enabled,
+  verify that the boot image exists in IMS.
+    * If the [`ims_errors_fatal` option](Options.md#ims_errors_fatal) is also enabled,
+      then the boot set validation will fail if BOS is unable to contact IMS to perform
+      this check.
+    * This check is not performed in the case that the boot set validation is being
+      done when creating a shutdown session.
+* Verify that the architecture of the image in IMS matches the architecture specified
+  in the boot set.
+    * If the [`ims_errors_fatal` option](Options.md#ims_errors_fatal) is enabled,
+      then the boot set validation will fail if BOS is unable to contact IMS to perform
+      this check.
+    * This check is not performed in the case that the boot set validation is being
+      done when creating a shutdown session.
+* If the [`reject_nids` option](Options.md#reject_nids) is enabled,
+  verify that the [`node_list`](#node-list) field is either unset or does
+  not contain any [NIDs](../../glossary.md#node-id-nid).

--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md
@@ -1,8 +1,9 @@
-# Troubleshoot Compute Node Boot Issues Related to the Boot Script Service \(BSS\)
+# Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)
 
-Boot Script Service \(BSS\) delivers a boot script to a node based on its MAC address. This boot script tells the node where to obtain its boot artifacts, which include:
+The [Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) delivers a boot script to a node based on its MAC address.
+This boot script tells the node where to obtain its boot artifacts, which include:
 
-- `kernel`
+- kernel
 - `initrd`
 
 In addition, the boot script also contains the kernel boot parameters. This procedure helps resolve issues related to missing boot artifacts.
@@ -10,10 +11,6 @@ In addition, the boot script also contains the kernel boot parameters. This proc
 ## Prerequisites
 
 This procedure requires administrative privileges.
-
-## Limitations
-
-Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
 
 ## Procedure
 
@@ -29,18 +26,22 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
     cray-bss-fd888bd54-gvpxq       2/2     Running     0      2d3h    10.32.0.16   ncn-w002   <none>    <none>
     ```
 
-1. (`ncn-mw#`) Check that the boot script of the node that is failing to boot contains the correct boot artifacts.
+1. (`ncn-mw#`) Check that the boot scripts of the nodes that are failing to boot contain the correct boot artifacts.
 
     - If nodes are identified by their host names, then execute the following:
 
+        > In the following command, replace `HOST_NAMES` with a comma-separated list of the node component names ([xnames](../../glossary.md#xname)).
+
         ```bash
-        cray bss bootparameters list --hosts HOST_NAME
+        cray bss bootparameters list --hosts HOST_NAMES
         ```
 
     - If nodes are identified by their node IDs, then execute the following:
 
+        > In the following command, replace `NODE_IDS` with a comma-separated list of the [node IDs](../../glossary.md#node-id-nid).
+
         ```bash
-        cray bss bootparameters list --nids NODE_ID
+        cray bss bootparameters list --nids NODE_IDS
         ```
 
 1. (`ncn-mw#`) View the entire BSS contents.

--- a/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
+++ b/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
@@ -83,7 +83,7 @@ Set variables identifying the boot artifacts and parameters.
 
 1. (`ncn-mw#`) Set `PARAMS` to the boot kernel parameters.
 
-    -*IMPORTANT:** The `PARAMS` line must always include the substring `crashkernel=512M`.
+    **IMPORTANT:** The `PARAMS` line must always include the substring `crashkernel=512M`.
     This enables node dumps, which are needed to troubleshoot node crashes.
 
     > For readability, this example shows the variable being set over multiple lines.
@@ -140,7 +140,7 @@ There are three options for updating BSS:
 
 #### Update BSS by NID
 
-1. (`ncn-mw#`) Set `NIDS` to a comma-separated list of the [node IDs](../../glossary.md#nid) whose BSS entries should be updated.
+1. (`ncn-mw#`) Set `NIDS` to a comma-separated list of the [node IDs](../../glossary.md#node-id-nid) whose BSS entries should be updated.
 
     ```bash
     NIDS=1001,1032

--- a/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
+++ b/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
@@ -161,7 +161,7 @@ There are three options for updating BSS:
 #### Update BSS default boot setup
 
 BSS supports a mechanism that allows for a default boot setup, rather than needing to specify boot details for each specific node.
-This feature is particular useful with larger systems. To do this, follow the [Update BSS by host name](#update-bss-by-host-name)
+This feature is particularly useful with larger systems. To do this, follow the [Update BSS by host name](#update-bss-by-host-name)
 procedure, setting the `HOSTS` variable to `Default`.
 
 ### 3. Next step

--- a/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
+++ b/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
@@ -1,142 +1,230 @@
-# Upload Node Boot Information to Boot Script Service \(BSS\)
+# Upload Node Boot Information to Boot Script Service (BSS)
 
-The following information must be uploaded to BSS as a prerequisite to booting a node via iPXE:
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Procedure](#procedure)
+    1. [Set variables](#1-set-variables)
+    1. [Update BSS](#2-update-bss)
+        - [Update BSS by host name](#update-bss-by-host-name)
+        - [Update BSS by NID](#update-bss-by-nid)
+        - [Update BSS default boot setup](#update-bss-default-boot-setup)
+    1. [Next step](#3-next-step)
+- [Additional BSS queries](#additional-bss-queries)
+    - [View a boot script in BSS](#view-a-boot-script-in-bss)
+    - [View all BSS contents](#view-all-bss-contents)
+    - [View HSM information in BSS](#view-hsm-information-in-bss)
+    - [View all boot parameters in BSS](#view-all-boot-parameters-in-bss)
+- [Additional resources](#additional-resources)
+
+## Overview
+
+The following information must be uploaded to the
+[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss)
+as a prerequisite to booting a node using iPXE:
 
 - The location of an `initrd` image in the artifact repository
 - The location of a kernel image in the artifact repository
 - Kernel boot parameters
-- The nodes associated with that information, using either host name or node ID (NID)
+- The nodes associated with that information, using either host name or [node ID (NID)](../../glossary.md#node-id-nid)
 
 BSS manages the iPXE boot scripts that coordinate the boot process for nodes, and it enables basic association of boot scripts with nodes.
-The boot scripts supply a booting node with a pointer to the necessary images \(kernel and `initrd`\) and a set of boot-time parameters.
+The boot scripts supply a booting node with a pointer to the necessary images (kernel and `initrd`) and a set of boot-time parameters.
+
+When using BOS to boot nodes, this is done automatically. The information on this page describes how
+an administrator can do this manually, if desired.
 
 ## Prerequisites
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- The [Cray command line interface (CLI)](../../glossary.md#cray-cli-cray) tool is initialized and configured on the system.
   See [Configure the Cray CLI](../configure_cray_cli.md).
-- The Boot Script Service \(BSS\) is running.
+- The Boot Script Service (BSS) is running.
 - An `initrd` image and kernel image for one or more nodes have been uploaded to the artifact repository.
   See [Manage Artifacts with the Cray CLI](../artifact_management/Manage_Artifacts_with_the_Cray_CLI.md).
 
 ## Procedure
 
-Because the parameters that must be specified in the `PUT` command are lengthy, this procedure shows a simple Bash script
-\(not to be confused with iPXE boot scripts\) to enter the boot information into BSS. The first step creates a script that
-can use either NID or host name to identify the nodes with which to associate the boot information.
+> Throughout this procedure, be sure to replace the example values with the actual values for the hosts, boot artifacts,
+> and parameters.
 
-1. Create a Bash script to enter the following boot information into BSS in preparation for booting one or more nodes.
+### 1. Set variables
 
-    - `NCN` = the host name of a non-compute node \(NCN\) that is a Kubernetes master node. This procedure uses `api-gw-service-nmn.local`, the API
-      service name on the Node Management Network \(NMN\). For more information, see [Access to System Management Services](../network/Access_to_System_Management_Services.md).
-    - `KERNEL` = the download URL of the kernel image artifact that was uploaded to S3, which is in the `s3://s3_BUCKET/S3_OBJECT_KEY/kernel` format.
-    - `INITRD` = the download URL of the `initrd` image artifact that was uploaded to S3, which is in the `s3://s3_BUCKET/S3_OBJECT_KEY/initrd` format.
-    - `PARAMS` = the boot kernel parameters.
+Set variables identifying the boot artifacts and parameters.
 
-        **IMPORTANT:** The `PARAMS` line must always include the substring `crashkernel=360M`. This enables node dumps, which are needed to troubleshoot node crashes.
+1. (`ncn-mw#`) Set `KERNEL` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the kernel artifact.
 
-    - `NIDS` = a list of node IDs of the nodes to be booted.
-    - `HOSTS` = a list of strings identifying by host name the nodes to be booted.
-
-    The following script is generic. A script with specific values is below this one.
+    This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/kernel` format.
 
     ```bash
-    #!/bin/bash
-    NCN=api-gw-service-nmn.local
-    KERNEL=s3://S3_BUCKET/S3_OBJECT_KEY/initrd
-    INITRD=s3://S3_BUCKET/S3_OBJECT_KEY/kernel
-    PARAMS="STRING_WITH_BOOT_PARAMETERS crashkernel=360M"
-    #
-    # By NID
-    NIDS=NID1,NID2,NID3
-    cray bss bootparameters create --nids $NIDS --kernel $KERNEL --initrd $INITRD --params $PARAMS
-    #
-    # By host name
-    #HOSTS="STRING_IDENTIFYING_HOST1","STRING_IDENTIFYING_HOST2"
-    #cray bss bootparameters create --hosts $HOSTS --kernel $KERNEL --initrd $INITRD --params $PARAMS
-    ```
-
-    BSS supports a mechanism that allows for a default boot setup, rather than needing to specify boot details for each specific node.
-    The `HOSTS` value should be set to "Default" in order to utilize the default boot setup. This feature is particular useful with larger systems.
-
-    The following script has specific values for the kernel/`initrd` image names, the kernel parameters, and the list of NIDs and hosts.
-
-    ```bash
-    #!/bin/bash
-    NCN=api-gw-service-nmn.local
     KERNEL=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/kernel
-    INITRD=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/initrd
-    PARAMS="console=ttyS0,115200n8 console=tty0 initrd=97b548b9-2ea9-45c9-95ba-dfc77e5522eb root=nfs:$NCN:/var/lib/nfsroot/cmp000001_image rw nofb selinux=0 rd.net.timeout.carrier=20 crashkernel=360M"
-    PARAMS="console=ttyS0,115200n8 console=tty0 initrd=${INITRD##*/} \
-    root=nfs:10.2.0.1:$NFS_IMAGE_ROOT_DIR rw nofb selinux=0 rd.shell crashkernel=360M \
-    ip=dhcp rd.neednet=1 htburl=https://10.2.100.50/apis/hbtd/hmi/v1/heartbeat"
-    #
-    # By NID
-    NIDS=1
-    cray bss bootparameters create --nids $NIDS --kernel $KERNEL --initrd $INITRD --params $PARAMS
-    #
-    # By host name
-    #HOSTS="nid000001-nmn"
-    #cray bss bootparameters create --hosts $HOSTS --kernel $KERNEL --initrd $INITRD --params $PARAMS
     ```
 
-1. (`ncn-mw#`) Run the script to upload the boot information to BSS for the identified nodes.
+1. (`ncn-mw#`) Set `INITRD` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the `initrd` artifact.
+
+    This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/initrd` format.
 
     ```bash
-    chmod +x script.sh && ./script.sh
+    INITRD=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/initrd
     ```
 
-1. (`ncn-mw#`) View the boot script in BSS.
+1. (`ncn-mw#`) Set `ROOTFS` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the `rootfs` artifact.
 
-    This will show the specific boot script that will be passed to a given node when requesting a boot script. This is useful for debugging boot problems and to verify that BSS is configured correctly.
+    This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/rootfs` format.
+
+    ```bash
+    ROOTFS=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/rootfs
+    ```
+
+1. (`ncn-mw#`) Set `ETAG` to the `etag` of the `rootfs` in [S3](../../glossary.md#simple-storage-service-s3).
+
+    ```bash
+    S3_BUCKET_KEY=$(echo "${ROOTFS}" | sed 's#^s3://\([^/]\+\)/\(.*rootfs\)$#\1 \2#')
+    ETAG=$(cray artifacts describe ${S3_BUCKET_KEY} --format json | jq -r '.artifact.ETag' | tr -d '"')
+    ```
+
+1. (`ncn-mw#`) Set `PARAMS` to the boot kernel parameters.
+
+    -*IMPORTANT:** The `PARAMS` line must always include the substring `crashkernel=512M`.
+    This enables node dumps, which are needed to troubleshoot node crashes.
+
+    > For readability, this example shows the variable being set over multiple lines.
+
+    ```bash
+    PARAMS="console=ttyS0,115200 bad_page=panic crashkernel=512M,high "
+    PARAMS+="crashkernel=256M,low intel_pstate=disable numa_balancing=disable oops=panic "
+    PARAMS+="pcie_ports=native rd.retry=10 rd.shell split_lock_detect=off systemd.unified_cgroup_hierarchy=1 "
+    PARAMS+="ip=dhcp quiet spire_join_token=\${SPIRE_JOIN_TOKEN} "
+    PARAMS+="root=sbps-s3:${ROOTFS}:${ETAG}:sbps:v1:iqn.2023-06.csm.iscsi:_sbps-hsn._tcp.fanta.hpc.amslabs.hpecorp.net:300 "
+    PARAMS+="nmd_data=url=${ROOTFS},etag=${ETAG} bos_update_frequency=4h"
+    ```
+
+1. (`ncn-mw#`) Review the variables and verify that the values are correct.
+
+    ```bash
+    echo "KERNEL=${KERNEL}"
+    echo "INITRD=${INITRD}"
+    echo "ROOTFS=${ROOTFS}"
+    echo "ETAG=${ETAG}"
+    echo "PARAMS=${PARAMS}"
+    ```
+
+### 2. Update BSS
+
+> This step requires the variables from [1. Set variables](#1-set-variables).
+
+There are three options for updating BSS:
+
+- [Update BSS by host name](#update-bss-by-host-name)
+- [Update BSS by NID](#update-bss-by-nid)
+- [Update BSS default boot setup](#update-bss-default-boot-setup)
+
+#### Update BSS by host name
+
+1. (`ncn-mw#`) Set `HOSTS` to a comma-separated list of the node component names ([xnames](../../glossary.md#xname))
+   whose BSS entries should be updated.
+
+    ```bash
+    HOSTS=x3000c0s21b1n0,x3000c0s21b2n0
+    ```
+
+1. (`ncn-mw#`) Create the boot parameters in BSS for the selected nodes.
+
+    ```bash
+    cray bss bootparameters create --hosts "${HOSTS}" --kernel "${KERNEL}" --initrd "${INITRD}" --params "${PARAMS}"
+    ```
+
+1. (`ncn-mw#`) Confirm that the information has been uploaded to BSS.
+
+    ```bash
+    cray bss bootparameters list --hosts "${HOSTS}"
+    ```
+
+#### Update BSS by NID
+
+1. (`ncn-mw#`) Set `NIDS` to a comma-separated list of the [node IDs](../../glossary.md#nid) whose BSS entries should be updated.
+
+    ```bash
+    NIDS=1001,1032
+    ```
+
+1. (`ncn-mw#`) Create the boot parameters in BSS for the selected nodes.
+
+    ```bash
+    cray bss bootparameters create --nids "${NIDS}" --kernel "${KERNEL}" --initrd "${INITRD}" --params "${PARAMS}"
+    ```
+
+1. (`ncn-mw#`) Confirm that the information has been uploaded to BSS.
+
+    ```bash
+    cray bss bootparameters list --nids "${NIDS}"
+    ```
+
+#### Update BSS default boot setup
+
+BSS supports a mechanism that allows for a default boot setup, rather than needing to specify boot details for each specific node.
+This feature is particular useful with larger systems. To do this, follow the [Update BSS by host name](#update-bss-by-host-name)
+procedure, setting the `HOSTS` variable to `Default`.
+
+### 3. Next step
+
+Boot information has been added to BSS in preparation for iPXE booting all nodes in the list of host names or NIDs.
+
+As part of power up the nodes in the host name or NID list, the next step is to reboot the nodes.
+
+See also:
+[Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)](Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)
+
+## Additional BSS queries
+
+This section lists other BSS queries that may be useful when booting nodes or debugging boot issues.
+
+- [View a boot script in BSS](#view-a-boot-script-in-bss)
+- [View all BSS contents](#view-all-bss-contents)
+- [View HSM information in BSS](#view-hsm-information-in-bss)
+- [View all boot parameters in BSS](#view-all-boot-parameters-in-bss)
+
+### View a boot script in BSS
+
+This will show the specific boot script that will be passed to a given node when requesting a boot script.
+This is useful for debugging boot problems and to verify that BSS is configured correctly.
+
+- (`ncn-mw#`) View the boot script in BSS using a NID.
 
     ```bash
     cray bss bootscript list --nid NODE_ID
     ```
 
-1. (`ncn-mw#`) Confirm that the information has been uploaded to BSS.
-
-    - If nodes identified by host name:
-
-        ```bash
-        cray bss bootparameters list --hosts HOST_NAME
-        ```
-
-        For example:
-
-        ```bash
-        cray bss bootparameters list --hosts Default
-        ```
-
-    - If nodes identified by NID:
-
-        ```bash
-        cray bss bootparameters list --nids NODE_ID
-        ```
-
-        For example:
-
-        ```bash
-        cray bss bootparameters list --nids 1
-        ```
-
-1. (`ncn-mw#`) View entire contents of BSS, if desired.
+- (`ncn-mw#`) View the boot script in BSS using a host name.
 
     ```bash
-    cray bss dumpstate list
+    cray bss bootscript list --name HOST_NAME
     ```
 
-    To view the information retrieved from the HSM:
+### View all BSS contents
 
-    ```bash
-    cray bss hosts list
-    ```
+(`ncn-mw#`) View the entire contents of BSS.
 
-    To view the view the configured boot parameter information:
+```bash
+cray bss dumpstate list
+```
 
-    ```bash
-    cray bss bootparameters list
-    ```
+### View HSM information in BSS
 
-Boot information has been added to BSS in preparation for iPXE booting all nodes in the list of host names or NIDs.
+(`ncn-mw#`) View the information that BSS retrieved from the
+[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
 
-As part of power up the nodes in the host name or NID list, the next step is to reboot the nodes.
+```bash
+cray bss hosts list
+```
+
+### View all boot parameters in BSS
+
+(`ncn-mw#`) View all boot parameter information in BSS.
+
+```bash
+cray bss bootparameters list
+```
+
+## Additional resources
+
+- [BSS API specification](../../api/bss.md)
+- [Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)](Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)


### PR DESCRIPTION
[CASMCMS-9626](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9626): The latest installment of my documentation improvements for BOS and related areas. In this case, the major additions are descriptions of boot set validation and the BOS server migration job. I also cleaned up the BSS upload procedure, as it was broken as written, and also out of date.

Backports:
1.6: https://github.com/Cray-HPE/docs-csm/pull/6519
1.5: https://github.com/Cray-HPE/docs-csm/pull/6520
1.4: https://github.com/Cray-HPE/docs-csm/pull/6521
1.3: https://github.com/Cray-HPE/docs-csm/pull/6522
1.2: https://github.com/Cray-HPE/docs-csm/pull/6523
1.0: https://github.com/Cray-HPE/docs-csm/pull/6524