### PR TITLE
CASMCMS-9650: Update CFS known issues

### DIFF
--- a/operations/configuration_management/CFS_Batcher.md
+++ b/operations/configuration_management/CFS_Batcher.md
@@ -17,9 +17,12 @@ desired configuration, and then creating [CFS sessions](CFS_Sessions.md) to rect
     * [Batcher pending timeout](CFS_Global_Options.md#batcher-pending-timeout)
     * [Default batcher retry policy](CFS_Global_Options.md#default-batcher-retry-policy)
 * [CFS Components](CFS_Components.md)
-* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 * [Increasing verbosity for sessions that are not created directly](Change_the_Ansible_Verbosity.md#increasing-verbosity-for-sessions-that-are-not-created-directly)
 
 ## Known issues
 
+* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
+* [CFS Batcher Can Be Slow To See Updated CFS Options](../../troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md)
+* [CFS Batcher Creating Multiple Sessions For Same Batch](../../troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md)
+* [CFS Component State Updates Allow Invalid Values](../../troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
 * [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md)

--- a/operations/configuration_management/CFS_Components.md
+++ b/operations/configuration_management/CFS_Components.md
@@ -17,7 +17,7 @@ See [Automatic Configuration Management](Automatic_Configuration_Management.md) 
 - [Disable component configuration](#disable-component-configuration)
 - [Force component reconfiguration](#force-component-reconfiguration)
 - [Update components in bulk](#update-components-in-bulk)
-- [Component with zero-length ID](#component-with-zero-length-id)
+- [Known issues](#known-issues)
 
 ## Component data
 
@@ -170,8 +170,7 @@ Updating multiple components at once is not currently available in the CLI due t
 However for those programmatically interacting with the CFS API, it is possible to update multiple components at once by calling `/v3/components` with a `PATCH` operation.
 It is possible to either provide patches for multiple components in a list, or to provide a single patch and filters for which components to apply the patch to. See the [CFS API specification](../../api/cfs.md) for more information.
 
-## Component with zero-length ID
+## Known issues
 
-It is possible for CFS to end up with an invalid component whose ID field is a zero-length string. See
-[CFS Component With Zero-Length ID](../../troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md)
-for more details.
+- [CFS Component With Zero-Length ID](../../troubleshooting/known_issues/CFS_Component_With_Zero_Length_ID.md)
+- [CFS Component State Updates Allow Invalid Values](../../troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)

--- a/operations/configuration_management/CFS_Operator.md
+++ b/operations/configuration_management/CFS_Operator.md
@@ -12,8 +12,10 @@ calls and the Kafka bus.
 ## More information
 
 * [CFS Flow Diagrams](CFS_Flow_Diagrams.md)
-* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 
 ## Known issues
 
+* [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 * [Race Conditions in BOS and CFS](../../troubleshooting/known_issues/Race_Conditions_in_BOS_and_CFS.md)
+* [CFS Operator Creating Multiple Jobs For Same Session](../../troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
+* [CFS Batcher Creating Multiple Sessions For Same Batch](../../troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md)

--- a/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
+++ b/operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md
@@ -3,43 +3,113 @@
 The v3 CFS API contains a number of differences and improvements over the previous v2 API.
 For convenience all changes are listed here.
 
-* The v3 API supports paging through records for components, sessions, and configurations.
-  See [Paging CFS Records](Paging_CFS_Records.md) for more information.
-* The v3 API uses `snake_case` rather than `camelCase` for all parameters in queries and responses.
-  This brings the API in line with other CSM APIs.
-* The response format has changed for queries listing components, sessions, or configurations.
-  Responses are no longer a list of records, and instead contain a key for the record type which
-  contains the list of records. (E.g. `{"components":[]}` for the components endpoint).
-  Responses also include a `next` section that is used for paging through records.
-  See [Paging CFS Records](Paging_CFS_Records.md) for more information.
-* The v3 API supports the creation of [CFS Sources](CFS_Sources.md) which allows CFS to use
-  configuration and inventory content from external repositories. See
-  [Using sources in a configuration layer](CFS_Configurations.md#using-sources-in-a-configuration-layer).
-* Component records no longer include the `state` list of applied playbooks by default.
-  The `state` can requested with the `state_details` parameter.
-* Some fields now have maximum sizes:
-    * Configuration names are now limited to 60 characters.
-    * Additional inventory URLs are limited to 240 characters.
-    * Configuration layer names are limited to 45 characters.
-* The v3 API has new global options:
-  [Additional inventory source](CFS_Global_Options.md#additional-inventory-source),
-  [Default page size](CFS_Global_Options.md#default-page-size),
-  [Debug wait time](CFS_Global_Options.md#debug-wait-time), and
-  [Include ARA links](CFS_Global_Options.md#include-ara-links).
-  See [CFS Global Options](CFS_Global_Options.md) for more information.
-* Session and component records now include a `logs` field with a link to the ARA UI with the
-  appropriate filter for that session or component.
-  For more information, see [Ansible Log Collection](Ansible_Log_Collection.md) and
-  [Include ARA links](CFS_Global_Options.md#include-ara-links).
-* The `default_playbook` option is now deprecated.
-  It can still be read using the v3 API but can not be set using the v3 API.
-  Any value set using the v2 API will still be usable by configurations, even v3 configurations,
-  until the v2 API is removed.
-* Sessions now support a `debug_on_failure` option that will cause sessions that fail during Ansible
-  execution to remain up for a limited time so that users can `exec` into the
-  [Ansible Execution Environment (AEE)](Ansible_Execution_Environments.md) container and debug
-  the problem. See [Troubleshoot CFS Issues](Troubleshoot_CFS_Issues.md) for more information.
-* CFS v3 supports new debugging playbooks which are included by default.
-  This can be accessed by specifying `debug_fail`, `debug_facts` or `debug_noop` as the
-  configuration for a session if a configuration has not already been created with that name.
-  See [Troubleshoot CFS Issues](Troubleshoot_CFS_Issues.md) for more information.
+* [Parameter naming changed](#parameter-naming-changed)
+* [Paginated responses](#paginated-responses)
+* [Field length limits](#field-length-limits)
+* [ARA links](#ara-links)
+* [Component configuration state layers](#component-configuration-state-layers)
+    * [Configuration state not listed by default](#configuration-state-not-listed by-default)
+    * [Configuration layer status has dedicated field](#configuration-layer-status-has-dedicated-field)
+* [Global options](#global-options)
+    * [New global options](#new-global-options)
+    * [Default playbook deprecated](#default-playbook-deprecated)
+* [Session debugging](#session-debugging)
+    * [Debug on failure](#debug-on-failure)
+    * [Debugging playbooks](#debugging-playbooks)
+* [CFS sources](#cfs-sources)
+
+## Parameter naming changed
+
+The v3 API uses `snake_case` rather than `camelCase` for all parameters in queries and responses.
+This brings the API in line with other CSM APIs.
+
+## Paginated responses
+
+CFS v3 supports paging through records for [components](CFS_Components.md),
+[configurations](CFS_Configurations.md), and
+[sessions](CFS_Sessions.md).
+
+The response format has changed for queries listing these records.
+Responses are no longer a list of records, and instead contain a key for the record type which
+contains the list of records. (E.g. `{"components":[]}` for the components endpoint).
+Responses also include a `next` section that is used for paging through records.
+
+See [Paging CFS Records](Paging_CFS_Records.md) for more information.
+
+## Field length limits
+
+Some fields now have maximum sizes:
+
+* Configuration names are now limited to 60 characters.
+* [Additional inventory](Adding_Additional_Inventory.md) URLs are limited to 240 characters.
+* Configuration layer names are limited to 45 characters.
+
+## ARA links
+
+Session and component records now include a `logs` field with a link to the ARA UI with the
+appropriate filter for that session or component.
+
+For more information, see:
+
+* [Ansible Log Collection](Ansible_Log_Collection.md)
+* [Include ARA links](CFS_Global_Options.md#include-ara-links)
+
+## Component configuration state layers
+
+### Configuration state not listed by default
+
+Component records no longer include the `state` list of applied playbooks by default.
+The `state` can requested with the `state_details` parameter.
+
+### Configuration layer status has dedicated field
+
+In CFS v2, the configuration layer status is embedded as part of the `commit` field.
+In CFS v3, this is no longer the case; there is a dedicated `status` field for each layer.
+
+## Global options
+
+[CFS Global Options](CFS_Global_Options.md) control various aspects of CFS.
+CFS v3 includes some changes to these options.
+
+### New global options
+
+* [Additional inventory source](CFS_Global_Options.md#additional-inventory-source)
+* [Default page size](CFS_Global_Options.md#default-page-size)
+* [Debug wait time](CFS_Global_Options.md#debug-wait-time)
+* [Include ARA links](CFS_Global_Options.md#include-ara-links)
+
+### Default playbook deprecated
+
+The [Default playbook](CFS_Global_Options.md#default-playbook) option is now deprecated.
+It can still be read using the v3 API but can not be set using the v3 API.
+Any value set using the v2 API will still be usable by configurations, even v3 configurations,
+until the v2 API is removed.
+
+## Session debugging
+
+### Debug on failure
+
+Sessions now support a `debug_on_failure` option that will cause sessions that fail during Ansible
+execution to remain up for a limited time so that users can `exec` into the
+[Ansible Execution Environment (AEE)](Ansible_Execution_Environments.md) container and debug
+the problem.
+
+See [Troubleshoot CFS Issues](Troubleshoot_CFS_Issues.md) for more information.
+
+### Debugging playbooks
+
+CFS v3 supports new debugging playbooks which are included by default.
+This can be accessed by specifying `debug_fail`, `debug_facts` or `debug_noop` as the
+configuration for a session if a configuration has not already been created with that name.
+
+See [Troubleshoot CFS Issues](Troubleshoot_CFS_Issues.md) for more information.
+
+## CFS sources
+
+The CFS v3 supports the creation of [CFS Sources](CFS_Sources.md).
+Sources allow CFS to use configuration and inventory content from external repositories.
+
+For more information, see:
+
+* [CFS Sources](CFS_Sources.md)
+* [Using sources in a configuration layer](CFS_Configurations.md#using-sources-in-a-configuration-layer)

--- a/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
@@ -1,97 +1,67 @@
 # Troubleshoot CFS Sessions Failing to Start
 
-Troubleshoot issues where Configuration Framework Service (CFS)
-[sessions](CFS_Sessions.md) are being created, but the pods are never created and never run.
+This guide offers an overview of how [CFS sessions](CFS_Sessions.md) are created
+and started, in order to help troubleshoot related issues.
+Also see the [CFS Flow Diagram](CFS_Flow_Diagrams.md).
 
-## Prerequisites
+* [Manual sessions](#manual-sessions)
+* [Automated sessions](#automated-sessions)
+* [Booting nodes](#booting-nodes)
+* [Examples](#examples)
 
-[CFS Batcher](CFS_Batcher.md) is creating automatic sessions, but pods are not starting for those sessions.
-There are a number of communication reasons this could be happening, so check the CFS Batcher (`cfs-batcher-`)
-and [CFS Operator](CFS_Operator.md) (`cfs-operator-`) Kubernetes pod logs for these signatures.
+## Manual sessions
 
-CFS Batcher logs should show that it is creating sessions, but giving up waiting for those sessions to start:
+In this context, a manual CFS session is one that is created when an administrator
+directly makes an API or CLI request to create the session.
 
-```text
-2022-08-24 04:09:12,391 - WARNING - batcher.batch - Session batcher-d7f9bf52-e5f6-4742-849b-4086b1d59ab1 is stuck in pending and will be deleted.
-2022-08-24 04:09:12,492 - WARNING - batcher.batch - Session batcher-77c3c4d1-df39-4ebc-a6b4-32b8e102bdc5 is stuck in pending and will be deleted.
-2022-08-24 04:09:12,638 - WARNING - batcher.batch - Session batcher-f9a513c1-47ad-4539-98cc-b3f418f6b8bd is stuck in pending and will be deleted.
-2022-08-24 04:09:12,761 - WARNING - batcher.batch - Session batcher-7a291f2f-0149-46d7-889b-08331a46af2c is stuck in pending and will be deleted.
-2022-08-24 04:09:15,144 - WARNING - batcher.batch - Session batcher-b6c35dcc-b8b9-421b-9090-23bfc2a72ac3 is stuck in pending and will be deleted.
-```
+After performing some basic validation, the CFS API server does the following things
+in order:
 
-CFS operator logs should show that it is attempting to create sessions, but is unable to find the session records.
+1. Sends a message on the Kafka bus to the [CFS Operator](CFS_Operator.md), informing
+   it of the new session.
+1. Writes the new session data to the CFS database, with session `status` of `pending`.
 
-```text
-2022-08-24 05:48:06,476 - INFO    - cray.cfs.operator.events.session_events - EVENT: CREATE batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
-2022-08-24 05:48:06,509 - ERROR   - cray.cfs.operator.cfs.sessions - Unexpected response from CFS: 404 Client Error: Not Found for url: http://cray-cfs-api/v2/sessions/batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
-```
+When the CFS operator receives the Kafka message, it does the following things in order:
 
-If these two things are true, then it is likely that CFS is creating new sessions faster than it can keep up with session creation events.
+1. Creates a Kubernetes job to run the CFS session.
+1. Makes an API call to CFS to update the session with the Kubernetes job ID.
+1. Waits for the Kubernetes job to have a start time set (indicating that it is started running).
+1. Makes an API call to CFS to update the session `status` to `running`.
 
-## Procedure
+## Automated sessions
 
-The primary method of handling this problem is the [`batcher_max_backoff` option](CFS_Global_Options.md#batcher-maximum-backoff).
-This will slow automatic session creation in these situations and give the CFS Operator a chance to catch up.
+In this context, an automated CFS session is one that is created by the
+[CFS Batcher](CFS_Batcher.md).
 
-(`ncn-mw#`) If this value has been changed from its default value of 3600 (1 hour), then it should be set back to that value:
+Batcher periodically makes API calls to CFS to identify all [components](CFS_Components.md) that meet the
+following criteria:
 
-```bash
-cray cfs v3 options update --batcher-max-backoff 3600
-```
+* Enabled
+* Error count is less than the [batcher retry policy](CFS_Global_Options.md#default-batcher-retry-policy)
+* Desired [configuration](CFS_Configurations.md) is set
+* Component status is `pending` (which means that their desired configuration state does not match their actual configuration state)
 
-The issue should eventually resolve automatically.
+It groups these components into batches and periodically makes an API call to CFS
+to create a session to configure the components. What happens outside of batcher
+works exactly the same way as [Manual sessions](#manual-sessions).
 
-If there is a reason that users cannot wait for the back-off to resolve this automatically,
-then the following procedure can be used to purge the event queue. This will disrupt CFS operation and
-may disrupt existing sessions, so caution should be used.
+Batcher also monitors the `status` of all of the sessions that it creates. If any of them
+remain in in `pending` state for too long, it makes an API call to CFS to delete them.
 
-1. (`ncn-mw#`) Disable session creation.
+## Booting nodes
 
-    If any others users or scripts are creating sessions, make sure that they have stopped. CFS Batcher should then be disabled.
+When a node boots, the CFS state reporter runs. It makes an API call to CFS to patch the node.
+This patch enables the node in CFS and clears its `state` field. This causes the
+[Automated sessions](#automated-sessions) procedure to kick in.
 
-    ```bash
-    cray cfs v3 options update --batcher-disable true
-    ```
+## Examples
 
-1. Start a new consumer on the Kafka event queue.
+* If a node is rebooted but no session is created in CFS, then check the following:
 
-    1. (`ncn-mw#`) Open a shell in a Kafka pod.
+    1. Verify that CFS state reporter successfully ran on the node (`systemctl status cfs-state-reporter`).
+    1. Describe the CFS component and verify that it meets the batcher criteria.
+    1. Check the `cray-cfs-batcher` and `cray-cfs-api` Kubernetes pod logs to look for errors.
 
-        ```bash
-        kubectl -n services  exec -it  cray-shared-kafka-kafka-0 -c kafka -- /bin/bash
-        ```
+* If a CFS session is created but remains in `pending` state:
 
-    1. (`pod#`) Start a console consumer on the CFS event topic using the `cfs-operator` consumer group.
-
-        ```bash
-        bin/kafka-console-consumer.sh --bootstrap-server cray-shared-kafka-kafka-0.cray-shared-kafka-kafka-brokers.services.svc.cluster.local:9092 \
-            --topic cfs-session-events --group cfs-operator
-        ```
-
-       This command will likely produce not output at first, while Kafka re-balances the consumer group. Leave this command running.
-
-1. (`ncn-mw#`) In a new window, scale down the CFS Operator.
-
-    This forces the console consumer to handle the entire event queue.
-
-    ```bash
-    kubectl -n services scale --replicas=0 deployment/cray-cfs-operator
-    ```
-
-1. (`ncn-mw#`) Wait until the output from the console consumer stops.
-
-    Once the CFS Operator is scaled down, there should be a final burst of output from the console consumer. Wait until all output has stopped for at least a minute before continuing.
-
-1. (`pod#`) Cancel the console consumer command and exit the pod shell.
-
-1. (`ncn-mw#`) Restore CFS Operator.
-
-    ```bash
-    kubectl -n services scale --replicas=1 deployment/cray-cfs-operator
-    ```
-
-1. (`ncn-mw#`) Enable CFS Batcher.
-
-    ```bash
-    cray cfs v3 options update --batcher-disable false
-    ```
+    Check the `cray-cfs-operator` and `cray-cfs-api` Kubernetes pod logs to look for errors.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -90,6 +90,11 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Skipped Ansible if no CSM `root` secret in Vault](known_issues/Skipped_Ansible_if_no_CSM_root_secret_in_Vault.md)
 * [BOS Log Level Change Not Dynamic](known_issues/BOS_Log_Level_Change_Not_Dynamic.md)
 * [Race Conditions in BOS and CFS](known_issues/Race_Conditions_in_BOS_and_CFS.md)
+* [CFS Batcher Can Be Slow To See Updated CFS Options](known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md)
+* [CFS Batcher Creating Multiple Sessions For Same Batch](known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md)
+* [CFS Operator Creating Multiple Jobs For Same Session](known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
+* [CFS Component State Updates Allow Invalid Values](known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
+* [CFS Component State Update Does Not Preserve Layer Timestamps](known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md)
 
 ## Booting
 
@@ -124,6 +129,11 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [CFS Key Management](../operations/configuration_management/CFS_Key_Management.md)
 * [Skipped Ansible if no CSM `root` secret in Vault](known_issues/Skipped_Ansible_if_no_CSM_root_secret_in_Vault.md)
 * [Race Conditions in BOS and CFS](known_issues/Race_Conditions_in_BOS_and_CFS.md)
+* [CFS Batcher Can Be Slow To See Updated CFS Options](known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md)
+* [CFS Batcher Creating Multiple Sessions For Same Batch](known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md)
+* [CFS Operator Creating Multiple Jobs For Same Session](known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
+* [CFS Component State Updates Allow Invalid Values](known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
+* [CFS Component State Update Does Not Preserve Layer Timestamps](known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md)
 
 ## ConMan
 

--- a/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
@@ -1,0 +1,27 @@
+# CFS Batcher Can Be Slow To See Updated CFS Options
+
+The [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+has an issue in which the [CFS Batcher](../../operations/configuration_management/CFS_Batcher.md)
+takes a long time to read updated [CFS Global Option](../../operations/configuration_management/CFS_Global_Options.md)
+values.
+
+Batcher only checks the CFS global option values in two cases:
+
+* When it first starts up
+* When it scans and processes batches
+
+The [batcher check interval](../../operations/configuration_management/CFS_Global_Options.md#batcher-check-interval)
+option controls how often the batcher scans and processes batches.
+
+Because of this, if the check interval is set to a large value, then CFS batcher will not check
+the CFS global option values very often.
+
+## Fix
+
+None - this issue exists in all versions of CSM.
+
+## Workaround
+
+An administrator can force batcher to get updated CFS options values by
+restarting the `cray-cfs-batcher` Kubernetes deployment in the `services` namespace.
+This should not be done while batcher is scanning and processing batches.

--- a/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
@@ -1,0 +1,29 @@
+# CFS Batcher Creating Multiple Sessions For Same Batch
+
+The [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+has an issue in which the [CFS Batcher](../../operations/configuration_management/CFS_Batcher.md)
+creates multiple
+[CFS sessions](../../operations/configuration_management/CFS_Sessions.md) for the same batch of
+[components](../../operations/configuration_management/CFS_Components.md).
+
+This issue arises when CFS Batcher makes a request to the CFS API to create a new session,
+this request times out, but it ultimately succeeds (unbeknownst to CFS batcher). In this case,
+CFS Batcher will attempt to create a new CFS session (with a different name) for that same batch.
+
+CFS session creation timeouts like this have only been observed on systems which are experiencing
+Kafka problems, causing communication retries between the CFS API server and the
+[CFS Operator](../../operations/configuration_management/CFS_Operator.md).
+
+## Fix
+
+None -- this issue exists in all versions of CSM.
+
+## Workaround
+
+The only way to work around the issue is to investigate and address the problems that are
+causing the session creation timeouts.
+
+## Related
+
+Kafka problems can also trigger another known issue with CFS:
+[CFS Operator Creating Multiple Jobs For Same Session](CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md).

--- a/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
@@ -1,0 +1,37 @@
+# CFS Component State Update Does Not Preserve Layer Timestamps
+
+The [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+has issues in which updating the state of a
+[CFS component](../../operations/configuration_management/CFS_Components.md)
+updates the timestamps for layers that were not changed.
+
+## Details
+
+For this issue, it is important to understand that when patching component `state` in CFS,
+the patch data is not allowed to specify the last updated timestamps for the `state` layers -- it
+is a read-only field that CFS is responsible for maintaining.
+
+When patching component `state` in CFS, there is no direct way to tell it to remove a layer.
+Instead, one must perform a patch that includes all of the other layers, omitting the one
+that is to be removed. This results in the layer being removed, but it also does not
+preserve the last updated timestamps for all of the remaining layers, even though they were not
+changed.
+
+Component patching provides the `state_append` option mechanism for adding state layers
+that does not run afoul of this. However, if one desired to insert a new state layer at any place
+other than the end of the list, then this issue would still apply.
+
+Even a patch operation with a `state` list that exactly matched the current `state` list would
+encounter this issue, resulting in every timestamp being updated.
+
+## Fix
+
+None -- this issue exists in all versions of CSM.
+
+## Workaround
+
+Administrators can completely avoid this problem if they never perform CFS component patches
+that have non-empty `state` lists. In the normal course of operations, it is not required to
+perform such patches.
+
+If such a patch is required, then this issue is unavoidable.

--- a/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
@@ -1,0 +1,54 @@
+# CFS Component State Updates Allow Invalid Values
+
+The [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+has issues in which updating the state of a
+[CFS component](../../operations/configuration_management/CFS_Components.md)
+can leave the component with invalid state data. This in turn can cause problems, such as
+a complete failure of [CFS Batcher](../../operations/configuration_management/CFS_Batcher.md).
+
+## Details
+
+The issue is caused by a few problems:
+
+* CFS does not enforce any required fields for configuration status layers.
+* CFS does very little validation of values in these fields.
+* There is a bug in how CFS converts a v2 configuration status layer into v3 format.
+
+For some aspects of this issue, it is important to be aware that
+[Component configuration state layers](../../operations/configuration_management/Differences_Between_the_V2_and_V3_CFS_APIs.md#component-configuration-state-layers)
+changed between CFS v2 and v3. For this issue, the important change is that the layer `status` changes from
+being embedded in the `commit` field (CFS v2) to having its own dedicated `status` field (CFS v3).
+However, when a configuration state layer is converted from v2 format to v3 format, CFS ignores this;
+it leaves the `commit` field unchanged, and the v3 layer is missing the `status` field. This conversion
+takes place any time component `state` is patched using the CFS v2 endpoint (provided that the patch
+includes a non-empty `state` list).
+
+The end result of all of this is that it is possible to patch components so that their
+`state` fields contain configuration state layers that are missing fields and/or have
+fields with invalid values.
+
+The problems that will result from this vary based on the nature of the invalid data.
+If this issue causes a component to have configuration state layers that are missing the `status` field,
+then this will break CFS batcher. The symptom in the `cfs-batcher` Kubernetes pod logs resembles the following:
+
+```text
+2026-02-24 17:35:54,843 - ERROR   - __main__ - Unexpected error occurred: 'status'
+```
+
+## Fix
+
+None -- this issue exists in all versions of CSM.
+
+## Workaround
+
+This issue is only seen by user patch operations -- no CSM services perform any CFS patch
+operations that encounter this. Administrators can completely avoid this problem if they
+never perform CFS component patches that have non-empty `state` lists. In the normal course
+of operations, it is not required to perform such patches. If such a patch is required, then
+administrators should use the CFS v3 endpoint to do the patching, and should take care that
+the `state` value in the patch is complete and valid.
+
+## Remediation
+
+Perform a CFS v3 component patch to either set the `state` field to a valid list.
+A simple option is to set the `state` to an empty list.

--- a/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
+++ b/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
@@ -1,0 +1,29 @@
+# CFS Operator Creating Multiple Jobs For Same Session
+
+The [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+has an issue in which the [CFS Operator](../../operations/configuration_management/CFS_Operator.md)
+creates multiple Kubernetes jobs for the same
+[CFS session](../../operations/configuration_management/CFS_Sessions.md).
+
+When a new session is created, the CFS API server communicates this to the CFS operator
+over the Kafka bus. This communication is what causes the CFS operator to create a
+Kubernetes job for the session. This issue arises in a case where the CFS API server thinks the
+Kafka send failed or timed out, when it actually succeeded. The CFS API server then retries the
+send, resulting in multiple Kafka messages for the same session. There are no guardrails in place
+to handle this, and it results in the CFS operator creating multiple Kubernetes jobs.
+
+This issue has only been observed on systems which are experiencing Kafka problems.
+
+## Fix
+
+None -- this issue exists in all versions of CSM.
+
+## Workaround
+
+The only way to work around the issue is to investigate and address the problems that are
+causing the Kafka bus problems.
+
+## Related
+
+Kafka problems can also trigger another known issue with CFS:
+[CFS Batcher Creating Multiple Sessions For Same Batch](CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md).


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/docs-csm/pull/6597,
plus adding known issues that apply to CSM 1.5 and not CSM 1.6