### PR TITLE
CASMCMS-9581: Document known BOS logging issues

### DIFF
--- a/operations/boot_orchestration/API.md
+++ b/operations/boot_orchestration/API.md
@@ -61,6 +61,7 @@ the following options do:
     * This option determines the verbosity of BOS logging, including the BOS API server.
     * The server logs can be viewed by looking at the logs of the pods in the server
       [Kubernetes deployment](#kubernetes-deployment).
+    * See also: [BOS Log Level Change Issues](../../troubleshooting/known_issues/BOS_Log_Level_Change_Issues.md).
 * [`ims_read_timeout`](Options.md#ims_read_timeout)
     * This option determines how long the BOS API server will wait for a response to API requests to IMS.
     * BOS has other service-specific timeout options; these options would also apply to the BOS API server,

--- a/operations/boot_orchestration/Operators.md
+++ b/operations/boot_orchestration/Operators.md
@@ -52,6 +52,7 @@ The following BOS options apply to operators generally:
     * This option determines the verbosity of BOS logging, including the BOS operator logs.
     * The operator logs can be viewed by looking at the logs of the pods in the operator
       [Kubernetes deployment](#kubernetes-deployment).
+    * See also: [BOS Log Level Change Issues](../../troubleshooting/known_issues/BOS_Log_Level_Change_Issues.md).
 * [`polling_frequency`](Options.md#polling_frequency)
     * This option determines how long the sleep interval is in the [execution loop](#execution-loop).
     * The only operator which is an exception to this is the [`discovery`](#discovery) operator, which

--- a/operations/boot_orchestration/Options.md
+++ b/operations/boot_orchestration/Options.md
@@ -223,6 +223,8 @@ After this time, the request will time out. The default is 20 seconds.
 The logging level for the [BOS API](API.md) server and the [BOS Operators](Operators.md).
 Valid values for this option are `DEBUG`, `INFO`, and `WARN`.
 
+> See also: [BOS Log Level Change Issues](../../troubleshooting/known_issues/BOS_Log_Level_Change_Issues.md)
+
 ### `max_boot_wait_time`
 
 How long BOS will wait for a node to boot into a usable state before rebooting it again (in seconds).

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -94,12 +94,14 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [PostgreSQL System ID Mismatch](known_issues/postgres_system_id_mismatch.md)
 * [Kyverno policy management known issues](../operations/kubernetes/Kyverno.md#known-issues)
 * [Skipped Ansible if no CSM `root` secret in Vault](known_issues/Skipped_Ansible_if_no_CSM_root_secret_in_Vault.md)
+* [BOS Log Level Change Issues](known_issues/BOS_Log_Level_Change_Issues.md)
 
 ## Booting
 
 * [BOS Sessions Stuck Pending](known_issues/BOS_Sessions_Stuck_Pending.md)
 * [BOS Operator Pods `OOMKilled`](known_issues/BOS_Operator_Pods_OOMKilled.md)
 * `boot_sets` field always required when [Modifying a session template](../operations/boot_orchestration/Manage_a_Session_Template.md#modify-a-session-template)
+* [BOS Log Level Change Issues](known_issues/BOS_Log_Level_Change_Issues.md)
 
 ### UAN boot issues
 

--- a/troubleshooting/known_issues/BOS_Log_Level_Change_Issues.md
+++ b/troubleshooting/known_issues/BOS_Log_Level_Change_Issues.md
@@ -1,0 +1,45 @@
+# BOS Log Level Change Issues
+
+* [Summary](#summary)
+* [Non-dynamic change](#non-dynamic-change)
+* [Uninformative log level change message](#uninformative-log-level-change-message)
+
+## Summary
+
+There are a couple of issues related to changing the
+[logging level](../../operations/boot_orchestration/Options.md#logging_level) for the
+[Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos).
+
+* [Non-dynamic change](#non-dynamic-change)
+* [Uninformative log level change message](#uninformative-log-level-change-message)
+
+## Non-dynamic change
+
+After changing the BOS logging level, the [BOS API](../../operations/boot_orchestration/API.md)
+server pod logs show a message reflecting this change. However, the server does not fully
+pick up the change until the Kubernetes deployment of the API server is restarted.
+
+*NOTE*: The [BOS Operators](../../operations/boot_orchestration/Operators.md) do not
+have this issue -- they pick up the log level change without having to be restarted.
+
+This issue exists in BOS in CSM 1.3 through CSM 1.6. It is fixed in CSM 1.7.
+
+## Uninformative log level change message
+
+After changing the BOS logging level, the BOS Kubernetes pods show a message reflecting this change.
+There is an issue in which the new log level is displayed as an integer rather than a string.
+
+The following is an example of what the message should look like:
+
+```text
+Logging level changed from INFO to DEBUG
+```
+
+When this issue is present, the message looks like the following:
+
+```text
+Logging level changed from INFO to 10
+```
+
+For the BOS API server, this bug exists in CSM 1.6.0 and CSM 1.6.1; it is fixed in CSM 1.6.2.
+For the BOS operators, this bug exists in CSM 1.6; it is fixed in CSM 1.7.


### PR DESCRIPTION
This documents known issues with BOS logging. The issues were fixed by CASMCMS-9330 and CASMCMS-9351, but exist in CSM 1.3 through CSM 1.6.

Backports:
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/6580
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/6581
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/6582