### PR TITLE
CASMTRIAGE-9069 WAR

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -82,7 +82,7 @@ to the exiting problem seen into the existing search. (The example searches for 
       CSM 1.7+ reinstall.
 * [Cilium Migration Failure Due to Missing BSS Global Metadata Parameter](known_issues/cilium_migration_k8s_primary_cni_not_set.md)
 * [Kubelet Memory Pressure False Positive](known_issues/kubelet_memory_pressure_false_positive.md)
-* [
+* [iSCSI SBPS Marshal agent failure](known_issues/iscsi_sbps_marshal_failure.md)
 
 ## Booting
 
@@ -109,7 +109,6 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
 * [CFS Key Management](../operations/configuration_management/CFS_Key_Management.md)
-* [iSCSI SBPS Marshal agent failure](known_issues/iscsi_sbps_marshal_failure.md)
 
 ## ConMan
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -82,6 +82,7 @@ to the exiting problem seen into the existing search. (The example searches for 
       CSM 1.7+ reinstall.
 * [Cilium Migration Failure Due to Missing BSS Global Metadata Parameter](known_issues/cilium_migration_k8s_primary_cni_not_set.md)
 * [Kubelet Memory Pressure False Positive](known_issues/kubelet_memory_pressure_false_positive.md)
+* [
 
 ## Booting
 
@@ -108,6 +109,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
 * [CFS Key Management](../operations/configuration_management/CFS_Key_Management.md)
+* [iSCSI SBPS Marshal agent failure](known_issues/iscsi_sbps_marshal_failure.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -98,7 +98,7 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'e
 The failure to locate `/usr/lib/sbps-marshal/bin/sbps-marshal` is due to the absence of symbolic link between
 `/etc/systemd/system/multi-user.target.wants/sbps-marshal.service` and `/usr/lib/systemd/system/sbps-marshal.service`.
 This symbolic link is established when the `sbps-marshal` service is enabled. It looks that enabling `sbps-marshal`
-service is failed during the worker node personalization which likely led to this issue.
+service failed during the worker node personalization which likely led to this issue.
 
 ## Resolution
 
@@ -112,8 +112,7 @@ systemctl enable sbps-marshal.service
 
 Example output:
 
-```bash
-systemctl enable sbps-marshal.service
+```text
 Created symlink /etc/systemd/system/multi-user.target.wants/sbps-marshal.service → /usr/lib/systemd/system/sbps-marshal.service.
 ```
 

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -1,6 +1,6 @@
-# iSCSI SBPS systemd service (sbps-marshal) may fail during upgrade
+# iSCSI SBPS `systemd` service (`sbps-marshal`) may fail during upgrade
 
-## Symptom  
+## Symptom
 
 During the CSM upgrade from `1.6.x` to `1.7.x` or from `1.7.x` to `1.7.y`
 where 'x' and 'y' are the patch version(s), the NCN health checks may fail with
@@ -62,7 +62,7 @@ iSCSI SBPS as below:
 
 ## Root cause
 
-iSCSI SBPS marshal systemd service may not be active:
+iSCSI SBPS marshal `systemd` service may not be active:
 
 ```bash
 systemctl status sbps-marshal
@@ -74,7 +74,7 @@ systemctl status sbps-marshal
         CPU: 2ms
 ```
 
-The systemd journal may show the following errors:
+The `systemd` journal may show the following errors:
 
 ```bash
 journalctl -u sbps-marshal.service
@@ -97,7 +97,7 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'e
 
 The failure to locate `/usr/lib/sbps-marshal/bin/sbps-marshal` is due to the absence of symbolic link between
 `/etc/systemd/system/multi-user.target.wants/sbps-marshal.service` and `/usr/lib/systemd/system/sbps-marshal.service`.
-This symbolic link is established when the `sbps-marshal` service is enabled. It looks that enabling `sbps-marshal` 
+This symbolic link is established when the `sbps-marshal` service is enabled. It looks that enabling `sbps-marshal`
 service is failed during the worker node personalization which likely led to this issue.
 
 ## Resolution

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -2,8 +2,9 @@
 
 ## Symptom  
 
-During CSM upgrade from `1.6.x` to `1.7.x`, where 'x' is the patch version,
-the NCN checks may fail with iSCSI SBPS as below:
+During the CSM upgrade from `1.6.x` to `1.7.x` or from `1.7.x` to `1.7.y`
+where 'x' and 'y' are the patch version(s), the NCN health checks may fail with
+iSCSI SBPS as below:
 
 ```json
 {
@@ -76,7 +77,7 @@ systemctl status sbps-marshal
 The systemd journal may show the following errors:
 
 ```bash
-Journalctl -u sbps-marshal.service
+journalctl -u sbps-marshal.service
 ```
 
 Snippet of `journalctl` log:
@@ -94,10 +95,10 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Main process exited, 
 Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'exit-code'.
 ```
 
-The `/usr/lib/sbps-marshal/bin/sbps-marshal` is failed to locate is because, the symbolic link between
-`/etc/systemd/system/multi-user.target.wants/sbps-marshal.service` and `/usr/lib/systemd/system/sbps-marshal.service`
-was not established. This will get established when the sbps-marshal.service is enabled. There looks to be enable of
-sbps-marshal service failed during worker node personalization and hence issue.
+The failure to locate `/usr/lib/sbps-marshal/bin/sbps-marshal` is due to the absence of symbolic link between
+`/etc/systemd/system/multi-user.target.wants/sbps-marshal.service` and `/usr/lib/systemd/system/sbps-marshal.service`.
+This symbolic link is established when the `sbps-marshal` service is enabled. It looks that enabling `sbps-marshal` 
+service is failed during the worker node personalization which likely led to this issue.
 
 ## Resolution
 
@@ -122,18 +123,17 @@ Created symlink /etc/systemd/system/multi-user.target.wants/sbps-marshal.service
 systemctl restart sbps-marshal.service
 ```
 
-1. (`ncn-w#`) Check the status of the `sbps-marshal` service, it should be running fine as below:
+1. (`ncn-w#`) Check the status of the `sbps-marshal` service, it should be running:
 
 Example command:
 
 ```bash
-# systemctl status sbps-marshal.service
+systemctl status sbps-marshal.service
 ```
 
 Example command output:
 
-```bash
- systemctl status sbps-marshal.service
+```text
 ● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary>
      Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
      Active: active (running) since Thu 2026-02-26 18:07:51 UTC; 22min ago

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -1,11 +1,11 @@
-# iSCSI SBPS Marshal agent may fail during upgrade
+# iSCSI SBPS systemd service (sbps-marshal) may fail during upgrade
 
 ## Symptom  
 
-During CSM upgrade from `1.6.x` to `1.7.x`, where 'x' is the minor version,
+During CSM upgrade from `1.6.x` to `1.7.x`, where 'x' is the patch version,
 the NCN checks may fail with iSCSI SBPS as below:
 
-```text
+```json
 {
     "duration": 54160,
     "err": null,
@@ -25,14 +25,14 @@ the NCN checks may fail with iSCSI SBPS as below:
     "resource-type": "Command",
     "result": 1,
     "skipped": false,
-    "successful": false, --------
+    "successful": false,
     "summary-line": "Command: iSCSI-readiness-test: exit-status:\nExpected\n    <int>: 1\nto equal\n    <int>: 0",
     "test-type": 0,
     "title": "iSCSI-readinesss-test"
 }
 ```
 
-```text
+```json
 {
     "duration": 35375,
     "err": null,
@@ -52,7 +52,7 @@ the NCN checks may fail with iSCSI SBPS as below:
     "resource-type": "Command",
     "result": 1,
     "skipped": false,
-    "successful": false, --------
+    "successful": false,
     "summary-line": "Command: iscsi_cps_sanity: exit-status:\nExpected\n    <int>: 1\nto equal\n    <int>: 0",
     "test-type": 0,
     "title": "iSCSI boot content projection"
@@ -61,10 +61,10 @@ the NCN checks may fail with iSCSI SBPS as below:
 
 ## Root cause
 
-iSCSI SBPS marshal system service may not be in active state as below:
+iSCSI SBPS marshal systemd service may not be active:
 
 ```bash
-# systemctl status sbps-marshal
+systemctl status sbps-marshal
 ● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images simi>
      Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
      Active: activating (auto-restart) (Result: exit-code) since Thu 2026-02-26 09:11:36 UTC; 13s ago
@@ -73,10 +73,10 @@ iSCSI SBPS marshal system service may not be in active state as below:
         CPU: 2ms
 ```
 
-`journalctl` log for this service may have below errors:
+The systemd journal may show the following errors:
 
 ```bash
-# Journalctl -u sbps-marshal.service
+Journalctl -u sbps-marshal.service
 ```
 
 Snippet of `journalctl` log:
@@ -94,30 +94,35 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Main process exited, 
 Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'exit-code'.
 ```
 
+The `/usr/lib/sbps-marshal/bin/sbps-marshal` is failed to locate is because, the symbolic link between
+`/etc/systemd/system/multi-user.target.wants/sbps-marshal.service` and `/usr/lib/systemd/system/sbps-marshal.service`
+was not established. This will get established when the sbps-marshal.service is enabled. There looks to be enable of
+sbps-marshal service failed during worker node personalization and hence issue.
+
 ## Resolution
 
 Follow the sequence of steps on the affected node as below:
 
-1. Enable the `sbps-marshal` `systemd` service:
+1. (`ncn-w#`) Enable the `sbps-marshal` `systemd` service:
 
 ```bash
-# systemctl enable sbps-marshal.service
+systemctl enable sbps-marshal.service
 ```
 
 Example output:
 
 ```bash
-ncn-w003:~ # systemctl enable sbps-marshal.service
+systemctl enable sbps-marshal.service
 Created symlink /etc/systemd/system/multi-user.target.wants/sbps-marshal.service → /usr/lib/systemd/system/sbps-marshal.service.
 ```
 
-1. Restart `sbps-marshal` `systemd` service
+1. (`ncn-w#`) Restart the `sbps-marshal` `systemd` service
 
 ```bash
-# systemctl restart sbps-marshal.service
+systemctl restart sbps-marshal.service
 ```
 
-1. Check the status of `sbps-marshal` service, it should be running fine as below:
+1. (`ncn-w#`) Check the status of the `sbps-marshal` service, it should be running fine as below:
 
 Example command:
 
@@ -128,8 +133,7 @@ Example command:
 Example command output:
 
 ```bash
-
-ncn-w003:~ # systemctl status sbps-marshal.service
+ systemctl status sbps-marshal.service
 ● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary>
      Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
      Active: active (running) since Thu 2026-02-26 18:07:51 UTC; 22min ago

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -3,7 +3,7 @@
 ## Symptom  
 
 During CSM upgrade from `1.6.x` to `1.7.x`, where 'x' is the minor version,
-the NCN checks may fail with iSCSI SBPS as below: 
+the NCN checks may fail with iSCSI SBPS as below:
 
 ```text
 {
@@ -96,7 +96,7 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'e
 
 ## Resolution
 
-Follow the squence of steps on the affected node as below:
+Follow the sequence of steps on the affected node as below:
 
 1. Enable the `sbps-marshal` `systemd` service:
 

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -1,8 +1,9 @@
-# iSCSI SBPS Marshal agent may fail during upgrade 
+# iSCSI SBPS Marshal agent may fail during upgrade
 
 ## Symptom  
 
-During CSM upgrade from 1.6.x to 1.7.x, the NCN checks may fail with iSCSI SBPS as below: 
+During CSM upgrade from `1.6.x` to `1.7.x`, where 'x' is the minor version,
+the NCN checks may fail with iSCSI SBPS as below: 
 
 ```text
 {
@@ -72,13 +73,13 @@ iSCSI SBPS marshal system service may not be in active state as below:
         CPU: 2ms
 ```
 
-Journalctl log for this service may have below errors:
+`journalctl` log for this service may have below errors:
 
 ```bash
 # Journalctl -u sbps-marshal.service
 ```
 
-Snippet of journalctl log:
+Snippet of `journalctl` log:
 
 ```text
 Feb 26 09:11:00 ncn-w003 systemd[1]: Started System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images similar to PE..
@@ -97,7 +98,7 @@ Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'e
 
 Follow the squence of steps on the affected node as below:
 
-1. Enable the sbps-marshal systemd service: 
+1. Enable the `sbps-marshal` `systemd` service:
 
 ```bash
 # systemctl enable sbps-marshal.service
@@ -110,13 +111,13 @@ ncn-w003:~ # systemctl enable sbps-marshal.service
 Created symlink /etc/systemd/system/multi-user.target.wants/sbps-marshal.service → /usr/lib/systemd/system/sbps-marshal.service.
 ```
 
-1. Restart sbps-marshal systemd service
+1. Restart `sbps-marshal` `systemd` service
 
 ```bash
 # systemctl restart sbps-marshal.service
 ```
 
-1. Check the status of sbps-marshal.service, it should be running fine as below:
+1. Check the status of `sbps-marshal` service, it should be running fine as below:
 
 Example command:
 

--- a/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
+++ b/troubleshooting/known_issues/iscsi_sbps_marshal_failure.md
@@ -1,0 +1,151 @@
+# iSCSI SBPS Marshal agent may fail during upgrade 
+
+## Symptom  
+
+During CSM upgrade from 1.6.x to 1.7.x, the NCN checks may fail with iSCSI SBPS as below: 
+
+```text
+{
+    "duration": 54160,
+    "err": null,
+    "expected": [
+        "0"
+    ],
+    "found": [
+        "1"
+    ],
+    "human": "Expected\n    <int>: 1\nto equal\n    <int>: 0",
+    "meta": {
+        "desc": "Readiness Test for iSCSI.",
+        "sev": 0
+    },
+    "property": "exit-status",
+    "resource-id": "iSCSI-readiness-test",
+    "resource-type": "Command",
+    "result": 1,
+    "skipped": false,
+    "successful": false, --------
+    "summary-line": "Command: iSCSI-readiness-test: exit-status:\nExpected\n    <int>: 1\nto equal\n    <int>: 0",
+    "test-type": 0,
+    "title": "iSCSI-readinesss-test"
+}
+```
+
+```text
+{
+    "duration": 35375,
+    "err": null,
+    "expected": [
+        "0"
+    ],
+    "found": [
+        "1"
+    ],
+    "human": "Expected\n    <int>: 1\nto equal\n    <int>: 0",
+    "meta": {
+        "desc": "Checks for iSCSI portals and verifies that the iSCSI-based boot Content Projection Service is active and running.",
+        "sev": 0
+    },
+    "property": "exit-status",
+    "resource-id": "iscsi_cps_sanity",
+    "resource-type": "Command",
+    "result": 1,
+    "skipped": false,
+    "successful": false, --------
+    "summary-line": "Command: iscsi_cps_sanity: exit-status:\nExpected\n    <int>: 1\nto equal\n    <int>: 0",
+    "test-type": 0,
+    "title": "iSCSI boot content projection"
+}
+```
+
+## Root cause
+
+iSCSI SBPS marshal system service may not be in active state as below:
+
+```bash
+# systemctl status sbps-marshal
+● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images simi>
+     Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
+     Active: activating (auto-restart) (Result: exit-code) since Thu 2026-02-26 09:11:36 UTC; 13s ago
+    Process: 2241039 ExecStart=/usr/lib/sbps-marshal/bin/sbps-marshal (code=exited, status=203/EXEC)
+   Main PID: 2241039 (code=exited, status=203/EXEC)
+        CPU: 2ms
+```
+
+Journalctl log for this service may have below errors:
+
+```bash
+# Journalctl -u sbps-marshal.service
+```
+
+Snippet of journalctl log:
+
+```text
+Feb 26 09:11:00 ncn-w003 systemd[1]: Started System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images similar to PE..
+Feb 26 09:11:00 ncn-w003 (-marshal)[2230374]: sbps-marshal.service: Failed at step EXEC spawning /usr/lib/sbps-marshal/bin/sbps-marshal: No such file or directory
+Feb 26 09:11:00 ncn-w003 systemd[1]: sbps-marshal.service: Main process exited, code=exited, status=203/EXEC
+Feb 26 09:11:00 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'exit-code'.
+Feb 26 09:11:36 ncn-w003 systemd[1]: Stopped System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images similar to PE..
+Feb 26 09:11:36 ncn-w003 (-marshal)[2241039]: sbps-marshal.service: Failed to locate executable /usr/lib/sbps-marshal/bin/sbps-marshal: No such file or directory
+Feb 26 09:11:36 ncn-w003 (-marshal)[2241039]: sbps-marshal.service: Failed at step EXEC spawning /usr/lib/sbps-marshal/bin/sbps-marshal: No such file or directory
+Feb 26 09:11:36 ncn-w003 systemd[1]: Started System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary images similar to PE..
+Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Main process exited, code=exited, status=203/EXEC
+Feb 26 09:11:36 ncn-w003 systemd[1]: sbps-marshal.service: Failed with result 'exit-code'.
+```
+
+## Resolution
+
+Follow the squence of steps on the affected node as below:
+
+1. Enable the sbps-marshal systemd service: 
+
+```bash
+# systemctl enable sbps-marshal.service
+```
+
+Example output:
+
+```bash
+ncn-w003:~ # systemctl enable sbps-marshal.service
+Created symlink /etc/systemd/system/multi-user.target.wants/sbps-marshal.service → /usr/lib/systemd/system/sbps-marshal.service.
+```
+
+1. Restart sbps-marshal systemd service
+
+```bash
+# systemctl restart sbps-marshal.service
+```
+
+1. Check the status of sbps-marshal.service, it should be running fine as below:
+
+Example command:
+
+```bash
+# systemctl status sbps-marshal.service
+```
+
+Example command output:
+
+```bash
+
+ncn-w003:~ # systemctl status sbps-marshal.service
+● sbps-marshal.service - System service that manages Squashfs images projected via iSCSI for IMS, PE, and other ancillary>
+     Loaded: loaded (/usr/lib/systemd/system/sbps-marshal.service; enabled; preset: disabled)
+     Active: active (running) since Thu 2026-02-26 18:07:51 UTC; 22min ago
+   Main PID: 1297260 (sbps-marshal)
+      Tasks: 1
+        CPU: 3min 14.810s
+     CGroup: /system.slice/sbps-marshal.service
+             └─1297260 /usr/lib/sbps-marshal/bin/python /usr/lib/sbps-marshal/bin/sbps-marshal
+
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:314 INFO 2026-02-26T18:29:49+0000 No sbps-project key value>
+Feb 26 18:29:49 ncn-w003 sbps-marshal[1297260]: agent.py:main:405 INFO 2026-02-26T18:29:49+0000 END SCAN
+```


### PR DESCRIPTION
# Description
During upgrade from 1.6.x to 1.7.x or from 1.7.x to 1.7.y, the NCN health checks may fail with iSCSI SBPS.  This is the workaround solution for iSCSI SBPS failure encountered in https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9069 

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
