### PR TITLE
CASM-5776: adding WAR for removing udpIdleTimeout

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -85,6 +85,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Kubelet Memory Pressure False Positive](known_issues/kubelet_memory_pressure_false_positive.md)
 * [iSCSI SBPS Marshal agent failure](known_issues/iscsi_sbps_marshal_failure.md)
 * [Worker nodes unresponsive and `dmesg` flooded with iSCSI errors](known_issues/worker_nodes_unresponsive_and_dmesg_flooded_with_iSCSI_errors.md)
+* [Cloud init loops for master node: unknown field `udpIdleTimeout`](known_issues/management_nodes_rollout_stuck_at_cloud_init.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
+++ b/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
@@ -28,10 +28,10 @@ During a CSM upgrade, cloud init keeps looping with an error while fetching the 
     [ 2793.848637] cloud-init[12289]: If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
    ```
 
-1. Check whether `udpIdleTimeout` exists in `kube-proxy`.
+1. (`ncn-m#`)Check whether `udpIdleTimeout` exists in `kube-proxy`.
 
    ```bash
-   ncn-m#:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
+   kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
    ```
 
    Example output:

--- a/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
+++ b/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
@@ -28,12 +28,17 @@ During a CSM upgrade, cloud init keeps looping with an error while fetching the 
     [ 2793.848637] cloud-init[12289]: If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
    ```
 
-2. Check whether `udpIdleTimeout` exists in `kube-proxy`.
+1. Check whether `udpIdleTimeout` exists in `kube-proxy`.
 
    ```bash
-   ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
-    udpIdleTimeout: 0s
+   ncn-m#:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
    ```
+
+   Example output:
+
+   ```text
+    udpIdleTimeout: 0s
+    ```
 
 ## Issue conditions
 
@@ -41,7 +46,7 @@ This issue occurs when `PREPARE_KUBEADM` successfully patches `kube-proxy`, but 
 
 ## Workaround description
 
-1. Create the `PREPARE_KUBEADM.sh` script using the below command
+1. (`ncn-m#`)Create the `PREPARE_KUBEADM.sh` script using the below command
 
    ```bash
    cat > PREPARE_KUBEADM.sh <<'EOF'
@@ -72,15 +77,15 @@ This issue occurs when `PREPARE_KUBEADM` successfully patches `kube-proxy`, but 
    EOF
    ```
 
-2. Execute the script using these command:
+1. (`ncn-m#`)Execute the script using these command:
 
    ```bash
    chmod +x PREPARE_KUBEADM.sh
    ./PREPARE_KUBEADM.sh
    ```
 
-3. Verify that the `udpIdleTimeout` was removed post the script execution:
+1. (`ncn-m#`)Verify that the `udpIdleTimeout` was removed post the script execution:
 
    ```bash
-   ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
+   kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
    ```

--- a/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
+++ b/troubleshooting/known_issues/management_nodes_rollout_stuck_at_cloud_init.md
@@ -1,0 +1,86 @@
+# Cloud init loops for master node: unknown field `udpIdleTimeout`
+
+## Issue description
+
+During a CSM upgrade, cloud init keeps looping with an error while fetching the `kubeadm-config` `configmap` due to an unknown field `udpIdleTimeout` being present in the `configmap`.
+
+## Issue identification
+
+1. Console logs from cloud-init shows the below messages and keep looping.
+
+   ```bash
+    [ 2793.365094] cloud-init[12289]: [preflight] Running pre-flight checks
+    [ 2793.662029] cloud-init[12289]: [preflight] Reading configuration from the cluster...
+    [ 2793.662295] cloud-init[12289]: [preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
+    [ 2793.676480] cloud-init[12289]: W1202 18:35:21.771765   76408 configset.go:177] error unmarshaling configuration schema.GroupVersionKind{Group:"kubeproxy.config.k8s.io", Version:"v1alpha1", Kind:"KubeProxyConfiguration"}: strict decoding error: unknown field "udpIdleTimeout"
+    [ 2793.704137] cloud-init[12289]: error execution phase preflight: unable to fetch the kubeadm-config ConfigMap: this version of kubeadm only supports deploying clusters with the control plane version >= 1.25.0. Current version: v1.24.17
+    [ 2793.704351] cloud-init[12289]: To see the stack trace of this error execute with --v=5 or higher
+    [ 2793.770533] cloud-init[12289]: [preflight] Running pre-flight checks
+    [ 2793.770764] cloud-init[12289]: W1202 18:35:21.865871   76487 removeetcdmember.go:106] [reset] No kubeadm config, using etcd pod spec to get data directory
+    [ 2793.771215] cloud-init[12289]: [reset] Deleted contents of the etcd data directory: /var/lib/etcd
+    [ 2793.771312] cloud-init[12289]: [reset] Stopping the kubelet service
+    [ 2793.790699] cloud-init[12289]: [reset] Unmounting mounted directories in "/var/lib/kubelet"
+    [ 2793.847330] cloud-init[12289]: [reset] Deleting contents of directories: [/etc/kubernetes/manifests /var/lib/kubelet /etc/kubernetes/pki]
+    [ 2793.848054] cloud-init[12289]: [reset] Deleting files: [/etc/kubernetes/admin.conf /etc/kubernetes/kubelet.conf /etc/kubernetes/bootstrap-kubelet.conf /etc/kubernetes/controller-manager.conf /etc/kubernetes/scheduler.conf]
+    [ 2793.848241] cloud-init[12289]: The reset process does not clean CNI configuration. To do so, you must remove /etc/cni/net.d
+    [ 2793.848377] cloud-init[12289]: The reset process does not reset or clean up iptables rules or IPVS tables.
+    [ 2793.848508] cloud-init[12289]: If you wish to reset iptables, you must do so manually by using the "iptables" command.
+    [ 2793.848637] cloud-init[12289]: If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
+   ```
+
+2. Check whether `udpIdleTimeout` exists in `kube-proxy`.
+
+   ```bash
+   ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
+    udpIdleTimeout: 0s
+   ```
+
+## Issue conditions
+
+This issue occurs when `PREPARE_KUBEADM` successfully patches `kube-proxy`, but a later process updates `kube-proxy` ConfigMap content and reintroduces `udpIdleTimeout`.
+
+## Workaround description
+
+1. Create the `PREPARE_KUBEADM.sh` script using the below command
+
+   ```bash
+   cat > PREPARE_KUBEADM.sh <<'EOF'
+   #!/bin/bash
+
+   tmpdir=$(mktemp -d)
+
+   # This is necessary for the initial 1.24.17 to 1.26.15 bump. Otherwise,
+   # kubeadm commands in kubernetes-cloudinit.sh fail. We also need to make
+   # sure we don't enable the PodSecurityPolicy plugin by removing it from the
+   # existing configmap.
+   echo "Patching kubeadm-config configmap to update kubernetesVersion from 1.24.17 to 1.26.15 ..."
+   kubectl -n kube-system get configmap kubeadm-config -o go-template --template '{{ .data.ClusterConfiguration }}' \
+     | yq4 e '.kubernetesVersion="v1.26.15"' \
+     | yq4 e '.apiServer.extraArgs.enable-admission-plugins="NodeRestriction"' \
+       > "${tmpdir}/kubeadm-config.yaml"
+   patch=$(jq -c -n --rawfile text "${tmpdir}/kubeadm-config.yaml" '.data["ClusterConfiguration"]=$text')
+   kubectl -n kube-system patch configmap kubeadm-config --type merge --patch "${patch}"
+   
+   echo "Patching kube-proxy configmap to remove udpIdleTimeout ..."
+   kubectl -n kube-system get configmap kube-proxy -o go-template --template '{{ index .data "config.conf" }}' \
+     | yq4 e 'del(.udpIdleTimeout)' \
+       > "${tmpdir}/kube-proxy.yaml"
+   patch=$(jq -c -n --rawfile text "${tmpdir}/kube-proxy.yaml" '.data["config.conf"]=$text')
+   kubectl -n kube-system patch configmap kube-proxy --type merge --patch "${patch}"
+   
+   rm -rf "${tmpdir}"
+   EOF
+   ```
+
+2. Execute the script using these command:
+
+   ```bash
+   chmod +x PREPARE_KUBEADM.sh
+   ./PREPARE_KUBEADM.sh
+   ```
+
+3. Verify that the `udpIdleTimeout` was removed post the script execution:
+
+   ```bash
+   ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade # kubectl get cm -n kube-system kube-proxy -o yaml | grep udpIdle
+   ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Adding a WAR document to remove "udpIdleTimeout" from kubeadm-config configmap in case the field gets reintroduced due to some issues.

Resolves [CASM-5776](https://jira-pro.it.hpe.com:8443/browse/CASM-5776) and linked CAST [CAST-39713](https://jira-pro.it.hpe.com:8443/browse/CAST-39713)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
