### PR TITLE
CASMTRIAGE-9107 Updating multiple docs to fetch shasta-cfg utils from…

### DIFF
--- a/operations/configuration_management/VCS_Administrative_User.md
+++ b/operations/configuration_management/VCS_Administrative_User.md
@@ -173,7 +173,7 @@ This can be done either using the VCS web interface, or using the command line.
 
         > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
         > from the CSM repository as a fallback. Clone the repository on a local
-        > system that has internet aq2  access, then copy only the `utils` directory to the cluster node.
+        > system that has internet access, then copy only the `utils` directory to the cluster node.
         >
         > On the local system:
         >

--- a/operations/configuration_management/VCS_Administrative_User.md
+++ b/operations/configuration_management/VCS_Administrative_User.md
@@ -156,16 +156,36 @@ This can be done either using the VCS web interface, or using the command line.
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    > This procedure gets a copy of the `shasta-cfg/stable/utils` directory from `github`. If this procedure is being followed when
-    > the PIT node or expanded CSM release tarball is still available, then this directory can copied from those instead.
+    > This procedure gets a copy of the `shasta-cfg/utils` directory from latest IUF activity. If this procedure is being followed when
+    > the PIT node or expanded CSM release tarball is still available, then this directory can be copied from there instead.
 
-    1. Run `git clone https://github.com/Cray-HPE/csm.git -b release/1.7`.
-
-    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
 
         ```bash
-        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        source /etc/cray/upgrade/csm/myenv
         ```
+
+    1. Copy the `utils` directory from `shasta-cfg` into the desired working directory.
+
+        ```bash
+        cp -vr "${CSM_ARTI_DIR}/shasta-cfg/utils" .
+        ```
+
+        > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
+        > from the CSM repository as a fallback. Clone the repository on a local
+        > system that has internet access, then copy only the `utils` directory to the cluster node.
+        >
+        > On the local system:
+        >
+        > ```bash
+        > git clone https://github.com/Cray-HPE/csm.git
+        > ```
+        >
+        > Then copy the `utils` directory from the cloned repository to the cluster node:
+        >
+        > ```bash
+        > scp -r ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils <ncn-mw>:/path/to/working/directory/
+        > ```
 
     1. Change the password in the `customizations.yaml` file.
 

--- a/operations/configuration_management/VCS_Administrative_User.md
+++ b/operations/configuration_management/VCS_Administrative_User.md
@@ -156,10 +156,10 @@ This can be done either using the VCS web interface, or using the command line.
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    > This procedure gets a copy of the `shasta-cfg/utils` directory from latest IUF activity. If this procedure is being followed when
+    > This procedure gets a copy of the `shasta-cfg/utils` from the last upgraded CSM artifacts directory. If this procedure is being followed when
     > the PIT node or expanded CSM release tarball is still available, then this directory can be copied from there instead.
 
-    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest CSM artifacts directory used during the most recent upgrade.
 
         ```bash
         source /etc/cray/upgrade/csm/myenv
@@ -173,7 +173,7 @@ This can be done either using the VCS web interface, or using the command line.
 
         > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
         > from the CSM repository as a fallback. Clone the repository on a local
-        > system that has internet access, then copy only the `utils` directory to the cluster node.
+        > system that has internet aq2  access, then copy only the `utils` directory to the cluster node.
         >
         > On the local system:
         >

--- a/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
+++ b/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
@@ -52,13 +52,33 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
 
       **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-      1. Run `git clone https://github.com/Cray-HPE/csm.git`.
-
-      1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
+      1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
 
          ```bash
-         cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+         source /etc/cray/upgrade/csm/myenv
          ```
+
+      1. Copy the `utils` directory from `shasta-cfg` into the desired working directory.
+
+         ```bash
+         cp -vr "${CSM_ARTI_DIR}/shasta-cfg/utils" .
+         ```
+
+         > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
+         > from the CSM repository as a fallback. Clone the repository on a local
+         > system that has internet access, then copy only the `utils` directory to the cluster node.
+         >
+         > On the local system:
+         >
+         > ```bash
+         > git clone https://github.com/Cray-HPE/csm.git
+         > ```
+         >
+         > Then copy the `utils` directory from the cloned repository to the cluster node:
+         >
+         > ```bash
+         > scp -r ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils <ncn-mw>:/path/to/working/directory/
+         > ```
 
       1. Change the password in the `customizations.yaml` file.
 

--- a/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
+++ b/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
@@ -52,7 +52,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
 
       **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-      1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
