### PR TITLE
CASMCMS-9649: Document CFS changes in 1.7.1-patch.2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -674,6 +674,7 @@ oversubscription
 passthrough
 passwordless
 patch.1
+patch.2
 permissioned
 pickup
 playbook

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,7 @@ changes it includes.
 
 * [CSM 1.7.1 Release Notes](RELEASE_NOTES_1.7.1.md)
 * [CSM 1.7.1-patch.1 Release Notes](RELEASE_NOTES_1.7.1-patch.1.md)
+* [CSM 1.7.1-patch.2 Release Notes](RELEASE_NOTES_1.7.1-patch.2.md)
 
 ## New
 

--- a/RELEASE_NOTES_1.7.1-patch.2.md
+++ b/RELEASE_NOTES_1.7.1-patch.2.md
@@ -1,0 +1,37 @@
+# Cray System Management (CSM) 1.7.1-patch.2 Release Notes
+
+* [Introduction](#introduction)
+* [Bug fixes and improvements](#bug-fixes-and-improvements)
+* [Upgrade Steps](#upgrade-steps)
+
+## Introduction
+
+This document guides an administrator through the patch update to CSM 1.7.1-patch.2
+from CSM `1.7.1` onwards only.
+
+## Bug fixes and improvements
+
+### Configuration Framework Service (CFS)
+
+This patch includes many fixes and improvements for CFS.
+
+* Improvements
+    * Improved Kafka reliability in the CFS
+      API server and [CFS Operator](operations/configuration_management/CFS_Operator.md).
+    * Significantly faster [CFS session](operations/configuration_management/CFS_Sessions.md) creation.
+    * Improved debug logging by the CFS API server, CFS Operator, and
+      [CFS Batcher](operations/configuration_management/CFS_Batcher.md).
+    * Minor performance improvements to session filtering (used when performing bulk list, patch,
+      or delete operations on sessions).
+    * Improve CFS Batcher reliability with regards to system clock changes.
+* Known issues fixed
+    * [CFS Batcher Can Be Slow To See Updated CFS Options](troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md)
+    * [CFS Batcher Creating Multiple Sessions For Same Batch](troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md)
+    * [CFS Operator Creating Multiple Jobs For Same Session](troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
+    * [CFS Component State Updates Allow Invalid Values](troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
+    * [CFS Component State Update Does Not Preserve Layer Timestamps](troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md)
+* Several CVEs patched in CFS Batcher and CFS Operator.
+
+## Upgrade steps
+
+Follow the procedures described in [CSM major/minor version upgrade](upgrade/README.md#csm-majorminor-version-upgrade#option-1-upgrade-csm-with-additional-hpe-cray-ex-software-products)

--- a/RELEASE_NOTES_1.7.1-patch.2.md
+++ b/RELEASE_NOTES_1.7.1-patch.2.md
@@ -24,7 +24,7 @@ For a full list of CSM 1.7.1 patch releases, see
 
 ### Configuration Framework Service (CFS)
 
-This patch includes many fixes and improvements for CFS.
+This patch includes many fixes and improvements for [CFS](glossary.md#configuration-framework-service-cfs).
 
 * Improvements
     * Improved Kafka reliability in the CFS

--- a/RELEASE_NOTES_1.7.1-patch.2.md
+++ b/RELEASE_NOTES_1.7.1-patch.2.md
@@ -41,7 +41,8 @@ This patch includes many fixes and improvements for [CFS](glossary.md#configurat
     * [CFS Operator Creating Multiple Jobs For Same Session](troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
     * [CFS Component State Updates Allow Invalid Values](troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
     * [CFS Component State Update Does Not Preserve Layer Timestamps](troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md)
-* Several CVEs patched in CFS Batcher and CFS Operator.
+* Several CVEs patched in CFS Batcher, CFS Operator, and the
+  [Ansible execution environment](operations/configuration_management/Ansible_Execution_Environments.md).
 
 ## Upgrade steps
 

--- a/RELEASE_NOTES_1.7.1-patch.2.md
+++ b/RELEASE_NOTES_1.7.1-patch.2.md
@@ -1,15 +1,26 @@
 # Cray System Management (CSM) 1.7.1-patch.2 Release Notes
 
-* [Introduction](#introduction)
-* [Bug fixes and improvements](#bug-fixes-and-improvements)
-* [Upgrade Steps](#upgrade-steps)
+This document guides an administrator through the patch update to Cray Systems Management 1.7.1-patch.2
+from CSM 1.7.1 onwards only -- do not apply this patch directly to CSM 1.7.0.
 
-## Introduction
+This page documents the changes introduced by this patch, compared to the previous patch
+version of CSM.
 
-This document guides an administrator through the patch update to CSM 1.7.1-patch.2
-from CSM `1.7.1` onwards only.
+For the main CSM 1.7 release notes page, including links to other patch release notes,
+see [CSM 1.7 release notes](RELEASE_NOTES.md).
 
-## Bug fixes and improvements
+* [Patch releases](#patch-releases)
+* [Bug fixes, additions, and improvements](#bug-fixes-additions-and-improvements)
+* [Upgrade steps](#upgrade-steps)
+
+## Patch releases
+
+This is the release notes page for CSM 1.7.1-patch.2;
+each patch for CSM 1.7.1 has its own release notes, detailing what changes it includes.
+For a full list of CSM 1.7.1 patch releases, see
+[CSM 1.7.1 patch releases](RELEASE_NOTES_1.7.1.md#patch-releases).
+
+## Bug fixes, additions, and improvements
 
 ### Configuration Framework Service (CFS)
 
@@ -34,4 +45,4 @@ This patch includes many fixes and improvements for CFS.
 
 ## Upgrade steps
 
-Follow the procedures described in [CSM major/minor version upgrade](upgrade/README.md#csm-majorminor-version-upgrade#option-1-upgrade-csm-with-additional-hpe-cray-ex-software-products)
+See [Upgrade CSM](upgrade/README.md).

--- a/RELEASE_NOTES_1.7.1-patch.2.md
+++ b/RELEASE_NOTES_1.7.1-patch.2.md
@@ -22,6 +22,8 @@ For a full list of CSM 1.7.1 patch releases, see
 
 ## Bug fixes, additions, and improvements
 
+* Resolved CVEs in `console-node` and `csm-config`
+
 ### Configuration Framework Service (CFS)
 
 This patch includes many fixes and improvements for [CFS](glossary.md#configuration-framework-service-cfs).
@@ -41,7 +43,9 @@ This patch includes many fixes and improvements for [CFS](glossary.md#configurat
     * [CFS Operator Creating Multiple Jobs For Same Session](troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md)
     * [CFS Component State Updates Allow Invalid Values](troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md)
     * [CFS Component State Update Does Not Preserve Layer Timestamps](troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md)
-* Several CVEs patched in CFS Batcher, CFS Operator, and the
+* Several CVEs patched in CFS Batcher, CFS Operator,
+  [CFS Hardware Synchronization Agent](operations/configuration_management/CFS_Hardware_Synchronization_Agent.md),
+  CFS [ARA](glossary.md#ansible-records-ansible-ara), and the
   [Ansible execution environment](operations/configuration_management/Ansible_Execution_Environments.md).
 
 ## Upgrade steps

--- a/RELEASE_NOTES_1.7.1.md
+++ b/RELEASE_NOTES_1.7.1.md
@@ -36,6 +36,7 @@ This is the release notes page for CSM 1.7.1. Each patch for CSM 1.7.1 has its o
 changes it includes.
 
 * [CSM 1.7.1-patch.1 Release Notes](RELEASE_NOTES_1.7.1-patch.1.md)
+* [CSM 1.7.1-patch.2 Release Notes](RELEASE_NOTES_1.7.1-patch.2.md)
 
 ## Additions and improvements
 

--- a/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
@@ -18,7 +18,7 @@ the CFS global option values very often.
 
 ## Fix
 
-None - this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
@@ -18,7 +18,7 @@ the CFS global option values very often.
 
 ## Fix
 
-This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
+This issue is fixed in [CSM 1.7.1-patch.2](../../RELEASE_NOTES_1.7.1-patch.2.md); the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
@@ -16,7 +16,7 @@ Kafka problems, causing communication retries between the CFS API server and the
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
@@ -16,7 +16,7 @@ Kafka problems, causing communication retries between the CFS API server and the
 
 ## Fix
 
-This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
+This issue is fixed in [CSM 1.7.1-patch.2](../../RELEASE_NOTES_1.7.1-patch.2.md); the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
@@ -26,7 +26,7 @@ encounter this issue, resulting in every timestamp being updated.
 
 ## Fix
 
-This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
+This issue is fixed in [CSM 1.7.1-patch.2](../../RELEASE_NOTES_1.7.1-patch.2.md); the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
@@ -26,7 +26,7 @@ encounter this issue, resulting in every timestamp being updated.
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
@@ -37,7 +37,7 @@ then this will break CFS batcher. The symptom in the `cfs-batcher` Kubernetes po
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
@@ -37,7 +37,7 @@ then this will break CFS batcher. The symptom in the `cfs-batcher` Kubernetes po
 
 ## Fix
 
-This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
+This issue is fixed in [CSM 1.7.1-patch.2](../../RELEASE_NOTES_1.7.1-patch.2.md); the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
+++ b/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
@@ -16,7 +16,7 @@ This issue has only been observed on systems which are experiencing Kafka proble
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
+++ b/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
@@ -16,7 +16,7 @@ This issue has only been observed on systems which are experiencing Kafka proble
 
 ## Fix
 
-This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
+This issue is fixed in [CSM 1.7.1-patch.2](../../RELEASE_NOTES_1.7.1-patch.2.md); the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -22,6 +22,8 @@ software. Choose the appropriate procedure from the sections below.
 
 * [CSM 1.7.1-patch.1 Release Notes](../RELEASE_NOTES_1.7.1-patch.1.md)
 
+* [CSM 1.7.1-patch.2 Release Notes](../RELEASE_NOTES_1.7.1-patch.2.md)
+
 ## Fabric Manager on baremetal
 
 After CSM is upgraded from 1.7.0 to CSM 1.7.1, if desiring to enable Fabric Manager on baremetal,


### PR DESCRIPTION
**THIS SHOULD NOT MERGE until it is confirmed that [CASMCMS-9647](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9647) will be included in the patch**

**If the contents of the above PR are changed to exclude some of the smaller fixes, then these doc PRs will also need to be updated accordingly**

This creates the 1.7.1-patch.2 release notes page.
It also updates the known issues that are fixed in this patch, indicating that fact.

Backports (the known issue updates, but obviously not the release notes):

1.6: https://github.com/Cray-HPE/docs-csm/pull/6604
1.5: https://github.com/Cray-HPE/docs-csm/pull/6605
1.4: https://github.com/Cray-HPE/docs-csm/pull/6606
1.3: https://github.com/Cray-HPE/docs-csm/pull/6607
1.2: https://github.com/Cray-HPE/docs-csm/pull/6608