### PR TITLE
Casmtriage 9234 imsdoc fix 1.6

### DIFF
--- a/operations/image_management/Build_an_Image_Using_IMS_REST_Service.md
+++ b/operations/image_management/Build_an_Image_Using_IMS_REST_Service.md
@@ -571,7 +571,7 @@ use. Typically, customers access the system from outside the Kubernetes cluster 
 1. Touch the `complete` file once investigations are complete.
 
     ```bash
-    [root@POD image]# touch /mount/image/complete
+    [root@POD image]# touch /mnt/image/complete
     ```
 
 #### Verify Creation


### PR DESCRIPTION
# Description
An incorrect file path in the CSM documentation for building images using the IMS REST service. The procedure's final step instructs users to run touch /mount/image/complete to signal IMS that the SSH debugging session is finished, but the correct command is touch /mnt/image/complete. The typo affects both the CSM 1.6 and CSM 1.7 documentation pages. This PR is for CSM 1.6

# Checklist
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.