### PR TITLE
CASM-5740 Fixing review comments in FM on BM document

### DIFF
--- a/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
+++ b/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
@@ -19,7 +19,7 @@ and configuring the necessary networking to support Fabric Manager on `baremetal
 Post CSM Upgrade to CSM 1.7.1, if an administrator wishes to enable Fabric Manager on baremetal, they must follow below procedure.
 
 * Step 1: [FMN Prerequisites](#fmn-prerequisites)
-* step 2: [FMN Pre Boot](#fmn-pre-boot)
+* Step 2: [FMN Pre Boot](#fmn-pre-boot)
     * [FMN Base Image Creation](#fmn-base-image-creation)
     * [Add FMN nodes to CSM](#add-fmn-nodes-to-csm)
 * Step 3: [FMN Booting](#fmn-booting)

--- a/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
+++ b/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
@@ -82,7 +82,7 @@ images:
   base:
     product:
       name: csm
-      version: 1.7.1-beta.10
+      version: 1.7.1
       type: image
       filter:
         prefix: secure-kubernetes
@@ -108,7 +108,7 @@ sat bootprep run \
       --limit images --limit configurations \
       --overwrite-images --overwrite-configs \
       --format json \
-      --cfs-version v3
+      --cfs-version v3 \
       --bos-version v2 \
       $BOOTPREP_FILE_PATH
 ```
@@ -120,13 +120,17 @@ sat bootprep run \
 Follow the steps below to register FMNs in CSM (SLS/HSM/BSS) and configure the required network, storage, and cloud-init settings in BSS.
 These configurations will be provisioned automatically during node boot.
 
-#### Allocate NCN IP Addresses
+1) Follow [prerequisites](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#prerequisites) section of Add_Remove_Replace_NCNs.
 
-Follow [`Step-1 of NCN Add Procedure`](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-procedure) for allocating NCN IP addresses.
+2) Follow [NCN Add prerequisites](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-prerequisites) section which contains the prerequisites specific to the node addition procedure.
 
-#### Add NCN data
+3) Allocate NCN IP Addresses 
 
-Follow [`Step-3 of NCN Add Procedure`](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-procedure) for adding NCN data.
+   Follow [`Step-1 of NCN Add Procedure`](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-procedure) for allocating NCN IP addresses.
+
+4) Add NCN data
+
+   Follow [`Step-3 of NCN Add Procedure`](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-procedure) for adding NCN data.
 
 #### Generate Switch Configuration With CANU
 
@@ -187,7 +191,7 @@ Last login: Thu Dec  4 05:03:46 2025 from 10.252.1.10
 ...
 ```
 
-1. Check if both FMN nodes are shown under `sat status`:
+2. Check if both FMN nodes are shown under `sat status`:
 
 ```bash
 ncn-m001:~ # sat status | grep fmn
