### PR TITLE
CASMTRIAGE-9128:  Update IUF docs for procedure to follow after each batch of worker nodes rollout w.r.t iSCSI

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -580,9 +580,10 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
-    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded. Here ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability for iSCSI SBPS after the worker nodes rollout is complete.
- Proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
-   
+    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
+    Here ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability for iSCSI SBPS after the worker nodes rollout is complete.
+    Proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
+
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -580,10 +580,8 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
-    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
-
-    **`Note`** Ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability after the worker nodes rollout is complete.
-   - proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
+    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded. Here ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability for iSCSI SBPS after the worker nodes rollout is complete.
+ Proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
    
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -574,6 +574,9 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
+1. (`ncn-w001#`) Verify the health of the iSCSI SBPS on canary worker node
+
+1. (`ncn-n00*#`) Verify the health of the iSCSI SBPS on compute nodes
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -573,40 +573,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
-1. Verify whether there have been any changes to LUN assignments on the `iSCSI SBPS` target (canary worker node).
-
-    1. (`ncn-w001#`) Verify whether the following messages are observed on the canary worker node.       
-
-        ```bash
-        dmesg | grep "Detected NON_EXISTENT_LUN Access"
-        ```
-
-        Example output:
-
-        ```text
-        sd 2:0:0:10: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-        sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-        sd 2:0:0:7: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-        sd 2:0:0:9: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-        ```
-
-    1. (`ncn-nid#`) Verify whether the following messages are observed on any compute or UAN node.
-   
-        ```bash
-        dmesg | grep "LUN assignments"
-        ```
-
-        Example output:
-
-        ```text
-        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-        ```
-
-If above respective messages are encountered on the canary worker and any compute/UAN nodes, ensure the following procedure is followed before continuing.
-[Steps to follow after the worker node is down during Rebuild](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
+1. Ensure to [follow these steps after canary worker node rollout is complete](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
@@ -614,9 +581,9 @@ If above respective messages are encountered on the canary worker and any comput
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
-    **`Note`** We need to make sure at least two worker nodes (iSCSI SBPS targets) are healthy for high availability after completion of all the workers rollout.
-   - proceed with next set of worker nodes rollout in a batch, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
-       - execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](#management_rollout.md#23-ncn-worker-nodes] after each batch of worker nodes rollout.
+    **`Note`** Ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability after the worker nodes rollout is complete.
+   - proceed with next set of worker nodes rollout in a batch after canary wroker node rollout, followed by the remaining worker nodes rollout.
+   - execute Step 6 at [management rollout of ncn worker nodes](#management_rollout.md#23-ncn-worker-nodes] after each batch of worker nodes rollout.
         
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
@@ -650,6 +617,8 @@ If above respective messages are encountered on the canary worker and any comput
         cray cfs components describe $ncn --format json | jq -r ' .id+" "+.desiredConfig+" status="+.configurationStatus'
     done
     ```
+    
+1. Ensure to [follow these steps after worker nodes rollout is complete](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -583,10 +583,10 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
    all remaining worker nodes is complete.
 
    **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
-    node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
-    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
-    
-    **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
+   node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
+   with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
+
+   **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -282,8 +282,7 @@ The specific scripts executed as part of this hook are `/usr/share/doc/csm/upgra
 
         See [Configure the Cray Command Line Interface](../../configure_cray_cli.md) for details on how to do this.
 
-    1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m001`. This will rebuild `ncn-m001` with the    new CFS configuration and image built in
-    previous steps of the workflow.
+    1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m001`. This will rebuild `ncn-m001` with the new CFS  configuration and image built in previous steps of the workflow.
 
         (`ncn-m002#`) Upgrade `ncn-m001`. This **must** be executed on **`ncn-m002`**.
 
@@ -578,33 +577,33 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     1. (`ncn-w001#`) Verify whether the following messages are observed on the canary worker node.       
 
-    ```bash
-    dmesg | grep "Detected NON_EXISTENT_LUN Access"
-    ```
+        ```bash
+        dmesg | grep "Detected NON_EXISTENT_LUN Access"
+        ```
 
-    Example output:
+        Example output:
 
-    ```text
-    sd 2:0:0:10: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-    sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-    sd 2:0:0:7: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-    sd 2:0:0:9: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
-    ```
+        ```text
+        sd 2:0:0:10: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+        sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+        sd 2:0:0:7: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+        sd 2:0:0:9: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+        ```
 
-    1. (`ncn-n00*#`) Verify whether the following messages are observed on any compute or UAN node.
+    1. (`ncn-nid#`) Verify whether the following messages are observed on any compute or UAN node.
    
-    ```bash
-    dmesg | grep "LUN assignments"
-    ```
+        ```bash
+        dmesg | grep "LUN assignments"
+        ```
 
-    Example output:
+        Example output:
 
-    ```text
-    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
-    ```
+        ```text
+        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+        TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+        ```
 
 If above respective messages are encountered on the canary worker and any compute/UAN nodes, ensure the following procedure is followed before continuing.
 [Steps to follow after the worker node is down during Rebuild](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
@@ -616,8 +615,8 @@ If above respective messages are encountered on the canary worker and any comput
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
     **`Note`** We need to make sure at least two worker nodes (iSCSI SBPS targets) are healthy for high availability after completion of all the workers rollout.
-       - proceed with next set of worker nodes rollout in a batch, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
-           - execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](# management_rollout.md#23-ncn-worker-nodes].
+   - proceed with next set of worker nodes rollout in a batch, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
+       - execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](#management_rollout.md#23-ncn-worker-nodes] after each batch of worker nodes rollout.
         
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -574,7 +574,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
 
-1. Ensure to [follow these steps after canary worker node rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
+1. Ensure to [follow these steps after worker node rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -588,7 +588,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
    **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
-   
+
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 
         ```bash
@@ -597,7 +597,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes.
       The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
-   
+
         ```bash
         WORKER_NODES=$(kubectl get node | grep -P 'ncn-w\d+' | grep -v $WORKER_CANARY |  awk '{print $1}' | xargs)
         echo $WORKER_NODES

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -584,8 +584,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     **`Note`** Ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability after the worker nodes rollout is complete.
    - proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
-   - ensure to execute step 6 at [2.3 NCN worker nodes](23-ncn-worker-nodes) after each batch of worker nodes rollout.
-
+   
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -573,7 +573,8 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
-1. Ensure to [follow these steps after canary worker node rollout is complete](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
+    
+1. Ensure to [follow these steps after canary worker node rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
@@ -582,9 +583,9 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
     **`Note`** Ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability after the worker nodes rollout is complete.
-   - proceed with next set of worker nodes rollout in a batch after canary wroker node rollout, followed by the remaining worker nodes rollout.
-   - execute Step 6 at [management rollout of ncn worker nodes](#management_rollout.md#23-ncn-worker-nodes] after each batch of worker nodes rollout.
-        
+   - proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
+   - ensure to execute step 6 at [2.3 NCN worker nodes](23-ncn-worker-nodes) after each batch of worker nodes rollout.
+
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
@@ -617,8 +618,8 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
         cray cfs components describe $ncn --format json | jq -r ' .id+" "+.desiredConfig+" status="+.configurationStatus'
     done
     ```
-    
-1. Ensure to [follow these steps after worker nodes rollout is complete](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
+
+1. Ensure to [follow these steps after worker nodes rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
 
 Once this step has completed:
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -579,7 +579,8 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
    **`NOTE`** During the worker node rollout, ensure that at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
-   availability for iSCSI SBPS. Verify the health of these nodes before proceeding to the next batch of worker node rollouts. Continue this process until the rollout of
+   availability for iSCSI SBPS. We can rollout one more worker other than canary node to be labeled with `iuf-prevent-rollout=true` followed by rest of
+   the worker nodes rollout. Verify the health of these nodes before proceeding to the next batch of worker node rollouts. Continue this process until the rollout of
    all remaining worker nodes is complete.
 
    **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
@@ -587,7 +588,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
    **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
-
+     
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 
         ```bash
@@ -596,11 +597,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes.
       The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
-
-       **`NOTE`** Since we need to ensure at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
-       availability for iSCSI SBPS, we can rollout one more worker other than canary node to be labeled with `iuf-prevent-rollout=true` followed by rest of
-      the worker nodes rollout.  
-      
+   
         ```bash
         WORKER_NODES=$(kubectl get node | grep -P 'ncn-w\d+' | grep -v $WORKER_CANARY |  awk '{print $1}' | xargs)
         echo $WORKER_NODES

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -575,7 +575,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```
 
 1. Ensure to [follow these steps after worker node rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
-
+  
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
    **`NOTE`** During the worker node rollout, ensure that at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
@@ -597,6 +597,10 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     - (`ncn-m001#`) Execute `management-nodes-rollout` on a group of worker nodes.
       The list of worker nodes can be manually edited if it is undesirable to rebuild/upgrade all of the workers with one execution.
 
+       **`NOTE`** Since we need to ensure at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
+       availability for iSCSI SBPS, we can rollout one more worker other than canary node to be labeled with `iuf-prevent-rollout=true` followed by rest of
+      the worker nodes rollout.  
+      
         ```bash
         WORKER_NODES=$(kubectl get node | grep -P 'ncn-w\d+' | grep -v $WORKER_CANARY |  awk '{print $1}' | xargs)
         echo $WORKER_NODES

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -573,7 +573,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
-    
+
 1. Ensure to [follow these steps after canary worker node rollout is complete](../../iscsi_sbps/iscsi_steps_post_rollout.md) for iSCSI SBPS.
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -574,9 +574,9 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
-1. Verify whether there have been any changes to LUN assignments on the iSCSI SBPS target (canary worker node).
+1. Verify whether there have been any changes to LUN assignments on the `iSCSI SBPS` target (canary worker node).
 
-    1. (`ncn-w001#`) Check if below messages is seen on the canary worker node.
+    1. (`ncn-w001#`) Verify whether the following messages are observed on the canary worker node.       
 
     ```bash
     dmesg | grep "Detected NON_EXISTENT_LUN Access"
@@ -585,11 +585,14 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     Example output:
 
     ```text
-    Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+    sd 2:0:0:10: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+    sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+    sd 2:0:0:7: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+    sd 2:0:0:9: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
     ```
 
-    1. (`ncn-n00*#`) Check if below messages is seen on any of the compute/ UAN node.
-
+    1. (`ncn-n00*#`) Verify whether the following messages are observed on any compute or UAN node.
+   
     ```bash
     dmesg | grep "LUN assignments"
     ```
@@ -597,10 +600,13 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     Example output:
 
     ```text
-    sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+    TARGET_CORE[iSCSI]: Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
     ```
 
-If these respective messages are encountered on the canary worker and any compute/UAN nodes, ensure the following procedure is completed before continuing.
+If above respective messages are encountered on the canary worker and any compute/UAN nodes, ensure the following procedure is followed before continuing.
 [Steps to follow after the worker node is down during Rebuild](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
@@ -609,10 +615,9 @@ If these respective messages are encountered on the canary worker and any comput
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
-    **`Note`**
-        - We need to make sure at least two worker nodes (iSCSI SBPS targets) are healthy for high availability after completion of all the workers rollouts.
-            - After successful canary rollout, proceed with next set of worker nodes rollout in a batche, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
-            - After next set of worker nodes rollout completion, execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](# management_rollout.md#23-ncn-worker-nodes].
+    **`Note`** We need to make sure at least two worker nodes (iSCSI SBPS targets) are healthy for high availability after completion of all the workers rollout.
+       - proceed with next set of worker nodes rollout in a batch, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
+           - execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](# management_rollout.md#23-ncn-worker-nodes].
         
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -579,7 +579,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
    **`NOTE`** During the worker node rollout, ensure that at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
-   availability for iSCSI SBPS. We can rollout one more worker other than canary node to be labeled with `iuf-prevent-rollout=true` followed by rest of
+   availability for iSCSI SBPS. We can rollout one more worker node other than canary node to be labeled with `iuf-prevent-rollout=true` followed by rest of
    the worker nodes rollout. Verify the health of these nodes before proceeding to the next batch of worker node rollouts. Continue this process until the rollout of
    all remaining worker nodes is complete.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -588,7 +588,7 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
    with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
    **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
-     
+   
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.
 
         ```bash

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -574,9 +574,34 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
-1. (`ncn-w001#`) Verify the health of the iSCSI SBPS on canary worker node
+1. Verify whether there have been any changes to LUN assignments on the iSCSI SBPS target (canary worker node).
 
-1. (`ncn-n00*#`) Verify the health of the iSCSI SBPS on compute nodes
+    1. (`ncn-w001#`) Check if below messages is seen on the canary worker node.
+
+    ```bash
+    dmesg | grep "Detected NON_EXISTENT_LUN Access"
+    ```
+
+    Example output:
+
+    ```text
+    Detected NON_EXISTENT_LUN Access for 0x00000001 from iqn.2023-06.csm.iscsi:x 1000c1s1b1n0
+    ```
+
+    1. (`ncn-n00*#`) Check if below messages is seen on any of the compute/ UAN node.
+
+    ```bash
+    dmesg | grep "LUN assignments"
+    ```
+
+    Example output:
+
+    ```text
+    sd 2:0:0:12: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments.
+    ```
+
+If these respective messages are encountered on the canary worker and any compute/UAN nodes, ensure the following procedure is completed before continuing.
+[Steps to follow after the worker node is down during Rebuild](../..//iscsi_sbps/iscsi_pre-requisite_steps_during_rebuild.md).
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -609,6 +609,11 @@ If these respective messages are encountered on the canary worker and any comput
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
 
+    **`Note`**
+        - We need to make sure at least two worker nodes (iSCSI SBPS targets) are healthy for high availability after completion of all the workers rollouts.
+            - After successful canary rollout, proceed with next set of worker nodes rollout in a batche, followed by the remaining worker nodes rollout, to prevent impact on compute nodes.
+            - After next set of worker nodes rollout completion, execute Step 6 (LUN assignment verification) at [management rollout of ncn worker nodes](# management_rollout.md#23-ncn-worker-nodes].
+        
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -578,12 +578,14 @@ The worker canary node can be any worker node and does not have to be `ncn-w001`
 
 1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
-    **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
+   **`NOTE`** During the worker node rollout, ensure that at least two worker nodes (iSCSI SBPS targets) remain healthy after each rollout batch to maintain high
+   availability for iSCSI SBPS. Verify the health of these nodes before proceeding to the next batch of worker node rollouts. Continue this process until the rollout of
+   all remaining worker nodes is complete.
+
+   **`NOTE`** For this step, the argument to `--limit-management-rollout` can be `Management_Worker` or a list of worker
     node names separated by spaces. If `Management_Worker` is supplied, all worker nodes that are not labeled
     with `iuf-prevent-rollout=true` will be rebuilt/upgraded. If a list of worker node names is supplied, then those worker nodes will be rebuilt/upgraded.
-    Here ensure at least two worker nodes (iSCSI SBPS targets) remain healthy to maintain high availability for iSCSI SBPS after the worker nodes rollout is complete.
-    Proceed with next set of worker nodes rollout in a batch after canary worker node rollout, followed by the remaining worker nodes rollout.
-
+    
     **Choose one** of the following two options. The difference between the options is the `limit-management-rollout` argument, but the two options do the same thing.
 
     - (`ncn-m001#`) Execute `management-nodes-rollout` on all `Management_Worker` nodes.


### PR DESCRIPTION

# Description

On Upgrade CSM 25.9.0 (1.7.0) to CSM 26.3.0 (1.7.1) on Creek system:

After all worker nodes management rollouts complete, observed SQUASHFS errors and _"LUN assignments on this target have changed"_ messages from the compute nodes dmesg log and also _"Detected NON_EXISTENT_LUN Access"_ messages observed from the worker nodes. Compute nodes look to be frozen due to the flood of the messages and commands are failing.  

# Resolution
Update IUF management rollouts (for workers) section to validate if the issue can occur and apply the [CASMTRIAGE-9129](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9129) procedure as a preventive action to avoid the issue (compute nodes freezing/ unresponsive).

Relates to:
[CASMTRIAGE-9122](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9122)[CASMTRIAGE-9122] - Parent JIRA
[CASMTRIAGE-9128](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9128) - Current PR ref JIRA
[CASMTRIAGE-9129](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9129) - iSCSI SBPS procedure