### PR TITLE
CASMINST-7542: Linting & adding glossary links

### DIFF
--- a/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
+++ b/operations/boot_orchestration/Upload_Node_Boot_Information_to_Boot_Script_Service_BSS.md
@@ -19,27 +19,27 @@
 ## Overview
 
 The following information must be uploaded to the
-[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss)
+[Boot Script Service (BSS)][bss]
 as a prerequisite to booting a node using iPXE:
 
 - The location of an `initrd` image in the artifact repository
 - The location of a kernel image in the artifact repository
 - Kernel boot parameters
-- The nodes associated with that information, using either host name or [node ID (NID)](../../glossary.md#node-id-nid)
+- The nodes associated with that information, using either host name or [node ID (NID)][nid]
 
-BSS manages the iPXE boot scripts that coordinate the boot process for nodes, and it enables basic association of boot scripts with nodes.
+[BSS][bss] manages the iPXE boot scripts that coordinate the boot process for nodes, and it enables basic association of boot scripts with nodes.
 The boot scripts supply a booting node with a pointer to the necessary images (kernel and `initrd`) and a set of boot-time parameters.
 
-When using BOS to boot nodes, this is done automatically. The information on this page describes how
+When using [BOS][bos] to boot nodes, this is done automatically. The information on this page describes how
 an administrator can do this manually, if desired.
 
 ## Prerequisites
 
-- The [Cray command line interface (CLI)](../../glossary.md#cray-cli-cray) tool is initialized and configured on the system.
-  See [Configure the Cray CLI](../configure_cray_cli.md).
-- The Boot Script Service (BSS) is running.
+- The [Cray command line interface (CLI)][cli] tool is initialized and configured on the system.
+    - See [Configure the Cray CLI][config-cli].
+- The [Boot Script Service (BSS)][bss] is running.
 - An `initrd` image and kernel image for one or more nodes have been uploaded to the artifact repository.
-  See [Manage Artifacts with the Cray CLI](../artifact_management/Manage_Artifacts_with_the_Cray_CLI.md).
+    - See [Manage Artifacts with the Cray CLI](../artifact_management/Manage_Artifacts_with_the_Cray_CLI.md).
 
 ## Procedure
 
@@ -50,7 +50,7 @@ an administrator can do this manually, if desired.
 
 Set variables identifying the boot artifacts and parameters.
 
-1. (`ncn-mw#`) Set `KERNEL` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the kernel artifact.
+1. (`ncn-mw#`) Set `KERNEL` to the [S3][s3] download URL of the kernel artifact.
 
     This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/kernel` format.
 
@@ -58,7 +58,7 @@ Set variables identifying the boot artifacts and parameters.
     KERNEL=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/kernel
     ```
 
-1. (`ncn-mw#`) Set `INITRD` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the `initrd` artifact.
+1. (`ncn-mw#`) Set `INITRD` to the [S3][s3] download URL of the `initrd` artifact.
 
     This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/initrd` format.
 
@@ -66,7 +66,7 @@ Set variables identifying the boot artifacts and parameters.
     INITRD=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/initrd
     ```
 
-1. (`ncn-mw#`) Set `ROOTFS` to the [S3](../../glossary.md#simple-storage-service-s3) download URL of the `rootfs` artifact.
+1. (`ncn-mw#`) Set `ROOTFS` to the [S3][s3] download URL of the `rootfs` artifact.
 
     This should be in the `s3://s3_BUCKET/S3_OBJECT_KEY/rootfs` format.
 
@@ -74,7 +74,7 @@ Set variables identifying the boot artifacts and parameters.
     ROOTFS=s3://boot-images/97b548b9-2ea9-45c9-95ba-dfc77e5522eb/rootfs
     ```
 
-1. (`ncn-mw#`) Set `ETAG` to the `etag` of the `rootfs` in [S3](../../glossary.md#simple-storage-service-s3).
+1. (`ncn-mw#`) Set `ETAG` to the `etag` of the `rootfs` in [S3][s3].
 
     ```bash
     S3_BUCKET_KEY=$(echo "${ROOTFS}" | sed 's#^s3://\([^/]\+\)/\(.*rootfs\)$#\1 \2#')
@@ -111,7 +111,7 @@ Set variables identifying the boot artifacts and parameters.
 
 > This step requires the variables from [1. Set variables](#1-set-variables).
 
-There are three options for updating BSS:
+There are three options for updating [BSS][bss]:
 
 - [Update BSS by host name](#update-bss-by-host-name)
 - [Update BSS by NID](#update-bss-by-nid)
@@ -119,20 +119,20 @@ There are three options for updating BSS:
 
 #### Update BSS by host name
 
-1. (`ncn-mw#`) Set `HOSTS` to a comma-separated list of the node component names ([xnames](../../glossary.md#xname))
-   whose BSS entries should be updated.
+1. (`ncn-mw#`) Set `HOSTS` to a comma-separated list of the node component names ([xnames][xname])
+   whose [BSS][bss] entries should be updated.
 
     ```bash
     HOSTS=x3000c0s21b1n0,x3000c0s21b2n0
     ```
 
-1. (`ncn-mw#`) Create the boot parameters in BSS for the selected nodes.
+1. (`ncn-mw#`) Create the boot parameters in [BSS][bss] for the selected nodes.
 
     ```bash
     cray bss bootparameters create --hosts "${HOSTS}" --kernel "${KERNEL}" --initrd "${INITRD}" --params "${PARAMS}"
     ```
 
-1. (`ncn-mw#`) Confirm that the information has been uploaded to BSS.
+1. (`ncn-mw#`) Confirm that the information has been uploaded to [BSS][bss].
 
     ```bash
     cray bss bootparameters list --hosts "${HOSTS}"
@@ -140,19 +140,19 @@ There are three options for updating BSS:
 
 #### Update BSS by NID
 
-1. (`ncn-mw#`) Set `NIDS` to a comma-separated list of the [node IDs](../../glossary.md#node-id-nid) whose BSS entries should be updated.
+1. (`ncn-mw#`) Set `NIDS` to a comma-separated list of the [node IDs][nid] whose [BSS][bss] entries should be updated.
 
     ```bash
     NIDS=1001,1032
     ```
 
-1. (`ncn-mw#`) Create the boot parameters in BSS for the selected nodes.
+1. (`ncn-mw#`) Create the boot parameters in [BSS][bss] for the selected nodes.
 
     ```bash
     cray bss bootparameters create --nids "${NIDS}" --kernel "${KERNEL}" --initrd "${INITRD}" --params "${PARAMS}"
     ```
 
-1. (`ncn-mw#`) Confirm that the information has been uploaded to BSS.
+1. (`ncn-mw#`) Confirm that the information has been uploaded to [BSS][bss].
 
     ```bash
     cray bss bootparameters list --nids "${NIDS}"
@@ -160,22 +160,22 @@ There are three options for updating BSS:
 
 #### Update BSS default boot setup
 
-BSS supports a mechanism that allows for a default boot setup, rather than needing to specify boot details for each specific node.
+[BSS][bss] supports a mechanism that allows for a default boot setup, rather than needing to specify boot details for each specific node.
 This feature is particularly useful with larger systems. To do this, follow the [Update BSS by host name](#update-bss-by-host-name)
 procedure, setting the `HOSTS` variable to `Default`.
 
 ### 3. Next step
 
-Boot information has been added to BSS in preparation for iPXE booting all nodes in the list of host names or NIDs.
+Boot information has been added to [BSS][bss] in preparation for iPXE booting all nodes in the list of host names or [NIDs][nid].
 
-As part of power up the nodes in the host name or NID list, the next step is to reboot the nodes.
+As part of power up the nodes in the host name or [NID][nid] list, the next step is to reboot the nodes.
 
 See also:
-[Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)](Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)
+[Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)][troubleshoot-bss-node-boot]
 
 ## Additional BSS queries
 
-This section lists other BSS queries that may be useful when booting nodes or debugging boot issues.
+This section lists other [BSS][bss] queries that may be useful when booting nodes or debugging boot issues.
 
 - [View a boot script in BSS](#view-a-boot-script-in-bss)
 - [View all BSS contents](#view-all-bss-contents)
@@ -185,15 +185,15 @@ This section lists other BSS queries that may be useful when booting nodes or de
 ### View a boot script in BSS
 
 This will show the specific boot script that will be passed to a given node when requesting a boot script.
-This is useful for debugging boot problems and to verify that BSS is configured correctly.
+This is useful for debugging boot problems and to verify that [BSS][bss] is configured correctly.
 
-- (`ncn-mw#`) View the boot script in BSS using a NID.
+- (`ncn-mw#`) View the boot script in [BSS][bss] using a [NID][nid].
 
     ```bash
     cray bss bootscript list --nid NODE_ID
     ```
 
-- (`ncn-mw#`) View the boot script in BSS using a host name.
+- (`ncn-mw#`) View the boot script in [BSS][bss] using a host name.
 
     ```bash
     cray bss bootscript list --name HOST_NAME
@@ -201,7 +201,7 @@ This is useful for debugging boot problems and to verify that BSS is configured 
 
 ### View all BSS contents
 
-(`ncn-mw#`) View the entire contents of BSS.
+(`ncn-mw#`) View the entire contents of [BSS][bss].
 
 ```bash
 cray bss dumpstate list
@@ -209,8 +209,8 @@ cray bss dumpstate list
 
 ### View HSM information in BSS
 
-(`ncn-mw#`) View the information that BSS retrieved from the
-[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
+(`ncn-mw#`) View the information that [BSS][bss] retrieved from the
+[Hardware State Manager (HSM)][hsm].
 
 ```bash
 cray bss hosts list
@@ -218,7 +218,7 @@ cray bss hosts list
 
 ### View all boot parameters in BSS
 
-(`ncn-mw#`) View all boot parameter information in BSS.
+(`ncn-mw#`) View all boot parameter information in [BSS][bss].
 
 ```bash
 cray bss bootparameters list
@@ -227,4 +227,74 @@ cray bss bootparameters list
 ## Additional resources
 
 - [BSS API specification](../../api/bss.md)
-- [Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)](Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)
+- [Troubleshoot Compute Node Boot Issues Related to the Boot Script Service (BSS)][troubleshoot-bss-node-boot]
+
+<!--- Define the reference-style Markdown links used to make the page easier to edit -->
+
+[troubleshoot-bss-node-boot]: Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md
+
+<!-- markdownlint-disable MD053 -->
+<!---
+    For references that are likely to appear on a lot of pages (glossary references, for example), 
+    we allow definitions for entries that are not used on the page, as a convenience.
+-->
+
+<!-- non-glossary common links -->
+
+[config-cli]: ../configure_cray_cli.md
+[check-latest-docs]: ../../update_product_stream/README.md#check-for-latest-documentation
+
+<!-- glossary entries -->
+
+[aee]: ../../glossary.md#ansible-execution-environment-aee
+[an]: ../../glossary.md#application-node-an
+[ara]: ../../glossary.md#ara-records-ansible-ara
+[bmc]: ../../glossary.md#baseboard-management-controller-bmc
+[bos]: ../../glossary.md#boot-orchestration-service-bos
+[bss]: ../../glossary.md#boot-script-service-bss
+[can]: ../../glossary.md#customer-access-network-can
+[canu]: ../../glossary.md#csm-automatic-network-utility-canu
+[capmc]: ../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc
+[cdu]: ../../glossary.md#coolant-distribution-unit-cdu
+[cec]: ../../glossary.md#cabinet-environmental-controller-cec
+[cfs]: ../../glossary.md#configuration-framework-service-cfs
+[chn]: ../../glossary.md#customer-high-speed-network-chn
+[cli]: ../../glossary.md#cray-cli-cray
+[cn]: ../../glossary.md#compute-node-cn
+[csi]: ../../glossary.md#cray-site-init-csi
+[fas]: ../../glossary.md#firmware-action-service-fas
+[hbtd]: ../../glossary.md#heartbeat-tracker-daemon-hbtd
+[hmn]: ../../glossary.md#hardware-management-network-hmn
+[hsm]: ../../glossary.md#hardware-state-manager-hsm
+[hsn]: ../../glossary.md#high-speed-network-hsn
+[ims]: ../../glossary.md#image-management-service-ims
+[iuf]: ../../glossary.md#install-and-upgrade-framework-iuf
+[meds]: ../../glossary.md#mountain-endpoint-discovery-service-meds
+[mgmt-ncns]: ../../glossary.md#management-nodes
+[mountain]: ../../glossary.md#mountain-cabinet
+[ncn]: ../../glossary.md#non-compute-node-ncn
+[nid]: ../../glossary.md#node-id-nid
+[nmn]: ../../glossary.md#node-management-network-nmn
+[pcs]: ../../glossary.md#power-control-service-pcs
+[pdu]: ../../glossary.md#power-distribution-unit-pdu
+[pit]: ../../glossary.md#pre-install-toolkit-pit
+[river]: ../../glossary.md#river-cabinet
+[rts]: ../../glossary.md#redfish-translation-service-rts
+[s3]: ../../glossary.md#simple-storage-service-s3
+[sat]: ../../glossary.md#system-admin-toolkit-sat
+[sbps]: ../../glossary.md#scalable-boot-projection-service-sbps
+[scsd]: ../../glossary.md#system-configuration-service-scsd
+[shcd]: ../../glossary.md#shasta-cabling-diagram-shcd
+[slingshot]: ../../glossary.md#slingshot
+[sls]: ../../glossary.md#system-layout-service-sls
+[sma]: ../../glossary.md#system-monitoring-application-sma
+[smd]: ../../glossary.md#hardware-state-manager-smd
+[sops]: ../../glossary.md#secrets-operations-sops
+[tapms]: ../../glossary.md#tenant-and-partition-management-system-tapms
+[uan]: ../../glossary.md#user-access-node-uan
+[uss]: ../../glossary.md#user-services-software-uss
+[vcs]: ../../glossary.md#version-control-service-vcs
+[vnid]: ../../glossary.md#virtual-network-identifier-daemon-vnid
+[xname]: ../../glossary.md#xname
+
+<!-- markdownlint-restore -->

--- a/operations/iuf/workflows/managed_rollout.md
+++ b/operations/iuf/workflows/managed_rollout.md
@@ -1,170 +1,208 @@
 # Managed Rollout
 
-This section updates the software running on managed compute and application (UAN, etc.) nodes.
+This section updates the software running on managed [compute][cn] and [application][an] ([UAN][uan], etc.) nodes.
 
-- [1. Update managed host firmware (FAS)](#1-update-managed-host-firmware-fas)
-- [2. Execute the IUF `managed-nodes-rollout` stage](#2-execute-the-iuf-managed-nodes-rollout-stage)
-    - [2.1 LNet router nodes and gateway nodes](#21-lnet-router-nodes-and-gateway-nodes)
-    - [2.2 Compute nodes](#22-compute-nodes)
-    - [2.3 Application nodes](#23-application-nodes)
-- [3. Update managed host Slingshot NIC firmware](#3-update-managed-host-slingshot-nic-firmware)
-- [4. Execute the IUF `post-install-check` stage](#4-execute-the-iuf-post-install-check-stage)
-- [5. Next steps](#5-next-steps)
+1. [Update managed host firmware (FAS)](#1-update-managed-host-firmware-fas)
+1. [Execute the IUF `managed-nodes-rollout` stage](#2-execute-the-iuf-managed-nodes-rollout-stage)
+    1. [LNet router nodes and gateway nodes](#21-lnet-router-nodes-and-gateway-nodes)
+    1. [Compute nodes](#22-compute-nodes)
+        1. [Preparation](#221-preparation)
+        1. [Reboot compute nodes](#222-reboot-compute-nodes)
+            - [Reboot compute nodes with PBS](#reboot-compute-nodes-with-pbs)
+            - [Reboot compute nodes with Slurm](#reboot-compute-nodes-with-slurm)
+        1. [Compute reboot complete](#223-compute-reboot-complete)
+    1. [Application nodes](#23-application-nodes)
+1. [Update managed host Slingshot NIC firmware](#3-update-managed-host-slingshot-nic-firmware)
+1. [Execute the IUF `post-install-check` stage](#4-execute-the-iuf-post-install-check-stage)
+1. [Next steps](#5-next-steps)
 
 ## 1. Update managed host firmware (FAS)
 
 Refer to [Update Firmware with FAS](../../firmware/Update_Firmware_with_FAS.md) for details on how to upgrade the
-firmware on managed nodes.
+firmware on managed nodes using [FAS][fas].
 
 Once this step has completed:
 
-- Host firmware has been updated on managed nodes
+- Host firmware has been updated on managed nodes.
 
 ## 2. Execute the IUF `managed-nodes-rollout` stage
 
-This section describes how to update software on managed nodes. It describes how to test a new image and CFS
-configuration on a single "canary node" first before rolling it out to the other managed nodes. Modify the procedure as
-necessary to accommodate site preferences for rebooting managed nodes. If the system has heterogeneous nodes, it may be
-desirable to repeat this process with multiple canary nodes, one for each distinct node configuration. The images, CFS
-configurations, and BOS session templates used are created by the `prepare-images` stage; see
-the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation for details on how
-to query the images and CFS configurations.
+This section describes how to update software on managed nodes. It describes how to test a new [IMS][ims] image
+and [CFS][cfs] [configuration][cfs-configs] on a single "canary node" first before rolling it out to the other
+managed nodes. Modify the procedure as necessary to accommodate site preferences for rebooting managed nodes.
+If the system has heterogeneous nodes, it may be desirable to repeat this process with multiple canary nodes,
+one for each distinct node configuration. The [IMS][ims] images, [CFS][cfs] [configurations][cfs-configs], and
+[BOS][bos] [session templates][bos-templates] used are created by the `prepare-images` stage; see the
+[`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation for details on
+how to query the [IMS][ims] images and [CFS][cfs] [configurations][cfs-configs].
 
-**`NOTE`** Additional arguments are available to control the behavior of the `managed-nodes-rollout` stage. See
-the [`managed-nodes-rollout` stage documentation](../stages/managed_nodes_rollout.md) for details and adjust the
+**NOTE** Additional arguments are available to control the behavior of the `managed-nodes-rollout` stage. See
+the [`managed-nodes-rollout` stage documentation][managed-nodes-rollout] for details and adjust the
 examples below if necessary.
 
 ### 2.1 LNet router nodes and gateway nodes
 
-LNet router nodes or gateway nodes should be upgraded before rebooting compute nodes to new images and CFS
-configurations. Since LNet routers and gateway nodes are examples of application nodes, the instructions in this section
-are the same as in [2.3 Application nodes](#23-application-nodes).
+LNet router nodes or gateway nodes should be upgraded before rebooting compute nodes to new [IMS][ims] images and
+[CFS][cfs] [configurations][cfs-configs]. Because LNet routers and gateway nodes are examples of [application nodes][an],
+the instructions in this section are the same as in [2.3 Application nodes](#23-application-nodes).
 
-Since LNet router nodes and gateway nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage
-cannot reboot them in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage can
-reboot LNet router and gateway nodes using the `-mrs reboot` argument, but an immediate reboot of the nodes is likely to
-be disruptive to users and overall system health and is not recommended. Administrators should determine the best
-approach for rebooting LNet router and gateway nodes outside of IUF that aligns with site preferences.
+Because LNet router nodes and gateway nodes are not managed by workload managers, the [IUF][iuf]
+`managed-nodes-rollout` stage cannot reboot them in a controlled manner via the `-mrs stage` argument. The
+[IUF][iuf] `managed-nodes-rollout` stage can reboot LNet router and gateway nodes using the `-mrs reboot` argument;
+however, this is not recommended, because an immediate reboot of the nodes is likely to be disruptive to users and
+overall system health. Administrators should determine the best approach for rebooting LNet router and gateway nodes
+outside of [IUF][iuf] that aligns with site preferences.
 
 Once this step has completed:
 
-- Managed LNet router and gateway nodes (if any) have been rebooted to the images and CFS configurations created in
-  previous steps of this workflow
-- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures
-  were used to perform the reboots
+- Managed LNet router and gateway nodes (if any) have been rebooted to the [IMS][ims] images and [CFS][cfs]
+  [configurations][cfs-configs] created in previous steps of this workflow.
+- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if [IUF][iuf]
+  `managed-nodes-rollout` procedures were used to perform the reboots.
 
 ### 2.2 Compute nodes
 
+#### 2.2.1 Preparation
+
 1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special
-   actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
+   actions that need to be performed outside of [IUF][iuf] for a stage. The "IUF Stage Documentation Per Product"
    section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table
    that summarizes which product documents contain information or actions for the `managed-nodes-rollout` stage. Refer
    to that table and any corresponding product documents before continuing to the next step.
 
-1. Before booting computes, consider if SMA `OpenSearch` needs to be tuned.
-Refer to the "Configure `OpenSearch`" section in the _HPE Cray EX System Monitoring Application Administration Guide_ for instructions on tuning `OpenSearch`.
+1. Before booting computes, consider if [SMA][sma] `OpenSearch` needs to be tuned.
+   Refer to the "Configure `OpenSearch`" section in the _HPE Cray EX System Monitoring Application Administration Guide_
+   for instructions on tuning `OpenSearch`.
 
-1. Invoke `iuf run` with `-r` to execute the [`managed-nodes-rollout`](../stages/managed_nodes_rollout.md) stage on a
-   single node to ensure the node reboots successfully with the desired image and CFS configuration. This node is
-   referred to as the "canary node" in the remainder of this section. Use `--limit-managed-rollout` to target the canary
-   node only and use `-mrs reboot` to reboot the canary node immediately.
+1. Invoke `iuf run` with `-r` to execute the [`managed-nodes-rollout`][managed-nodes-rollout] stage on a
+   single node to ensure the node reboots successfully with the desired [IMS][ims] image and [CFS][cfs]
+   [configuration][cfs-configs]. This node is referred to as the "canary node" in the remainder of this section. Use
+   `--limit-managed-rollout` to target the canary node only and use `-mrs reboot` to reboot the canary node immediately.
 
-   (`ncn-m001#`) Execute the `managed-nodes-rollout` stage with a single xname, rebooting the canary node immediately.
-   Replace the example value of `${XNAME}` with the xname of the canary node.
+   (`ncn-m001#`) Execute the `managed-nodes-rollout` stage with a single [xname][xname], rebooting the canary node
+   immediately. Replace the example value of `${XNAME}` with the [xname][xname] of the canary node.
 
    ```bash
    XNAME=x3000c0s29b1n0
    iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout --limit-managed-rollout "${XNAME}" -mrs reboot
    ```
 
-1. Verify the canary node booted successfully with the desired image and CFS configuration.
+1. Verify that the canary node booted successfully with the desired [IMS][ims] image and [CFS][cfs] [configuration][cfs-configs].
 
-1. Invoke `iuf run` with `-r` to execute the [managed-nodes-rollout](../stages/managed_nodes_rollout.md) stage on all
-   nodes. This will stage data to BOS and allow the workload manager to reboot the nodes when it is ready to do so. The
-   workload manager must be configured to tell BOS to reboot nodes using this staged data.
+#### 2.2.2 Reboot compute nodes
 
-   - If PBS is the workload manager:
+If PBS is the workload manager, then proceed to [Reboot compute nodes with PBS](#reboot-compute-nodes-with-pbs).
+If Slurm is the workload manager, then proceed to [Reboot compute nodes with Slurm](#reboot-compute-nodes-with-slurm).
 
-     1. Create a maintenance reservation in PBS. For more information on maintenance reservations, see the
-        [_PBS Professional Administrator's Guide_](https://community.altair.com/community?id=altair_product_documentation&spa=1&filter=language%3Denglish%5Eproduct%3D20069018db0348102af07608f4961995%5Eguide_type%3DAdministration&p=1&d=asc).
+##### Reboot compute nodes with PBS
 
-     1. (`ncn-m001#`) After the reservation has started, execute the `managed-nodes-rollout` stage with the `-mrs reboot` option to
-        immediately reboot all compute nodes.
+1. Create a maintenance reservation in PBS. For more information on maintenance reservations, see the
+   [_PBS Professional Administrator's Guide_](https://community.altair.com/community?id=altair_product_documentation&spa=1&filter=language%3Denglish%5Eproduct%3D20069018db0348102af07608f4961995%5Eguide_type%3DAdministration&p=1&d=asc).
 
-        ```bash
-        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout -mrs reboot
-        ```
+1. (`ncn-m001#`) After the reservation has started, execute the `managed-nodes-rollout` stage with the `-mrs reboot`
+   option to immediately reboot all compute nodes.
 
-   - If Slurm is the workload manager:
+   ```bash
+   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout -mrs reboot
+   ```
 
-     1. Follow the instructions in the section
-        [Using staged sessions with Slurm](../../boot_orchestration/Rolling_Upgrades.md#using-staged-sessions-with-slurm)
-        of the [Rolling Upgrades using BOS](../../boot_orchestration/Rolling_Upgrades.md) documentation. These instructions
-        describe two parameters that must be set in the `slurm.conf` file. Return to these instructions after setting them.
+1. Proceed to [2.2.3 Compute reboot complete](#223-compute-reboot-complete).
 
-     1. (`ncn-m001#`) Execute the `managed-nodes-rollout` stage. If an immediate reboot of compute nodes is desired instead,
-        add `-mrs reboot` to the `iuf run` command.
+##### Reboot compute nodes with Slurm
 
-        ```bash
-        iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout
-        ```
+1. Configure Slurm to [stage data][bos-stage] in [BOS][bos].
 
-        **NOTE:** If the `-mrs reboot` option is used with Slurm, skip the following step.
+   Follow the instructions in the section
+   [Using staged sessions with Slurm](../../boot_orchestration/Rolling_Upgrades.md#using-staged-sessions-with-slurm)
+   of the [Rolling Upgrades using BOS](../../boot_orchestration/Rolling_Upgrades.md) documentation. These instructions
+   describe two parameters that must be set in the `slurm.conf` file. Return to these instructions after setting them.
 
-     1. Tell Slurm to reboot the compute nodes. This only works for compute nodes, and they must be specified
-        explicitly.
+1. (`ncn-m001#`) Execute the `managed-nodes-rollout` stage.
 
-        - Use this command to list all of the compute nodes in the system using their Node Identities (NIDs). First, enter the
-          SAT bash shell using `sat bash`.
+   This will not reboot the nodes immediately; instead, it will [stage data][bos-stage] to [BOS][bos] and allow the
+   workload manager to reboot the nodes when it is ready to do so.
 
-          (`ncn-m001#`) Enter the sat container and fetch the compute list
+   If an immediate reboot of [compute nodes][cn] is desired instead, add `-mrs reboot` to the `iuf run` command.
+   **NOTE:** If the `-mrs reboot` option is used with Slurm, then skip the remaining steps in this section and proceed
+   directly to [2.2.3 Compute reboot complete](#223-compute-reboot-complete).
 
-          ```bash
-          sat bash
-          (ef637ae8a8b5) sat-container:/sat/share # sat status --fields xname --filter role=compute --no-headings --no-borders | xargs sat xname2nid
-          nid[000001-000004]
-          (ef637ae8a8b5) sat-container:/sat/share # exit
-          logout
-          ```
+   ```bash
+   iuf -a "${ACTIVITY_NAME}" -m "${MEDIA_DIR}" run -r managed-nodes-rollout
+   ```
 
-        - Now, tell the workload manager to reboot the compute nodes. Paste the output from the previous step as the last
-          argument.
+1. List all of the compute nodes in the system by their [node IDs (NIDs)][nid].
 
-          (`compute#`) A sample reboot command to reboot NIDs 1 through 4.
+   > **NOTE:** If the `-mrs reboot` option was used with Slurm in the previous step, then skip the remaining steps in
+   > this section and proceed directly to [2.2.3 Compute reboot complete](#223-compute-reboot-complete).
 
-          ```bash
-          scontrol reboot nextstate=Resume Reason="IUF Managed Nodes Rollout" nid[000001-000004]
-          ```
+   1. (`ncn-m001#`) Enter the [SAT][sat] container.
+
+      ```bash
+      sat bash
+      ```
+
+   1. (`sat-container#`) Fetch the [compute][cn] list:
+
+      ```bash
+      sat status --fields xname --filter role=compute --no-headings --no-borders | xargs sat xname2nid
+      ```
+
+      Example output:
+
+      ```text
+      nid[000001-000004]
+      ```
+
+   1. (`sat-container#`) Exit the SAT container.
+
+      ```bash
+      exit
+      ```
+
+1. Tell Slurm to reboot the [compute nodes][cn].
+
+    This only works for compute nodes, and they must be specified explicitly.
+    Use the [compute][cn] list output from the previous step as the last argument.
+
+    (`compute#`) A sample reboot command to reboot [NIDs][nid] 1 through 4.
+
+    ```bash
+    scontrol reboot nextstate=Resume Reason="IUF Managed Nodes Rollout" nid[000001-000004]
+    ```
+
+1. Proceed to [2.2.3 Compute reboot complete](#223-compute-reboot-complete).
+
+#### 2.2.3 Compute reboot complete
 
 Once this step has completed:
 
-- Managed compute nodes have been rebooted to the images and CFS configurations created in previous steps of this
-  workflow
-- Per-stage product hooks have executed for the `managed-nodes-rollout` stage
+- Managed [compute nodes][cn] have been rebooted to the [IMS][ims] images and [CFS][cfs]
+ [configurations][cfs-configs] created in previous steps of this workflow.
+- Per-stage product hooks have executed for the `managed-nodes-rollout` stage.
 
 ### 2.3 Application nodes
 
-**`NOTE`** If LNet router or gateway nodes were upgraded in
+**NOTE** If LNet router or gateway nodes were upgraded in
 the [2.1 LNet router nodes and gateway nodes](#21-lnet-router-nodes-and-gateway-nodes) section, there is no need to
-upgrade them again in this section. Follow the instructions in this section to upgrade any remaining applications (UANs,
-etc.) that have not been upgraded yet.
+upgrade them again in this section. Follow the instructions in this section to upgrade any remaining
+[application nodes][an] ([UANs][uan], etc.) that have not been upgraded yet.
 
-Since application nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage cannot reboot them
-in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage can reboot application nodes
-using the `-mrs reboot` argument, but an immediate reboot of application nodes is likely to be disruptive to users and
-overall system health and is not recommended. Administrators should determine the best approach for rebooting
-application nodes outside of IUF that aligns with site preferences.
+Because [application nodes][an] are not managed by workload managers, the [IUF][iuf] `managed-nodes-rollout` stage
+cannot reboot them in a controlled manner via the `-mrs stage` argument. The [IUF][iuf] `managed-nodes-rollout` stage
+can reboot [application nodes][an] using the `-mrs reboot` argument; however, this is not recommended, because an
+immediate reboot of the nodes is likely to be disruptive to users and overall system health. Administrators should
+determine the best approach for rebooting [application nodes][an] outside of [IUF][iuf] that aligns with site preferences.
 
 Once this step has completed:
 
-- Managed application (UAN, etc.) nodes have been rebooted to the images and CFS configurations created in previous
-  steps of this workflow
-- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures
-  were used to perform the reboots
+- Managed [application nodes][an] ([UAN][uan], etc.) have been rebooted to the [IMS][ims] images and [CFS][cfs]
+  [configurations][cfs-configs] created in previous steps of this workflow.
+- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if [IUF][iuf] `managed-nodes-rollout`
+  procedures were used to perform the reboots.
 
 ## 3. Update managed host Slingshot NIC firmware
 
-If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of
+If new [Slingshot][slingshot] NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of
 the _HPE Slingshot Installation Guide for Bare Metal_ for details on how to update NIC firmware on managed nodes.
 
 Reboot the managed nodes for which Slingshot NIC firmware has been updated.
@@ -173,12 +211,12 @@ managed nodes that aligns with site preferences.
 
 Once this step has completed:
 
-- Slingshot NIC firmware has been updated on managed nodes
+- Slingshot NIC firmware has been updated on managed nodes.
 
 ## 4. Execute the IUF `post-install-check` stage
 
 1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special
-   actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
+   actions that need to be performed outside of [IUF][iuf] for a stage. The "IUF Stage Documentation Per Product"
    section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table
    that summarizes which product documents contain information or actions for the `post-install-check` stage. Refer to
    that table and any corresponding product documents before continuing to the next step.
@@ -194,7 +232,7 @@ Once this step has completed:
 Once this step has completed:
 
 - Per-stage product hooks have executed for the `post-install-check` stage to verify product software is executing as
-  expected
+  expected.
 
 ## 5. Next steps
 
@@ -202,6 +240,79 @@ Once this step has completed:
   [Install or upgrade additional products with IUF](install_or_upgrade_additional_products_with_iuf.md)
   workflow to continue the install or upgrade.
 
-- If performing an upgrade that includes upgrading CSM and additional products with IUF,
+- If performing an upgrade that includes upgrading CSM and additional products with [IUF][iuf],
   return to the [Upgrade CSM and additional products with IUF](upgrade_csm_and_additional_products_with_iuf.md)
   workflow to continue the upgrade.
+
+<!--- Define the reference-style Markdown links used to make the page easier to edit -->
+
+[bos-stage]: ../../boot_orchestration/Stage_Changes_with_BOS.md
+[bos-templates]: ../../boot_orchestration/Session_Templates.md
+[cfs-configs]: ../../configuration_management/CFS_Configurations.md
+[managed-nodes-rollout]: ../stages/managed_nodes_rollout.md
+
+<!-- markdownlint-disable MD053 -->
+<!---
+    For references that are likely to appear on a lot of pages (glossary references, for example), 
+    we allow definitions for entries that are not used on the page, as a convenience.
+-->
+
+<!-- non-glossary common links -->
+
+[config-cli]: ../../configure_cray_cli.md
+[check-latest-docs]: ../../../update_product_stream/README.md#check-for-latest-documentation
+
+<!-- glossary entries -->
+
+[aee]: ../../../glossary.md#ansible-execution-environment-aee
+[an]: ../../../glossary.md#application-node-an
+[ara]: ../../../glossary.md#ara-records-ansible-ara
+[bmc]: ../../../glossary.md#baseboard-management-controller-bmc
+[bos]: ../../../glossary.md#boot-orchestration-service-bos
+[bss]: ../../../glossary.md#boot-script-service-bss
+[can]: ../../../glossary.md#customer-access-network-can
+[canu]: ../../../glossary.md#csm-automatic-network-utility-canu
+[capmc]: ../../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc
+[cdu]: ../../../glossary.md#coolant-distribution-unit-cdu
+[cec]: ../../../glossary.md#cabinet-environmental-controller-cec
+[cfs]: ../../../glossary.md#configuration-framework-service-cfs
+[chn]: ../../../glossary.md#customer-high-speed-network-chn
+[cli]: ../../../glossary.md#cray-cli-cray
+[cn]: ../../../glossary.md#compute-node-cn
+[csi]: ../../../glossary.md#cray-site-init-csi
+[fas]: ../../../glossary.md#firmware-action-service-fas
+[hbtd]: ../../../glossary.md#heartbeat-tracker-daemon-hbtd
+[hmn]: ../../../glossary.md#hardware-management-network-hmn
+[hsm]: ../../../glossary.md#hardware-state-manager-hsm
+[hsn]: ../../../glossary.md#high-speed-network-hsn
+[ims]: ../../../glossary.md#image-management-service-ims
+[iuf]: ../../../glossary.md#install-and-upgrade-framework-iuf
+[meds]: ../../../glossary.md#mountain-endpoint-discovery-service-meds
+[mgmt-ncns]: ../../../glossary.md#management-nodes
+[mountain]: ../../../glossary.md#mountain-cabinet
+[ncn]: ../../../glossary.md#non-compute-node-ncn
+[nid]: ../../../glossary.md#node-id-nid
+[nmn]: ../../../glossary.md#node-management-network-nmn
+[pcs]: ../../../glossary.md#power-control-service-pcs
+[pdu]: ../../../glossary.md#power-distribution-unit-pdu
+[pit]: ../../../glossary.md#pre-install-toolkit-pit
+[river]: ../../../glossary.md#river-cabinet
+[rts]: ../../../glossary.md#redfish-translation-service-rts
+[s3]: ../../../glossary.md#simple-storage-service-s3
+[sat]: ../../../glossary.md#system-admin-toolkit-sat
+[sbps]: ../../../glossary.md#scalable-boot-projection-service-sbps
+[scsd]: ../../../glossary.md#system-configuration-service-scsd
+[shcd]: ../../../glossary.md#shasta-cabling-diagram-shcd
+[slingshot]: ../../../glossary.md#slingshot
+[sls]: ../../../glossary.md#system-layout-service-sls
+[sma]: ../../../glossary.md#system-monitoring-application-sma
+[smd]: ../../../glossary.md#hardware-state-manager-smd
+[sops]: ../../../glossary.md#secrets-operations-sops
+[tapms]: ../../../glossary.md#tenant-and-partition-management-system-tapms
+[uan]: ../../../glossary.md#user-access-node-uan
+[uss]: ../../../glossary.md#user-services-software-uss
+[vcs]: ../../../glossary.md#version-control-service-vcs
+[vnid]: ../../../glossary.md#virtual-network-identifier-daemon-vnid
+[xname]: ../../../glossary.md#xname
+
+<!-- markdownlint-restore -->

--- a/operations/system_admin_toolkit/about_sat/SAT_Command_Overview.md
+++ b/operations/system_admin_toolkit/about_sat/SAT_Command_Overview.md
@@ -3,18 +3,18 @@
 The `sat` command-line utility is organized into multiple subcommands that
 perform different administrative tasks. Most `sat` subcommands depend on services
 or components from other products in the HPE Cray EX software stack. For more
-information, see [SAT Dependencies](SAT_Dependencies.md).
+information, see [SAT Dependencies][sat-deps].
 
 While some `sat` subcommands use the Kubernetes API, others require another form
 of authentication in order to function. For example, commands that make requests
 through the API gateway to the HPE Cray EX services must first authenticate to the
 API gateway. A handful of `sat` commands require S3 to be configured in order to
-function. To use the SAT S3 bucket, the system administrator must generate both
+function. To use the [SAT][sat] [S3][s3] bucket, the system administrator must generate both
 the S3 access key and secret keys before writing them to a local file. This must
 be done on every Kubernetes control plane node where SAT commands are run. To
-configure SAT authentication and S3 credentials, see
-[Authenticate SAT Commands](../configuration/Authenticate_SAT_Commands.md) and
-[Generate SAT S3 Credentials](../configuration/Generate_SAT_S3_Credentials.md).
+configure [SAT][sat] authentication and [S3][s3] credentials, see
+[Authenticate SAT Commands][auth-sat] and
+[Generate SAT S3 Credentials][gen-sat-s3-creds].
 
 The following table summarizes the various subcommands provided by the `sat`
 CLI. It includes information about the types of authentication required by the
@@ -24,24 +24,96 @@ command.
 |SAT Subcommand|Authentication/Credentials Required|Man Page|Description|
 |--------------|-----------------------------------|--------|-----------|
 |`sat auth`|None|`sat-auth`|Authenticate to the API gateway and save the token.|
-|`sat bmccreds`|Requires authentication to the API gateway.|`sat-bmccreds`|Set BMC passwords.|
-|`sat bootprep`|Requires authentication to the API gateway. Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation.|`sat-bootprep`|Prepare to boot nodes with images and configurations.|
-|`sat bootsys`|Requires authentication to the API gateway. Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation. Some stages require passwordless SSH to be configured to all other NCNs. Some stages require S3 to be configured.|`sat-bootsys`|Boot or shutdown the system, including compute nodes, application nodes, and non-compute nodes (NCNs) running the management software.|
-|`sat diag`|Requires authentication to the API gateway.|`sat-diag`|Launch diagnostics on the HSN switches and generate a report.|
+|`sat bmccreds`|Requires authentication to the API gateway.|`sat-bmccreds`|Set [BMC][bmc] passwords.|
+|`sat bootprep`|Requires authentication to the API gateway. Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation.|`sat-bootprep`|Prepare to boot nodes with [IMS][ims] images and [CFS][cfs] configurations.|
+|`sat bootsys`|Requires authentication to the API gateway. Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation. Some stages require passwordless SSH to be configured to all other [NCNs][ncn]. Some stages require [S3][s3] to be configured.|`sat-bootsys`|Boot or shutdown the system, including [compute nodes][cn], [application nodes][an], and [non-compute nodes (NCNs)][ncn] running the management software.|
+|`sat diag`|Requires authentication to the API gateway.|`sat-diag`|Launch diagnostics on the [HSN][hsn] switches and generate a report.|
 |`sat firmware`|Requires authentication to the API gateway.|`sat-firmware`|Report firmware version.|
 |`sat hwhist`|Requires authentication to the API gateway.|`sat-hwhist`|Report hardware component history.|
 |`sat hwinv`|Requires authentication to the API gateway.|`sat-hwinv`|Give a hardware list of the HPE Cray EX system.|
 |`sat hwmatch`|Requires authentication to the API gateway.|`sat-hwmatch`|Report hardware mismatches.|
-|`sat init`|None|`sat-init`|Create a default SAT configuration file.|
+|`sat init`|None|`sat-init`|Create a default [SAT][sat] configuration file.|
 |`sat jobstat`|Requires authentication to the API gateway.|`sat-jobstat`|Check the status of jobs and applications.|
-|`sat k8s`|Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation.|`sat-k8s`|Report on Kubernetes replica sets that have co-located \(on the same node\) replicas.|
+|`sat k8s`|Requires Kubernetes configuration and authentication, which is done on `ncn-m001` during installation.|`sat-k8s`|Report on Kubernetes replica sets that have co-located (on the same node) replicas.|
 |`sat linkhealth`|**This command has been deprecated.**|
-|`sat nid2xname`|Requires authentication to the API gateway.|`sat-nid2xname`|Translate node IDs to node XNames.|
+|`sat nid2xname`|Requires authentication to the API gateway.|`sat-nid2xname`|Translate [node IDs][nid] to node [xnames][xname].|
 |`sat sensors`|Requires authentication to the API gateway.|`sat-sensors`|Report current sensor data.|
 |`sat setrev`|Requires S3 to be configured for site information such as system name, serial number, install date, and site name.|`sat-setrev`|Set HPE Cray EX system revision information.|
-|`sat showrev`|Requires authentication to the API gateway to query the Interconnect from HSM. Requires S3 to be configured for site information such as system name, serial number, install date, and site name.|`sat-showrev`|Print HPE Cray EX system revision information.|
-|`sat slscheck`|Requires authentication to the API gateway.|`sat-slscheck`|Perform a cross-check between SLS and HSM.|
+|`sat showrev`|Requires authentication to the API gateway to query the Interconnect from [HSM][hsm]. Requires [S3][s3] to be configured for site information such as system name, serial number, install date, and site name.|`sat-showrev`|Print HPE Cray EX system revision information.|
+|`sat slscheck`|Requires authentication to the API gateway.|`sat-slscheck`|Perform a cross-check between [SLS][sls] and [HSM][hsm].|
 |`sat status`|Requires authentication to the API gateway.|`sat-status`|Report node status across the HPE Cray EX system.|
-|`sat swap`|Requires authentication to the API gateway.|`sat-swap`|Prepare a compute blade, HSN switch, or HSN cable for replacement and bring those components into service after replacement.|
+|`sat swap`|Requires authentication to the API gateway.|`sat-swap`|Prepare a [compute][cn] blade, [HSN][hsn] switch, or HSN cable for replacement and bring those components into service after replacement.|
 |`sat switch`|**This command has been deprecated.** It has been replaced by `sat swap`.|
-|`sat xname2nid`|Requires authentication to the API gateway.|`sat-xname2nid`|Translate node and node BMC XNames to node IDs.|
+|`sat xname2nid`|Requires authentication to the API gateway.|`sat-xname2nid`|Translate node and node [BMC][bmc] [xnames][xname] to [node IDs][nid].|
+
+<!--- Define the reference-style Markdown links used to make the page easier to edit -->
+
+[auth-sat]: ../configuration/Authenticate_SAT_Commands.md
+[gen-sat-s3-creds]: ../configuration/Generate_SAT_S3_Credentials.md
+[sat-deps]: SAT_Dependencies.md
+
+<!-- markdownlint-disable MD053 -->
+<!---
+    For references that are likely to appear on a lot of pages (glossary references, for example), 
+    we allow definitions for entries that are not used on the page, as a convenience.
+-->
+
+<!-- non-glossary common links -->
+
+[config-cli]: ../../configure_cray_cli.md
+[check-latest-docs]: ../../../update_product_stream/README.md#check-for-latest-documentation
+
+<!-- glossary entries -->
+
+[aee]: ../../../glossary.md#ansible-execution-environment-aee
+[an]: ../../../glossary.md#application-node-an
+[ara]: ../../../glossary.md#ara-records-ansible-ara
+[bmc]: ../../../glossary.md#baseboard-management-controller-bmc
+[bos]: ../../../glossary.md#boot-orchestration-service-bos
+[bss]: ../../../glossary.md#boot-script-service-bss
+[can]: ../../../glossary.md#customer-access-network-can
+[canu]: ../../../glossary.md#csm-automatic-network-utility-canu
+[capmc]: ../../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc
+[cdu]: ../../../glossary.md#coolant-distribution-unit-cdu
+[cec]: ../../../glossary.md#cabinet-environmental-controller-cec
+[cfs]: ../../../glossary.md#configuration-framework-service-cfs
+[chn]: ../../../glossary.md#customer-high-speed-network-chn
+[cli]: ../../../glossary.md#cray-cli-cray
+[cn]: ../../../glossary.md#compute-node-cn
+[csi]: ../../../glossary.md#cray-site-init-csi
+[fas]: ../../../glossary.md#firmware-action-service-fas
+[hbtd]: ../../../glossary.md#heartbeat-tracker-daemon-hbtd
+[hmn]: ../../../glossary.md#hardware-management-network-hmn
+[hsm]: ../../../glossary.md#hardware-state-manager-hsm
+[hsn]: ../../../glossary.md#high-speed-network-hsn
+[ims]: ../../../glossary.md#image-management-service-ims
+[iuf]: ../../../glossary.md#install-and-upgrade-framework-iuf
+[meds]: ../../../glossary.md#mountain-endpoint-discovery-service-meds
+[mgmt-ncns]: ../../../glossary.md#management-nodes
+[mountain]: ../../../glossary.md#mountain-cabinet
+[ncn]: ../../../glossary.md#non-compute-node-ncn
+[nid]: ../../../glossary.md#node-id-nid
+[nmn]: ../../../glossary.md#node-management-network-nmn
+[pcs]: ../../../glossary.md#power-control-service-pcs
+[pdu]: ../../../glossary.md#power-distribution-unit-pdu
+[pit]: ../../../glossary.md#pre-install-toolkit-pit
+[river]: ../../../glossary.md#river-cabinet
+[rts]: ../../../glossary.md#redfish-translation-service-rts
+[s3]: ../../../glossary.md#simple-storage-service-s3
+[sat]: ../../../glossary.md#system-admin-toolkit-sat
+[sbps]: ../../../glossary.md#scalable-boot-projection-service-sbps
+[scsd]: ../../../glossary.md#system-configuration-service-scsd
+[shcd]: ../../../glossary.md#shasta-cabling-diagram-shcd
+[slingshot]: ../../../glossary.md#slingshot
+[sls]: ../../../glossary.md#system-layout-service-sls
+[sma]: ../../../glossary.md#system-monitoring-application-sma
+[smd]: ../../../glossary.md#hardware-state-manager-smd
+[sops]: ../../../glossary.md#secrets-operations-sops
+[tapms]: ../../../glossary.md#tenant-and-partition-management-system-tapms
+[uan]: ../../../glossary.md#user-access-node-uan
+[uss]: ../../../glossary.md#user-services-software-uss
+[vcs]: ../../../glossary.md#version-control-service-vcs
+[vnid]: ../../../glossary.md#virtual-network-identifier-daemon-vnid
+[xname]: ../../../glossary.md#xname
+
+<!-- markdownlint-restore -->

--- a/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
+++ b/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
@@ -236,14 +236,14 @@ This procedure adds one or more liquid-cooled cabinets and associated [CDU][cdu]
     Configuration
     ========================
     SLS State File: sls_dump.json
-    [CDU][cdu] Switch:     d1w1
+    CDU Switch:     d1w1
     Brand:          Dell
     Alias:          sw-cdu-003
 
     ================================
-    [CDU][cdu] Switch Network Configuration
+    CDU Switch Network Configuration
     ================================
-    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in HMN's network_hardware subnet
+    Selecting IP Reservation for d1w1 CDU Switch in HMN's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.254.0.2
       Found existing IP reservation sw-spine-002 with IP 10.254.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.254.0.4
@@ -251,7 +251,7 @@ This procedure adds one or more liquid-cooled cabinets and associated [CDU][cdu]
       Found existing IP reservation sw-cdu-001 with IP 10.254.0.6
       Found existing IP reservation sw-cdu-002 with IP 10.254.0.7
       10.254.0.8 Available for use.
-    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in NMN's network_hardware subnet
+    Selecting IP Reservation for d1w1 CDU Switch in NMN's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.252.0.2
       Found existing IP reservation sw-spine-002 with IP 10.252.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.252.0.4
@@ -259,7 +259,7 @@ This procedure adds one or more liquid-cooled cabinets and associated [CDU][cdu]
       Found existing IP reservation sw-cdu-001 with IP 10.252.0.6
       Found existing IP reservation sw-cdu-002 with IP 10.252.0.7
       10.252.0.8 Available for use.
-    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in MTL's network_hardware subnet
+    Selecting IP Reservation for d1w1 CDU Switch in MTL's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.1.0.2
       Found existing IP reservation sw-spine-002 with IP 10.1.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.1.0.4

--- a/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
+++ b/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
@@ -1,32 +1,34 @@
 # Add Liquid-Cooled Cabinets to SLS
 
-This procedure adds one or more liquid-cooled cabinets and associated CDU management switches to SLS.
+This procedure adds one or more liquid-cooled cabinets and associated [CDU][cdu] management switches to [SLS][sls].
 
-**`NOTES`**
+## Notes
 
-- This procedure is intended to be used in conjunction with the top level [Add additional Liquid-Cooled Cabinets to a System](../node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md) procedure.
+- This procedure is intended to be used in conjunction with the top level [Add additional Liquid-Cooled Cabinets to a System][add-lcc-to-sys] procedure.
 - This procedure will only add the liquid-cooled hardware present in an EX2500 cabinet with a single liquid-cooled chassis and a single air-cooled chassis.
-- An alternative to this procedure can be found here: [Add A Cabinet To SLS Using CANI](../cani/Add_A_Cabinet_To_SLS.md).
+- For an alternative to this procedure, see [Add A Cabinet To SLS Using CANI][add-cab-to-sls].
 
 ## Prerequisites
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
-- The latest CSM documentation is installed on the system. See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+- The [Cray command line interface (CLI)][cli] tool is initialized and configured on the system.
+    - See [Configure the Cray CLI][config-cli].
+- The latest CSM documentation is installed on the system.
+    - See [Check for latest documentation][check-latest-docs].
 - Collect information for the liquid-cooled cabinets being added to the system. For each cabinet collect:
-  - Cabinet component name (xname) (for example `x1004`)
-  - Hardware Management Network (HMN) VLAN ID configured on the CEC (for example `3004`)
-  - Node Management Network (NMN) VLAN ID configured on the CEC (for example `2004`)
-  - Starting compute node ID (NID) (for example `2025`)
-  - Cabinet type: Mountain (8 chassis) or Hill (2 chassis)
+    - Cabinet component name ([xname][xname]) (for example `x1004`)
+    - [Hardware Management Network (HMN)][hmn] VLAN ID configured on the [CEC][cec] (for example `3004`)
+    - [Node Management Network (NMN)][nmn] VLAN ID configured on the [CEC][cec] (for example `2004`)
+    - Starting [compute][cn] [node ID (NID)][nid] (for example `2025`)
+    - Cabinet type: [Mountain][mountain] (8 chassis) or Hill (2 chassis)
 
-- Collect information for the CDU switches (if any) being added to the system. For each CDU management switch, collect:
-  - CDU switch component name (xname) (for example `d1w1`)
-  - CDU switch brand (for example Dell or Aruba)
-  - CDU switch alias (for example `sw-cdu-004`)
+- Collect information for the [CDU][cdu] switches (if any) being added to the system. For each [CDU][cdu] management switch, collect:
+    - [CDU][cdu] switch component name ([xname][xname]) (for example `d1w1`)
+    - [CDU][cdu] switch brand (for example Dell or Aruba)
+    - [CDU][cdu] switch alias (for example `sw-cdu-004`)
 
 ## Procedure
 
-1. (`ncn-m#`) Perform an SLS dump state operation:
+1. (`ncn-m#`) Perform an [SLS][sls] dump state operation:
 
     ```bash
     cray sls dumpstate list --format json > sls_dump.json
@@ -35,11 +37,11 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
 
 1. **For each** new liquid-cooled cabinet being added to the system, collect the following information about each cabinet:
 
-    - Cabinet component name (xname) (for example `x1004`)
-    - Hardware Management Network (HMN) VLAN ID configured on the CEC (for example `3004`)
-    - Node Management Network (NMN) VLAN ID configured on the CEC (for example `2004`)
-    - Starting compute node ID (NID) (for example `2025`)
-    - Cabinet type: Mountain (8 chassis) or Hill (2 chassis)
+    - Cabinet component name ([xname][xname]) (for example `x1004`)
+    - [Hardware Management Network (HMN)][hmn] VLAN ID configured on the [CEC][cec] (for example `3004`)
+    - [Node Management Network (NMN)][nmn] VLAN ID configured on the [CEC][cec] (for example `2004`)
+    - Starting [compute][cn] [node ID (NID)][nid] (for example `2025`)
+    - Cabinet type: [Mountain][mountain] (8 chassis) or Hill (2 chassis)
 
     > The `inspect_sls_cabinets.py` script can be used to help display information about existing cabinets present in the system:
     >
@@ -73,19 +75,20 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     > x3000 (River)       | 1513      | 10.107.0.0/22       | 1770      | 10.106.0.0/22
     > ```
 
-1. **For each** new liquid-cooled cabinet, add it to the previously taken SLS state dump in **ascending order**:
+1. **For each** new liquid-cooled cabinet, add it to the previously taken [SLS][sls] state dump in **ascending order**:
 
     Command line flags for `add_liquid_cooled_cabinet.py`:
-    | Argument                        | Description                                                       | Example value                   |
-    | ------------------------------- | ----------------------------------------------------------------- | ------------------------------- |
-    | `--cabinet`                     | Component name (xname) of the liquid-cooled cabinet to add        | `x1000`                         |
-    | `--cabinet-type`                | Type of liquid-cooled cabinet to add                              | `Mountain`, `Hill`, or `EX2500` |
-    | `--cabinet-vlan-hmn`            | Hardware Management Network (HMN) VLAN ID configured on the CEC   | `3004`                          |
-    | `--cabinet-vlan-nmn`            | Node Management Network (NMN) VLAN ID configured on the CEC       | `2004`                          |
-    | `--starting-nid`                | Starting NID for new cabinet. Each cabinet is allocated 256 NIDs  | `2024`                          |
-    | `--liquid-cooled-chassis-count` | Number of liquid-cooled chassis present in EX2500 cabinet. The value range is 1 to 3. This option is unused for `Mountain` or `Hill` | `3` |
 
-    - (`ncn-m#`) For `Mountain` or `Hill` cabinets:
+    | Argument                        | Description                                                      | Example value                   |
+    | ------------------------------- | ---------------------------------------------------------------- | ------------------------------- |
+    | `--cabinet`                     | Component name (xname) of the liquid-cooled cabinet to add       | `x1000`                         |
+    | `--cabinet-type`                | Type of liquid-cooled cabinet to add                             | `Mountain`, `Hill`, or `EX2500` |
+    | `--cabinet-vlan-hmn`            | Hardware Management Network (HMN) VLAN ID configured on the CEC  | `3004`                          |
+    | `--cabinet-vlan-nmn`            | Node Management Network (NMN) VLAN ID configured on the CEC      | `2004`                          |
+    | `--starting-nid`                | Starting NID for new cabinet. Each cabinet is allocated 256 NIDs | `2024`                          |
+    | `--liquid-cooled-chassis-count` | Number of liquid-cooled chassis present in EX2500 cabinet. The value range is 1 to 3. This option is unused for Mountain or Hill | `3` |
+
+    - (`ncn-m#`) For [Mountain][mountain] or Hill cabinets:
 
         ```bash
         /usr/share/doc/csm/scripts/operations/system_layout_service/add_liquid_cooled_cabinet.py sls_dump.json \
@@ -152,15 +155,18 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     Writing updated SLS state to sls_dump.json
     ```
 
-   > **`NOTE`**: If adding more than one cabinet and contiguous NIDs are desired, the value of the `Next available NID 2280` can be used as the value for the `--start-nid` argument when adding the next cabinet.
+   > **NOTE**: If adding more than one cabinet and contiguous [NIDs][nid] are desired,
+   > the value of the next available NID (`2280` in the above example output) can be used
+   > as the value for the `--start-nid` argument when adding the next cabinet.
 
-    Possible Errors:
+    Possible errors:
+
     | Problem                        | Error Message                                                         | Resolution |
     | ------------------------------ | --------------------------------------------------------------------- | ---------- |
-    | Duplicate Cabinet Xname        | `Error x1000 already exists in sls_dump.json!`                        | The cabinet has already present in SLS. Ensure the new cabinet has a unique component name (xname), or the cabinet is already present in SLS. |
+    | Duplicate cabinet xname        | `Error x1000 already exists in sls_dump.json!`                        | The cabinet has already present in SLS. Ensure the new cabinet has a unique component name (xname), or the cabinet is already present in SLS. |
     | Duplicate NID values           | `Error found duplicate NID 3000`                                      | Need to choose a different starting NID value for the cabinet that does not overlap with existing nodes. |
-    | Duplicate Cabinet HMN VLAN ID: | `Error found duplicate VLAN 3022 with subnet cabinet_1001 in HMN_MTN` | Ensure that the this new cabinet has an unique HMN VLAN ID. |
-    | Duplicate Cabinet NMN VLAN ID  | `Error found duplicate VLAN 3023 with subnet cabinet_1001 in NMN_MTN` | Ensure that the this new cabinet has an unique NMN VLAN ID. |
+    | Duplicate cabinet HMN VLAN ID  | `Error found duplicate VLAN 3022 with subnet cabinet_1001 in HMN_MTN` | Ensure that the this new cabinet has an unique HMN VLAN ID. |
+    | Duplicate cabinet NMN VLAN ID  | `Error found duplicate VLAN 3023 with subnet cabinet_1001 in NMN_MTN` | Ensure that the this new cabinet has an unique NMN VLAN ID. |
 
 1. (`ncn-m#`) Inspect cabinet subnet and VLAN allocations in the system after adding the new cabinets.
 
@@ -196,23 +202,25 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     x3000 (River)       | 1513      | 10.107.0.0/22       | 1770      | 10.106.0.0/22
     ```
 
-1. **For each** new CDU switch being added to the system, collect the following information about it:
+1. **For each** new [CDU][cdu] switch being added to the system, collect the following information about it:
 
-    - CDU switch component name (xname)
+    - [Coolant Distribution Unit (CDU)][cdu] switch component name ([xname][xname])
       - If within a CDU: `dDwW`
-            - `dD` : where `D` is the Coolant Distribution Unit (CDU).
+            - `dD` : where `D` is the CDU.
             - `wW` : where `W` is the management switch in a CDU.
       - If within a standard rack: `xXcChHsS`
-        - `xX` : where `X` is the River cabinet identification number (the figure above is `3000`).
+        - `xX` : where `X` is the [River][river] cabinet identification number (the figure above is `3000`).
         - `cC` : where `C` is the chassis identification number.
           - If the switch is within an air-cooled cabinet, then this should be `0`.
           - If the switch is within an air-cooled chassis in an EX2500 cabinet, then this should be `4`.
         - `hH` : where `H` is the slot number in the cabinet (height).
         - `sS` : where `S` is the horizontal space number.
-    - CDU switch brand (for example Dell or Aruba)
-    - CDU switch alias (for example `sw-cdu-004` )
+    - [CDU][cdu] switch brand (for example Dell or Aruba)
+    - [CDU][cdu] switch alias (for example `sw-cdu-004` )
 
-1. (`ncn-m#`) **For each** new CDU switch, add it to the SLS state dump taken in step 1 in **ascending order** based on the switch alias:
+1. (`ncn-m#`) **For each** new [CDU][cdu] switch, add it to the [SLS][sls] state dump taken in step 1.
+
+    > Add the switches in **ascending order** based on the switch alias.
 
     ```bash
     /usr/share/doc/csm/scripts/operations/system_layout_service/add_cdu_switch.py sls_dump.json \
@@ -228,14 +236,14 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     Configuration
     ========================
     SLS State File: sls_dump.json
-    CDU Switch:     d1w1
+    [CDU][cdu] Switch:     d1w1
     Brand:          Dell
     Alias:          sw-cdu-003
 
     ================================
-    CDU Switch Network Configuration
+    [CDU][cdu] Switch Network Configuration
     ================================
-    Selecting IP Reservation for d1w1 CDU Switch in HMN's network_hardware subnet
+    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in HMN's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.254.0.2
       Found existing IP reservation sw-spine-002 with IP 10.254.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.254.0.4
@@ -243,7 +251,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
       Found existing IP reservation sw-cdu-001 with IP 10.254.0.6
       Found existing IP reservation sw-cdu-002 with IP 10.254.0.7
       10.254.0.8 Available for use.
-    Selecting IP Reservation for d1w1 CDU Switch in NMN's network_hardware subnet
+    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in NMN's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.252.0.2
       Found existing IP reservation sw-spine-002 with IP 10.252.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.252.0.4
@@ -251,7 +259,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
       Found existing IP reservation sw-cdu-001 with IP 10.252.0.6
       Found existing IP reservation sw-cdu-002 with IP 10.252.0.7
       10.252.0.8 Available for use.
-    Selecting IP Reservation for d1w1 CDU Switch in MTL's network_hardware subnet
+    Selecting IP Reservation for d1w1 [CDU][cdu] Switch in MTL's network_hardware subnet
       Found existing IP reservation sw-spine-001 with IP 10.1.0.2
       Found existing IP reservation sw-spine-002 with IP 10.1.0.3
       Found existing IP reservation sw-leaf-bmc-001 with IP 10.1.0.4
@@ -267,18 +275,90 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     Writing updated SLS state to sls_dump.json
     ```
 
-1. (`ncn-m#`) Inspect the differences between the original SLS state file and the modified one.
+1. (`ncn-m#`) Inspect the differences between the original [SLS][sls] state file and the modified one.
 
     ```bash
     diff sls_dump.original.json sls_dump.json
     ```
 
-1. (`ncn-m#`) Perform a SLS load state operation to replace the contents of SLS with the data from the `sls_dump.json` file.
+1. (`ncn-m#`) Perform an [SLS][sls] load state operation to replace the contents of [SLS][sls] with the data from the `sls_dump.json` file.
 
     ```bash
     cray sls loadstate create sls_dump.json
     ```
 
-1. MEDS will automatically start looking for potential hardware in the newly added liquid-cooled cabinets.
+1. [MEDS][meds] will automatically start looking for potential hardware in the newly added liquid-cooled cabinets.
 
-   > **`NOTE`**: No hardware in these new cabinets will be discovered until the management network has been reconfigured to support the new cabinets, and routes have been added to the management NCNs in the system.
+   > **NOTE**: No hardware in these new cabinets will be discovered until the management network has been reconfigured
+   > to support the new cabinets, and routes have been added to the [management NCNs][mgmt-ncns] in the system.
+
+<!--- Define the reference-style Markdown links used to make the page easier to edit -->
+
+[add-cab-to-sls]: ../cani/Add_A_Cabinet_To_SLS.md
+[add-lcc-to-sys]: ../node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+
+<!-- markdownlint-disable MD053 -->
+<!---
+    For references that are likely to appear on a lot of pages (glossary references, for example), 
+    we allow definitions for entries that are not used on the page, as a convenience.
+-->
+
+<!-- non-glossary common links -->
+
+[config-cli]: ../configure_cray_cli.md
+[check-latest-docs]: ../../update_product_stream/README.md#check-for-latest-documentation
+
+<!-- glossary entries -->
+
+[aee]: ../../glossary.md#ansible-execution-environment-aee
+[an]: ../../glossary.md#application-node-an
+[ara]: ../../glossary.md#ara-records-ansible-ara
+[bmc]: ../../glossary.md#baseboard-management-controller-bmc
+[bos]: ../../glossary.md#boot-orchestration-service-bos
+[bss]: ../../glossary.md#boot-script-service-bss
+[can]: ../../glossary.md#customer-access-network-can
+[canu]: ../../glossary.md#csm-automatic-network-utility-canu
+[capmc]: ../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc
+[cdu]: ../../glossary.md#coolant-distribution-unit-cdu
+[cec]: ../../glossary.md#cabinet-environmental-controller-cec
+[cfs]: ../../glossary.md#configuration-framework-service-cfs
+[chn]: ../../glossary.md#customer-high-speed-network-chn
+[cli]: ../../glossary.md#cray-cli-cray
+[cn]: ../../glossary.md#compute-node-cn
+[csi]: ../../glossary.md#cray-site-init-csi
+[fas]: ../../glossary.md#firmware-action-service-fas
+[hbtd]: ../../glossary.md#heartbeat-tracker-daemon-hbtd
+[hmn]: ../../glossary.md#hardware-management-network-hmn
+[hsm]: ../../glossary.md#hardware-state-manager-hsm
+[hsn]: ../../glossary.md#high-speed-network-hsn
+[ims]: ../../glossary.md#image-management-service-ims
+[iuf]: ../../glossary.md#install-and-upgrade-framework-iuf
+[meds]: ../../glossary.md#mountain-endpoint-discovery-service-meds
+[mgmt-ncns]: ../../glossary.md#management-nodes
+[mountain]: ../../glossary.md#mountain-cabinet
+[ncn]: ../../glossary.md#non-compute-node-ncn
+[nid]: ../../glossary.md#node-id-nid
+[nmn]: ../../glossary.md#node-management-network-nmn
+[pcs]: ../../glossary.md#power-control-service-pcs
+[pdu]: ../../glossary.md#power-distribution-unit-pdu
+[pit]: ../../glossary.md#pre-install-toolkit-pit
+[river]: ../../glossary.md#river-cabinet
+[rts]: ../../glossary.md#redfish-translation-service-rts
+[s3]: ../../glossary.md#simple-storage-service-s3
+[sat]: ../../glossary.md#system-admin-toolkit-sat
+[sbps]: ../../glossary.md#scalable-boot-projection-service-sbps
+[scsd]: ../../glossary.md#system-configuration-service-scsd
+[shcd]: ../../glossary.md#shasta-cabling-diagram-shcd
+[slingshot]: ../../glossary.md#slingshot
+[sls]: ../../glossary.md#system-layout-service-sls
+[sma]: ../../glossary.md#system-monitoring-application-sma
+[smd]: ../../glossary.md#hardware-state-manager-smd
+[sops]: ../../glossary.md#secrets-operations-sops
+[tapms]: ../../glossary.md#tenant-and-partition-management-system-tapms
+[uan]: ../../glossary.md#user-access-node-uan
+[uss]: ../../glossary.md#user-services-software-uss
+[vcs]: ../../glossary.md#version-control-service-vcs
+[vnid]: ../../glossary.md#virtual-network-identifier-daemon-vnid
+[xname]: ../../glossary.md#xname
+
+<!-- markdownlint-restore -->

--- a/troubleshooting/known_issues/antero_node_NID_allocation.md
+++ b/troubleshooting/known_issues/antero_node_NID_allocation.md
@@ -1,96 +1,201 @@
 # Antero node NID allocation
 
-There is a known issue with Antero nodes where node NIDs are not correctly allocated. When Cray Site Init (CSI) generates hardware for the liquid-cooled cabinets for the System Layout Service (SLS) input file it assumes all blades in the cabinet are Windom
-compute blades. Even though both Antero and Windom blades both have 4 nodes, they have different physical layouts.
+- [Overview](#overview)
+- [Workaround](#workaround)
+    - [List Antero blade NIDs](#list-antero-blade-nids)
+    - [List Antero nodes](#list-antero-nodes)
+    - [List all compute NIDs](#list-all-compute-nids)
+- [Correct the NID numbering](#correct-the-nid-numbering)
 
-- Windom blades have 2 node BMCs with 2 nodes per node BMC with the following nodes: `b0n0`, `b0n1`, `b1n0`, `b1n1`
-- Antero blades have 1 Node BMC with 4 nodes per node BMC with the following nodes: `b0n0`, `b0n1`, `b0n2`, `b0n3`
+## Overview
 
-SLS has NIDS only allocated for nodes `b0n0`, `b0n1`, `b1n0`, `b1n1` on a compute node blade. On a Antero blade the nodes `b0n2`, `b0n3` will have automatically assigned NIDs that are not contiguous with the NIDs on nodes `b0n0` and `b0n1`.
+There is a known issue with Antero nodes where [NIDs][nid]
+are not correctly allocated. When [Cray Site Init (CSI)][csi]
+generates the [System Layout Service (SLS)][sls]
+input file, it assumes that all blades in liquid-cooled cabinets are Windom [compute][cn] blades.
+Even though both Antero and Windom blades have 4 nodes, they have different physical layouts.
 
-It is important to note the nodes `b0n2` and `b0n3` on a Antero blade are functional, but do not have NIDs in contiguous range with its peers.
+- Windom blades have 2 node [BMCs][bmc], 2 nodes per node [BMC][bmc], resulting in the following nodes: `b0n0`, `b0n1`, `b1n0`, `b1n1`
+- Antero blades have 1 node [BMC][bmc], 4 nodes per node [BMC][bmc], resulting in the following nodes: `b0n0`, `b0n1`, `b0n2`, `b0n3`
 
-## How to identify NIDs on Antero blades
+[SLS][sls] has [NIDs][nid] only allocated for nodes `b0n0`, `b0n1`, `b1n0`, and `b1n1` on a [compute][cn] node blade.
+On an Antero blade, the nodes `b0n2` and `b0n3` will have automatically assigned [NIDs][nid] that are not contiguous
+with the [NIDs][nid] on nodes `b0n0` and `b0n1`.
 
-To work around this issue the appropriate NID values for nodes `b0n2` and `n0n3` on Antero blades need to be supplied to Work Load Manager (WLM) when launch jobs. The following commands are some examples to determine the NIDs in use for Antero blades.
+It is important to note that the nodes `b0n2` and `b0n3` on an Antero blade are functional,
+but do not have [NIDs][nid] in contiguous range with their peers.
 
-1. (`ncn#`) View the NIDs for Antero blades in the system:
+## Workaround
 
-    ```bash
-    ANTERO_FILTER=$(sat hwinv --list-node-enclosures --fields=xname --filter='Model=ANTERO' --format json  | jq '.node_enclosure_list[] | "xname=\(.xname)*"' -r | sed 's/e0//' | paste -sd " " | sed 's/ / or /g')
-    sat status --type Node --fields 'xname,role,nid' --filter "$ANTERO_FILTER"
-    ```
+This section gives information on how to work around this issue until there is a system
+maintenance window in which to [Correct the NID numbering](#correct-the-nid-numbering).
+To work around this issue, the appropriate [NID][nid] values for nodes `b0n2` and `n0n3` on Antero blades
+must be supplied to the Work Load Manager (WLM) when it launches jobs.
 
-    Example output:
+The following sections provide examples of [SAT][sat] commands that can help determine the
+[NIDs][nid] that are in use for Antero blades.
 
-    ```text
-    +---------------+---------+-----------+
-    | xname         | Role    | NID       |
-    +---------------+---------+-----------+
-    | x9000c1s4b0n0 | Compute | 1016      |
-    | x9000c1s4b0n1 | Compute | 1017      |
-    | x9000c1s4b0n2 | Compute | 147474562 |
-    | x9000c1s4b0n3 | Compute | 147474563 |
-    | x9000c1s5b0n0 | Compute | 1020      |
-    | x9000c1s5b0n1 | Compute | 1021      |
-    | x9000c1s5b0n2 | Compute | 147474594 |
-    | x9000c1s5b0n3 | Compute | 147474595 |
-    +---------------+---------+-----------+
-    ```
+- [List Antero blade NIDs](#list-antero-blade-nids)
+- [List Antero nodes](#list-antero-nodes)
+- [List all compute NIDs](#list-all-compute-nids)
 
-    > (`ncn#`) Identify the Antero nodes present in the system:
-    >
-    > ```bash
-    > sat hwinv --list-nodes --fields 'xname,"Model"' --filter='Model="HPE EX4252"'
-    > ```
-    >
-    > Example output:
-    >
-    > ```text
-    > ################################################################################
-    > Listing of all nodes
-    > ################################################################################
-    > +---------------+------------+
-    > | xname         | Model      |
-    > +---------------+------------+
-    > | x9000c1s7b0n0 | HPE EX4252 |
-    > | x9000c1s7b0n1 | HPE EX4252 |
-    > | x9000c1s7b0n2 | HPE EX4252 |
-    > | x9000c1s7b0n3 | HPE EX4252 |
-    > | x9000c3s0b0n0 | HPE EX4252 |
-    > | x9000c3s0b0n1 | HPE EX4252 |
-    > | x9000c3s0b0n2 | HPE EX4252 |
-    > | x9000c3s0b0n3 | HPE EX4252 |
-    > +---------------+------------+
-    > ```
+### List Antero blade NIDs
 
-1. (`ncn#`) View NIDS for all compute nodes in the system:
+(`ncn-mw#`) View the [NIDs][nid] for Antero blades in the system:
 
-    ```bash
-    sat status --type Node --fields 'xname,role,nid' --filter 'role=compute'
-    ```
+```bash
+ANTERO=$(sat hwinv --list-node-enclosures --fields=xname \
+             --filter='Model=ANTERO' --format json  | \
+         jq '.node_enclosure_list[] | "xname=\(.xname)*"' -r | sed 's/e0//' | \
+         paste -sd " " | sed 's/ / or /g')
+sat status --type Node --fields 'xname,role,nid' --filter "${ANTERO}"
+```
 
-    Example output:
+Example output:
 
-    ```text
-    +---------------+---------+-----------+
-    | xname         | Role    | NID       |
-    +---------------+---------+-----------+
-    | x9000c1s0b0n0 | Compute | 1000      |
-    | x9000c1s0b0n1 | Compute | 1001      |
-    | x9000c1s1b0n0 | Compute | 1004      |
-    | x9000c1s1b0n1 | Compute | 1005      |
-    | x9000c1s7b0n0 | Compute | 1028      |
-    | x9000c1s7b0n1 | Compute | 1029      |
-    | x9000c1s7b0n2 | Compute | 147474562 |
-    | x9000c1s7b0n3 | Compute | 147474563 |
-    | x9000c3s0b0n0 | Compute | 1032      |
-    | x9000c3s0b0n1 | Compute | 1033      |
-    | x9000c3s0b0n2 | Compute | 147474594 |
-    | x9000c3s0b0n3 | Compute | 147474595 |
-    +---------------+---------+-----------+
-    ```
+```text
++---------------+---------+-----------+
+| xname         | Role    | NID       |
++---------------+---------+-----------+
+| x9000c1s4b0n0 | Compute | 1016      |
+| x9000c1s4b0n1 | Compute | 1017      |
+| x9000c1s4b0n2 | Compute | 147474562 |
+| x9000c1s4b0n3 | Compute | 147474563 |
+| x9000c1s5b0n0 | Compute | 1020      |
+| x9000c1s5b0n1 | Compute | 1021      |
+| x9000c1s5b0n2 | Compute | 147474594 |
+| x9000c1s5b0n3 | Compute | 147474595 |
++---------------+---------+-----------+
+```
 
-## Correcting the NID Numbering
+### List Antero nodes
 
-Optionally, during a system maintenance window, the Antero node NID numbering can be corrected by following the [Defragment NID Numbering](../../operations/node_management/Defragment_NID_Numbering.md) procedure.
+(`ncn-mw#`) Identify the Antero nodes present in the system:
+
+```bash
+sat hwinv --list-nodes --fields 'xname,"Model"' --filter='Model="HPE EX4252"'
+```
+
+Example output:
+
+```text
+################################################################################
+Listing of all nodes
+################################################################################
++---------------+------------+
+| xname         | Model      |
++---------------+------------+
+| x9000c1s7b0n0 | HPE EX4252 |
+| x9000c1s7b0n1 | HPE EX4252 |
+| x9000c1s7b0n2 | HPE EX4252 |
+| x9000c1s7b0n3 | HPE EX4252 |
+| x9000c3s0b0n0 | HPE EX4252 |
+| x9000c3s0b0n1 | HPE EX4252 |
+| x9000c3s0b0n2 | HPE EX4252 |
+| x9000c3s0b0n3 | HPE EX4252 |
++---------------+------------+
+```
+
+### List all compute NIDs
+
+(`ncn-mw#`) View [NIDs][nid] for all [compute nodes][cn] in the system:
+
+```bash
+sat status --type Node --fields 'xname,role,nid' --filter 'role=compute'
+```
+
+Example output:
+
+```text
++---------------+---------+-----------+
+| xname         | Role    | NID       |
++---------------+---------+-----------+
+| x9000c1s0b0n0 | Compute | 1000      |
+| x9000c1s0b0n1 | Compute | 1001      |
+| x9000c1s1b0n0 | Compute | 1004      |
+| x9000c1s1b0n1 | Compute | 1005      |
+| x9000c1s7b0n0 | Compute | 1028      |
+| x9000c1s7b0n1 | Compute | 1029      |
+| x9000c1s7b0n2 | Compute | 147474562 |
+| x9000c1s7b0n3 | Compute | 147474563 |
+| x9000c3s0b0n0 | Compute | 1032      |
+| x9000c3s0b0n1 | Compute | 1033      |
+| x9000c3s0b0n2 | Compute | 147474594 |
+| x9000c3s0b0n3 | Compute | 147474595 |
++---------------+---------+-----------+
+```
+
+## Correct the NID numbering
+
+Optionally, during a system maintenance window, the Antero [NID][nid] numbering can be corrected by following the
+[Defragment NID Numbering][defrag-nids] procedure.
+
+<!--- Define the reference-style Markdown links used to make the page easier to edit -->
+
+[defrag-nids]: ../../operations/node_management/Defragment_NID_Numbering.md
+
+<!-- markdownlint-disable MD053 -->
+<!---
+    For references that are likely to appear on a lot of pages (glossary references, for example), 
+    we allow definitions for entries that are not used on the page, as a convenience.
+-->
+
+<!-- non-glossary common links -->
+
+[config-cli]: ../configure_cray_cli.md
+[check-latest-docs]: ../../update_product_stream/README.md#check-for-latest-documentation
+
+<!-- glossary entries -->
+
+[aee]: ../../glossary.md#ansible-execution-environment-aee
+[an]: ../../glossary.md#application-node-an
+[ara]: ../../glossary.md#ara-records-ansible-ara
+[bmc]: ../../glossary.md#baseboard-management-controller-bmc
+[bos]: ../../glossary.md#boot-orchestration-service-bos
+[bss]: ../../glossary.md#boot-script-service-bss
+[can]: ../../glossary.md#customer-access-network-can
+[canu]: ../../glossary.md#csm-automatic-network-utility-canu
+[capmc]: ../../glossary.md#cray-advanced-platform-monitoring-and-control-capmc
+[cdu]: ../../glossary.md#coolant-distribution-unit-cdu
+[cec]: ../../glossary.md#cabinet-environmental-controller-cec
+[cfs]: ../../glossary.md#configuration-framework-service-cfs
+[chn]: ../../glossary.md#customer-high-speed-network-chn
+[cli]: ../../glossary.md#cray-cli-cray
+[cn]: ../../glossary.md#compute-node-cn
+[csi]: ../../glossary.md#cray-site-init-csi
+[fas]: ../../glossary.md#firmware-action-service-fas
+[hbtd]: ../../glossary.md#heartbeat-tracker-daemon-hbtd
+[hmn]: ../../glossary.md#hardware-management-network-hmn
+[hsm]: ../../glossary.md#hardware-state-manager-hsm
+[hsn]: ../../glossary.md#high-speed-network-hsn
+[ims]: ../../glossary.md#image-management-service-ims
+[iuf]: ../../glossary.md#install-and-upgrade-framework-iuf
+[meds]: ../../glossary.md#mountain-endpoint-discovery-service-meds
+[mgmt-ncns]: ../../glossary.md#management-nodes
+[mountain]: ../../glossary.md#mountain-cabinet
+[ncn]: ../../glossary.md#non-compute-node-ncn
+[nid]: ../../glossary.md#node-id-nid
+[nmn]: ../../glossary.md#node-management-network-nmn
+[pcs]: ../../glossary.md#power-control-service-pcs
+[pdu]: ../../glossary.md#power-distribution-unit-pdu
+[pit]: ../../glossary.md#pre-install-toolkit-pit
+[river]: ../../glossary.md#river-cabinet
+[rts]: ../../glossary.md#redfish-translation-service-rts
+[s3]: ../../glossary.md#simple-storage-service-s3
+[sat]: ../../glossary.md#system-admin-toolkit-sat
+[sbps]: ../../glossary.md#scalable-boot-projection-service-sbps
+[scsd]: ../../glossary.md#system-configuration-service-scsd
+[shcd]: ../../glossary.md#shasta-cabling-diagram-shcd
+[slingshot]: ../../glossary.md#slingshot
+[sls]: ../../glossary.md#system-layout-service-sls
+[sma]: ../../glossary.md#system-monitoring-application-sma
+[smd]: ../../glossary.md#hardware-state-manager-smd
+[sops]: ../../glossary.md#secrets-operations-sops
+[tapms]: ../../glossary.md#tenant-and-partition-management-system-tapms
+[uan]: ../../glossary.md#user-access-node-uan
+[uss]: ../../glossary.md#user-services-software-uss
+[vcs]: ../../glossary.md#version-control-service-vcs
+[vnid]: ../../glossary.md#virtual-network-identifier-daemon-vnid
+[xname]: ../../glossary.md#xname
+
+<!-- markdownlint-restore -->


### PR DESCRIPTION
CASMINST-7542: The main purpose of this PR was to add links to the glossary to several pages. But while I was there, I also tidied them up and did some linting. 

I decided to define link definitions at the bottoms of the pages, since this makes it easier to add links as needed, and may encourage people in the future to add them on their own.

No real content changes in these PRs.

Backports:

* 1.6: https://github.com/Cray-HPE/docs-csm/pull/6528
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/6529
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/6530
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/6531
* 1.2: https://github.com/Cray-HPE/docs-csm/pull/6532
* 1.0: https://github.com/Cray-HPE/docs-csm/pull/6533