+      1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest CSM artifacts directory used during the most recent upgrade.
 
          ```bash
          source /etc/cray/upgrade/csm/myenv

--- a/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
+++ b/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
@@ -32,13 +32,33 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
-
-    1. Copy the directory `./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils` from the cloned repository into the desired working directory.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
 
         ```bash
-        cp -vr ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils .
+        source /etc/cray/upgrade/csm/myenv
         ```
+
+    1. Copy the `utils` directory from `shasta-cfg` into the desired working directory.
+
+        ```bash
+        cp -vr "${CSM_ARTI_DIR}/shasta-cfg/utils" .
+        ```
+
+        > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
+        > from the CSM repository as a fallback. Clone the repository on a local
+        > system that has access to the internet, then copy only the `utils` directory to the cluster node.
+        >
+        > On the local system:
+        >
+        > ```bash
+        > git clone https://github.com/Cray-HPE/csm.git
+        > ```
+        >
+        > Then copy the `utils` directory from the cloned repository to the cluster node:
+        >
+        > ```bash
+        > scp -r ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils <ncn-mw>:/path/to/working/directory/
+        > ```
 
     1. Acquire sealed secret keys.
 

--- a/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
+++ b/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
@@ -32,7 +32,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest CSM artifacts directory used during the most recent upgrade.
 
         ```bash
         source /etc/cray/upgrade/csm/myenv

--- a/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
+++ b/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
@@ -35,7 +35,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest CSM artifacts directory used during the most recent upgrade.
 
         ```bash
         source /etc/cray/upgrade/csm/myenv

--- a/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
+++ b/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
@@ -35,13 +35,33 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
-
-    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
 
         ```bash
-        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        source /etc/cray/upgrade/csm/myenv
         ```
+
+    1. Copy the `utils` directory from `shasta-cfg` into the desired working directory.
+
+        ```bash
+        cp -vr "${CSM_ARTI_DIR}/shasta-cfg/utils" .
+        ```
+
+        > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
+        > from the CSM repository as a fallback. Clone the repository on a local
+        > system that has internet access, then copy only the `utils` directory to the cluster node.
+        >
+        > On the local system:
+        >
+        > ```bash
+        > git clone https://github.com/Cray-HPE/csm.git
+        > ```
+        >
+        > Then copy the `utils` directory from the cloned repository to the cluster node:
+        >
+        > ```bash
+        > scp -r ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils <ncn-mw>:/path/to/working/directory/
+        > ```
 
     1. Acquire sealed secret keys.
 

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -38,7 +38,7 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest CSM artifacts directory used during the most recent upgrade.
 
         ```bash
         source /etc/cray/upgrade/csm/myenv

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -38,13 +38,33 @@ Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.m
 
     **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
-
-    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
+    1. Source the environment file to get the `CSM_ARTI_DIR` value, which contains the path to the latest IUF activity media directory used during the most recent upgrade.
 
         ```bash
-        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        source /etc/cray/upgrade/csm/myenv
         ```
+
+    1. Copy the `utils` directory from `shasta-cfg` into the desired working directory.
+
+        ```bash
+        cp -vr "${CSM_ARTI_DIR}/shasta-cfg/utils" .
+        ```
+
+        > **NOTE:** If the media directory is not present or does not contain the latest content, the `utils` directory can be obtained
+        > from the CSM repository as a fallback. Clone the repository on a local
+        > system that has internet access, then copy only the `utils` directory to the cluster node.
+        >
+        > On the local system:
+        >
+        > ```bash
+        > git clone https://github.com/Cray-HPE/csm.git
+        > ```
+        >
+        > Then copy the `utils` directory from the cloned repository to the cluster node:
+        >
+        > ```bash
+        > scp -r ./csm/vendor/github.com/Cray-HPE/shasta-cfg/utils <ncn-mw>:/path/to/working/directory/
+        > ```
 
     1. Acquire sealed secret keys.
 


### PR DESCRIPTION
… IUF instead of GIT

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

[CASMTRIAGE-9107](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9107) was raised during creek testing because some procedures in CSM use git clone on the CSM repository to fetch shasta-cfg/util files. Since CSM systems are air-gapped, they cannot access Git repositories directly.

Additionally, these utility files are not available on the NCNs, making them difficult to access when needed.

Most of these utility files are primarily used during the installation process, where they are available in the prep directory. However, the affected procedures can now be executed at any time, which complicates access to these files.

As an alternative, the procedures can use the CSM media directory generated by IUF during the latest upgrade. The documentation has been updated to prefer using files from the CSM media directory, with git clone retained only as a fallback option when the files are not available locally.
 
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
