### PR TITLE
CASMCMS-9540/CASMCMS-9541: Document race conditions in BOS and CFS

### DIFF
--- a/operations/boot_orchestration/API.md
+++ b/operations/boot_orchestration/API.md
@@ -23,6 +23,8 @@ All of the core BOS work is done by the [BOS operators](Operators.md) and the [B
 > Other than the API server, there are only two parts of BOS that ever directly access the BOS databases.
 > See [BOS database access](Database.md#access) for details.
 
+See also: [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md).
+
 ## Kubernetes deployment
 
 (`ncn-mw#`) The BOS API server is a Kubernetes deployment in the `services` namespace:

--- a/operations/boot_orchestration/Operators.md
+++ b/operations/boot_orchestration/Operators.md
@@ -31,6 +31,8 @@ These operators are always running, even when no session is actively underway.
 This is a big difference from BOS version 1, where each session created a new dedicated Kubernetes job
 that handled everything associated with that session.
 
+See also: [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md).
+
 ## Execution loop
 
 Each operator follows the same basic execution loop:

--- a/operations/configuration_management/Automatic_Configuration_Management.md
+++ b/operations/configuration_management/Automatic_Configuration_Management.md
@@ -1,15 +1,18 @@
 # Automatic Configuration Management
 
-In addition to creating individual configuration sessions, the Configuration Framework Service \(CFS\) can also automatically configure any registered system components.
-The `CFS-Batcher` periodically examines the configuration state of registered components and schedules CFS sessions against those that have not been configured to their desired state.
-The frequency of scheduling, the maximum number of components to schedule in the same CFS session, and the expiration time for scheduling less than full sessions are configurable.
+In addition to creating individual configuration sessions, the Configuration Framework Service \(CFS\)
+can also automatically configure any registered system components.
+The [CFS Batcher](CFS_Batcher.md) periodically examines the configuration state of registered components
+and schedules CFS sessions against those that have not been configured to their desired state.
+The frequency of scheduling, the maximum number of components to schedule in the same CFS session,
+and the expiration time for scheduling less than full sessions are configurable.
 
 * [Automatic configuration triggers](#automatic-configuration-triggers)
-* [`CFS-Batcher` scheduling](#cfs-batcher-scheduling)
-* [`CFS-Batcher` safety mechanisms](#cfs-batcher-safety-mechanisms)
-* [Configure `CFS-Batcher`](#configure-cfs-batcher)
-* [List `CFS-Batcher` sessions](#list-cfs-batcher-sessions)
-* [Map `CFS-Batcher` sessions to BOS sessions](#map-cfs-batcher-sessions-to-bos-sessions)
+* [CFS Batcher scheduling](#cfs-batcher-scheduling)
+* [CFS Batcher safety mechanisms](#cfs-batcher-safety-mechanisms)
+* [Configure CFS Batcher](#configure-cfs-batcher)
+* [List CFS Batcher sessions](#list-cfs-batcher-sessions)
+* [Map CFS Batcher sessions to BOS sessions](#map-cfs-batcher-sessions-to-bos-sessions)
 
 ## Automatic configuration triggers
 
@@ -21,44 +24,44 @@ There are several situations that will cause automatic configuration:
 * When a user manually resets the configuration state of a component, it will force reconfiguration without rebooting a node.
 * If a manual CFS session applies a version of a playbook that conflicts with the version in the desired configuration, CFS will re-apply the desired version after the manual session is completed.
 * Any other situation that causes the desired state to not match with the current state of a component will trigger automatic configuration.
-CFS only tracks the current state of components as they are configured by CFS sessions.
-It does not track configuration state created or modified by other tooling on the system.
+  CFS only tracks the current state of components as they are configured by CFS sessions.
+  It does not track configuration state created or modified by other tooling on the system.
 
-## `CFS-Batcher` scheduling
+## CFS Batcher scheduling
 
-The `CFS-Batcher` schedules CFS sessions according to the following rules:
+The CFS Batcher schedules CFS sessions according to the following rules:
 
 * Components are assigned to a batch if they need configuration, are not disabled, and are currently not assigned to a batch.
-  * Components are grouped according to their desired state information.
-  * A new batch is created if no partial batches match the desired state, and all similar batches are full.
+    * Components are grouped according to their desired state information.
+    * A new batch is created if no partial batches match the desired state, and all similar batches are full.
 * Batches are scheduled as CFS sessions when the batch is full or the batch window time has been exceeded.
-  * The timer for the batch window is started when the first component is added, and is never reset.
-  Nodes should never wait more than the window period between being ready for configuration and being scheduled in a CFS session.
+    * The timer for the batch window is started when the first component is added, and is never reset.
+      Nodes should never wait more than the window period between being ready for configuration and being scheduled in a CFS session.
 * CFS cannot guarantee that jobs for similar batches will start at the same time, even if all CFS sessions are created at the same time.
   This variability is due to the nature of Kubernetes scheduling.
-  * Checking the start time for the CFS session is more accurate than checking the pod start time when determining when a batch was scheduled.
+    * Checking the start time for the CFS session is more accurate than checking the pod start time when determining when a batch was scheduled.
 
-## `CFS-Batcher` safety mechanisms
+## CFS Batcher safety mechanisms
 
-There are two safety mechanisms built into the `CFS-Batcher` scheduling that can delay batches more than the usual amount of time.
+There are two safety mechanisms built into the CFS Batcher scheduling that can delay batches more than the usual amount of time.
 Both mechanisms are indicated in the logs:
 
-* `CFS-Batcher` will not schedule multiple sessions to configure the same component.
-  `CFS-Batcher` monitors on-going sessions that it started so that if one session is started and the desired configuration changes,
-  `CFS-Batcher` can wait until the initial session is completed before scheduling the component with the new configuration to a new session.
-  * If `CFS-Batcher` is restarted, it will attempt to rebuild its state based on sessions with the "batcher-" naming scheme that are still in progress.
-  This ensures that scheduling conflicts will not occur even if `CFS-Batcher` is restarted.
-  * On restart, some information on the in-flight sessions is lost, so this wait ensures that `CFS-Batcher` does not schedule multiple configuration sessions for the same component at the same time.
-* If several CFS sessions that are created by the `CFS-Batcher` fail in a row \(the most recent 20 sessions\), `CFS-Batcher` will start
+* CFS Batcher will not schedule multiple sessions to configure the same component.
+  CFS Batcher monitors on-going sessions that it started so that if one session is started and the desired configuration changes,
+  CFS Batcher can wait until the initial session is completed before scheduling the component with the new configuration to a new session.
+    * If CFS Batcher is restarted, it will attempt to rebuild its state based on sessions with the "batcher-" naming scheme that are still in progress.
+      This ensures that scheduling conflicts will not occur even if CFS Batcher is restarted.
+    * On restart, some information on the in-flight sessions is lost, so this wait ensures that CFS Batcher does not schedule multiple configuration sessions for the same component at the same time.
+* If several CFS sessions that are created by the CFS Batcher fail in a row \(the most recent 20 sessions\), CFS Batcher will start
   throttling the creation of new sessions.
-  * The throttling is automatically reset if a single session succeeds. Users can also manually reset this by restarting `CFS-Batcher`.
-  * The back-off is increased if new sessions continue to fail.
-  * This helps protect against cases where high numbers of retries are allowed so that `CFS-Batcher` cannot flood Kubernetes with new jobs in a short period of time.
+    * The throttling is automatically reset if a single session succeeds. Users can also manually reset this by restarting CFS Batcher.
+    * The back-off is increased if new sessions continue to fail.
+    * This helps protect against cases where high numbers of retries are allowed so that CFS Batcher cannot flood Kubernetes with new jobs in a short period of time.
 
-## Configure `CFS-Batcher`
+## Configure CFS Batcher
 
-(`ncn-mw#`) Several `CFS-Batcher` behaviors are configurable.
-All of the `CFS-Batcher` configuration is available through the CFS options:
+(`ncn-mw#`) Several CFS Batcher behaviors are configurable.
+All of the CFS Batcher configuration is available through the CFS options:
 
 ```bash
 cray cfs v3 options list --format json | grep -i batch
@@ -79,11 +82,11 @@ Example output:
 See [CFS Global Options](CFS_Global_Options.md) for more information.
 
 Setting these to non-optimal values may affect system performance.
-The optimal values will depend on system size and the specifics of the configuration layers that will be applied in the sessions created by `CFS-Batcher`.
+The optimal values will depend on system size and the specifics of the configuration layers that will be applied in the sessions created by CFS Batcher.
 
-## List `CFS-Batcher` sessions
+## List CFS Batcher sessions
 
-(`ncn-mw#`) The `CFS-Batcher` prepends all CFS session names it creates with `batcher-`. Sessions that have be created by `CFS-Batcher`
+(`ncn-mw#`) The CFS Batcher prepends all CFS session names it creates with `batcher-`. Sessions that have be created by CFS Batcher
 are found by using the following command with the `--name-contains` option:
 
 ```bash
@@ -98,9 +101,9 @@ cray cfs v3 sessions list --name-contains batcher- --status running
 
 Use the `cray cfs v3 sessions list --help` command output for all filtering options, including session age, tags, status, and success.
 
-## Map `CFS-Batcher` sessions to BOS sessions
+## Map CFS Batcher sessions to BOS sessions
 
-(`ncn-mw#`) To find all of the sessions created by the `CFS-Batcher` because of configuration requests made by a specific
+(`ncn-mw#`) To find all of the sessions created by the CFS Batcher because of configuration requests made by a specific
 Boot Orchestration Service \(BOS\) session, filter the sessions by the name of the BOS session, which is added as a tag on the CFS sessions.
 The BOS session ID is required to run the following command.
 

--- a/operations/configuration_management/CFS_Batcher.md
+++ b/operations/configuration_management/CFS_Batcher.md
@@ -1,0 +1,25 @@
+# CFS Batcher
+
+The CFS Batcher manages the configuration state of system components (nodes).
+It is responsible for noticing when a node's actual configuration does not match its
+desired configuration, and then creating [CFS sessions](CFS_Sessions.md) to rectify that.
+
+## More information
+
+* [Automatic Configuration Management](Automatic_Configuration_Management.md)
+* [Automated session flow](CFS_Flow_Diagrams.md#automated-session-flow)
+* The following [CFS Global Options](CFS_Global_Options.md):
+    * [Batch size](CFS_Global_Options.md#batch-size)
+    * [Batch window](CFS_Global_Options.md#batch-window)
+    * [Batcher check interval](CFS_Global_Options.md#batcher-check-interval)
+    * [Batcher disable](CFS_Global_Options.md#batcher-disable)
+    * [Batcher maximum backoff](CFS_Global_Options.md#batcher-maximum-backoff)
+    * [Batcher pending timeout](CFS_Global_Options.md#batcher-pending-timeout)
+    * [Default batcher retry policy](CFS_Global_Options.md#default-batcher-retry-policy)
+* [CFS Components](CFS_Components.md)
+* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
+* [Increasing verbosity for sessions that are not created directly](Change_the_Ansible_Verbosity.md#increasing-verbosity-for-sessions-that-are-not-created-directly)
+
+## Known issues
+
+* [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md)

--- a/operations/configuration_management/CFS_Components.md
+++ b/operations/configuration_management/CFS_Components.md
@@ -1,9 +1,14 @@
 # CFS Components
 
-The Configuration Framework Service \(CFS\) contains a database of the configuration state of available hardware known to the Hardware State Manager \(HSM\).
-When new nodes are added to the HSM database, the `CFS-Hardware-Sync-Agent` enters the component into the CFS database with an empty state of configuration.
+The Configuration Framework Service \(CFS\) contains a database of the configuration state of
+available hardware known to the [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
+When new nodes are added to the HSM database, the
+[CFS Hardware Synchronization Agent](CFS_Hardware_Synchronization_Agent.md)
+enters the component into the CFS database with an empty state of configuration.
 
-Administrators are able to set a desired CFS configuration for each component, and the `CFS-Batcher` ensures the desired configuration state and the current configuration state match.
+Administrators are able to set a desired CFS configuration for each component, and the
+[CFS Batcher](CFS_Batcher.md) ensures the desired configuration state and the current
+configuration state match.
 See [Automatic Configuration Management](Automatic_Configuration_Management.md) for more information.
 
 - [Component data](#component-data)

--- a/operations/configuration_management/CFS_Flow_Diagrams.md
+++ b/operations/configuration_management/CFS_Flow_Diagrams.md
@@ -5,17 +5,18 @@
 
 ## Single session flow
 
-This section covers the components and actions taken when a user or service creates a session using the CFS sessions endpoint.
+This section covers the components and actions taken when a user or service creates a
+[session](CFS_Sessions.md) using the CFS sessions endpoint.
 
 ![Single Session Flow](../../img/operations/CFS_Single_Session_Flow.png)
 
-1. A user creates a CFS configuration.
+1. A user creates a [CFS configuration](CFS_Configurations.md).
 1. A user creates a CFS session, causing a session record to be created.
-1. When a session record is created, the `CFS-API` also posts an event to a Kafka queue.
-1. The `CFS-Operator` is always monitoring the Kafka queue, and handles events as they come in.
-1. The `CFS-Operator` creates a Kubernetes job for the session in response to a session creation event.
-1. The `CFS-Operator` monitors the Kubernetes job (not the pod) for completion.
-1. When the Kubernetes job is complete, the `CFS-Operator` updates the session record in the `CFS-API`.
+1. When a session record is created, the CFS API also posts an event to a Kafka queue.
+1. The [CFS Operator](CFS_Operator.md) is always monitoring the Kafka queue, and handles events as they come in.
+1. The CFS Operator creates a Kubernetes job for the session in response to a session creation event.
+1. The CFS Operator monitors the Kubernetes job (not the pod) for completion.
+1. When the Kubernetes job is complete, the CFS Operator updates the session record in the CFS API.
 
 ## Automated session flow
 
@@ -24,15 +25,17 @@ This section covers the components and actions taken when a user or service sets
 ![Automated Session Flow](../../img/operations/CFS_Automated_Session_Flow.png)
 
 1. A user creates a CFS configuration.
-1. A user sets the desired configuration for some number of components. This may immediately trigger configuration if the component is enabled in CFS and the desired
+1. A user sets the desired configuration for some number of [components](CFS_Components.md).
+   This may immediately trigger configuration if the component is enabled in CFS and the desired
    configuration has not yet been applied. If that is the case, then skip to step 4.
-1. When a node reboots, the `CFS-State-Reporter` runs on the node, and contacts the `CFS-API` to enable and clear the state for the current node. This will always trigger
+1. When a node reboots, the CFS State Reporter runs on the node, and contacts the CFS API to enable and clear the state for the current node. This will always trigger
    the next steps for configuration as long as a desired configuration is set for the node.
-1. The `CFS-Batcher` monitors the `CFS-API`, periodically querying for enabled components with a `pending` configuration status. (The status is determined by the API at
-   query time based on the desired and current state of the component). Any components found are placed into batches.
-1. The `CFS-Batcher` calls the `CFS-API` to create sessions for each batch, using the `ansible-limit` parameter to limit each session to the components in a batch.
-1. The `CFS-API` creates a session record and session creation event. See [Single session flow](#single-session-flow) for details.
-1. The `CFS-Operator` monitors for session creation events. See [Single session flow](#single-session-flow) for details.
-1. The `CFS-Operator` creates a Kubernetes job. See [Single session flow](#single-session-flow) for details.
-1. The Ansible Execution Environment contains a custom Ansible plugin that calls CFS to update the status of all components affected after each play.
+1. The [CFS Batcher](CFS_Batcher.md) monitors the CFS API, periodically querying for enabled components with a `pending` configuration status.
+   (The status is determined by the API at query time based on the desired and current state of the component). Any components found are placed into batches.
+1. The CFS Batcher calls the CFS API to create sessions for each batch, using the `ansible-limit` parameter to limit each session to the components in a batch.
+1. The CFS API creates a session record and session creation event. See [Single session flow](#single-session-flow) for details.
+1. The CFS Operator monitors for session creation events. See [Single session flow](#single-session-flow) for details.
+1. The CFS Operator creates a Kubernetes job. See [Single session flow](#single-session-flow) for details.
+1. The [Ansible Execution Environment](Ansible_Execution_Environments.md) contains a custom Ansible plugin that calls CFS to update the status of all components
+   affected after each play.
 1. If the component does not have a `configured` status due to failure or other reasons, return to step 4.

--- a/operations/configuration_management/CFS_Global_Options.md
+++ b/operations/configuration_management/CFS_Global_Options.md
@@ -84,7 +84,8 @@ See [Adding Additional Inventory](Adding_Additional_Inventory.md) for more infor
 
 ## Batch size
 
-This option determines the maximum number of components that will be included in each session created by CFS Batcher.
+This option determines the maximum number of components that will be included in each session created by the
+[CFS Batcher](CFS_Batcher.md).
 
 * v3 name: `batch_size`
 * v2 name: `batchSize`
@@ -236,14 +237,16 @@ For more information on configuration layers, see [CFS Configurations](CFS_Confi
 
 ## Hardware synchronization interval
 
-The number of seconds between checks to the [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm)
-for new hardware additions to the system.
+The number of seconds that the [CFS Hardware Synchronization Agent](CFS_Hardware_Synchronization_Agent.md)
+waits between checks to the [Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm)
+for hardware additions to the system.
 
 * v3 name: `hardware_sync_interval`
 * v2 name: `hardwareSyncInterval`
 * Default: `10` seconds
 
-When new hardware is registered with HSM, CFS will add it as a component.
+When new hardware is registered with HSM, the CFS Hardware Synchronization Agent will make an API call
+to create corresponding CFS components.
 
 For more information on configuration management of system components, see [CFS Components](CFS_Components.md).
 

--- a/operations/configuration_management/CFS_Hardware_Synchronization_Agent.md
+++ b/operations/configuration_management/CFS_Hardware_Synchronization_Agent.md
@@ -1,0 +1,16 @@
+# CFS Hardware Synchronization Agent
+
+The CFS Hardware Synchronization Agent is responsible for keeping the CFS
+database updated with hardware changes in the
+[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm).
+
+## More information
+
+* The following [CFS Global Option](CFS_Global_Options.md):
+  [Hardware synchronization interval](CFS_Global_Options.md#hardware-synchronization-interval)
+* [CFS Components](CFS_Components.md)
+
+## Known issues
+
+* [CFS Component With Zero Length ID](../../troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md)
+* [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md)

--- a/operations/configuration_management/CFS_Operator.md
+++ b/operations/configuration_management/CFS_Operator.md
@@ -1,0 +1,19 @@
+# CFS Operator
+
+The CFS Operator is responsible for executing [CFS sessions](CFS_Sessions.md).
+This includes:
+
+* Managing the setup and teardown of Kubernetes jobs that run the [AEE](Ansible_Execution_Environments.md).
+* Changing the session status from `pending` to `running` and from `running` to `complete`.
+
+The CFS Operator communicates with the CFS API server using both traditional REST API
+calls and the Kafka bus.
+
+## More information
+
+* [CFS Flow Diagrams](CFS_Flow_Diagrams.md)
+* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
+
+## Known issues
+
+* [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md)

--- a/operations/configuration_management/Change_the_Ansible_Verbosity.md
+++ b/operations/configuration_management/Change_the_Ansible_Verbosity.md
@@ -24,8 +24,8 @@ command when the playbooks are executed.
 
 ## How Ansible verbosity level is determined
 
-The Ansible verbosity is determined at the time that the CFS session starts.
-The verbosity is applied to all configuration layers in the session.
+The Ansible verbosity is determined at the time that the [CFS session](CFS_Sessions.md) starts.
+The verbosity is applied to all [configuration](CFS_Configurations.md) layers in the session.
 The verbosity is set to the first one of the following things that successfully
 specifies a verbosity level.
 
@@ -81,8 +81,7 @@ Not all CFS sessions are created directly by an administrator. For example:
 
 * A session may be created indirectly (as part of a [SAT][sat] or [IUF][iuf] operation,
   for example).
-* A session may be created by the CFS batcher. For more information on the CFS batcher,
-  see [Automatic Configuration Management](Automatic_Configuration_Management.md).
+* A session may be created by the [CFS Batcher](CFS_Batcher.md).
 
 In these cases, an administrator is not able to directly specify these parameters using the
 method described in the previous section. However, these sessions will run using the

--- a/operations/configuration_management/Configuration_Management.md
+++ b/operations/configuration_management/Configuration_Management.md
@@ -1,40 +1,43 @@
 # Configuration Management
 
-The Configuration Framework Service \(CFS\) is available on systems for remote execution and configuration management of nodes and boot images.
-This includes nodes available in the Hardware State Manager \(HSM\) inventory \(compute, management, and application nodes\), and boot images hosted by the Image Management Service \(IMS\).
+The Configuration Framework Service (CFS) is available on systems for remote execution and configuration management of nodes and boot images.
+This includes nodes available in the
+[Hardware State Manager (HSM)](../../glossary.md#hardware-state-manager-hsm) inventory (compute, management, and application nodes),
+and boot images hosted by the
+[Image Management Service (IMS)](../../glossary.md#image-management-service-ims).
 
-CFS configures nodes and images via a `gitops` methodology. All configuration content is stored in a version control service \(VCS\), and is managed by authorized system administrators.
-CFS provides a scalable Ansible Execution Environment \(AEE\) for the configuration to be applied with flexible inventory and node targeting options.
+CFS configures nodes and images via a `gitops` methodology. All configuration content is stored in a version control service (VCS), and is managed by authorized system administrators.
+CFS provides a scalable [Ansible Execution Environment (AEE)](Ansible_Execution_Environments.md) for the configuration to be applied with flexible inventory and node targeting options.
 
-## Use Cases
+## Use cases
 
 CFS is available for the following use cases on systems:
 
 * Image customization: Pre-configure bootable images available via IMS. This use case enables provisioning a full configuration of a target node.
-Non-node-specific settings are applied pre-boot, which reduces the amount of configuration required after a node boots, and therefore reduces the bring-up time for nodes.
+  Non-node-specific settings are applied pre-boot, which reduces the amount of configuration required after a node boots, and therefore reduces the bring-up time for nodes.
 * Post-boot configuration: Fully configure or reconfigure booted nodes in a scalable, performant way to add the required settings.
 * "Push-based" deployment: When using post-boot configuration with only node-specific configuration data, the target undergoes node personalization.
 The two-step process of pre-boot image customization and post-boot node personalization results in a fully configured node, optimized for minimal bring-up times.
 * "Pull-based" deployment: Provide configuration management to nodes by prescribing a desired configuration state and ensuring the current node configuration state matches the desired state automatically.
 This is achieved via the CFS Hardware Synchronization Agent and the CFS Batcher implementation.
 
-## CFS Components
+## CFS components
 
-CFS is comprised of a group of services and components interacting within the Cray System Management \(CSM\) service mesh, and provides a means for system administrators to configure nodes and boot images via Ansible. CFS includes the following components:
+CFS is comprised of a group of services and components interacting within the Cray System Management (CSM) service mesh, and provides a means for system administrators to configure nodes and boot images via Ansible. CFS includes the following components:
 
-* `CFS-API`, a REST API service.
-* A command-line interface \(CLI\) to the API \(via the `cray cfs` command\).
-* A pre-packaged Ansible Execution Environment \(AEE\) with values tuned for performant configuration for executing Ansible playbooks, and reporting plug-ins for communication with CFS.
-* The `CFS-Hardware-Sync-Agent`, which pulls in node information from the system inventory to the CFS database to track the node configuration state.
-* The `CFS-Operator`, which manages the setup and teardown of Kubernetes jobs that run the AEE.
-* The `CFS-Batcher`, which manages the configuration state of system components \(nodes\).
-* `CFS-Trust`, which manages the keys and certificates CFS uses to access other system components \(nodes\).
-* `CFS-State-Reporter`, which runs on each of the system components \(nodes\) to alert the CFS API when a component is rebooted and requires configuration.
-* `CFS-ARA`, which collects the Ansible logs from the AEE pods.
+* CFS API, a REST API service.
+* A command-line interface (CLI) to the API (via the `cray cfs` command).
+* A pre-packaged Ansible Execution Environment (AEE) with values tuned for performant configuration for executing Ansible playbooks, and reporting plug-ins for communication with CFS.
+* The [CFS Hardware Synchronization Agent](CFS_Hardware_Synchronization_Agent.md).
+* The [CFS Operator](CFS_Operator.md).
+* The [CFS Batcher](CFS_Batcher.md).
+* CFS Trust, which manages the keys and certificates CFS uses to access other system components (nodes).
+* CFS State Reporter, which runs on each of the system components (nodes) to alert the CFS API when a component is rebooted and requires configuration.
+* CFS ARA, which collects the Ansible logs from the AEE pods.
 
-Although it is not a formal part of the service, CFS integrates with a Gitea instance \(VCS\) running in the CSM service mesh for management of the configuration content life-cycle.
+Although it is not a formal part of the service, CFS integrates with a Gitea instance (VCS) running in the CSM service mesh for management of the configuration content life-cycle.
 
-## High-Level Configuration Workflow
+## High-level configuration workflow
 
 CFS remotely executes Ansible configuration content on nodes or boot images with the following workflow:
 

--- a/operations/configuration_management/Management_Node_Personalization.md
+++ b/operations/configuration_management/Management_Node_Personalization.md
@@ -6,8 +6,9 @@
 
 ## Introduction
 
-Management node personalization refers to the process of CFS applying a configuration to a
-management node after it is booted.
+Management node personalization refers to the process of CFS applying a
+[configuration](CFS_Configurations.md) to a
+[management node](../../glossary.md#management-nodes) after it is booted.
 
 The same CFS configuration is used for post-boot personalization of master, storage, and worker
 management nodes. However, some individual parts of that configuration will only be applied to
@@ -24,10 +25,8 @@ no changes have been made to the configuration layers (such as a new layer, diff
 or new commit made).
 
 This procedures causes CFS to re-run personalization on management nodes by clearing the
-configuration state and error count on the management node components. This causes the CFS Batcher
-to reconfigure these components.
-See [Automatic Configuration Management](Automatic_Configuration_Management.md)
-for more information on the CFS Batcher.
+configuration state and error count on the management node components. This causes the
+[CFS Batcher](CFS_Batcher.md) to reconfigure these components.
 
 This procedure has a scripted option and a manual option. Use the scripted option if possible.
 
@@ -107,8 +106,7 @@ commit made).
 
 This procedures causes CFS to re-run personalization on a management node by clearing the
 configuration state and error count on the management node component. This causes the CFS Batcher
-to reconfigure these components.
-See [Automatic Configuration Management](Automatic_Configuration_Management.md)
+to reconfigure these components. See [CFS Batcher](CFS_Batcher.md)
 for more information on the CFS Batcher.
 
 ### Prerequisites to re-run node personalization on a specific management node

--- a/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
@@ -1,12 +1,15 @@
 # Troubleshoot CFS Sessions Failing to Start
 
-Troubleshoot issues where Configuration Framework Service \(CFS\) sessions are being created, but the pods are never created and never run.
+Troubleshoot issues where Configuration Framework Service (CFS)
+[sessions](CFS_Sessions.md) are being created, but the pods are never created and never run.
 
 ## Prerequisites
 
-CFS-batcher is creating automatic sessions, but pods are not starting for those sessions. There are a number of communication reasons this could be happening, so check the `cfs-batcher` and `cfs-operator` logs for these signatures.
+[CFS Batcher](CFS_Batcher.md) is creating automatic sessions, but pods are not starting for those sessions.
+There are a number of communication reasons this could be happening, so check the CFS Batcher (`cfs-batcher-`)
+and [CFS Operator](CFS_Operator.md) (`cfs-operator-`) Kubernetes pod logs for these signatures.
 
-CFS-batcher logs should show that it is creating sessions, but giving up waiting for those sessions to start:
+CFS Batcher logs should show that it is creating sessions, but giving up waiting for those sessions to start:
 
 ```text
 2022-08-24 04:09:12,391 - WARNING - batcher.batch - Session batcher-d7f9bf52-e5f6-4742-849b-4086b1d59ab1 is stuck in pending and will be deleted.
@@ -16,7 +19,7 @@ CFS-batcher logs should show that it is creating sessions, but giving up waiting
 2022-08-24 04:09:15,144 - WARNING - batcher.batch - Session batcher-b6c35dcc-b8b9-421b-9090-23bfc2a72ac3 is stuck in pending and will be deleted.
 ```
 
-CFS-operator logs should show that it is attempting to create sessions, but is unable to find the session records.
+CFS operator logs should show that it is attempting to create sessions, but is unable to find the session records.
 
 ```text
 2022-08-24 05:48:06,476 - INFO    - cray.cfs.operator.events.session_events - EVENT: CREATE batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
@@ -27,7 +30,8 @@ If these two things are true, then it is likely that CFS is creating new session
 
 ## Procedure
 
-The primary method of handling this problem is the `batcher_max_backoff` option. This will slow automatic session creation in these situations and give the `cfs-operator` a chance to catch up.
+The primary method of handling this problem is the [`batcher_max_backoff` option](CFS_Global_Options.md#batcher-maximum-backoff).
+This will slow automatic session creation in these situations and give the CFS Operator a chance to catch up.
 
 (`ncn-mw#`) If this value has been changed from its default value of 3600 (1 hour), then it should be set back to that value:
 
@@ -37,11 +41,13 @@ cray cfs v3 options update --batcher-max-backoff 3600
 
 The issue should eventually resolve automatically.
 
-If there is a reason that users cannot wait for the back-off to resolve this automatically, then the following procedure can be used to purge the event queue. This will disrupt CFS operation and may disrupt existing sessions, so caution should be used.
+If there is a reason that users cannot wait for the back-off to resolve this automatically,
+then the following procedure can be used to purge the event queue. This will disrupt CFS operation and
+may disrupt existing sessions, so caution should be used.
 
 1. (`ncn-mw#`) Disable session creation.
 
-    If any others users or scripts are creating sessions, make sure that they have stopped. `cfs-batcher` should then be disabled.
+    If any others users or scripts are creating sessions, make sure that they have stopped. CFS Batcher should then be disabled.
 
     ```bash
     cray cfs v3 options update --batcher-disable true
@@ -64,7 +70,7 @@ If there is a reason that users cannot wait for the back-off to resolve this aut
 
        This command will likely produce not output at first, while Kafka re-balances the consumer group. Leave this command running.
 
-1. (`ncn-mw#`) In a new window, scale down the `cfs-operator`.
+1. (`ncn-mw#`) In a new window, scale down the CFS Operator.
 
     This forces the console consumer to handle the entire event queue.
 
@@ -74,17 +80,17 @@ If there is a reason that users cannot wait for the back-off to resolve this aut
 
 1. (`ncn-mw#`) Wait until the output from the console consumer stops.
 
-    Once the `cfs-operator` is scaled down, there should be a final burst of output from the console consumer. Wait until all output has stopped for at least a minute before continuing.
+    Once the CFS Operator is scaled down, there should be a final burst of output from the console consumer. Wait until all output has stopped for at least a minute before continuing.
 
 1. (`pod#`) Cancel the console consumer command and exit the pod shell.
 
-1. (`ncn-mw#`) Restore `cfs-operator`.
+1. (`ncn-mw#`) Restore CFS Operator.
 
     ```bash
     kubectl -n services scale --replicas=1 deployment/cray-cfs-operator
     ```
 
-1. (`ncn-mw#`) Enable `cfs-batcher`.
+1. (`ncn-mw#`) Enable CFS Batcher.
 
     ```bash
     cray cfs v3 options update --batcher-disable false

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -86,10 +86,12 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [iSCSI SBPS Marshal agent failure](known_issues/iscsi_sbps_marshal_failure.md)
 * [Worker nodes unresponsive and `dmesg` flooded with iSCSI errors](known_issues/worker_nodes_unresponsive_and_dmesg_flooded_with_iSCSI_errors.md)
 * [Cloud init loops for master node: unknown field `udpIdleTimeout`](known_issues/management_nodes_rollout_stuck_at_cloud_init.md)
+* [Race Conditions in BOS and CFS](known_issues/Race_Conditions_in_BOS_and_CFS.md)
 
 ## Booting
 
 * [Common issues with staging sessions](../operations/boot_orchestration/Stage_Changes_with_BOS.md#common-issues-with-staging)
+* [Race Conditions in BOS and CFS](known_issues/Race_Conditions_in_BOS_and_CFS.md)
 
 ### UAN boot issues
 
@@ -114,6 +116,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [VCS Password With Illegal Characters](known_issues/VCS_Password_With_Illegal_Characters.md)
 * [CFS Session for Image Customization Status Stuck at `running`](known_issues/cfs_session_status_for_image_customization_on_remote_node_stuck_at_running.md)
 * [CFS Key Management](../operations/configuration_management/CFS_Key_Management.md)
+* [Race Conditions in BOS and CFS](known_issues/Race_Conditions_in_BOS_and_CFS.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
+++ b/troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md
@@ -1,6 +1,8 @@
 # CFS Component With Zero-Length ID
 
-In CSM versions lower than 1.7, it is possible in some situations for a CFS component to be created with a zero-length string for an `id` field.
+In CSM versions lower than 1.7, it is possible in some situations for a CFS component to be created with a zero-length string for an `id` field
+(either manually by an administrator, or by the
+[CFS Hardware Synchronization Agent](../../operations/configuration_management/CFS_Hardware_Synchronization_Agent.md)).
 In CSM 1.7, the bug that allowed these to be created has been fixed, but such a component could still exist on systems that were upgraded to CSM 1.7.
 Such a component cannot be deleted using the Cray CLI or the CFS API.
 

--- a/troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md
+++ b/troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md
@@ -1,0 +1,59 @@
+# Race Conditions in BOS and CFS
+
+## Summary
+
+Both the [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) and
+[Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+have issues where race conditions can lead to unexpected or invalid behavior. These issues
+come in two varieties:
+
+* [API server race conditions](#api-server-race-conditions)
+* [Operator race conditions](#operator-race-conditions)
+
+## API server race conditions
+
+The API servers for both BOS and CFS are multi-process and multi-threaded, allowing
+multiple requests to be handled simultaneously. In the case where these requests impact
+overlapping resources, problems can arise. This happens because the API servers are implemented
+without taking this parallelism into account. An endpoint which modifies a resource will
+read that resource from the database, modify the resource, and then write the modified
+resource back to the database. If a delete request for that same resource is handled in the
+middle of that process, the delete request will succeed, but the resource will still exist
+in the database.
+
+### Workaround for API server race conditions
+
+In general, administrators should avoid making parallel requests that
+change or delete the same resources.
+
+### Fix for API server race conditions
+
+This issue exists in all versions of BOS.
+This issue exists in all versions of CFS prior to CSM 1.7.1.
+
+## Operator race conditions
+
+Both BOS and CFS include operators that run separately from the API server.
+In the case of CFS, these are the
+[CFS batcher](../../operations/configuration_management/CFS_Batcher.md), the
+[CFS hardware synchronization agent](../../operations/configuration_management/CFS_Hardware_Synchronization_Agent.md),
+and the [CFS operator](../../operations/configuration_management/CFS_Operator.md).
+In the case of BOS, there are many different
+[BOS operators](../../operations/boot_orchestration/Operators.md).
+In all cases, these operators generally work in a loop where they make a query to the
+main service API, do some work based on the contents of the response, and possibly send a
+request back to the main service to change or delete some resources. This offers a window
+where a resource may change on the API server in the meantime, without the operator being
+aware of it. This can lead to the operator overwriting changes or taking incorrect actions.
+
+Because BOS has far more operators than CFS, it is more likely to encounter this race
+condition than CFS is, but both services are susceptible to it.
+
+### Workaround for operator race conditions
+
+None.
+
+### Fix for operator race conditions
+
+This issue exists in all versions of BOS v2.
+This issue exists in all versions of CFS.


### PR DESCRIPTION
This PR documents the race condition vulnerabilities in BOS and CFS. It also does some related minor linting and reorganization of the CFS documentation. Backports:

* 1.6: https://github.com/Cray-HPE/docs-csm/pull/6589
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/6590
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/6591
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/6592
* 1.2: https://github.com/Cray-HPE/docs-csm/pull/6593
* 1.0: https://github.com/Cray-HPE/docs-csm/pull/6594