@@ -199,7 +203,7 @@ INFO: All values for 'Most Recent Session Template' are 'MISSING', omitting key.
 | x3000c0s29b0n0 | fmn002    | Node | 100012   | On        | OK   | True    | X86  | River | Management  | FabricManager | Sling    | True    | fmn-bm-default-configuration | configured           | 0           | stable      | MISSING                              | MISSING                              |
 ```
 
-1. Optionally check more details on the FMN nodes
+3. Optionally check more details on the FMN nodes
 
 For Example:
 

--- a/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
+++ b/operations/fm_on_baremetal/Configure_FM_On_Baremetal.md
@@ -120,11 +120,11 @@ sat bootprep run \
 Follow the steps below to register FMNs in CSM (SLS/HSM/BSS) and configure the required network, storage, and cloud-init settings in BSS.
 These configurations will be provisioned automatically during node boot.
 
-1) Follow [prerequisites](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#prerequisites) section of Add_Remove_Replace_NCNs.
+1) Follow [prerequisites](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#prerequisites) section of `Add_Remove_Replace_NCNs`.
 
 2) Follow [NCN Add prerequisites](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-prerequisites) section which contains the prerequisites specific to the node addition procedure.
 
-3) Allocate NCN IP Addresses 
+3) Allocate NCN IP Addresses
 
    Follow [`Step-1 of NCN Add Procedure`](../node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md#add-ncn-procedure) for allocating NCN IP addresses.
 
@@ -179,55 +179,55 @@ ncn-m001:~ # /opt/cray/platform-utils/spire/fix-spire-on-fmn.sh
 
 1. Check if we are able to access both FMN nodes (`fmn001` and `fmn002`):
 
-```bash
-ncn-m001:~ # ssh fmn001
-Last login: Thu Dec  4 11:25:30 2025 from 10.252.1.10
-...
-```
+    ```bash
+    ncn-m001:~ # ssh fmn001
+    Last login: Thu Dec  4 11:25:30 2025 from 10.252.1.10
+    ...
+    ```
 
-```bash
-ncn-m001:~ # ssh fmn002
-Last login: Thu Dec  4 05:03:46 2025 from 10.252.1.10
-...
-```
+    ```bash
+    ncn-m001:~ # ssh fmn002
+    Last login: Thu Dec  4 05:03:46 2025 from 10.252.1.10
+    ...
+    ```
 
-2. Check if both FMN nodes are shown under `sat status`:
+1. Check if both FMN nodes are shown under `sat status`:
 
-```bash
-ncn-m001:~ # sat status | grep fmn
-```
+    ```bash
+    ncn-m001:~ # sat status | grep fmn
+    ```
 
-```text
-INFO: All values for 'Most Recent Session Template' are 'MISSING', omitting key.
-| x3000c0s28b0n0 | fmn001    | Node | 100011   | On        | OK   | True    | X86  | River | Management  | FabricManager | Sling    | True    | fmn-bm-default-configuration | configured           | 0           | stable      | MISSING                              | MISSING                              |
-| x3000c0s29b0n0 | fmn002    | Node | 100012   | On        | OK   | True    | X86  | River | Management  | FabricManager | Sling    | True    | fmn-bm-default-configuration | configured           | 0           | stable      | MISSING                              | MISSING                              |
-```
+    ```text
+    INFO: All values for 'Most Recent Session Template' are 'MISSING', omitting key.
+    | x3000c0s28b0n0 | fmn001    | Node | 100011   | On        | OK   | True    | X86  | River | Management  | FabricManager | Sling    | True    | fmn-bm-default-configuration | configured           | 0           | stable      | MISSING                              | MISSING                              |
+    | x3000c0s29b0n0 | fmn002    | Node | 100012   | On        | OK   | True    | X86  | River | Management  | FabricManager | Sling    | True    | fmn-bm-default-configuration | configured           | 0           | stable      | MISSING                              | MISSING                              |
+    ```
 
-3. Optionally check more details on the FMN nodes
+1. Optionally check more details on the FMN nodes
 
-For Example:
+    For Example:
 
-```bash
-ncn-m001:~ # XNAME=x3000c0s28b0n0
-```
+    ```bash
+    ncn-m001:~ # XNAME=x3000c0s28b0n0
+    ```
 
-```bash
-ncn-m001:~ # cray hsm state components describe "${XNAME}" --format toml
-```
+    ```bash
+    ncn-m001:~ # cray hsm state components describe "${XNAME}" --format toml
+    ```
 
-```text
-ID = "x3000c0s28b0n0"
-Type = "Node"
-State = "On"
-Flag = "OK"
-Enabled = true
-Role = "Management"
-SubRole = "FabricManager"
-NID = 100011
-NetType = "Sling"
-Arch = "X86"
-Class = "River"
-```
+    ```text
+    ID = "x3000c0s28b0n0"
+    Type = "Node"
+    State = "On"
+    Flag = "OK"
+    Enabled = true
+    Role = "Management"
+    SubRole = "FabricManager"
+    NID = 100011
+    NetType = "Sling"
+    Arch = "X86"
+    Class = "River"
+    ```
 
 #### Validate FMN required networking configuration
 

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
@@ -441,23 +441,24 @@ def add_ncn_network_update(add_ncn_count, network_list, api_header, sls_networks
         last_reserved_ip = sorted_ip_set[last_ip]
         start_dhcp_pool = ip_dhcp_pool_start[network]
         ip_white_space = int(ipaddress.IPv4Address(str(start_dhcp_pool))) - int(
-            ipaddress.IPv4Address(str(last_reserved_ip)))
+              ipaddress.IPv4Address(str(last_reserved_ip))) - 1
 
         print()
         print(f'Checking {network}.')
         print(f'last_reserved_ip: {last_reserved_ip}    start_dhcp_pool:{start_dhcp_pool}')
-        if adding_fmns:
+
+        # Only check for FMN VIP on networks that support it (NMN, HMN)
+        network_adding_fmns = adding_fmns
+        has_fmn_vip = False
+        if adding_fmns and network in ["NMN", "HMN"]:
             has_fmn_vip = network_has_fmn_vip.get(network, False)
             if has_fmn_vip:
-                print(f"{network} already has an existing fmn-vip reservation. Not adding additional VIP")
-                adding_fmns = False
-            else:
-                print(f"{network} does not have an existing fmn-vip reservation. Will add VIP along with FMN NCN(s)")
+                network_adding_fmns = False
+
         if ip_white_space < 0:
             print(f'FATAL last_reserved_ip {last_reserved_ip} exceeds start_dhcp_pool {start_dhcp_pool}')
             print(f'Verify DHCPStart and DHCPEnd are correct for the {network} network in SLS.')
             sys.exit(1)
-        print(f'The space between last_reserved_ip and start_dhcp_pool is {ip_white_space} IP.\n')
         log.info(f'Unsorted static ips:'
                   f' {ip_set}')
         log.info(f'Sorted static ips:'
@@ -468,13 +469,25 @@ def add_ncn_network_update(add_ncn_count, network_list, api_header, sls_networks
         ips_to_delete_from_smd[network] = set()
         new_ip_dhcp_pool_start[network] = ''
         ip_shift = 0
-        if add_ncn_count >= ip_white_space-1:
+
+        # Calculate IPs needed based on network-specific FMN VIP setting
+        ips_needed = required_ip_counts(add_ncn_count, network_adding_fmns, network)
+
+        print(f'The space between last_reserved_ip and start_dhcp_pool is {ip_white_space} IP. '
+              f'IPs needed: {ips_needed}. '
+              f'{"No DHCP pool adjustment needed." if ips_needed <= ip_white_space else "DHCP pool adjustment required."}\n')
+
+        if ips_needed > ip_white_space:
+            if adding_fmns and network in ["NMN", "HMN"]:
+                if has_fmn_vip:
+                    print(f"{network} already has an existing fmn-vip reservation. Not adding additional VIP")
+                else:
+                    print(f"{network} does not have an existing fmn-vip reservation. Will add VIP along with FMN NCN(s)")
             print('There is not enough static IP space to add an NCN. Adjusting DHCP pool start.')
-            ips_needed = required_ip_counts(add_ncn_count, adding_fmns, network)
             for offset in range(1, ips_needed + 1):
                 ip = ipaddress.IPv4Address(last_reserved_ip) + offset
                 ips_to_delete_from_smd[network].add(str(ip))
-            ip_shift = ips_needed
+            ip_shift = ips_needed - ip_white_space
 
             temp = ipaddress.IPv4Address(start_dhcp_pool) + ip_shift
             new_ip_dhcp_pool_start[network] = str(temp)
@@ -487,9 +500,11 @@ def add_ncn_network_update(add_ncn_count, network_list, api_header, sls_networks
         else:
             new_ip_dhcp_pool_start[network] = str(temp)
 
-            print("IPs to be removed from SMD EthernetInterfaces and Kea active leases:")
-            print(ips_to_delete_from_smd)
-            print()
+            ips_with_removals = {net: ips for net, ips in ips_to_delete_from_smd.items() if ips}
+            if ips_with_removals:
+                print("IPs to be removed from SMD EthernetInterfaces and Kea active leases:")
+                print(ips_with_removals)
+                print()
             print(f'add_ncn_count: {add_ncn_count}\n'
                   f'ip_dhcp_pool_start:\n{ip_dhcp_pool_start}\n'
                   f'new_ip_dhcp_pool_start: \n{new_ip_dhcp_pool_start}\n')

--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

CASM-5740 Fixing review comments in FM on BM document provided by @SavioJoshua 

Relates to :
- [pr-link-1](https://github.com/Cray-HPE/docs-csm/pull/6557)

Also updated ncn_add_pre-req.sh script with few changes - majorly changes related to messaging along with few logic change which are observed during EGO testing

Changes - 

Correct DHCP pool shift — Pool now moves by the minimum required amount instead of the full IP count needed
Accurate whitespace reporting — Available IP gap between last static reservation and DHCP start is now reported correctly
FMN VIP logic scoped correctly — VIP checks now only apply to NMN and HMN networks, not all networks
FMN VIP messages only shown when relevant — Messages about existing/missing VIP reservations only appear when a DHCP adjustment is actually required
Cleaner status output — Each network check now shows IPs needed and adjustment status on one line
Cleaner IPs-to-remove output — Only networks with actual IPs to remove are listed, empty entries suppressed

Output before changes - 

```
Checking CMN.
last_reserved_ip: 10.102.194.28    start_dhcp_pool:10.102.194.31
CMN does not have an existing fmn-vip reservation. Will add VIP along with FMN NCN(s)
The space between last_reserved_ip and start_dhcp_pool is 3 IP.
 
There is not enough static IP space to add an NCN. Adjusting DHCP pool start.
IPs to be removed from SMD EthernetInterfaces and Kea active leases:
{'CMN': {'10.102.194.29', '10.102.194.30'}}
 
add_ncn_count: 2
ip_dhcp_pool_start:
{'CAN': '10.102.194.146', 'HMN': '10.254.1.28', 'MTL': '10.1.1.14', 'NMN': '10.252.1.17', 'CMN': '10.102.194.31'}
new_ip_dhcp_pool_start:
{'CMN': '10.102.194.33'}
```

Output after changes - 

```
Checking CHN.
last_reserved_ip: 10.102.193.207    start_dhcp_pool:10.102.193.208
The space between last_reserved_ip and start_dhcp_pool is 0 IP. IPs needed: 2. DHCP pool adjustment required.

There is not enough static IP space to add an NCN. Adjusting DHCP pool start.
IPs to be removed from SMD EthernetInterfaces and Kea active leases:
{'CHN': {'10.102.193.208', '10.102.193.209'}}

add_ncn_count: 2
ip_dhcp_pool_start:
{'MTL': '10.1.1.14', 'NMN': '10.252.1.17', 'CHN': '10.102.193.208', 'CMN': '10.102.193.46', 'HMN': '10.254.1.28'}
new_ip_dhcp_pool_start: 
{'NMN': '10.252.1.17', 'CHN': '10.102.193.210'}
```

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
