### PR TITLE
Add troubleshooting for CASMTRIAGE-9225

### DIFF
--- a/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
+++ b/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
@@ -1,0 +1,138 @@
+# Troubleshoot Kubernetes Encryption Status Stuck at `current: unknown`
+
+Use this procedure to diagnose and resolve a Kubernetes encryption status mismatch where `current` remains `unknown`.
+
+## Symptoms
+
+One or more of the following issues are possible symptoms:
+
+- `/usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status` reports:
+
+```text
+current: unknown
+goal: identity
+etcd: identity
+interim state detected, ensure all control plane nodes are in sync
+```
+
+- `cray-k8s-encryption` logs show RBAC failure when rewriting secrets:
+
+```text
+failed to list CRDs: customresourcedefinitions.apiextensions.k8s.io is forbidden
+User "system:serviceaccount:kube-system:cray-k8s-encryption" cannot list resource "customresourcedefinitions"
+```
+
+- Upgrade workflow is blocked by encryption status checks.
+
+## Procedure
+
+In the following procedure, unless otherwise directed, run commands on any management NCN with a working `kubectl` context.
+
+### Identify the RBAC issue
+
+1. (`ncn-mw#`) Confirm the encryption status pattern.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+   ```
+
+2. (`ncn-mw#`) Check recent controller logs.
+
+   ```bash
+   kubectl logs -n kube-system -l app=cray-k8s-encryption --tail=200
+   ```
+
+3. (`ncn-mw#`) Verify effective permissions for the service account.
+
+   ```bash
+   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption list customresourcedefinitions.apiextensions.k8s.io
+   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption get customresourcedefinitions.apiextensions.k8s.io
+   ```
+
+   Expected result for this issue: one or both commands return `no`.
+
+4. (`ncn-mw#`) Inspect existing role and binding.
+
+   ```bash
+   kubectl get clusterrole cray-k8s-encryption -o yaml
+   kubectl get clusterrolebinding cray-k8s-encryption -o yaml
+   ```
+
+   Confirm whether this rule is missing from `ClusterRole`:
+
+   ```yaml
+   - apiGroups: ["apiextensions.k8s.io"]
+     resources: ["customresourcedefinitions"]
+     verbs: ["get", "list"]
+   ```
+
+### Apply the permanent fix
+
+5. (`ncn-mw#`) Update the `cray-k8s-encryption` `ClusterRole` with required RBAC rules.
+
+   ```bash
+   kubectl apply -f - <<'EOF'
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: cray-k8s-encryption
+   rules:
+   - apiGroups: [""]
+     resources: ["nodes", "secrets"]
+     verbs: ["get", "list", "create", "delete", "patch", "update"]
+   - apiGroups: ["apps"]
+     resources: ["daemonsets"]
+     verbs: ["get", "list", "create", "delete", "patch", "update"]
+   - apiGroups: ["apiextensions.k8s.io"]
+     resources: ["customresourcedefinitions"]
+     verbs: ["get", "list"]
+   EOF
+   ```
+
+6. (`ncn-mw#`) Restart the daemonset and wait for rollout.
+
+   ```bash
+   kubectl rollout restart daemonset/cray-k8s-encryption -n kube-system
+   kubectl rollout status daemonset/cray-k8s-encryption -n kube-system
+   ```
+
+### Optional workaround to unblock upgrade
+
+Use this workaround only if all control-plane nodes, `goal`, and `etcd` are already `identity`.
+
+7. (`ncn-mw#`) Set the `current` annotation manually.
+
+   ```bash
+   kubectl annotate secret --overwrite -n kube-system cray-k8s-encryption current=identity
+   ```
+
+8. (`ncn-mw#`) Re-run status.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
+   ```
+
+> This workaround may unblock the runbook but does not replace the RBAC fix.
+
+### Validate the fix
+
+9. (`ncn-mw#`) Confirm authorization checks now pass.
+
+   ```bash
+   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption list customresourcedefinitions.apiextensions.k8s.io
+   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption get customresourcedefinitions.apiextensions.k8s.io
+   ```
+
+10. (`ncn-mw#`) Confirm logs do not show CRD permission failures.
+
+    ```bash
+    kubectl logs -n kube-system -l app=cray-k8s-encryption --tail=200
+    ```
+
+11. (`ncn-mw#`) Confirm final status convergence.
+
+    ```text
+    current: identity
+    goal: identity
+    etcd: identity
+    ```

--- a/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
+++ b/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
@@ -68,7 +68,7 @@ In the following procedure, unless otherwise directed, run commands on any manag
 
 ### Apply the permanent fix
 
-5. (`ncn-mw#`) Update the `cray-k8s-encryption` `ClusterRole` with required RBAC rules.
+1. (`ncn-mw#`) Update the `cray-k8s-encryption` `ClusterRole` with required RBAC rules.
 
    ```bash
    kubectl apply -f - <<'EOF'
@@ -89,7 +89,7 @@ In the following procedure, unless otherwise directed, run commands on any manag
    EOF
    ```
 
-6. (`ncn-mw#`) Restart the daemonset and wait for rollout.
+2. (`ncn-mw#`) Restart the DaemonSet and wait for rollout.
 
    ```bash
    kubectl rollout restart daemonset/cray-k8s-encryption -n kube-system
@@ -100,36 +100,36 @@ In the following procedure, unless otherwise directed, run commands on any manag
 
 Use this workaround only if all control-plane nodes, `goal`, and `etcd` are already `identity`.
 
-7. (`ncn-mw#`) Set the `current` annotation manually.
+1. (`ncn-mw#`) Set the `current` annotation manually.
 
    ```bash
    kubectl annotate secret --overwrite -n kube-system cray-k8s-encryption current=identity
    ```
 
