### PR TITLE
CASMNET-2388: document dhcp-helper SMD EthernetInterface race condition

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -561,6 +561,7 @@ haproxy
 heartbeating
 highspeed
 hms-discovery
+honor
 honored
 hostname
 hostnames

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -16,7 +16,7 @@
       - [State Manager Daemon](#state-manager-daemon)
    1. [Duplicate IP address](#23-duplicate-ip-address)
    1. [Numerous DHCP decline messages during node boot](#24-numerous-dhcp-decline-messages-during-node-boot)
-   1. [Deleted SMD EthernetInterface record restored by DHCP helper](#25-deleted-smd-ethernetinterface-record-restored-by-dhcp-helper)
+   1. [Deleted SMD `ethernetInterfaces` record restored by DHCP helper](#25-deleted-smd-ethernetinterface-record-restored-by-dhcp-helper)
 - [3 Network troubleshooting](#3-network-troubleshooting)
    1. [Check BGP/MetalLB](#31-check-bgpmetallb)
       - [Mellanox spine switches](#mellanox-spine-switches)
@@ -537,13 +537,13 @@ troubleshoot and remediate the problem.
    The standard discovery/DHCP/DNS process should complete in about 5 minutes.
    This will get the node to boot up.
 
-### 2.5 Deleted SMD EthernetInterface record restored by DHCP helper
+### 2.5 Deleted SMD `ethernetInterfaces` record restored by DHCP helper
 
 **Symptom:** An SMD `EthernetInterface` record deleted via the API or `cray hsm` CLI reappears
 within 3 minutes, and the `cray-dhcp-kea-helper` job logs show an `Added {'MACAddress': ...}`
 message.
 
-**Cause:** `dhcp-helper.py` runs on a 3-minute CronJob and reconciles active Kea DHCP leases
+**Cause:** `dhcp-helper.py` runs on a 3 minute CronJob and reconciles active Kea DHCP leases
 against SMD. If it finds an active lease for a MAC address with no corresponding SMD record, it
 re-creates the record. There is no locking mechanism to honour admin deletions, so any deletion is
 silently reversed on the next run as long as the Kea lease remains active.

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -545,7 +545,7 @@ message.
 
 **Cause:** `dhcp-helper.py` runs on a 3 minute CronJob and reconciles active Kea DHCP leases
 against SMD. If it finds an active lease for a MAC address with no corresponding SMD record, it
-re-creates the record. There is no locking mechanism to honour admin deletions, so any deletion is
+re-creates the record. There is no locking mechanism to honor admin deletions, so any deletion is
 silently reversed on the next run as long as the Kea lease remains active.
 
 **Workaround:** Delete the Kea lease **before** deleting the SMD record.
@@ -585,7 +585,7 @@ silently reversed on the next run as long as the Kea lease remains active.
 
 > **Important:** Do **not** delete the SMD record first. If the Kea lease is still active when the
 > next `dhcp-helper` CronJob runs (within 3 minutes), the SMD record will be restored
-> automatically. Minimise the time between steps 2 and 3 to reduce the chance of a cron run
+> automatically. Minimize the time between steps 2 and 3 to reduce the chance of a cron run
 > occurring in between.
 
 ## 3 Network troubleshooting

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -16,7 +16,7 @@
       - [State Manager Daemon](#state-manager-daemon)
    1. [Duplicate IP address](#23-duplicate-ip-address)
    1. [Numerous DHCP decline messages during node boot](#24-numerous-dhcp-decline-messages-during-node-boot)
-   1. [Deleted SMD `ethernetInterfaces` record restored by DHCP helper](#25-deleted-smd-ethernetinterface-record-restored-by-dhcp-helper)
+   1. [Deleted SMD `ethernetInterfaces` record restored by DHCP helper](#25-deleted-smd-ethernetinterfaces-record-restored-by-dhcp-helper)
 - [3 Network troubleshooting](#3-network-troubleshooting)
    1. [Check BGP/MetalLB](#31-check-bgpmetallb)
       - [Mellanox spine switches](#mellanox-spine-switches)

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -16,6 +16,7 @@
       - [State Manager Daemon](#state-manager-daemon)
    1. [Duplicate IP address](#23-duplicate-ip-address)
    1. [Numerous DHCP decline messages during node boot](#24-numerous-dhcp-decline-messages-during-node-boot)
+   1. [Deleted SMD EthernetInterface record restored by DHCP helper](#25-deleted-smd-ethernetinterface-record-restored-by-dhcp-helper)
 - [3 Network troubleshooting](#3-network-troubleshooting)
    1. [Check BGP/MetalLB](#31-check-bgpmetallb)
       - [Mellanox spine switches](#mellanox-spine-switches)
@@ -535,6 +536,57 @@ troubleshoot and remediate the problem.
 
    The standard discovery/DHCP/DNS process should complete in about 5 minutes.
    This will get the node to boot up.
+
+### 2.5 Deleted SMD EthernetInterface record restored by DHCP helper
+
+**Symptom:** An SMD `EthernetInterface` record deleted via the API or `cray hsm` CLI reappears
+within 3 minutes, and the `cray-dhcp-kea-helper` job logs show an `Added {'MACAddress': ...}`
+message.
+
+**Cause:** `dhcp-helper.py` runs on a 3-minute CronJob and reconciles active Kea DHCP leases
+against SMD. If it finds an active lease for a MAC address with no corresponding SMD record, it
+re-creates the record. There is no locking mechanism to honour admin deletions, so any deletion is
+silently reversed on the next run as long as the Kea lease remains active.
+
+**Workaround:** Delete the Kea lease **before** deleting the SMD record.
+
+1. (`ncn-mw#`) Find the IP address currently associated with the MAC address to be removed.
+
+   ```bash
+   cray hsm inventory ethernetInterfaces describe <MAC-no-colons> --format json | jq '.IPAddresses[].IPAddress'
+   ```
+
+1. (`ncn-mw#`) Delete the Kea lease for that IP address.
+
+   ```bash
+   curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+       -X POST \
+       -H "Content-Type: application/json" \
+       -d '{"command": "lease4-del", "service": ["dhcp4"], "arguments": {"ip-address": "<IP>"}}' \
+       https://api-gw-service-nmn.local/apis/dhcp-kea | jq
+   ```
+
+   A successful deletion returns a result of `0`:
+
+   ```text
+   [
+     {
+       "result": 0,
+       "text": "IPv4 lease deleted."
+     }
+   ]
+   ```
+
+1. (`ncn-mw#`) Delete the SMD `EthernetInterface` record.
+
+   ```bash
+   cray hsm inventory ethernetInterfaces delete <MAC-no-colons>
+   ```
+
+> **Important:** Do **not** delete the SMD record first. If the Kea lease is still active when the
+> next `dhcp-helper` CronJob runs (within 3 minutes), the SMD record will be restored
+> automatically. Minimise the time between steps 2 and 3 to reduce the chance of a cron run
+> occurring in between.
 
 ## 3 Network troubleshooting
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!---
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Adds section 2.5 to the DHCP troubleshooting runbook documenting a known issue where
`dhcp-helper.py` silently restores SMD `EthernetInterface` records that have been deleted by an
administrator.

`dhcp-helper.py` runs on a 3-minute Kubernetes CronJob and reconciles active Kea DHCP leases
against SMD. When it finds an active lease for a MAC address with no corresponding SMD record, it
re-creates the record with no warning. Because there is no locking mechanism, any admin deletion
is silently reversed on the next cron run as long as the Kea lease remains active.

The new section covers:

- **Symptom** — deleted SMD `EthernetInterface` records reappear within 3 minutes
- **Cause** — the unprotected read-then-write pattern in `dhcp-helper.py`
- **Workaround** — step-by-step procedure to delete the Kea lease before deleting the SMD record,
  preventing the helper from restoring it

Relates to:
- CASMNET-2388

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR.

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR -->
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams