### PR TITLE
CASMTRIAGE-9222: DOCS: Correct errors in documents Prepare_the_System_for_Power_Off.md and Dump_a_Non-Compute_Node.md

### DIFF
--- a/operations/node_management/Dump_a_Non-Compute_Node.md
+++ b/operations/node_management/Dump_a_Non-Compute_Node.md
@@ -26,7 +26,7 @@ An NCN has crashed or an administrator has triggered a node crash.
     For more information on the SDU command options, use the `sdu --help` command.
 
     ```bash
-    sdu --scenario triage --start_time DATE_OR_TIME_STRING --end_time DATE_OR_TIME_STRING --plugin ncn.gather.nodes --plugin ncn.gather.kernel.dumps
+    sdu scenario triage --start_time DATE_OR_TIME_STRING --end_time DATE_OR_TIME_STRING --plugin ncn.gather.nodes --plugin ncn.gather.kernel.dumps
     ```
 
     Refer to the [SUSE documentation](https://documentation.suse.com/) for more information on memory dumps or crash dumps.

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -344,7 +344,7 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
         **Important:** SDU may take about 45 minutes to run on a small system \(longer for large systems\).
 
         ```bash
-        sdu --scenario triage --start_time '-4 hours' \
+        sdu scenario triage --start_time '-4 hours' \
                  --reason "saving state before powerdown"
         ```
 
@@ -407,7 +407,7 @@ managed nodes, including compute nodes and User Access Nodes (UANs).
 
         ```bash
         kubectl exec -it -n services \
-            "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager
+            "$(kubectl get pod -l app.kubernetes.io/name=slingshot-fabric-manager \
             -n services --no-headers | head -1 | awk '{print $1}')" \
              -c slingshot-fabric-manager -- fmn-show-status --details \
            | tee -a fmn-show-status-details.txt


### PR DESCRIPTION
# Description
Document updated to correct errors in documents "Prepare the System for Power Off" and "Dump a Non-Compute Node".

Relates to:
[CASMTRIAGE-9222](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9222)

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