-8. (`ncn-mw#`) Re-run status.
+2. (`ncn-mw#`) Re-run status.
 
    ```bash
    /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
    ```
 
-> This workaround may unblock the runbook but does not replace the RBAC fix.
+> This workaround may unblock the process but does not replace the RBAC fix.
 
 ### Validate the fix
 
-9. (`ncn-mw#`) Confirm authorization checks now pass.
+1. (`ncn-mw#`) Confirm authorization checks now pass.
 
    ```bash
    kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption list customresourcedefinitions.apiextensions.k8s.io
    kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption get customresourcedefinitions.apiextensions.k8s.io
    ```
 
-10. (`ncn-mw#`) Confirm logs do not show CRD permission failures.
+2. (`ncn-mw#`) Confirm logs do not show CRD permission failures.
 
     ```bash
     kubectl logs -n kube-system -l app=cray-k8s-encryption --tail=200
     ```
 
-11. (`ncn-mw#`) Confirm final status convergence.
+3. (`ncn-mw#`) Confirm final status convergence.
 
     ```text
     current: identity

--- a/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
+++ b/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
@@ -4,7 +4,7 @@ Use this procedure to diagnose and resolve a Kubernetes encryption status mismat
 
 ## Symptoms
 
-One or more of the following issues are possible symptoms:
+One or more of the following symptoms are possible:
 
 - `/usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status` reports:
 

--- a/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
+++ b/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Encryption_Status.md
@@ -26,77 +26,9 @@ User "system:serviceaccount:kube-system:cray-k8s-encryption" cannot list resourc
 
 ## Procedure
 
-In the following procedure, unless otherwise directed, run commands on any management NCN with a working `kubectl` context.
+In the following procedure, run commands on any management NCN with a working `kubectl` context.
 
-### Identify the RBAC issue
-
-1. (`ncn-mw#`) Confirm the encryption status pattern.
-
-   ```bash
-   /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
-   ```
-
-2. (`ncn-mw#`) Check recent controller logs.
-
-   ```bash
-   kubectl logs -n kube-system -l app=cray-k8s-encryption --tail=200
-   ```
-
-3. (`ncn-mw#`) Verify effective permissions for the service account.
-
-   ```bash
-   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption list customresourcedefinitions.apiextensions.k8s.io
-   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption get customresourcedefinitions.apiextensions.k8s.io
-   ```
-
-   Expected result for this issue: one or both commands return `no`.
-
-4. (`ncn-mw#`) Inspect existing role and binding.
-
-   ```bash
-   kubectl get clusterrole cray-k8s-encryption -o yaml
-   kubectl get clusterrolebinding cray-k8s-encryption -o yaml
-   ```
-
-   Confirm whether this rule is missing from `ClusterRole`:
-
-   ```yaml
-   - apiGroups: ["apiextensions.k8s.io"]
-     resources: ["customresourcedefinitions"]
-     verbs: ["get", "list"]
-   ```
-
-### Apply the permanent fix
-
-1. (`ncn-mw#`) Update the `cray-k8s-encryption` `ClusterRole` with required RBAC rules.
-
-   ```bash
-   kubectl apply -f - <<'EOF'
-   apiVersion: rbac.authorization.k8s.io/v1
-   kind: ClusterRole
-   metadata:
-     name: cray-k8s-encryption
-   rules:
-   - apiGroups: [""]
-     resources: ["nodes", "secrets"]
-     verbs: ["get", "list", "create", "delete", "patch", "update"]
-   - apiGroups: ["apps"]
-     resources: ["daemonsets"]
-     verbs: ["get", "list", "create", "delete", "patch", "update"]
-   - apiGroups: ["apiextensions.k8s.io"]
-     resources: ["customresourcedefinitions"]
-     verbs: ["get", "list"]
-   EOF
-   ```
-
-2. (`ncn-mw#`) Restart the DaemonSet and wait for rollout.
-
-   ```bash
-   kubectl rollout restart daemonset/cray-k8s-encryption -n kube-system
-   kubectl rollout status daemonset/cray-k8s-encryption -n kube-system
-   ```
-
-### Optional workaround to unblock upgrade
+### Fix encryption status
 
 Use this workaround only if all control-plane nodes, `goal`, and `etcd` are already `identity`.
 
@@ -112,24 +44,9 @@ Use this workaround only if all control-plane nodes, `goal`, and `etcd` are alre
    /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --status
    ```
 
-> This workaround may unblock the process but does not replace the RBAC fix.
-
 ### Validate the fix
 
-1. (`ncn-mw#`) Confirm authorization checks now pass.
-
-   ```bash
-   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption list customresourcedefinitions.apiextensions.k8s.io
-   kubectl auth can-i --as=system:serviceaccount:kube-system:cray-k8s-encryption get customresourcedefinitions.apiextensions.k8s.io
-   ```
-
-2. (`ncn-mw#`) Confirm logs do not show CRD permission failures.
-
-    ```bash
-    kubectl logs -n kube-system -l app=cray-k8s-encryption --tail=200
-    ```
-
-3. (`ncn-mw#`) Confirm final status convergence.
+1. (`ncn-mw#`) Confirm final status convergence.
 
     ```text
     current: identity


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Troubleshoot the cray-k8s-encryption ClusterRole to grant the controller the cluster-scoped permissions it needs to complete encryption status reconciliation.

* Resolves [CASMTRIAGE-9225](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9225), [CASMTRIAGE-9118](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9118)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
