### PR TITLE
CASMCMS-9649: Update known issues to indicate ones that are fixed in 1.7.1-patch.2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -666,6 +666,8 @@ osds*
 oversubscription
 passthrough
 passwordless
+patch.1
+patch.2
 permissioned
 pickup
 playbook

--- a/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Can_Be_Slow_To_See_Updated_CFS_Options.md
@@ -18,7 +18,7 @@ the CFS global option values very often.
 
 ## Fix
 
-None - this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
+++ b/troubleshooting/known_issues/CFS_Batcher_Creating_Multiple_Sessions_For_Same_Batch.md
@@ -16,7 +16,7 @@ Kafka problems, causing communication retries between the CFS API server and the
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Update_Does_Not_Preserve_Layer_Timestamps.md
@@ -26,7 +26,7 @@ encounter this issue, resulting in every timestamp being updated.
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
+++ b/troubleshooting/known_issues/CFS_Component_State_Updates_Allow_Invalid_Values.md
@@ -37,7 +37,7 @@ then this will break CFS batcher. The symptom in the `cfs-batcher` Kubernetes po
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 

--- a/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
+++ b/troubleshooting/known_issues/CFS_Operator_Creating_Multiple_Jobs_For_Same_Session.md
@@ -16,7 +16,7 @@ This issue has only been observed on systems which are experiencing Kafka proble
 
 ## Fix
 
-None -- this issue exists in all versions of CSM.
+This issue is fixed in CSM 1.7.1-patch.2; the issue exists in all earlier versions of CSM.
 
 ## Workaround
 


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/docs-csm/pull/6603